### PR TITLE
Add CockroachDB integrations: vector store, reader, retriever, KV/doc/index/chat stores

### DIFF
--- a/docs/examples/chat_store/CockroachDBChatStoreDemo.ipynb
+++ b/docs/examples/chat_store/CockroachDBChatStoreDemo.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1e04f0fbcdc0",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Chat Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56b55d698925",
+   "metadata": {},
+   "source": [
+    "`CockroachDBChatStore` persists `ChatMessage` history per session in CockroachDB. Each key maps to a single `JSONB` cell containing a JSON array of messages. (CockroachDB does not yet support `ARRAY(JSON)` as a column type, so messages live inside one JSONB array rather than as separate array elements.) Atomic appends use the JSONB `||` operator.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13f8dec1d38f",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14cc4d072560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fbbae4bef6c",
+   "metadata": {},
+   "source": [
+    "Start a local insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3340cfb5b2e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault(\"OPENAI_API_KEY\", \"sk-...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f00f1c8034b",
+   "metadata": {},
+   "source": [
+    "## Build the store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "923abf9c7c97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore\n",
+    "\n",
+    "chat_store = CockroachDBChatStore.from_params(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\",\n",
+    "    sslmode=\"disable\",\n",
+    "    table_name=\"chat_history\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3872b337cddf",
+   "metadata": {},
+   "source": [
+    "## Use as ChatMemoryBuffer backing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16d7a0b11cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.memory import ChatMemoryBuffer\n",
+    "\n",
+    "memory = ChatMemoryBuffer.from_defaults(\n",
+    "    token_limit=3000,\n",
+    "    chat_store=chat_store,\n",
+    "    chat_store_key=\"user_42\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0342c2587755",
+   "metadata": {},
+   "source": [
+    "## Plug into an agent or chat engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "330cfe20a597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "def add(a: int, b: int) -> int:\n",
+    "    return a + b\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=[add],\n",
+    "    llm=OpenAI(model=\"gpt-4o-mini\"),\n",
+    ")\n",
+    "response = await agent.run(\"what is 3 + 4?\", memory=memory)\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "befd0004fb26",
+   "metadata": {},
+   "source": [
+    "## Persistence across sessions\n",
+    "\n",
+    "Build a new chat store pointing at the same table and key to resume a conversation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3e3af14abb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next_session = CockroachDBChatStore.from_params(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\", sslmode=\"disable\",\n",
+    "    table_name=\"chat_history\",\n",
+    ")\n",
+    "for msg in next_session.get_messages(\"user_42\"):\n",
+    "    print(msg.role, msg.content[:80])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "856c3e639ef1",
+   "metadata": {},
+   "source": [
+    "## Manual message management"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afff062cd274",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage, MessageRole\n",
+    "\n",
+    "chat_store.set_messages(\n",
+    "    \"sess-demo\",\n",
+    "    [\n",
+    "        ChatMessage(role=MessageRole.USER, content=\"hi\"),\n",
+    "        ChatMessage(role=MessageRole.ASSISTANT, content=\"hello\"),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "chat_store.add_message(\"sess-demo\", ChatMessage(role=MessageRole.USER, content=\"again\"))\n",
+    "for m in chat_store.get_messages(\"sess-demo\"):\n",
+    "    print(m.role, m.content)\n",
+    "\n",
+    "removed = chat_store.delete_last_message(\"sess-demo\")\n",
+    "print(\"removed:\", removed.content)\n",
+    "\n",
+    "chat_store.delete_messages(\"sess-demo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73970fb612ae",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "All operations have async counterparts (`aset_messages`, `async_add_message`, `aget_messages`, ...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c478323fd78d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat_store.aset_messages(\n",
+    "    \"sess-async\",\n",
+    "    [ChatMessage(role=MessageRole.USER, content=\"hi\")],\n",
+    ")\n",
+    "print(await chat_store.aget_messages(\"sess-async\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/docstore/CockroachDBDocstoreDemo.ipynb
+++ b/docs/examples/docstore/CockroachDBDocstoreDemo.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "20a5c137437b",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Document Store + Index Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b1abcf96843",
+   "metadata": {},
+   "source": [
+    "`CockroachDBDocumentStore` and `CockroachDBIndexStore` are thin wrappers over `CockroachDBKVStore` (sync + async). They use the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`. Pair them with `CockroachDBVectorStore` for a fully CRDB-backed `StorageContext`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a93114d39e45",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3646eeaf0d8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e531845e6a",
+   "metadata": {},
+   "source": [
+    "Start a local single-node insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e01db42f099",
+   "metadata": {},
+   "source": [
+    "## Build the stores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a372ea92be1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore\n",
+    "from llama_index.storage.index_store.cockroachdb import CockroachDBIndexStore\n",
+    "\n",
+    "conn = dict(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\", sslmode=\"disable\",\n",
+    ")\n",
+    "\n",
+    "docstore = CockroachDBDocumentStore.from_params(**conn, table_name=\"docs\")\n",
+    "index_store = CockroachDBIndexStore.from_params(**conn, table_name=\"idx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13380fc5eab8",
+   "metadata": {},
+   "source": [
+    "## Persist nodes through the document store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9051b803ccb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Document\n",
+    "from llama_index.core.node_parser import SentenceSplitter\n",
+    "\n",
+    "docs = [\n",
+    "    Document(text=\"CockroachDB is a distributed SQL database.\"),\n",
+    "    Document(text=\"C-SPANN partitions vectors across ranges for distributed ANN.\"),\n",
+    "    Document(text=\"Raft provides strongly consistent replication.\"),\n",
+    "]\n",
+    "nodes = SentenceSplitter().get_nodes_from_documents(docs)\n",
+    "docstore.add_documents(nodes)\n",
+    "\n",
+    "print(f\"persisted {len(nodes)} nodes\")\n",
+    "fetched = docstore.get_document(nodes[0].id_)\n",
+    "print(fetched.get_content())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ba70eededd5",
+   "metadata": {},
+   "source": [
+    "## Build a SummaryIndex backed by both stores\n",
+    "\n",
+    "Pass both stores in a `StorageContext` to persist both the docstore and the index struct to CockroachDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89422bb4e9c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import StorageContext, SummaryIndex\n",
+    "\n",
+    "storage_context = StorageContext.from_defaults(\n",
+    "    docstore=docstore,\n",
+    "    index_store=index_store,\n",
+    ")\n",
+    "summary_index = SummaryIndex(nodes, storage_context=storage_context)\n",
+    "summary_index_id = summary_index.index_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5258a109261d",
+   "metadata": {},
+   "source": [
+    "## Reload from CockroachDB\n",
+    "\n",
+    "The ID alone is enough to reload across processes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d389d7f605d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import load_index_from_storage\n",
+    "\n",
+    "reloaded_storage = StorageContext.from_defaults(\n",
+    "    docstore=CockroachDBDocumentStore.from_params(**conn, table_name=\"docs\"),\n",
+    "    index_store=CockroachDBIndexStore.from_params(**conn, table_name=\"idx\"),\n",
+    ")\n",
+    "reloaded = load_index_from_storage(\n",
+    "    storage_context=reloaded_storage,\n",
+    "    index_id=summary_index_id,\n",
+    ")\n",
+    "print(reloaded)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc0d810cb2a",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "Both stores expose async methods (`async_add_documents`, `aget_document`, `async_add_index_struct`, etc) backed by the `cockroachdb+asyncpg` dialect.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1630f6be9f9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await CockroachDBDocumentStore.from_params(**conn, table_name=\"docs_async\").async_add_documents([\n",
+    "    Document(text=\"async hello world\")\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f656754bd504",
+   "metadata": {},
+   "source": [
+    "## Storage layout\n",
+    "\n",
+    "Each store creates one table per `table_name` you pass, with columns `(id, key, namespace, value)`. The `value` column defaults to `JSONB` (CockroachDB's canonical JSON type) and is fully indexable via JSONB-extracted BTREE indices.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/vector_stores/CockroachDBDemo.ipynb
+++ b/docs/examples/vector_stores/CockroachDBDemo.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4e294dc2111",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Vector Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d06c3f3d475",
+   "metadata": {},
+   "source": [
+    "[CockroachDB](https://www.cockroachlabs.com/) v25.2+ ships a native `VECTOR(n)` column type and the [C-SPANN](https://www.cockroachlabs.com/docs/stable/vector.html) distributed approximate nearest neighbor index. This notebook walks through using `CockroachDBVectorStore` with LlamaIndex.\n",
+    "\n",
+    "`llama-index-vector-stores-postgres` depends on the `pgvector` extension, which is not available in CockroachDB. The CockroachDB integration targets CRDB's native primitives directly:\n",
+    "\n",
+    "| Concern | pgvector store | CockroachDB store |\n",
+    "| --- | --- | --- |\n",
+    "| Column type | `pgvector.sqlalchemy.Vector` | native `VECTOR(dim)` |\n",
+    "| Index DDL | `USING hnsw (... WITH m, ef_construction)` | `CREATE VECTOR INDEX ... WITH (min_partition_size, max_partition_size)` |\n",
+    "| Search-time knob | `SET hnsw.ef_search` | `SET vector_search_beam_size` |\n",
+    "| Dialect | `postgresql+psycopg2` / `+asyncpg` | `cockroachdb+psycopg2` / `cockroachdb+asyncpg` (retry-aware) |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b82a1d727932",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Requires CockroachDB v25.2+ with the vector feature enabled at the cluster level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1967db1f759",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb llama-index-embeddings-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1abc1be9375a",
+   "metadata": {},
+   "source": [
+    "Start a local single-node insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "cockroach sql --insecure -e \"SET CLUSTER SETTING feature.vector_index.enabled = true;\"\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bee2eded90b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault(\"OPENAI_API_KEY\", \"sk-...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49691c6f7694",
+   "metadata": {},
+   "source": [
+    "## Build the store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78c22d26a90b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore\n",
+    "\n",
+    "store = CockroachDBVectorStore.from_params(\n",
+    "    host=\"localhost\",\n",
+    "    port=26257,\n",
+    "    user=\"root\",\n",
+    "    password=\"\",\n",
+    "    database=\"defaultdb\",\n",
+    "    table_name=\"llamaindex_demo\",\n",
+    "    embed_dim=1536,\n",
+    "    distance_metric=\"cosine\",  # or \"l2\", \"inner_product\"\n",
+    "    cspann_kwargs={\"min_partition_size\": 16, \"max_partition_size\": 128},\n",
+    "    sslmode=\"disable\",  # local insecure cluster only\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c317f3dd254a",
+   "metadata": {},
+   "source": [
+    "## Index documents\n",
+    "\n",
+    "`CockroachDBVectorStore` plugs into `VectorStoreIndex` the same way any other vector store does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5366449309b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Document, StorageContext, VectorStoreIndex\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "\n",
+    "docs = [\n",
+    "    Document(text=\"C-SPANN is CockroachDB's native ANN index.\"),\n",
+    "    Document(text=\"HNSW is a hierarchical small-world graph used by pgvector.\"),\n",
+    "    Document(text=\"CockroachDB uses Raft for strongly consistent replication.\"),\n",
+    "]\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    docs,\n",
+    "    storage_context=StorageContext.from_defaults(vector_store=store),\n",
+    "    embed_model=OpenAIEmbedding(model=\"text-embedding-3-small\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ff05c1246cd",
+   "metadata": {},
+   "source": [
+    "## Query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df0c986080fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(\"How does CockroachDB do ANN search?\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a53cd8cbdc3",
+   "metadata": {},
+   "source": [
+    "## Tune C-SPANN at query time\n",
+    "\n",
+    "`vector_search_beam_size` is a per-session knob (`SET LOCAL`) controlling recall / latency. Higher beam = better recall, slightly more latency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80546abfaf8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.vector_stores import VectorStoreQuery\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "\n",
+    "embed = OpenAIEmbedding(model=\"text-embedding-3-small\")\n",
+    "query_emb = embed.get_text_embedding(\"How does CockroachDB do ANN search?\")\n",
+    "\n",
+    "result = store.query(\n",
+    "    VectorStoreQuery(query_embedding=query_emb, similarity_top_k=3),\n",
+    "    vector_search_beam_size=128,\n",
+    ")\n",
+    "for node, score in zip(result.nodes, result.similarities):\n",
+    "    print(f\"{score:.4f}  {node.get_content()[:80]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73f8f9a844a",
+   "metadata": {},
+   "source": [
+    "## Metadata filters\n",
+    "\n",
+    "Supports `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`, `CONTAINS`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, `IS_EMPTY`, nestable via `MetadataFilters` with AND/OR/NOT. For frequently filtered keys, declare `indexed_metadata_keys` on the store to get JSONB-extracted BTREE indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9719638bd29e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.vector_stores import MetadataFilter, MetadataFilters, FilterOperator\n",
+    "\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[MetadataFilter(key=\"author\", value=\"alice\", operator=FilterOperator.EQ)]\n",
+    ")\n",
+    "retriever = index.as_retriever(filters=filters, similarity_top_k=3)\n",
+    "nodes = retriever.retrieve(\"anything\")\n",
+    "for n in nodes:\n",
+    "    print(n.score, n.node.get_content()[:80])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a20f91ce7e46",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "All methods have an async counterpart via the `cockroachdb+asyncpg` dialect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "909e900ddd4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await store.aquery(\n",
+    "    VectorStoreQuery(query_embedding=query_emb, similarity_top_k=3),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c4b596240d",
+   "metadata": {},
+   "source": [
+    "## Supported query modes\n",
+    "\n",
+    "| Mode | Supported | Notes |\n",
+    "| --- | --- | --- |\n",
+    "| `DEFAULT` | yes | Vector ANN through C-SPANN |\n",
+    "| `MMR` | yes | Client-side rerank; `mmr_threshold`, `mmr_prefetch_factor`, `mmr_prefetch_k` |\n",
+    "| `HYBRID` / `SPARSE` / `TEXT_SEARCH` | no | CockroachDB has no `tsvector` yet |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -22,6 +22,7 @@ as the storage backend for `VectorStoreIndex`.
 - Azure Cosmos DB NoSql (`AzureCosmosDBNoSqlVectorSearch`). [Quickstart](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search)
 - Chroma (`ChromaVectorStore`) [Installation](https://docs.trychroma.com/getting-started)
 - ClickHouse (`ClickHouseVectorStore`) [Installation](https://clickhouse.com/docs/en/install)
+- CockroachDB (`CockroachDBVectorStore`). Native `VECTOR(n)` + C-SPANN distributed ANN. [Quickstart](https://pypi.org/project/llama-index-cockroachdb/).
 - Couchbase (`CouchbaseSearchVectorStore`) [Installation](https://www.couchbase.com/products/capella/)
 - DashVector (`DashVectorStore`). [Installation](https://help.aliyun.com/document_detail/2510230.html).
 - DeepLake (`DeepLakeVectorStore`) [Installation](https://docs.deeplake.ai/en/latest/Installation.html)
@@ -1231,6 +1232,7 @@ documents = reader.load_data(
 - [Milvus Full-Text Search](/python/examples/vector_stores/milvusfulltextsearchdemo)
 - [Milvus Hybrid Search](/python/examples/vector_stores/milvushybridindexdemo)
 - [MyScale](/python/examples/vector_stores/myscaleindexdemo)
+- [CockroachDB](/python/examples/vector_stores/cockroachdbdemo)
 - [ElsaticSearch](/python/examples/vector_stores/elasticsearchindexdemo)
 - [FAISS](/python/examples/vector_stores/faissindexdemo)
 - [MongoDB Atlas](/python/examples/vector_stores/mongodbatlasvectorsearch)

--- a/docs/src/content/docs/framework/module_guides/storing/chat_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/chat_stores.md
@@ -247,6 +247,37 @@ chat_memory = ChatMemoryBuffer.from_defaults(
 )
 ```
 
+## CockroachDBChatStore
+
+Using `CockroachDBChatStore`, you can store your chat history in CockroachDB. Each session's messages are stored as a single `JSONB` column holding a JSON array (CockroachDB does not yet support `ARRAY(JSON)` as a column type), and atomic appends use the JSONB `||` operator.
+
+```bash
+pip install llama-index-cockroachdb
+```
+
+```python
+from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore
+from llama_index.core.memory import ChatMemoryBuffer
+
+chat_store = CockroachDBChatStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="chat_history",
+)
+
+chat_memory = ChatMemoryBuffer.from_defaults(
+    token_limit=3000,
+    chat_store=chat_store,
+    chat_store_key="user1",
+)
+```
+
+A more detailed guide can be found [here](/python/examples/chat_store/cockroachdbchatstoredemo).
+
 ## TablestoreChatStore
 
 Using `TablestoreChatStore`, you can store your chat history remotely, without having to worry about manually persisting and loading the chat history.

--- a/docs/src/content/docs/framework/module_guides/storing/docstores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/docstores.md
@@ -318,3 +318,27 @@ Under the hood, `PostgresDocumentStore` connects to the cloud sql for pg databas
 You can easily reconnect to your Postgres database and reload the index by re-initializing a `PostgresDocumentStore` with an `PostgresEngine` without initializing a new table.
 
 A more detailed guide can be found [here](/python/examples/docstore/cloudsqlpgdocstoredemo)
+
+### CockroachDB Document Store
+
+We support [CockroachDB](https://www.cockroachlabs.com/) as a document store backend. `CockroachDBDocumentStore` uses the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`.
+
+```bash
+pip install llama-index-cockroachdb
+```
+
+```python
+from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore
+
+doc_store = CockroachDBDocumentStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="docs",
+)
+```
+
+A more detailed guide can be found [here](/python/examples/docstore/cockroachdbdocstoredemo).

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/.gitignore
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/LICENSE
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/README.md
@@ -1,0 +1,43 @@
+# LlamaIndex Readers Integration: CockroachDB
+
+Load rows from an existing [CockroachDB](https://www.cockroachlabs.com/) table or arbitrary SELECT into LlamaIndex `Document` objects.
+
+## Installation
+
+```bash
+pip install llama-index-readers-cockroachdb
+```
+
+## Usage
+
+```python
+from llama_index.readers.cockroachdb import CockroachDBReader
+
+reader = CockroachDBReader.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",
+)
+
+# Mode 1: table + columns
+docs = reader.load_data(
+    table="articles",
+    text_column="body",
+    metadata_columns=["id", "author", "tag"],
+    id_column="id",
+)
+
+# Mode 2: parameterized query
+docs = reader.load_data(
+    query="SELECT id, body, author FROM articles WHERE author = :a",
+    text_column="body",
+    metadata_columns=["id", "author"],
+    id_column="id",
+    params={"a": "alice"},
+)
+```
+
+The reader uses the `cockroachdb+psycopg2` SQLAlchemy dialect for serialization-retry support. Pair it with [`llama-index-vector-stores-cockroachdb`](../../vector_stores/llama-index-vector-stores-cockroachdb) if you want to index the rows you load.

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/llama_index/readers/cockroachdb/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/llama_index/readers/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.cockroachdb.base import CockroachDBReader
+
+__all__ = ["CockroachDBReader"]

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/llama_index/readers/cockroachdb/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/llama_index/readers/cockroachdb/base.py
@@ -1,0 +1,125 @@
+"""CockroachDB reader for pulling rows into LlamaIndex Documents."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+
+class CockroachDBReader(BaseReader):
+    """Read rows from CockroachDB into LlamaIndex Documents.
+
+    Two modes:
+
+    1. ``query=...``: provide a raw SELECT and the reader maps each row to a
+       Document using ``text_column`` and ``metadata_columns``.
+    2. ``table=...`` + ``text_column=...``: the reader builds
+       ``SELECT * FROM table`` and applies the same mapping.
+
+    Examples:
+        ```python
+        reader = CockroachDBReader.from_params(
+            host="localhost", port=26257, database="defaultdb", user="root",
+        )
+        docs = reader.load_data(
+            table="articles",
+            text_column="body",
+            metadata_columns=["id", "author", "published_at"],
+        )
+        ```
+    """
+
+    uri: str | None = Field(
+        default=None,
+        description="SQLAlchemy URL, e.g. cockroachdb+psycopg2://root@host:26257/db",
+    )
+    engine: Any | None = Field(default=None, exclude=True)
+
+    def __init__(
+        self,
+        uri: str | sqlalchemy.engine.URL | None = None,
+        engine: sqlalchemy.engine.Engine | None = None,
+    ) -> None:
+        super().__init__()
+        if uri is None and engine is None:
+            raise ValueError("Provide either uri or engine.")
+        self.uri = str(uri) if uri is not None else None
+        self.engine = engine
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str,
+        port: int | str = 26257,
+        database: str = "defaultdb",
+        user: str = "root",
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+    ) -> CockroachDBReader:
+        params: list[str] = []
+        if sslmode:
+            params.append(f"sslmode={sslmode}")
+        if sslrootcert:
+            params.append(f"sslrootcert={sslrootcert}")
+        qs = ("?" + "&".join(params)) if params else ""
+        cred = f"{user}:{password}" if password else user
+        uri = f"cockroachdb+psycopg2://{cred}@{host}:{port}/{database}{qs}"
+        return cls(uri=uri)
+
+    def _get_engine(self) -> sqlalchemy.engine.Engine:
+        if self.engine is not None:
+            return self.engine
+        from sqlalchemy import create_engine
+
+        self.engine = create_engine(self.uri)
+        return self.engine
+
+    def load_data(
+        self,
+        query: str | None = None,
+        table: str | None = None,
+        schema: str = "public",
+        text_column: str = "text",
+        metadata_columns: Sequence[str] | None = None,
+        id_column: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> list[Document]:
+        if query is None and table is None:
+            raise ValueError("Provide either query or table.")
+        if query is None:
+            cols = "*"
+            query = f"SELECT {cols} FROM {schema}.{table}"
+
+        engine = self._get_engine()
+        from sqlalchemy import text as sql_text
+
+        docs: list[Document] = []
+        with engine.connect() as conn:
+            result = conn.execute(sql_text(query), params or {})
+            rows = result.mappings().all()
+            for row in rows:
+                row_dict = dict(row)
+                if text_column not in row_dict:
+                    raise KeyError(f"text_column {text_column!r} not in row keys {list(row_dict)}")
+                content = row_dict.pop(text_column)
+                if content is None:
+                    continue
+                doc_id = (
+                    str(row_dict.get(id_column)) if id_column and id_column in row_dict else None
+                )
+                if metadata_columns is not None:
+                    metadata = {k: row_dict.get(k) for k in metadata_columns if k in row_dict}
+                else:
+                    metadata = {k: v for k, v in row_dict.items() if not _looks_like_blob(v)}
+                docs.append(Document(text=str(content), metadata=metadata, id_=doc_id))
+        return docs
+
+
+def _looks_like_blob(value: Any) -> bool:
+    return isinstance(value, (bytes, bytearray, memoryview))

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-readers-cockroachdb"
+version = "0.1.0"
+description = "llama-index readers cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "sql", "reader"]
+dependencies = [
+    "psycopg2-binary>=2.9.9,<3.0.0",
+    "sqlalchemy-cockroachdb>=2.0.2",
+    "sqlalchemy>=2.0.0,<2.1",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBReader = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/readers/llama-index-readers-cockroachdb/tests/test_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-cockroachdb/tests/test_reader.py
@@ -1,0 +1,81 @@
+"""Tests for CockroachDBReader."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg2
+import pytest
+
+from llama_index.readers.cockroachdb import CockroachDBReader
+
+
+@pytest.fixture()
+def seeded_table(fresh_db: dict[str, Any]) -> dict[str, Any]:
+    conn = psycopg2.connect(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        dbname=fresh_db["database"],
+        sslmode="disable",
+    )
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE articles (
+                id INT PRIMARY KEY,
+                body STRING NOT NULL,
+                author STRING,
+                tag STRING
+            )
+            """
+        )
+        cur.execute(
+            "INSERT INTO articles VALUES (1, 'hello world', 'alice', 'a'), "
+            "(2, 'goodbye world', 'bob', 'b'), (3, 'cspann rocks', 'alice', 'a')"
+        )
+    conn.close()
+    return fresh_db
+
+
+def test_load_data_from_table(seeded_table: dict[str, Any]) -> None:
+    reader = CockroachDBReader.from_params(
+        host=seeded_table["host"],
+        port=seeded_table["port"],
+        database=seeded_table["database"],
+        user=seeded_table["user"],
+        password=seeded_table["password"] or "",
+        sslmode="disable",
+    )
+    docs = reader.load_data(
+        table="articles",
+        text_column="body",
+        metadata_columns=["id", "author", "tag"],
+        id_column="id",
+    )
+    assert len(docs) == 3
+    by_id = {d.id_: d for d in docs}
+    assert by_id["1"].text == "hello world"
+    assert by_id["1"].metadata["author"] == "alice"
+    assert set(by_id["2"].metadata) == {"id", "author", "tag"}
+
+
+def test_load_data_from_query(seeded_table: dict[str, Any]) -> None:
+    reader = CockroachDBReader.from_params(
+        host=seeded_table["host"],
+        port=seeded_table["port"],
+        database=seeded_table["database"],
+        user=seeded_table["user"],
+        password=seeded_table["password"] or "",
+        sslmode="disable",
+    )
+    docs = reader.load_data(
+        query="SELECT id, body, author FROM articles WHERE tag = :tag",
+        text_column="body",
+        metadata_columns=["id", "author"],
+        id_column="id",
+        params={"tag": "a"},
+    )
+    assert {d.text for d in docs} == {"hello world", "cspann rocks"}

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/.gitignore
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/LICENSE
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/Makefile
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/README.md
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/README.md
@@ -1,0 +1,38 @@
+# LlamaIndex Retrievers Integration: CockroachDB
+
+Standalone `BaseRetriever` wrapping [`llama-index-vector-stores-cockroachdb`](../../vector_stores/llama-index-vector-stores-cockroachdb) with knobs for C-SPANN beam-size tuning and MMR. Use this when you want CRDB-backed vector retrieval outside `VectorStoreIndex`, for example in a custom query pipeline.
+
+## Installation
+
+```bash
+pip install llama-index-retrievers-cockroachdb
+```
+
+(`llama-index-vector-stores-cockroachdb` is pulled in as a dependency.)
+
+## Usage
+
+```python
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.retrievers.cockroachdb import CockroachDBRetriever
+from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+store = CockroachDBVectorStore.from_params(
+    host="localhost", port=26257, user="root", password="",
+    database="defaultdb", table_name="my_index",
+    embed_dim=1536, distance_metric="cosine",
+    sslmode="disable",
+)
+
+retriever = CockroachDBRetriever(
+    vector_store=store,
+    embed_model=OpenAIEmbedding(model="text-embedding-3-small"),
+    similarity_top_k=5,
+    vector_search_beam_size=128,
+)
+
+for node in retriever.retrieve("How does C-SPANN compare to HNSW?"):
+    print(f"{node.score:.4f}  {node.node.get_content()[:80]}")
+```
+
+`mmr_threshold`, `mmr_prefetch_factor`, `mmr_prefetch_k`, and `filters` are also supported on the constructor.

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/llama_index/retrievers/cockroachdb/__init__.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/llama_index/retrievers/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.retrievers.cockroachdb.base import CockroachDBRetriever
+
+__all__ = ["CockroachDBRetriever"]

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/llama_index/retrievers/cockroachdb/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/llama_index/retrievers/cockroachdb/base.py
@@ -1,0 +1,111 @@
+"""Retriever wrapping CockroachDBVectorStore with C-SPANN tuning."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.embeddings.utils import EmbedType, resolve_embed_model
+from llama_index.core.retrievers import BaseRetriever
+from llama_index.core.schema import NodeWithScore, QueryBundle
+from llama_index.core.vector_stores.types import (
+    MetadataFilters,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+)
+
+from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+
+class CockroachDBRetriever(BaseRetriever):
+    """Standalone retriever over a CockroachDBVectorStore.
+
+    Embeds the query with ``embed_model``, runs the vector search through the
+    store, and returns ``NodeWithScore`` results. Use this when you want vector
+    retrieval without going through ``VectorStoreIndex``, for example when
+    inserting CRDB-side retrieval into a custom query pipeline.
+
+    Examples:
+        ```python
+        retriever = CockroachDBRetriever(
+            vector_store=store,
+            embed_model="local",
+            similarity_top_k=5,
+            vector_search_beam_size=64,
+        )
+        nodes = retriever.retrieve("what is C-SPANN?")
+        ```
+    """
+
+    def __init__(
+        self,
+        vector_store: CockroachDBVectorStore,
+        embed_model: EmbedType | None = None,
+        similarity_top_k: int = 4,
+        mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT,
+        filters: MetadataFilters | None = None,
+        vector_search_beam_size: int | None = None,
+        mmr_threshold: float | None = None,
+        mmr_prefetch_factor: float | None = None,
+        mmr_prefetch_k: int | None = None,
+        callback_manager: CallbackManager | None = None,
+    ) -> None:
+        self._vector_store = vector_store
+        self._embed_model = resolve_embed_model(embed_model)
+        self._similarity_top_k = similarity_top_k
+        self._mode = mode
+        self._filters = filters
+        self._vector_search_beam_size = vector_search_beam_size
+        self._mmr_threshold = mmr_threshold
+        self._mmr_prefetch_factor = mmr_prefetch_factor
+        self._mmr_prefetch_k = mmr_prefetch_k
+        super().__init__(callback_manager=callback_manager)
+
+    def _build_query_kwargs(self) -> dict:
+        kwargs: dict = {}
+        if self._vector_search_beam_size is not None:
+            kwargs["vector_search_beam_size"] = self._vector_search_beam_size
+        if self._mmr_threshold is not None:
+            kwargs["mmr_threshold"] = self._mmr_threshold
+        if self._mmr_prefetch_factor is not None:
+            kwargs["mmr_prefetch_factor"] = self._mmr_prefetch_factor
+        if self._mmr_prefetch_k is not None:
+            kwargs["mmr_prefetch_k"] = self._mmr_prefetch_k
+        return kwargs
+
+    def _build_query(self, embedding: list[float]) -> VectorStoreQuery:
+        return VectorStoreQuery(
+            query_embedding=embedding,
+            similarity_top_k=self._similarity_top_k,
+            filters=self._filters,
+            mode=self._mode,
+            mmr_threshold=self._mmr_threshold,
+        )
+
+    def _retrieve(self, query_bundle: QueryBundle) -> list[NodeWithScore]:
+        embedding = (
+            query_bundle.embedding
+            if query_bundle.embedding is not None
+            else self._embed_model.get_query_embedding(query_bundle.query_str)
+        )
+        result = self._vector_store.query(
+            self._build_query(embedding), **self._build_query_kwargs()
+        )
+        return self._to_nodes_with_score(result)
+
+    async def _aretrieve(self, query_bundle: QueryBundle) -> list[NodeWithScore]:
+        embedding = (
+            query_bundle.embedding
+            if query_bundle.embedding is not None
+            else await self._embed_model.aget_query_embedding(query_bundle.query_str)
+        )
+        result = await self._vector_store.aquery(
+            self._build_query(embedding), **self._build_query_kwargs()
+        )
+        return self._to_nodes_with_score(result)
+
+    @staticmethod
+    def _to_nodes_with_score(result: Any) -> list[NodeWithScore]:
+        nodes = result.nodes or []
+        sims = result.similarities or [None] * len(nodes)
+        return [NodeWithScore(node=n, score=s) for n, s in zip(nodes, sims, strict=False)]

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/pyproject.toml
@@ -1,0 +1,72 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-retrievers-cockroachdb"
+version = "0.1.0"
+description = "llama-index retrievers cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "retriever", "cspann"]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "llama-index-vector-stores-cockroachdb>=0.1.0",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.retrievers.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBRetriever = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning:"]
+markers = ["asyncio"]

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/tests/test_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-cockroachdb/tests/test_retriever.py
@@ -1,0 +1,62 @@
+"""Tests for CockroachDBRetriever (uses a stub embedder, no model downloads)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.schema import TextNode
+
+from llama_index.retrievers.cockroachdb import CockroachDBRetriever
+from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+EMBED_DIM = 4
+
+
+class HashEmbedding(BaseEmbedding):
+    """Deterministic 4-d embedding so tests don't hit the network."""
+
+    def _get_query_embedding(self, query: str) -> list[float]:
+        h = hash(query) % 1000 / 1000.0
+        return [h, 1.0, 1.0, 1.0]
+
+    async def _aget_query_embedding(self, query: str) -> list[float]:
+        return self._get_query_embedding(query)
+
+    def _get_text_embedding(self, text: str) -> list[float]:
+        return self._get_query_embedding(text)
+
+
+@pytest.fixture()
+def populated_store(fresh_db: dict[str, Any]) -> CockroachDBVectorStore:
+    s = CockroachDBVectorStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        database=fresh_db["database"],
+        table_name="retr_idx",
+        embed_dim=EMBED_DIM,
+        sslmode="disable",
+    )
+    embed = HashEmbedding()
+    nodes = []
+    for nid, txt in [("a", "alpha"), ("b", "beta"), ("c", "gamma")]:
+        n = TextNode(id_=nid, text=txt)
+        n.embedding = embed._get_text_embedding(txt)
+        nodes.append(n)
+    s.add(nodes)
+    return s
+
+
+def test_retriever_returns_nodes_with_scores(populated_store: CockroachDBVectorStore) -> None:
+    retr = CockroachDBRetriever(
+        vector_store=populated_store,
+        embed_model=HashEmbedding(),
+        similarity_top_k=2,
+    )
+    out = retr.retrieve("alpha")
+    assert len(out) == 2
+    assert all(n.node.id_ in {"a", "b", "c"} for n in out)
+    assert out[0].score is not None

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/.gitignore
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/LICENSE
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/Makefile
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/README.md
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/README.md
@@ -1,0 +1,34 @@
+# LlamaIndex Storage_Chat_Store Integration: CockroachDB
+
+A chat store backed by [CockroachDB](https://www.cockroachlabs.com/).
+
+Each session's messages are stored as a single `JSONB` column holding a JSON array (CockroachDB does not yet support `ARRAY(JSON)` as a column type, see [crdb#23468](https://github.com/cockroachdb/cockroach/issues/23468)). Appends use the JSONB `||` operator inside an `INSERT ... ON CONFLICT DO UPDATE` so they are atomic and retry-safe under `SERIALIZATION_FAILURE`.
+
+## Installation
+
+```bash
+pip install llama-index-storage-chat-store-cockroachdb
+```
+
+## Usage
+
+```python
+from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore
+from llama_index.core.memory import ChatMemoryBuffer
+
+chat_store = CockroachDBChatStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="chat_history",
+)
+
+memory = ChatMemoryBuffer.from_defaults(
+    token_limit=3000,
+    chat_store=chat_store,
+    chat_store_key="user1",
+)
+```

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/llama_index/storage/chat_store/cockroachdb/__init__.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/llama_index/storage/chat_store/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.storage.chat_store.cockroachdb.base import CockroachDBChatStore
+
+__all__ = ["CockroachDBChatStore"]

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/llama_index/storage/chat_store/cockroachdb/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/llama_index/storage/chat_store/cockroachdb/base.py
@@ -1,0 +1,404 @@
+"""CockroachDB Chat store for LlamaIndex."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlparse
+
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.llms import ChatMessage
+from llama_index.core.storage.chat_store.base import BaseChatStore
+from sqlalchemy import (
+    Column,
+    Index,
+    Integer,
+    UniqueConstraint,
+    create_engine,
+    delete,
+    inspect,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSON, JSONB, VARCHAR
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+def get_data_model(
+    base: type,
+    index_name: str,
+    schema_name: str,
+    use_jsonb: bool = True,
+) -> Any:
+    """Build a dynamic SQLAlchemy model for the chat store table.
+
+    On CockroachDB we store the list of messages as a single JSONB column
+    holding a JSON array, because CRDB does not support ``ARRAY(JSON)`` as a
+    column type (see crdb issue 23468).
+    """
+    index_name = index_name or "chatstore"
+    tablename = index_name
+    class_name = f"{index_name[0].upper()}{index_name[1:]}"
+
+    chat_dtype = JSONB if use_jsonb else JSON
+
+    class AbstractData(base):  # type: ignore[misc, valid-type]
+        __abstract__ = True
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        key = Column(VARCHAR, nullable=False)
+        value = Column(chat_dtype)
+
+    return type(
+        class_name,
+        (AbstractData,),
+        {
+            "__tablename__": tablename,
+            "__table_args__": (
+                UniqueConstraint("key", name=f"{tablename}:unique_key"),
+                Index(f"{tablename}:idx_key", "key"),
+                {"schema": schema_name},
+            ),
+        },
+    )
+
+
+def _serialize(messages: list[ChatMessage]) -> str:
+    return json.dumps([json.loads(m.model_dump_json()) for m in messages])
+
+
+def _deserialize(value: Any) -> list[dict]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = json.loads(value)
+    return list(value)
+
+
+class CockroachDBChatStore(BaseChatStore):
+    """CockroachDB-backed Chat store.
+
+    Each conversation key maps to a single ``JSONB`` cell containing a JSON
+    array of messages. Uses the ``cockroachdb+psycopg2`` and
+    ``cockroachdb+asyncpg`` SQLAlchemy dialects so retries on
+    ``SERIALIZATION_FAILURE`` are transparent.
+    """
+
+    table_name: str | None = Field(default="chatstore", description="CRDB table name.")
+    schema_name: str | None = Field(default="public", description="CRDB schema name.")
+
+    _table_class: Any | None = PrivateAttr()
+    _session: sessionmaker | None = PrivateAttr()
+    _async_session: sessionmaker | None = PrivateAttr()
+
+    def __init__(
+        self,
+        session: sessionmaker,
+        async_session: sessionmaker,
+        table_name: str,
+        schema_name: str = "public",
+        use_jsonb: bool = True,
+    ) -> None:
+        super().__init__(
+            table_name=table_name.lower(),
+            schema_name=schema_name.lower(),
+        )
+
+        base = declarative_base()
+        self._table_class = get_data_model(
+            base,
+            self.table_name,
+            self.schema_name,
+            use_jsonb=use_jsonb,
+        )
+        self._session = session
+        self._async_session = async_session
+        self._initialize(base)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "CockroachDBChatStore"
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str | None = None,
+        port: int | str | None = None,
+        database: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+        table_name: str = "chatstore",
+        schema_name: str = "public",
+        connection_string: str | None = None,
+        async_connection_string: str | None = None,
+        debug: bool = False,
+        use_jsonb: bool = True,
+    ) -> CockroachDBChatStore:
+        port = port or 26257
+        if connection_string is None:
+            params: list[str] = []
+            if sslmode:
+                params.append(f"sslmode={sslmode}")
+            if sslrootcert:
+                params.append(f"sslrootcert={sslrootcert}")
+            qs = "?" + "&".join(params) if params else ""
+            connection_string = (
+                f"cockroachdb+psycopg2://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+        if async_connection_string is None:
+            params = []
+            if sslmode and sslmode != "disable":
+                params.append("ssl=true")
+            qs = "?" + "&".join(params) if params else ""
+            async_connection_string = (
+                f"cockroachdb+asyncpg://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+        session, async_session = cls._connect(connection_string, async_connection_string, debug)
+        return cls(
+            session=session,
+            async_session=async_session,
+            table_name=table_name,
+            schema_name=schema_name,
+            use_jsonb=use_jsonb,
+        )
+
+    @classmethod
+    def from_uri(
+        cls,
+        uri: str,
+        table_name: str = "chatstore",
+        schema_name: str = "public",
+        debug: bool = False,
+        use_jsonb: bool = True,
+    ) -> CockroachDBChatStore:
+        params = params_from_uri(uri)
+        return cls.from_params(
+            **params,
+            table_name=table_name,
+            schema_name=schema_name,
+            debug=debug,
+            use_jsonb=use_jsonb,
+        )
+
+    @classmethod
+    def _connect(
+        cls, connection_string: str, async_connection_string: str, debug: bool
+    ) -> tuple[sessionmaker, sessionmaker]:
+        sync_engine = create_engine(connection_string, echo=debug)
+        session = sessionmaker(sync_engine)
+        async_engine = create_async_engine(async_connection_string)
+        async_session = sessionmaker(async_engine, class_=AsyncSession)
+        return session, async_session
+
+    def _create_schema_if_not_exists(self) -> None:
+        with self._session() as session, session.begin():
+            inspector = inspect(session.connection())
+            existing_schemas = inspector.get_schema_names()
+            if self.schema_name not in existing_schemas:
+                session.execute(text(f"CREATE SCHEMA IF NOT EXISTS {self.schema_name}"))
+
+    def _create_tables_if_not_exists(self, base: type) -> None:
+        with self._session() as session, session.begin():
+            base.metadata.create_all(session.connection())
+
+    def _initialize(self, base: type) -> None:
+        self._create_schema_if_not_exists()
+        self._create_tables_if_not_exists(base)
+
+    def _qualified_table(self) -> str:
+        return f"{self.schema_name}.{self._table_class.__tablename__}"
+
+    def set_messages(self, key: str, messages: list[ChatMessage]) -> None:
+        with self._session() as session:
+            stmt = text(
+                f"""
+                INSERT INTO {self._qualified_table()} (key, value)
+                VALUES (:key, CAST(:value AS JSONB))
+                ON CONFLICT (key)
+                DO UPDATE SET value = EXCLUDED.value;
+                """
+            )
+            session.execute(stmt, {"key": key, "value": _serialize(messages)})
+            session.commit()
+
+    async def aset_messages(self, key: str, messages: list[ChatMessage]) -> None:
+        async with self._async_session() as session:
+            stmt = text(
+                f"""
+                INSERT INTO {self._qualified_table()} (key, value)
+                VALUES (:key, CAST(:value AS JSONB))
+                ON CONFLICT (key)
+                DO UPDATE SET value = EXCLUDED.value;
+                """
+            )
+            await session.execute(stmt, {"key": key, "value": _serialize(messages)})
+            await session.commit()
+
+    def get_messages(self, key: str) -> list[ChatMessage]:
+        with self._session() as session:
+            row = session.execute(select(self._table_class).filter_by(key=key)).scalars().first()
+            if row is None:
+                return []
+            return [ChatMessage.model_validate(m) for m in _deserialize(row.value)]
+
+    async def aget_messages(self, key: str) -> list[ChatMessage]:
+        async with self._async_session() as session:
+            result = await session.execute(select(self._table_class).filter_by(key=key))
+            row = result.scalars().first()
+            if row is None:
+                return []
+            return [ChatMessage.model_validate(m) for m in _deserialize(row.value)]
+
+    def add_message(self, key: str, message: ChatMessage) -> None:
+        # JSONB || operator concatenates two JSON arrays. Atomic at row level.
+        with self._session() as session:
+            stmt = text(
+                f"""
+                INSERT INTO {self._qualified_table()} (key, value)
+                VALUES (:key, CAST(:value AS JSONB))
+                ON CONFLICT (key)
+                DO UPDATE SET value = COALESCE({self._qualified_table()}.value, '[]'::JSONB) || EXCLUDED.value;
+                """
+            )
+            session.execute(
+                stmt,
+                {"key": key, "value": _serialize([message])},
+            )
+            session.commit()
+
+    async def async_add_message(self, key: str, message: ChatMessage) -> None:
+        async with self._async_session() as session:
+            stmt = text(
+                f"""
+                INSERT INTO {self._qualified_table()} (key, value)
+                VALUES (:key, CAST(:value AS JSONB))
+                ON CONFLICT (key)
+                DO UPDATE SET value = COALESCE({self._qualified_table()}.value, '[]'::JSONB) || EXCLUDED.value;
+                """
+            )
+            await session.execute(
+                stmt,
+                {"key": key, "value": _serialize([message])},
+            )
+            await session.commit()
+
+    def delete_messages(self, key: str) -> list[ChatMessage] | None:
+        with self._session() as session:
+            session.execute(delete(self._table_class).filter_by(key=key))
+            session.commit()
+        return None
+
+    async def adelete_messages(self, key: str) -> list[ChatMessage] | None:
+        async with self._async_session() as session:
+            await session.execute(delete(self._table_class).filter_by(key=key))
+            await session.commit()
+        return None
+
+    def delete_message(self, key: str, idx: int) -> ChatMessage | None:
+        with self._session() as session:
+            row = session.execute(select(self._table_class).filter_by(key=key)).scalars().first()
+            if row is None:
+                return None
+            current = _deserialize(row.value)
+            if idx < 0 or idx >= len(current):
+                return None
+            removed = current[idx]
+            new_value = current[:idx] + current[idx + 1 :]
+            update = text(
+                f"""
+                UPDATE {self._qualified_table()}
+                SET value = CAST(:value AS JSONB)
+                WHERE key = :key;
+                """
+            )
+            session.execute(update, {"key": key, "value": json.dumps(new_value)})
+            session.commit()
+            return ChatMessage.model_validate(removed)
+
+    async def adelete_message(self, key: str, idx: int) -> ChatMessage | None:
+        async with self._async_session() as session:
+            result = await session.execute(select(self._table_class).filter_by(key=key))
+            row = result.scalars().first()
+            if row is None:
+                return None
+            current = _deserialize(row.value)
+            if idx < 0 or idx >= len(current):
+                return None
+            removed = current[idx]
+            new_value = current[:idx] + current[idx + 1 :]
+            update = text(
+                f"""
+                UPDATE {self._qualified_table()}
+                SET value = CAST(:value AS JSONB)
+                WHERE key = :key;
+                """
+            )
+            await session.execute(update, {"key": key, "value": json.dumps(new_value)})
+            await session.commit()
+            return ChatMessage.model_validate(removed)
+
+    def delete_last_message(self, key: str) -> ChatMessage | None:
+        with self._session() as session:
+            row = session.execute(select(self._table_class).filter_by(key=key)).scalars().first()
+            if row is None:
+                return None
+            current = _deserialize(row.value)
+            if not current:
+                return None
+            removed = current[-1]
+            new_value = current[:-1]
+            update = text(
+                f"""
+                UPDATE {self._qualified_table()}
+                SET value = CAST(:value AS JSONB)
+                WHERE key = :key;
+                """
+            )
+            session.execute(update, {"key": key, "value": json.dumps(new_value)})
+            session.commit()
+            return ChatMessage.model_validate(removed)
+
+    async def adelete_last_message(self, key: str) -> ChatMessage | None:
+        async with self._async_session() as session:
+            result = await session.execute(select(self._table_class).filter_by(key=key))
+            row = result.scalars().first()
+            if row is None:
+                return None
+            current = _deserialize(row.value)
+            if not current:
+                return None
+            removed = current[-1]
+            new_value = current[:-1]
+            update = text(
+                f"""
+                UPDATE {self._qualified_table()}
+                SET value = CAST(:value AS JSONB)
+                WHERE key = :key;
+                """
+            )
+            await session.execute(update, {"key": key, "value": json.dumps(new_value)})
+            await session.commit()
+            return ChatMessage.model_validate(removed)
+
+    def get_keys(self) -> list[str]:
+        with self._session() as session:
+            return list(session.execute(select(self._table_class.key)).scalars().all())
+
+    async def aget_keys(self) -> list[str]:
+        async with self._async_session() as session:
+            return list((await session.execute(select(self._table_class.key))).scalars().all())
+
+
+def params_from_uri(uri: str) -> dict:
+    result = urlparse(uri)
+    database = result.path[1:]
+    port = result.port if result.port else 26257
+    return {
+        "database": database,
+        "user": result.username,
+        "password": result.password,
+        "host": result.hostname,
+        "port": port,
+    }

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/pyproject.toml
@@ -1,0 +1,74 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-storage-chat-store-cockroachdb"
+version = "0.1.0"
+description = "llama-index chat_store cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "chat-store", "storage"]
+dependencies = [
+    "psycopg2-binary>=2.9.9,<3.0.0",
+    "asyncpg>=0.29.0,<1.0.0",
+    "sqlalchemy-cockroachdb>=2.0.2",
+    "sqlalchemy[asyncio]>=2.0.0,<2.1",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.storage.chat_store.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBChatStore = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/tests/test_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-cockroachdb/tests/test_chat_store.py
@@ -1,0 +1,113 @@
+"""Tests for CockroachDBChatStore."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from llama_index.core.llms import ChatMessage, MessageRole
+
+from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore
+
+
+@pytest.fixture()
+def chat_store(fresh_db: dict[str, Any]) -> CockroachDBChatStore:
+    return CockroachDBChatStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="chats",
+    )
+
+
+def _msg(role: MessageRole, text: str) -> ChatMessage:
+    return ChatMessage(role=role, content=text)
+
+
+def test_set_and_get_messages(chat_store: CockroachDBChatStore) -> None:
+    msgs = [_msg(MessageRole.USER, "hi"), _msg(MessageRole.ASSISTANT, "hello")]
+    chat_store.set_messages("sess-1", msgs)
+    out = chat_store.get_messages("sess-1")
+    assert [m.content for m in out] == ["hi", "hello"]
+    assert [m.role for m in out] == [MessageRole.USER, MessageRole.ASSISTANT]
+
+
+def test_add_message_appends(chat_store: CockroachDBChatStore) -> None:
+    chat_store.add_message("sess-2", _msg(MessageRole.USER, "first"))
+    chat_store.add_message("sess-2", _msg(MessageRole.ASSISTANT, "second"))
+    chat_store.add_message("sess-2", _msg(MessageRole.USER, "third"))
+    out = chat_store.get_messages("sess-2")
+    assert [m.content for m in out] == ["first", "second", "third"]
+
+
+def test_delete_message_by_index(chat_store: CockroachDBChatStore) -> None:
+    chat_store.set_messages(
+        "sess-3",
+        [
+            _msg(MessageRole.USER, "a"),
+            _msg(MessageRole.USER, "b"),
+            _msg(MessageRole.USER, "c"),
+        ],
+    )
+    removed = chat_store.delete_message("sess-3", 1)
+    assert removed is not None
+    assert removed.content == "b"
+    out = chat_store.get_messages("sess-3")
+    assert [m.content for m in out] == ["a", "c"]
+
+    assert chat_store.delete_message("sess-3", 99) is None
+
+
+def test_delete_last_message(chat_store: CockroachDBChatStore) -> None:
+    chat_store.set_messages(
+        "sess-4",
+        [_msg(MessageRole.USER, "x"), _msg(MessageRole.USER, "y")],
+    )
+    removed = chat_store.delete_last_message("sess-4")
+    assert removed is not None
+    assert removed.content == "y"
+    out = chat_store.get_messages("sess-4")
+    assert [m.content for m in out] == ["x"]
+
+
+def test_delete_all_and_keys(chat_store: CockroachDBChatStore) -> None:
+    chat_store.set_messages("k1", [_msg(MessageRole.USER, "a")])
+    chat_store.set_messages("k2", [_msg(MessageRole.USER, "b")])
+    keys = set(chat_store.get_keys())
+    assert {"k1", "k2"}.issubset(keys)
+
+    chat_store.delete_messages("k1")
+    assert chat_store.get_messages("k1") == []
+
+
+@pytest.mark.asyncio
+async def test_async_round_trip(fresh_db: dict[str, Any]) -> None:
+    store = CockroachDBChatStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="chats_async",
+    )
+    await store.aset_messages(
+        "s1",
+        [_msg(MessageRole.USER, "hi"), _msg(MessageRole.ASSISTANT, "hey")],
+    )
+    out = await store.aget_messages("s1")
+    assert [m.content for m in out] == ["hi", "hey"]
+
+    await store.async_add_message("s1", _msg(MessageRole.USER, "again"))
+    out = await store.aget_messages("s1")
+    assert [m.content for m in out] == ["hi", "hey", "again"]
+
+    removed = await store.adelete_last_message("s1")
+    assert removed is not None
+    assert removed.content == "again"
+
+    await store.adelete_messages("s1")
+    assert await store.aget_messages("s1") == []

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/.gitignore
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/LICENSE
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/Makefile
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/README.md
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/README.md
@@ -1,0 +1,27 @@
+# LlamaIndex Storage_Docstore Integration: CockroachDB
+
+A document (node) store backed by [CockroachDB](https://www.cockroachlabs.com/). Thin wrapper over `CockroachDBKVStore`.
+
+## Installation
+
+```bash
+pip install llama-index-storage-docstore-cockroachdb
+```
+
+This pulls in `llama-index-storage-kvstore-cockroachdb` as a transitive dependency.
+
+## Usage
+
+```python
+from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore
+
+doc_store = CockroachDBDocumentStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="docs",
+)
+```

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/llama_index/storage/docstore/cockroachdb/__init__.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/llama_index/storage/docstore/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.storage.docstore.cockroachdb.base import CockroachDBDocumentStore
+
+__all__ = ["CockroachDBDocumentStore"]

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/llama_index/storage/docstore/cockroachdb/base.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/llama_index/storage/docstore/cockroachdb/base.py
@@ -1,0 +1,83 @@
+"""CockroachDB Document (Node) store for LlamaIndex."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llama_index.core.storage.docstore.keyval_docstore import KVDocumentStore
+from llama_index.core.storage.docstore.types import DEFAULT_BATCH_SIZE
+
+from llama_index.storage.kvstore.cockroachdb import CockroachDBKVStore
+
+
+class CockroachDBDocumentStore(KVDocumentStore):
+    """CockroachDB-backed Document (Node) store.
+
+    Thin wrapper over :class:`CockroachDBKVStore`.
+    """
+
+    def __init__(
+        self,
+        cockroachdb_kvstore: CockroachDBKVStore,
+        namespace: str | None = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        super().__init__(cockroachdb_kvstore, namespace=namespace, batch_size=batch_size)
+
+    @classmethod
+    def from_uri(
+        cls,
+        uri: str,
+        namespace: str | None = None,
+        table_name: str = "docstore",
+        schema_name: str = "public",
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        create_engine_kwargs: dict[str, Any] | None = None,
+    ) -> CockroachDBDocumentStore:
+        kvstore = CockroachDBKVStore.from_uri(
+            uri=uri,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
+        )
+        return cls(kvstore, namespace)
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str | None = None,
+        port: int | str | None = None,
+        database: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+        namespace: str | None = None,
+        table_name: str = "docstore",
+        schema_name: str = "public",
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        create_engine_kwargs: dict[str, Any] | None = None,
+    ) -> CockroachDBDocumentStore:
+        kvstore = CockroachDBKVStore.from_params(
+            host=host,
+            port=port,
+            database=database,
+            user=user,
+            password=password,
+            sslmode=sslmode,
+            sslrootcert=sslrootcert,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
+        )
+        return cls(kvstore, namespace)

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-storage-docstore-cockroachdb"
+version = "0.1.0"
+description = "llama-index docstore cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "docstore", "storage"]
+dependencies = [
+    "llama-index-storage-kvstore-cockroachdb>=0.1.0,<0.2",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.storage.docstore.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBDocumentStore = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/tests/test_docstore.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-cockroachdb/tests/test_docstore.py
@@ -1,0 +1,56 @@
+"""Tests for CockroachDBDocumentStore."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from llama_index.core.schema import TextNode
+
+from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore
+
+
+@pytest.fixture()
+def docstore(fresh_db: dict[str, Any]) -> CockroachDBDocumentStore:
+    return CockroachDBDocumentStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="docs",
+    )
+
+
+def test_add_get_delete(docstore: CockroachDBDocumentStore) -> None:
+    nodes = [
+        TextNode(text="hello", id_="a"),
+        TextNode(text="world", id_="b"),
+    ]
+    docstore.add_documents(nodes)
+
+    fetched = docstore.get_document("a")
+    assert fetched is not None
+    assert fetched.get_content() == "hello"
+
+    docstore.delete_document("a")
+    assert docstore.get_document("a", raise_error=False) is None
+    assert docstore.get_document("b") is not None
+
+
+@pytest.mark.asyncio
+async def test_async_add_get(fresh_db: dict[str, Any]) -> None:
+    store = CockroachDBDocumentStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="docs_async",
+    )
+    await store.async_add_documents([TextNode(text="alpha", id_="x")])
+    fetched = await store.aget_document("x")
+    assert fetched is not None
+    assert fetched.get_content() == "alpha"

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/.gitignore
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/LICENSE
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/Makefile
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/README.md
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/README.md
@@ -1,0 +1,27 @@
+# LlamaIndex Storage_Index_Store Integration: CockroachDB
+
+An index store backed by [CockroachDB](https://www.cockroachlabs.com/). Thin wrapper over `CockroachDBKVStore`.
+
+## Installation
+
+```bash
+pip install llama-index-storage-index-store-cockroachdb
+```
+
+This pulls in `llama-index-storage-kvstore-cockroachdb` as a transitive dependency.
+
+## Usage
+
+```python
+from llama_index.storage.index_store.cockroachdb import CockroachDBIndexStore
+
+index_store = CockroachDBIndexStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="idx",
+)
+```

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/llama_index/storage/index_store/cockroachdb/__init__.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/llama_index/storage/index_store/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.storage.index_store.cockroachdb.base import CockroachDBIndexStore
+
+__all__ = ["CockroachDBIndexStore"]

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/llama_index/storage/index_store/cockroachdb/base.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/llama_index/storage/index_store/cockroachdb/base.py
@@ -1,0 +1,86 @@
+"""CockroachDB Index store for LlamaIndex."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llama_index.core.storage.index_store.keyval_index_store import KVIndexStore
+
+from llama_index.storage.kvstore.cockroachdb import CockroachDBKVStore
+
+
+class CockroachDBIndexStore(KVIndexStore):
+    """CockroachDB-backed Index store.
+
+    Thin wrapper over :class:`CockroachDBKVStore`.
+    """
+
+    def __init__(
+        self,
+        cockroachdb_kvstore: CockroachDBKVStore,
+        namespace: str | None = None,
+        collection_suffix: str | None = None,
+    ) -> None:
+        super().__init__(
+            cockroachdb_kvstore,
+            namespace=namespace,
+            collection_suffix=collection_suffix,
+        )
+
+    @classmethod
+    def from_uri(
+        cls,
+        uri: str,
+        namespace: str | None = None,
+        table_name: str = "indexstore",
+        schema_name: str = "public",
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        collection_suffix: str | None = None,
+    ) -> CockroachDBIndexStore:
+        kvstore = CockroachDBKVStore.from_uri(
+            uri=uri,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+        )
+        return cls(kvstore, namespace, collection_suffix)
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str | None = None,
+        port: int | str | None = None,
+        database: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+        namespace: str | None = None,
+        table_name: str = "indexstore",
+        schema_name: str = "public",
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        collection_suffix: str | None = None,
+        create_engine_kwargs: dict[str, Any] | None = None,
+    ) -> CockroachDBIndexStore:
+        kvstore = CockroachDBKVStore.from_params(
+            host=host,
+            port=port,
+            database=database,
+            user=user,
+            password=password,
+            sslmode=sslmode,
+            sslrootcert=sslrootcert,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
+        )
+        return cls(kvstore, namespace, collection_suffix)

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-storage-index-store-cockroachdb"
+version = "0.1.0"
+description = "llama-index index_store cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "index-store", "storage"]
+dependencies = [
+    "llama-index-storage-kvstore-cockroachdb>=0.1.0,<0.2",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.storage.index_store.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBIndexStore = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/tests/test_index_store.py
+++ b/llama-index-integrations/storage/index_store/llama-index-storage-index-store-cockroachdb/tests/test_index_store.py
@@ -1,0 +1,56 @@
+"""Tests for CockroachDBIndexStore."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from llama_index.core.data_structs.data_structs import IndexDict
+
+from llama_index.storage.index_store.cockroachdb import CockroachDBIndexStore
+
+
+@pytest.fixture()
+def index_store(fresh_db: dict[str, Any]) -> CockroachDBIndexStore:
+    return CockroachDBIndexStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="idx",
+    )
+
+
+def test_add_get_delete(index_store: CockroachDBIndexStore) -> None:
+    struct = IndexDict(index_id="my-index")
+    index_store.add_index_struct(struct)
+
+    fetched = index_store.get_index_struct("my-index")
+    assert fetched is not None
+    assert fetched.index_id == "my-index"
+
+    structs = index_store.index_structs()
+    assert any(s.index_id == "my-index" for s in structs)
+
+    index_store.delete_index_struct("my-index")
+    assert index_store.get_index_struct("my-index") is None
+
+
+@pytest.mark.asyncio
+async def test_async_add_get(fresh_db: dict[str, Any]) -> None:
+    store = CockroachDBIndexStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="idx_async",
+    )
+    struct = IndexDict(index_id="async-idx")
+    await store.async_add_index_struct(struct)
+    fetched = await store.aget_index_struct("async-idx")
+    assert fetched is not None
+    assert fetched.index_id == "async-idx"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/.gitignore
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/LICENSE
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/Makefile
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/README.md
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/README.md
@@ -1,0 +1,32 @@
+# LlamaIndex Storage_Kvstore Integration: CockroachDB
+
+A key-value store backed by [CockroachDB](https://www.cockroachlabs.com/). Used as the underlying storage for `CockroachDBDocumentStore` and `CockroachDBIndexStore`, and can also be used directly.
+
+Uses the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`. Values are stored in a `JSONB` column with `(collection, key)` as the primary key.
+
+## Installation
+
+```bash
+pip install llama-index-storage-kvstore-cockroachdb
+```
+
+## Usage
+
+```python
+from llama_index.storage.kvstore.cockroachdb import CockroachDBKVStore
+
+kvstore = CockroachDBKVStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="kv",
+)
+
+kvstore.put("hello", {"value": 1})
+print(kvstore.get("hello"))  # {"value": 1}
+```
+
+Async variant: `aput`, `aget`, `aput_all`, `aget_all`, `adelete`.

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/llama_index/storage/kvstore/cockroachdb/__init__.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/llama_index/storage/kvstore/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.storage.kvstore.cockroachdb.base import CockroachDBKVStore
+
+__all__ = ["CockroachDBKVStore"]

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/llama_index/storage/kvstore/cockroachdb/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/llama_index/storage/kvstore/cockroachdb/base.py
@@ -1,0 +1,398 @@
+"""CockroachDB KV store backend for LlamaIndex."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.storage.kvstore.types import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COLLECTION,
+    BaseKVStore,
+)
+
+try:
+    import sqlalchemy
+    import sqlalchemy.ext.asyncio  # noqa: F401
+    from sqlalchemy import Column, Index, Integer, UniqueConstraint, inspect
+    from sqlalchemy.schema import CreateSchema
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("`sqlalchemy[asyncio]` package should be pre installed") from exc
+
+
+def get_data_model(
+    base: type,
+    index_name: str,
+    schema_name: str,
+    use_jsonb: bool = True,
+) -> Any:
+    """Build a dynamic SQLAlchemy model for the KV table.
+
+    CockroachDB ships JSONB as the canonical JSON type, so we default to it.
+    """
+    from sqlalchemy.dialects.postgresql import JSON, JSONB, VARCHAR
+
+    tablename = f"data_{index_name}"
+    class_name = f"Data{index_name}"
+
+    metadata_dtype = JSONB if use_jsonb else JSON
+
+    class AbstractData(base):  # type: ignore[misc, valid-type]
+        __abstract__ = True
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        key = Column(VARCHAR, nullable=False)
+        namespace = Column(VARCHAR, nullable=False)
+        value = Column(metadata_dtype)
+
+    return type(
+        class_name,
+        (AbstractData,),
+        {
+            "__tablename__": tablename,
+            "__table_args__": (
+                UniqueConstraint("key", "namespace", name=f"{tablename}:unique_key_namespace"),
+                Index(f"{tablename}:idx_key_namespace", "key", "namespace"),
+                {"schema": schema_name},
+            ),
+        },
+    )
+
+
+class CockroachDBKVStore(BaseKVStore):
+    """CockroachDB-backed Key-Value store.
+
+    Uses the ``cockroachdb+psycopg2`` and ``cockroachdb+asyncpg`` SQLAlchemy
+    dialects so that CockroachDB's transparent retries on
+    ``SERIALIZATION_FAILURE`` errors are applied automatically.
+
+    Args:
+        connection_string: psycopg2 connection string.
+        async_connection_string: asyncpg connection string.
+        table_name: table name (will be lowercased and prefixed with ``data_``).
+        schema_name: schema name (defaults to ``public``).
+        perform_setup: create schema + table on first use.
+        debug: enable SQLAlchemy echo.
+        use_jsonb: store ``value`` as JSONB (recommended on CRDB).
+        create_engine_kwargs: extra kwargs forwarded to ``create_engine`` and
+            ``create_async_engine`` (for example ``connect_args`` for pooling).
+
+    """
+
+    connection_string: str | None
+    async_connection_string: str | None
+    table_name: str
+    schema_name: str
+    perform_setup: bool
+    debug: bool
+    use_jsonb: bool
+    create_engine_kwargs: dict[str, Any]
+    _engine: sqlalchemy.engine.Engine | None = PrivateAttr()
+    _async_engine: sqlalchemy.ext.asyncio.AsyncEngine | None = PrivateAttr()
+
+    def __init__(
+        self,
+        table_name: str,
+        connection_string: str | None = None,
+        async_connection_string: str | None = None,
+        schema_name: str = "public",
+        create_engine_kwargs: dict[str, Any] | None = None,
+        engine: sqlalchemy.engine.Engine | None = None,
+        async_engine: sqlalchemy.ext.asyncio.AsyncEngine | None = None,
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+    ) -> None:
+        try:
+            import asyncpg  # noqa: F401
+            import psycopg2  # noqa: F401
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "`psycopg2-binary` and `asyncpg` packages should be pre installed"
+            ) from exc
+
+        table_name = table_name.lower()
+        schema_name = schema_name.lower()
+        self.connection_string = connection_string
+        self.async_connection_string = async_connection_string
+        self.table_name = table_name
+        self.schema_name = schema_name
+        self.perform_setup = perform_setup
+        self.debug = debug
+        self.use_jsonb = use_jsonb
+        self.create_engine_kwargs = create_engine_kwargs or {}
+        self._engine = engine
+        self._async_engine = async_engine
+        self._is_initialized = False
+
+        if not self._async_engine and not self.async_connection_string:
+            raise ValueError(
+                "Provide an asynchronous connection string when no async engine is supplied."
+            )
+        if not self._engine and not self.connection_string:
+            raise ValueError(
+                "Provide a synchronous connection string when no sync engine is supplied."
+            )
+
+        from sqlalchemy.orm import declarative_base
+
+        self._base = declarative_base()
+        self._table_class = get_data_model(
+            self._base,
+            table_name,
+            schema_name,
+            use_jsonb=use_jsonb,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "CockroachDBKVStore"
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str | None = None,
+        port: int | str | None = None,
+        database: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+        table_name: str = "kvstore",
+        schema_name: str = "public",
+        connection_string: str | None = None,
+        async_connection_string: str | None = None,
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        create_engine_kwargs: dict[str, Any] | None = None,
+    ) -> CockroachDBKVStore:
+        """Build a store from individual connection parameters.
+
+        Default port is 26257. SSL is on by default; pass ``sslmode="disable"``
+        for an insecure local cluster.
+        """
+        port = port or 26257
+        if connection_string is None:
+            params: list[str] = []
+            if sslmode:
+                params.append(f"sslmode={sslmode}")
+            if sslrootcert:
+                params.append(f"sslrootcert={sslrootcert}")
+            qs = "?" + "&".join(params) if params else ""
+            connection_string = (
+                f"cockroachdb+psycopg2://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+        if async_connection_string is None:
+            params = []
+            if sslmode and sslmode != "disable":
+                params.append("ssl=true")
+            qs = "?" + "&".join(params) if params else ""
+            async_connection_string = (
+                f"cockroachdb+asyncpg://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+        return cls(
+            connection_string=connection_string,
+            async_connection_string=async_connection_string,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
+        )
+
+    @classmethod
+    def from_uri(
+        cls,
+        uri: str,
+        table_name: str = "kvstore",
+        schema_name: str = "public",
+        perform_setup: bool = True,
+        debug: bool = False,
+        use_jsonb: bool = True,
+        create_engine_kwargs: dict[str, Any] | None = None,
+    ) -> CockroachDBKVStore:
+        """Build a store from a URI like ``cockroachdb://user:pass@host:26257/db``."""
+        params = params_from_uri(uri)
+        return cls.from_params(
+            **params,
+            table_name=table_name,
+            schema_name=schema_name,
+            perform_setup=perform_setup,
+            debug=debug,
+            use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
+        )
+
+    def _connect(self) -> None:
+        from sqlalchemy import create_engine
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        self._engine = self._engine or create_engine(
+            self.connection_string, echo=self.debug, **self.create_engine_kwargs
+        )
+        self._session = sessionmaker(self._engine)
+
+        self._async_engine = self._async_engine or create_async_engine(
+            self.async_connection_string, **self.create_engine_kwargs
+        )
+        self._async_session = sessionmaker(self._async_engine, class_=AsyncSession)
+
+    def _create_schema_if_not_exists(self) -> None:
+        with self._session() as session, session.begin():
+            inspector = inspect(session.connection())
+            existing_schemas = inspector.get_schema_names()
+            if self.schema_name not in existing_schemas:
+                session.execute(CreateSchema(self.schema_name))
+
+    def _create_tables_if_not_exists(self) -> None:
+        with self._session() as session, session.begin():
+            self._base.metadata.create_all(session.connection())
+
+    def _initialize(self) -> None:
+        if not self._is_initialized:
+            self._connect()
+            if self.perform_setup:
+                self._create_schema_if_not_exists()
+                self._create_tables_if_not_exists()
+            self._is_initialized = True
+
+    def put(
+        self,
+        key: str,
+        val: dict,
+        collection: str = DEFAULT_COLLECTION,
+    ) -> None:
+        self.put_all([(key, val)], collection=collection)
+
+    async def aput(
+        self,
+        key: str,
+        val: dict,
+        collection: str = DEFAULT_COLLECTION,
+    ) -> None:
+        await self.aput_all([(key, val)], collection=collection)
+
+    def put_all(
+        self,
+        kv_pairs: list[tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        from sqlalchemy.dialects.postgresql import insert
+
+        self._initialize()
+        with self._session() as session:
+            for i in range(0, len(kv_pairs), batch_size):
+                batch = kv_pairs[i : i + batch_size]
+                rows = [
+                    {"key": key, "namespace": collection, "value": value} for key, value in batch
+                ]
+                stmt = insert(self._table_class).values(rows)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["key", "namespace"],
+                    set_={"value": stmt.excluded.value},
+                )
+                session.execute(stmt)
+                session.commit()
+
+    async def aput_all(
+        self,
+        kv_pairs: list[tuple[str, dict]],
+        collection: str = DEFAULT_COLLECTION,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        from sqlalchemy.dialects.postgresql import insert
+
+        self._initialize()
+        async with self._async_session() as session:
+            for i in range(0, len(kv_pairs), batch_size):
+                batch = kv_pairs[i : i + batch_size]
+                rows = [
+                    {"key": key, "namespace": collection, "value": value} for key, value in batch
+                ]
+                stmt = insert(self._table_class).values(rows)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["key", "namespace"],
+                    set_={"value": stmt.excluded.value},
+                )
+                await session.execute(stmt)
+                await session.commit()
+
+    def get(self, key: str, collection: str = DEFAULT_COLLECTION) -> dict | None:
+        from sqlalchemy import select
+
+        self._initialize()
+        with self._session() as session:
+            result = session.execute(
+                select(self._table_class).filter_by(key=key).filter_by(namespace=collection)
+            )
+            row = result.scalars().first()
+            return row.value if row else None
+
+    async def aget(self, key: str, collection: str = DEFAULT_COLLECTION) -> dict | None:
+        from sqlalchemy import select
+
+        self._initialize()
+        async with self._async_session() as session:
+            result = await session.execute(
+                select(self._table_class).filter_by(key=key).filter_by(namespace=collection)
+            )
+            row = result.scalars().first()
+            return row.value if row else None
+
+    def get_all(self, collection: str = DEFAULT_COLLECTION) -> dict[str, dict]:
+        from sqlalchemy import select
+
+        self._initialize()
+        with self._session() as session:
+            results = session.execute(select(self._table_class).filter_by(namespace=collection))
+            rows = results.scalars().all()
+        return {row.key: row.value for row in rows} if rows else {}
+
+    async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> dict[str, dict]:
+        from sqlalchemy import select
+
+        self._initialize()
+        async with self._async_session() as session:
+            results = await session.execute(
+                select(self._table_class).filter_by(namespace=collection)
+            )
+            rows = results.scalars().all()
+        return {row.key: row.value for row in rows} if rows else {}
+
+    def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        from sqlalchemy import delete
+
+        self._initialize()
+        with self._session() as session:
+            result = session.execute(
+                delete(self._table_class).filter_by(namespace=collection).filter_by(key=key)
+            )
+            session.commit()
+        return result.rowcount > 0
+
+    async def adelete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:
+        from sqlalchemy import delete
+
+        self._initialize()
+        async with self._async_session() as session, session.begin():
+            result = await session.execute(
+                delete(self._table_class).filter_by(namespace=collection).filter_by(key=key)
+            )
+        return result.rowcount > 0
+
+
+def params_from_uri(uri: str) -> dict:
+    result = urlparse(uri)
+    database = result.path[1:]
+    port = result.port if result.port else 26257
+    return {
+        "database": database,
+        "user": result.username,
+        "password": result.password,
+        "host": result.hostname,
+        "port": port,
+    }

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/pyproject.toml
@@ -1,0 +1,74 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-storage-kvstore-cockroachdb"
+version = "0.1.0"
+description = "llama-index kvstore cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "kvstore", "storage"]
+dependencies = [
+    "psycopg2-binary>=2.9.9,<3.0.0",
+    "asyncpg>=0.29.0,<1.0.0",
+    "sqlalchemy-cockroachdb>=2.0.2",
+    "sqlalchemy[asyncio]>=2.0.0,<2.1",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.storage.kvstore.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBKVStore = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning"]

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/tests/test_kvstore.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-cockroachdb/tests/test_kvstore.py
@@ -1,0 +1,75 @@
+"""Tests for CockroachDBKVStore (sync + async)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from llama_index.storage.kvstore.cockroachdb import CockroachDBKVStore
+
+
+@pytest.fixture()
+def kvstore(fresh_db: dict[str, Any]) -> CockroachDBKVStore:
+    return CockroachDBKVStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="kv_test",
+    )
+
+
+def test_put_get_delete(kvstore: CockroachDBKVStore) -> None:
+    kvstore.put("alpha", {"n": 1})
+    kvstore.put("beta", {"n": 2})
+
+    assert kvstore.get("alpha") == {"n": 1}
+    assert kvstore.get("missing") is None
+
+    all_rows = kvstore.get_all()
+    assert all_rows == {"alpha": {"n": 1}, "beta": {"n": 2}}
+
+    assert kvstore.delete("alpha") is True
+    assert kvstore.delete("alpha") is False
+    assert kvstore.get("alpha") is None
+
+
+def test_collection_isolation(kvstore: CockroachDBKVStore) -> None:
+    kvstore.put("k", {"v": 1}, collection="a")
+    kvstore.put("k", {"v": 2}, collection="b")
+    assert kvstore.get("k", collection="a") == {"v": 1}
+    assert kvstore.get("k", collection="b") == {"v": 2}
+
+
+def test_put_all_upsert(kvstore: CockroachDBKVStore) -> None:
+    kvstore.put_all([("k1", {"x": 1}), ("k2", {"x": 2})])
+    kvstore.put_all([("k1", {"x": 10})])
+    assert kvstore.get("k1") == {"x": 10}
+    assert kvstore.get("k2") == {"x": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_round_trip(fresh_db: dict[str, Any]) -> None:
+    store = CockroachDBKVStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        database=fresh_db["database"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        sslmode="disable",
+        table_name="kv_async",
+    )
+    await store.aput("alpha", {"n": 1})
+    await store.aput_all([("beta", {"n": 2}), ("gamma", {"n": 3})])
+
+    assert await store.aget("alpha") == {"n": 1}
+    assert await store.aget("missing") is None
+
+    rows = await store.aget_all()
+    assert rows == {"alpha": {"n": 1}, "beta": {"n": 2}, "gamma": {"n": 3}}
+
+    assert await store.adelete("beta") is True
+    assert await store.adelete("beta") is False

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/.gitignore
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/LICENSE
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/Makefile
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/README.md
@@ -1,0 +1,66 @@
+# LlamaIndex Vector_Stores Integration: CockroachDB
+
+This integration adds [CockroachDB](https://www.cockroachlabs.com/) as a vector store for LlamaIndex, backed by CRDB's native `VECTOR(n)` column type and the [C-SPANN](https://www.cockroachlabs.com/docs/stable/vector.html) distributed approximate nearest neighbor index.
+
+`llama-index-vector-stores-postgres` depends on the pgvector extension, which is not available in CockroachDB. CRDB ships its own vector primitives instead: a native `VECTOR(n)` type, a `CREATE VECTOR INDEX ... WITH (min_partition_size, max_partition_size)` DDL, and a `vector_search_beam_size` session var for runtime recall/latency trade-offs. This package targets those primitives directly.
+
+## Installation
+
+```bash
+pip install llama-index-vector-stores-cockroachdb
+```
+
+Requires CockroachDB v25.2 or later. Enable the vector feature once at the cluster level (the store will attempt this on first init if the user has permission):
+
+```sql
+SET CLUSTER SETTING feature.vector_index.enabled = true;
+```
+
+## Usage
+
+```python
+from llama_index.core import Document, StorageContext, VectorStoreIndex
+from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+store = CockroachDBVectorStore.from_params(
+    host="localhost",
+    port=26257,
+    user="root",
+    password="",
+    database="defaultdb",
+    table_name="my_index",
+    embed_dim=1536,
+    distance_metric="cosine",
+    cspann_kwargs={"min_partition_size": 16, "max_partition_size": 128},
+    sslmode="disable",
+)
+
+index = VectorStoreIndex.from_documents(
+    [Document(text="...")],
+    storage_context=StorageContext.from_defaults(vector_store=store),
+)
+print(index.as_query_engine().query("..."))
+```
+
+## Tuning C-SPANN
+
+Two levers:
+
+1. Build-time: `cspann_kwargs={"min_partition_size": ..., "max_partition_size": ...}` on `from_params()`.
+2. Query-time: `vector_search_beam_size=N` per `query()` call. Higher beam means better recall, slightly more latency. Issued as `SET LOCAL vector_search_beam_size` per session.
+
+## Supported query modes
+
+| Mode | Supported | Notes |
+| --- | --- | --- |
+| `DEFAULT` | yes | ANN through C-SPANN |
+| `MMR` | yes | Client-side rerank with `mmr_threshold`, `mmr_prefetch_factor`, `mmr_prefetch_k` |
+| `HYBRID` / `SPARSE` / `TEXT_SEARCH` | no | CRDB has no `tsvector` yet; raises `NotImplementedError` |
+
+## Distance metrics
+
+`cosine`, `l2`, `inner_product`. Picks the matching opclass (`vector_cosine_ops`, `vector_l2_ops`, `vector_ip_ops`) at index creation time.
+
+## Metadata filters
+
+All standard LlamaIndex operators: `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`, `CONTAINS`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, `IS_EMPTY`, nestable via `MetadataFilters` with AND/OR/NOT. For frequently filtered keys, declare `indexed_metadata_keys={("category", "text"), ("year", "int")}` on the store to get JSONB-extracted BTREE indices.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/llama_index/vector_stores/cockroachdb/__init__.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/llama_index/vector_stores/cockroachdb/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.vector_stores.cockroachdb.base import CockroachDBVectorStore
+
+__all__ = ["CockroachDBVectorStore"]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/llama_index/vector_stores/cockroachdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/llama_index/vector_stores/cockroachdb/base.py
@@ -1,0 +1,999 @@
+"""CockroachDB vector store backed by native VECTOR + C-SPANN index."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable, Sequence
+from typing import (
+    Any,
+    Literal,
+    NamedTuple,
+)
+
+import asyncpg  # noqa: F401  (asyncpg engine driver, ensures dep is installed)
+import psycopg2  # noqa: F401
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.indices.query.embedding_utils import get_top_k_mmr_embeddings
+from llama_index.core.schema import BaseNode, MetadataMode, TextNode
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+    VectorStoreQueryResult,
+)
+from llama_index.core.vector_stores.utils import (
+    metadata_dict_to_node,
+    node_to_metadata_dict,
+)
+from sqlalchemy import select, text
+from sqlalchemy.sql.selectable import Select
+
+DEFAULT_MMR_PREFETCH_FACTOR = 4.0
+
+CRDBType = Literal[
+    "text",
+    "int",
+    "integer",
+    "numeric",
+    "float",
+    "double precision",
+    "boolean",
+    "date",
+    "timestamp",
+    "uuid",
+]
+
+
+class DBEmbeddingRow(NamedTuple):
+    node_id: str
+    text: str
+    metadata: dict
+    custom_fields: dict
+    similarity: float
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _normalize_distance_metric(metric: str) -> str:
+    metric = metric.lower().strip()
+    if metric in {"cosine", "<=>"}:
+        return "<=>"
+    if metric in {"l2", "euclidean", "<->"}:
+        return "<->"
+    if metric in {"ip", "inner_product", "negative_inner_product", "<#>"}:
+        return "<#>"
+    raise ValueError(f"Unknown distance metric {metric!r}. Use 'cosine', 'l2', or 'inner_product'.")
+
+
+def _get_data_model(
+    base: type,
+    table_name: str,
+    schema_name: str,
+    embed_dim: int,
+    indexed_metadata_keys: set[tuple[str, CRDBType]] | None,
+) -> Any:
+    """Build a dynamic SQLAlchemy model with a CockroachDB native VECTOR column.
+
+    Note: SQLAlchemy has no built-in VECTOR type, so we use a UserDefinedType
+    that emits ``VECTOR(dim)`` in DDL and forwards Python lists/tuples as
+    pgwire parameters cast with ``::vector`` at bind time.
+    """
+    from sqlalchemy import (
+        Boolean,
+        Column,
+        Date,
+        DateTime,
+        Float,
+        Integer,
+        Numeric,
+        String,
+    )
+    from sqlalchemy import (
+        cast as sql_cast,
+    )
+    from sqlalchemy.dialects.postgresql import JSONB, UUID, VARCHAR
+    from sqlalchemy.schema import Index
+    from sqlalchemy.types import UserDefinedType
+
+    pg_type_map = {
+        "text": String,
+        "int": Integer,
+        "integer": Integer,
+        "numeric": Numeric,
+        "float": Float,
+        "double precision": Float,
+        "boolean": Boolean,
+        "date": Date,
+        "timestamp": DateTime,
+        "uuid": UUID,
+    }
+
+    class CRDBVector(UserDefinedType):
+        """CockroachDB native VECTOR(dim) column type."""
+
+        cache_ok = True
+
+        def __init__(self, dim: int) -> None:
+            self.dim = dim
+
+        def get_col_spec(self, **kw: Any) -> str:
+            return f"VECTOR({self.dim})"
+
+        def bind_processor(self, dialect: Any) -> Callable[[Any], Any]:
+            def process(value: Any) -> str | None:
+                if value is None:
+                    return None
+                if hasattr(value, "tolist"):
+                    value = value.tolist()
+                return "[" + ",".join(repr(float(x)) for x in value) + "]"
+
+            return process
+
+        def result_processor(self, dialect: Any, coltype: Any) -> Callable[[Any], Any]:
+            def process(value: Any) -> list[float] | None:
+                if value is None:
+                    return None
+                if isinstance(value, (list, tuple)):
+                    return [float(x) for x in value]
+                return [float(x) for x in value.strip("[]").split(",") if x]
+
+            return process
+
+        def bind_expression(self, bindvalue: Any) -> Any:
+            """Force an inline ::VECTOR(n) cast on every parameter.
+
+            Required for asyncpg, which prepares statements eagerly and
+            cannot infer placeholder types from outer SELECT casts.
+            """
+            return sql_cast(bindvalue, self)
+
+        class comparator_factory(UserDefinedType.Comparator):  # type: ignore[misc]
+            def cosine_distance(self, other: Any) -> Any:
+                return self.op("<=>", return_type=Float())(other)
+
+            def l2_distance(self, other: Any) -> Any:
+                return self.op("<->", return_type=Float())(other)
+
+            def negative_inner_product(self, other: Any) -> Any:
+                return self.op("<#>", return_type=Float())(other)
+
+    indexed_metadata_keys = indexed_metadata_keys or set()
+    for key, crdb_type in indexed_metadata_keys:
+        if crdb_type not in pg_type_map:
+            raise ValueError(
+                f"Invalid type {crdb_type} for key {key}. "
+                f"Must be one of {sorted(pg_type_map.keys())}"
+            )
+
+    tablename = f"data_{table_name}"
+    class_name = f"Data{table_name}"
+    indexname = f"{table_name}_idx"
+
+    from sqlalchemy import cast, column
+    from sqlalchemy.dialects.postgresql import BIGINT
+
+    btree_indices = [
+        Index(
+            f"{indexname}_{key}_{crdb_type.replace(' ', '_')}",
+            cast(column("metadata_").op("->>")(key), pg_type_map[crdb_type]),
+            postgresql_using="btree",
+        )
+        for key, crdb_type in indexed_metadata_keys
+    ]
+
+    class AbstractData(base):  # type: ignore[misc, valid-type]
+        __abstract__ = True
+        id = Column(BIGINT, primary_key=True, autoincrement=True)
+        text = Column(VARCHAR, nullable=False)
+        metadata_ = Column(JSONB)
+        node_id = Column(VARCHAR)
+        embedding = Column(CRDBVector(embed_dim))
+
+    return type(
+        class_name,
+        (AbstractData,),
+        {
+            "__tablename__": tablename,
+            "__table_args__": (*btree_indices, {"schema": schema_name}),
+        },
+    )
+
+
+class CockroachDBVectorStore(BasePydanticVectorStore):
+    """CockroachDB-backed vector store using native VECTOR + C-SPANN index.
+
+    Examples:
+        ```python
+        from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+        store = CockroachDBVectorStore.from_params(
+            host="localhost",
+            port=26257,
+            database="defaultdb",
+            user="root",
+            table_name="my_index",
+            embed_dim=1536,
+            distance_metric="cosine",
+            cspann_kwargs={"min_partition_size": 16, "max_partition_size": 128},
+        )
+        ```
+    """
+
+    stores_text: bool = True
+    flat_metadata: bool = False
+    is_embedding_query: bool = True
+
+    connection_string: str
+    async_connection_string: str
+    table_name: str
+    schema_name: str
+    embed_dim: int
+    distance_metric: str
+    perform_setup: bool
+    debug: bool
+    create_engine_kwargs: dict
+    cspann_kwargs: dict[str, Any] | None
+    vector_search_beam_size: int | None
+    indexed_metadata_keys: set[tuple[str, CRDBType]] | None
+    enable_feature_setting: bool
+    initialization_fail_on_error: bool
+
+    _base: Any = PrivateAttr()
+    _table_class: Any = PrivateAttr()
+    _engine: sqlalchemy.engine.Engine | None = PrivateAttr(default=None)
+    _session: Any = PrivateAttr(default=None)
+    _async_engine: sqlalchemy.ext.asyncio.AsyncEngine | None = PrivateAttr(default=None)
+    _async_session: Any = PrivateAttr(default=None)
+    _is_initialized: bool = PrivateAttr(default=False)
+    _customize_query_fn: Callable[[Select, Any, Any], Select] | None = PrivateAttr(default=None)
+    _distance_op: str = PrivateAttr(default="<=>")
+
+    def __init__(
+        self,
+        connection_string: str | sqlalchemy.engine.URL,
+        async_connection_string: str | sqlalchemy.engine.URL,
+        table_name: str = "llamaindex",
+        schema_name: str = "public",
+        embed_dim: int = 1536,
+        distance_metric: str = "cosine",
+        perform_setup: bool = True,
+        debug: bool = False,
+        create_engine_kwargs: dict[str, Any] | None = None,
+        cspann_kwargs: dict[str, Any] | None = None,
+        vector_search_beam_size: int | None = None,
+        indexed_metadata_keys: set[tuple[str, CRDBType]] | None = None,
+        enable_feature_setting: bool = True,
+        initialization_fail_on_error: bool = False,
+        engine: sqlalchemy.engine.Engine | None = None,
+        async_engine: sqlalchemy.ext.asyncio.AsyncEngine | None = None,
+        customize_query_fn: Callable[[Select, Any, Any], Select] | None = None,
+    ) -> None:
+        table_name = (table_name or "llamaindex").lower()
+        schema_name = (schema_name or "public").lower()
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", table_name):
+            raise ValueError(f"Invalid table_name: {table_name}")
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", schema_name):
+            raise ValueError(f"Invalid schema_name: {schema_name}")
+
+        from sqlalchemy.orm import declarative_base
+
+        super().__init__(
+            connection_string=str(connection_string),
+            async_connection_string=str(async_connection_string),
+            table_name=table_name,
+            schema_name=schema_name,
+            embed_dim=embed_dim,
+            distance_metric=distance_metric,
+            perform_setup=perform_setup,
+            debug=debug,
+            create_engine_kwargs=create_engine_kwargs or {},
+            cspann_kwargs=cspann_kwargs,
+            vector_search_beam_size=vector_search_beam_size,
+            indexed_metadata_keys=indexed_metadata_keys,
+            enable_feature_setting=enable_feature_setting,
+            initialization_fail_on_error=initialization_fail_on_error,
+        )
+        self._distance_op = _normalize_distance_metric(distance_metric)
+        self._base = declarative_base()
+        self._table_class = _get_data_model(
+            self._base,
+            table_name=table_name,
+            schema_name=schema_name,
+            embed_dim=embed_dim,
+            indexed_metadata_keys=indexed_metadata_keys,
+        )
+
+        if (engine is None) != (async_engine is None):
+            raise ValueError("engine and async_engine must both be provided or both be None")
+        if engine is not None:
+            self._engine = engine
+            self._async_engine = async_engine
+        self._customize_query_fn = customize_query_fn
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "CockroachDBVectorStore"
+
+    @classmethod
+    def from_params(
+        cls,
+        host: str | None = None,
+        port: int | str | None = None,
+        database: str | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        sslmode: str = "verify-full",
+        sslrootcert: str | None = None,
+        table_name: str = "llamaindex",
+        schema_name: str = "public",
+        connection_string: str | sqlalchemy.engine.URL | None = None,
+        async_connection_string: str | sqlalchemy.engine.URL | None = None,
+        embed_dim: int = 1536,
+        distance_metric: str = "cosine",
+        perform_setup: bool = True,
+        debug: bool = False,
+        create_engine_kwargs: dict[str, Any] | None = None,
+        cspann_kwargs: dict[str, Any] | None = None,
+        vector_search_beam_size: int | None = None,
+        indexed_metadata_keys: set[tuple[str, CRDBType]] | None = None,
+        enable_feature_setting: bool = True,
+        customize_query_fn: Callable[[Select, Any, Any], Select] | None = None,
+    ) -> CockroachDBVectorStore:
+        """Construct a CockroachDBVectorStore from individual connection params.
+
+        Uses the ``cockroachdb+psycopg2`` / ``cockroachdb+asyncpg`` dialects
+        provided by ``sqlalchemy-cockroachdb`` so transaction retries on
+        SERIALIZATION_FAILURE work transparently.
+        """
+        if connection_string is None:
+            qs = ""
+            params: list[str] = []
+            if sslmode:
+                params.append(f"sslmode={sslmode}")
+            if sslrootcert:
+                params.append(f"sslrootcert={sslrootcert}")
+            if params:
+                qs = "?" + "&".join(params)
+            connection_string = (
+                f"cockroachdb+psycopg2://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+        if async_connection_string is None:
+            qs = ""
+            params = []
+            if sslmode and sslmode != "disable":
+                params.append("ssl=true")
+            if params:
+                qs = "?" + "&".join(params)
+            async_connection_string = (
+                f"cockroachdb+asyncpg://{user}:{password}@{host}:{port}/{database}{qs}"
+            )
+
+        return cls(
+            connection_string=connection_string,
+            async_connection_string=async_connection_string,
+            table_name=table_name,
+            schema_name=schema_name,
+            embed_dim=embed_dim,
+            distance_metric=distance_metric,
+            perform_setup=perform_setup,
+            debug=debug,
+            create_engine_kwargs=create_engine_kwargs,
+            cspann_kwargs=cspann_kwargs,
+            vector_search_beam_size=vector_search_beam_size,
+            indexed_metadata_keys=indexed_metadata_keys,
+            enable_feature_setting=enable_feature_setting,
+            customize_query_fn=customize_query_fn,
+        )
+
+    @property
+    def client(self) -> Any:
+        return self._engine if self._is_initialized else None
+
+    def _connect(self) -> None:
+        from sqlalchemy import create_engine
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        if self._engine is None:
+            self._engine = create_engine(
+                self.connection_string, echo=self.debug, **self.create_engine_kwargs
+            )
+        self._session = sessionmaker(self._engine, expire_on_commit=False)
+        if self._async_engine is None:
+            self._async_engine = create_async_engine(
+                self.async_connection_string, **self.create_engine_kwargs
+            )
+        self._async_session = sessionmaker(
+            self._async_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+    def _create_schema_if_not_exists(self) -> None:
+        with self._session() as session, session.begin():
+            session.execute(text(f"CREATE SCHEMA IF NOT EXISTS {self.schema_name}"))
+
+    def _create_tables_if_not_exists(self) -> None:
+        with self._session() as session, session.begin():
+            self._table_class.__table__.create(session.connection(), checkfirst=True)
+
+    def _enable_vector_feature(self) -> None:
+        """Required on CRDB v25.2+ before the first VECTOR INDEX is created.
+
+        Cluster settings must run outside a transaction, so we use a fresh
+        AUTOCOMMIT connection rather than the session-bound transaction.
+        """
+        with self._engine.connect() as conn:
+            conn.execution_options(isolation_level="AUTOCOMMIT").execute(
+                text("SET CLUSTER SETTING feature.vector_index.enabled = true")
+            )
+
+    def _create_cspann_index(self) -> None:
+        """Create the C-SPANN vector index. Idempotent via IF NOT EXISTS."""
+        if not self.cspann_kwargs:
+            return
+        index_name = f"{self._table_class.__tablename__}_embedding_cspann_idx"
+        with_clauses: list[str] = []
+        if "min_partition_size" in self.cspann_kwargs:
+            with_clauses.append(
+                f"min_partition_size = {int(self.cspann_kwargs['min_partition_size'])}"
+            )
+        if "max_partition_size" in self.cspann_kwargs:
+            with_clauses.append(
+                f"max_partition_size = {int(self.cspann_kwargs['max_partition_size'])}"
+            )
+        with_sql = f" WITH ({', '.join(with_clauses)})" if with_clauses else ""
+        op_class = {
+            "<=>": "vector_cosine_ops",
+            "<->": "vector_l2_ops",
+            "<#>": "vector_ip_ops",
+        }[self._distance_op]
+        stmt = (
+            f"CREATE VECTOR INDEX IF NOT EXISTS {index_name} "
+            f"ON {self.schema_name}.{self._table_class.__tablename__} "
+            f"(embedding {op_class}){with_sql}"
+        )
+        with self._session() as session, session.begin():
+            session.execute(text(stmt))
+
+    def _initialize(self) -> None:
+        if self._is_initialized:
+            return
+        self._connect()
+        if self.perform_setup:
+            fail = self.initialization_fail_on_error
+            try:
+                self._create_schema_if_not_exists()
+            except Exception as e:
+                _logger.warning(f"CRDB setup: schema: {e}")
+                if fail:
+                    raise
+            try:
+                self._create_tables_if_not_exists()
+            except Exception as e:
+                _logger.warning(f"CRDB setup: table: {e}")
+                if fail:
+                    raise
+            if self.enable_feature_setting and self.cspann_kwargs:
+                try:
+                    self._enable_vector_feature()
+                except Exception as e:
+                    _logger.warning(f"CRDB setup: feature flag: {e}")
+                    if fail:
+                        raise
+            try:
+                self._create_cspann_index()
+            except Exception as e:
+                _logger.warning(f"CRDB setup: vector index: {e}")
+                if fail:
+                    raise
+        self._is_initialized = True
+
+    def _node_to_row(self, node: BaseNode) -> Any:
+        return self._table_class(
+            node_id=node.node_id,
+            embedding=node.get_embedding(),
+            text=node.get_content(metadata_mode=MetadataMode.NONE),
+            metadata_=node_to_metadata_dict(
+                node, remove_text=True, flat_metadata=self.flat_metadata
+            ),
+        )
+
+    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> list[str]:
+        self._initialize()
+        ids: list[str] = []
+        with self._session() as session, session.begin():
+            for node in nodes:
+                session.add(self._node_to_row(node))
+                ids.append(node.node_id)
+        return ids
+
+    async def async_add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> list[str]:
+        self._initialize()
+        ids: list[str] = []
+        async with self._async_session() as session, session.begin():
+            for node in nodes:
+                session.add(self._node_to_row(node))
+                ids.append(node.node_id)
+        return ids
+
+    def _to_sql_operator(self, op: FilterOperator) -> str:
+        return {
+            FilterOperator.EQ: "=",
+            FilterOperator.GT: ">",
+            FilterOperator.LT: "<",
+            FilterOperator.NE: "!=",
+            FilterOperator.GTE: ">=",
+            FilterOperator.LTE: "<=",
+            FilterOperator.IN: "IN",
+            FilterOperator.NIN: "NOT IN",
+            FilterOperator.CONTAINS: "@>",
+            FilterOperator.TEXT_MATCH: "LIKE",
+            FilterOperator.TEXT_MATCH_INSENSITIVE: "ILIKE",
+            FilterOperator.IS_EMPTY: "IS NULL",
+        }.get(op, "=")
+
+    def _build_filter_clause(self, f: MetadataFilter) -> Any:
+        op = f.operator
+        if op in (FilterOperator.IN, FilterOperator.NIN):
+            joined = ", ".join(f"'{v}'" for v in f.value)
+            return text(f"metadata_->>'{f.key}' {self._to_sql_operator(op)} ({joined})")
+        if op == FilterOperator.CONTAINS:
+            return text(f"metadata_->'{f.key}' @> '[\"{f.value}\"]'::jsonb")
+        if op in (FilterOperator.TEXT_MATCH, FilterOperator.TEXT_MATCH_INSENSITIVE):
+            return text(f"metadata_->>'{f.key}' {self._to_sql_operator(op)} '%{f.value}%'")
+        if op == FilterOperator.IS_EMPTY:
+            return text(f"metadata_->>'{f.key}' IS NULL")
+        try:
+            return text(
+                f"(metadata_->>'{f.key}')::float {self._to_sql_operator(op)} {float(f.value)}"
+            )
+        except (TypeError, ValueError):
+            return text(f"metadata_->>'{f.key}' {self._to_sql_operator(op)} '{f.value}'")
+
+    def _apply_filters(self, filters: MetadataFilters) -> Any:
+        from sqlalchemy.sql import and_, or_
+
+        combiner = {"and": and_, "or": or_}.get((filters.condition or "and").lower(), and_)
+        return combiner(
+            *(
+                self._apply_filters(f)
+                if isinstance(f, MetadataFilters)
+                else self._build_filter_clause(f)
+                for f in filters.filters
+            )
+        )
+
+    def _apply_filters_and_limit(
+        self, stmt: Select, limit: int, filters: MetadataFilters | None
+    ) -> Select:
+        if filters:
+            stmt = stmt.where(self._apply_filters(filters))
+        return stmt.limit(limit)
+
+    def _distance_expr(self, embedding: list[float]) -> Any:
+        col = self._table_class.embedding
+        if self._distance_op == "<=>":
+            return col.cosine_distance(embedding)
+        if self._distance_op == "<->":
+            return col.l2_distance(embedding)
+        return col.negative_inner_product(embedding)
+
+    def _build_query(
+        self,
+        embedding: list[float],
+        limit: int,
+        filters: MetadataFilters | None,
+        with_embedding: bool = False,
+        **kwargs: Any,
+    ) -> Select:
+        cols = [
+            self._table_class.id,
+            self._table_class.node_id,
+            self._table_class.text,
+            self._table_class.metadata_,
+            self._distance_expr(embedding).label("distance"),
+        ]
+        if with_embedding:
+            cols.insert(-1, self._table_class.embedding)
+        stmt = select(*cols).order_by(text("distance asc"))
+        if self._customize_query_fn is not None:
+            stmt = self._customize_query_fn(stmt, self._table_class, **kwargs)
+        return self._apply_filters_and_limit(stmt, limit, filters)
+
+    def _session_pre_stmts(self, **kwargs: Any) -> list[tuple[str, dict]]:
+        out: list[tuple[str, dict]] = []
+        beam = kwargs.get("vector_search_beam_size") or self.vector_search_beam_size
+        if beam is not None:
+            out.append(
+                (
+                    "SET LOCAL vector_search_beam_size = :beam",
+                    {"beam": int(beam)},
+                )
+            )
+        return out
+
+    @staticmethod
+    def _row_to_dbrow(item: Any, dist_attr: str = "distance") -> DBEmbeddingRow:
+        d = item._asdict()
+        distance = d.get(dist_attr)
+        return DBEmbeddingRow(
+            node_id=item.node_id,
+            text=item.text,
+            metadata=item.metadata_,
+            custom_fields={
+                k: v
+                for k, v in d.items()
+                if k
+                not in {
+                    "id",
+                    "node_id",
+                    "text",
+                    "metadata_",
+                    "distance",
+                    "embedding",
+                }
+            },
+            similarity=(1 - distance) if distance is not None else 0.0,
+        )
+
+    def _query_default(
+        self,
+        embedding: list[float],
+        limit: int,
+        filters: MetadataFilters | None,
+        **kwargs: Any,
+    ) -> list[DBEmbeddingRow]:
+        stmt = self._build_query(embedding, limit, filters, **kwargs)
+        with self._session() as session, session.begin():
+            for sql, params in self._session_pre_stmts(**kwargs):
+                session.execute(text(sql), params)
+            res = session.execute(stmt)
+            return [self._row_to_dbrow(item) for item in res.all()]
+
+    async def _aquery_default(
+        self,
+        embedding: list[float],
+        limit: int,
+        filters: MetadataFilters | None,
+        **kwargs: Any,
+    ) -> list[DBEmbeddingRow]:
+        stmt = self._build_query(embedding, limit, filters, **kwargs)
+        async with self._async_session() as session, session.begin():
+            for sql, params in self._session_pre_stmts(**kwargs):
+                await session.execute(text(sql), params)
+            res = await session.execute(stmt)
+            return [self._row_to_dbrow(item) for item in res.all()]
+
+    def _query_with_embeddings(
+        self,
+        embedding: list[float],
+        limit: int,
+        filters: MetadataFilters | None,
+        **kwargs: Any,
+    ) -> list[tuple[DBEmbeddingRow, list[float]]]:
+        stmt = self._build_query(embedding, limit, filters, with_embedding=True, **kwargs)
+        with self._session() as session, session.begin():
+            for sql, params in self._session_pre_stmts(**kwargs):
+                session.execute(text(sql), params)
+            res = session.execute(stmt)
+            out: list[tuple[DBEmbeddingRow, list[float]]] = []
+            for item in res.all():
+                emb = list(item.embedding) if item.embedding is not None else []
+                out.append((self._row_to_dbrow(item), emb))
+            return out
+
+    async def _aquery_with_embeddings(
+        self,
+        embedding: list[float],
+        limit: int,
+        filters: MetadataFilters | None,
+        **kwargs: Any,
+    ) -> list[tuple[DBEmbeddingRow, list[float]]]:
+        stmt = self._build_query(embedding, limit, filters, with_embedding=True, **kwargs)
+        async with self._async_session() as session, session.begin():
+            for sql, params in self._session_pre_stmts(**kwargs):
+                await session.execute(text(sql), params)
+            res = await session.execute(stmt)
+            out: list[tuple[DBEmbeddingRow, list[float]]] = []
+            for item in res.all():
+                emb = list(item.embedding) if item.embedding is not None else []
+                out.append((self._row_to_dbrow(item), emb))
+            return out
+
+    def _prepare_mmr(self, query: VectorStoreQuery, **kwargs: Any) -> tuple[int, float | None]:
+        if query.query_embedding is None:
+            raise ValueError("MMR query requires query_embedding")
+        if (
+            kwargs.get("mmr_prefetch_factor") is not None
+            and kwargs.get("mmr_prefetch_k") is not None
+        ):
+            raise ValueError("mmr_prefetch_factor and mmr_prefetch_k are mutually exclusive")
+        if kwargs.get("mmr_prefetch_k") is not None:
+            prefetch_k = int(kwargs["mmr_prefetch_k"])
+        else:
+            prefetch_k = int(
+                query.similarity_top_k
+                * kwargs.get("mmr_prefetch_factor", DEFAULT_MMR_PREFETCH_FACTOR)
+            )
+        prefetch_k = max(prefetch_k, query.similarity_top_k)
+        threshold = (
+            query.mmr_threshold if query.mmr_threshold is not None else kwargs.get("mmr_threshold")
+        )
+        if threshold is not None and not (0 <= threshold <= 1):
+            raise ValueError(f"mmr_threshold must be between 0 and 1, got {threshold}")
+        return prefetch_k, threshold
+
+    def _mmr_rerank(
+        self,
+        query: VectorStoreQuery,
+        prefetched: list[tuple[DBEmbeddingRow, list[float]]],
+        threshold: float | None,
+    ) -> VectorStoreQueryResult | None:
+        if not prefetched:
+            return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+        embeddings = [emb for _, emb in prefetched]
+        ids = [row.node_id for row, _ in prefetched]
+        valid = [i for i, e in enumerate(embeddings) if e]
+        if not valid:
+            return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+        valid_embeddings = [embeddings[i] for i in valid]
+        valid_ids = [ids[i] for i in valid]
+        if len(valid_embeddings) < query.similarity_top_k:
+            return None
+        sims, picked_ids = get_top_k_mmr_embeddings(
+            query_embedding=query.query_embedding,
+            embeddings=valid_embeddings,
+            similarity_top_k=query.similarity_top_k,
+            embedding_ids=valid_ids,
+            mmr_threshold=threshold,
+        )
+        row_map = {row.node_id: row for row, _ in prefetched}
+        ordered = [
+            DBEmbeddingRow(
+                node_id=row_map[nid].node_id,
+                text=row_map[nid].text,
+                metadata=row_map[nid].metadata,
+                custom_fields=row_map[nid].custom_fields,
+                similarity=sim,
+            )
+            for sim, nid in zip(sims, picked_ids, strict=False)
+            if nid in row_map
+        ]
+        return self._rows_to_result(ordered)
+
+    def _mmr_query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        prefetch_k, threshold = self._prepare_mmr(query, **kwargs)
+        db_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"mmr_prefetch_factor", "mmr_prefetch_k", "mmr_threshold"}
+        }
+        prefetched = self._query_with_embeddings(
+            query.query_embedding, prefetch_k, query.filters, **db_kwargs
+        )
+        out = self._mmr_rerank(query, prefetched, threshold)
+        if out is not None:
+            return out
+        rows = self._query_default(
+            query.query_embedding, query.similarity_top_k, query.filters, **db_kwargs
+        )
+        return self._rows_to_result(rows)
+
+    async def _amrr_query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        prefetch_k, threshold = self._prepare_mmr(query, **kwargs)
+        db_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"mmr_prefetch_factor", "mmr_prefetch_k", "mmr_threshold"}
+        }
+        prefetched = await self._aquery_with_embeddings(
+            query.query_embedding, prefetch_k, query.filters, **db_kwargs
+        )
+        out = self._mmr_rerank(query, prefetched, threshold)
+        if out is not None:
+            return out
+        rows = await self._aquery_default(
+            query.query_embedding, query.similarity_top_k, query.filters, **db_kwargs
+        )
+        return self._rows_to_result(rows)
+
+    def _rows_to_result(self, rows: list[DBEmbeddingRow]) -> VectorStoreQueryResult:
+        nodes: list[BaseNode] = []
+        sims: list[float] = []
+        ids: list[str] = []
+        for row in rows:
+            try:
+                node = metadata_dict_to_node(row.metadata)
+                node.set_content(str(row.text))
+            except Exception:
+                node = TextNode(id_=row.node_id, text=row.text, metadata=row.metadata)
+            if row.custom_fields:
+                node.metadata["custom_fields"] = row.custom_fields
+            nodes.append(node)
+            sims.append(row.similarity)
+            ids.append(row.node_id)
+        return VectorStoreQueryResult(nodes=nodes, similarities=sims, ids=ids)
+
+    def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        self._initialize()
+        if query.mode == VectorStoreQueryMode.DEFAULT:
+            rows = self._query_default(
+                query.query_embedding, query.similarity_top_k, query.filters, **kwargs
+            )
+            return self._rows_to_result(rows)
+        if query.mode == VectorStoreQueryMode.MMR:
+            return self._mmr_query(query, **kwargs)
+        raise NotImplementedError(
+            f"CockroachDBVectorStore does not support query mode {query.mode}. "
+            f"Supported modes: DEFAULT, MMR. (HYBRID/SPARSE/TEXT_SEARCH require a "
+            f"tsvector-equivalent feature not yet available in CockroachDB.)"
+        )
+
+    async def aquery(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        self._initialize()
+        if query.mode == VectorStoreQueryMode.DEFAULT:
+            rows = await self._aquery_default(
+                query.query_embedding, query.similarity_top_k, query.filters, **kwargs
+            )
+            return self._rows_to_result(rows)
+        if query.mode == VectorStoreQueryMode.MMR:
+            return await self._amrr_query(query, **kwargs)
+        raise NotImplementedError(
+            f"CockroachDBVectorStore does not support query mode {query.mode}."
+        )
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        from sqlalchemy import delete
+
+        self._initialize()
+        with self._session() as session, session.begin():
+            stmt = delete(self._table_class).where(
+                self._table_class.metadata_["ref_doc_id"].astext == ref_doc_id
+            )
+            session.execute(stmt)
+
+    async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        from sqlalchemy import delete
+
+        self._initialize()
+        async with self._async_session() as session, session.begin():
+            stmt = delete(self._table_class).where(
+                self._table_class.metadata_["ref_doc_id"].astext == ref_doc_id
+            )
+            await session.execute(stmt)
+
+    def delete_nodes(
+        self,
+        node_ids: list[str] | None = None,
+        filters: MetadataFilters | None = None,
+        **delete_kwargs: Any,
+    ) -> None:
+        if not node_ids and not filters:
+            return
+        from sqlalchemy import delete
+
+        self._initialize()
+        with self._session() as session, session.begin():
+            stmt = delete(self._table_class)
+            if node_ids:
+                stmt = stmt.where(self._table_class.node_id.in_(node_ids))
+            if filters:
+                stmt = stmt.where(self._apply_filters(filters))
+            session.execute(stmt)
+
+    async def adelete_nodes(
+        self,
+        node_ids: list[str] | None = None,
+        filters: MetadataFilters | None = None,
+        **delete_kwargs: Any,
+    ) -> None:
+        if not node_ids and not filters:
+            return
+        from sqlalchemy import delete
+
+        self._initialize()
+        async with self._async_session() as session, session.begin():
+            stmt = delete(self._table_class)
+            if node_ids:
+                stmt = stmt.where(self._table_class.node_id.in_(node_ids))
+            if filters:
+                stmt = stmt.where(self._apply_filters(filters))
+            await session.execute(stmt)
+
+    def clear(self) -> None:
+        from sqlalchemy import delete
+
+        self._initialize()
+        with self._session() as session, session.begin():
+            session.execute(delete(self._table_class))
+
+    async def aclear(self) -> None:
+        from sqlalchemy import delete
+
+        self._initialize()
+        async with self._async_session() as session, session.begin():
+            await session.execute(delete(self._table_class))
+
+    def get_nodes(
+        self,
+        node_ids: list[str] | None = None,
+        filters: MetadataFilters | None = None,
+    ) -> list[BaseNode]:
+        if node_ids is None and filters is None:
+            raise ValueError("Either node_ids or filters must be provided")
+        self._initialize()
+        stmt = select(
+            self._table_class.node_id,
+            self._table_class.text,
+            self._table_class.metadata_,
+            self._table_class.embedding,
+        )
+        if node_ids:
+            stmt = stmt.where(self._table_class.node_id.in_(node_ids))
+        if filters:
+            stmt = stmt.where(self._apply_filters(filters))
+        out: list[BaseNode] = []
+        with self._session() as session, session.begin():
+            for item in session.execute(stmt).fetchall():
+                try:
+                    node = metadata_dict_to_node(item.metadata_)
+                    node.set_content(str(item.text))
+                    node.embedding = item.embedding
+                except Exception:
+                    node = TextNode(
+                        id_=item.node_id,
+                        text=item.text,
+                        metadata=item.metadata_,
+                        embedding=item.embedding,
+                    )
+                out.append(node)
+        return out
+
+    async def aget_nodes(
+        self,
+        node_ids: list[str] | None = None,
+        filters: MetadataFilters | None = None,
+    ) -> list[BaseNode]:
+        if node_ids is None and filters is None:
+            raise ValueError("Either node_ids or filters must be provided")
+        self._initialize()
+        stmt = select(
+            self._table_class.node_id,
+            self._table_class.text,
+            self._table_class.metadata_,
+            self._table_class.embedding,
+        )
+        if node_ids:
+            stmt = stmt.where(self._table_class.node_id.in_(node_ids))
+        if filters:
+            stmt = stmt.where(self._apply_filters(filters))
+        out: list[BaseNode] = []
+        async with self._async_session() as session, session.begin():
+            res = await session.execute(stmt)
+            for item in res.fetchall():
+                try:
+                    node = metadata_dict_to_node(item.metadata_)
+                    node.set_content(str(item.text))
+                    node.embedding = item.embedding
+                except Exception:
+                    node = TextNode(
+                        id_=item.node_id,
+                        text=item.text,
+                        metadata=item.metadata_,
+                        embedding=item.embedding,
+                    )
+                out.append(node)
+        return out
+
+    async def close(self) -> None:
+        if self._engine is not None:
+            self._engine.dispose()
+        if self._async_engine is not None:
+            await self._async_engine.dispose()
+        self._is_initialized = False

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/pyproject.toml
@@ -1,0 +1,76 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "testcontainers[postgres]>=4.7",
+]
+
+[project]
+name = "llama-index-vector-stores-cockroachdb"
+version = "0.1.0"
+description = "llama-index vector_stores cockroachdb integration"
+authors = [{name = "Amine Elkouhen", email = "amine.elkouhen@cockroachlabs.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["cockroachdb", "vector", "cspann", "ann"]
+dependencies = [
+    "psycopg2-binary>=2.9.9,<3.0.0",
+    "asyncpg>=0.29.0,<1.0.0",
+    "sqlalchemy-cockroachdb>=2.0.2",
+    "sqlalchemy[asyncio]>=2.0.0,<2.1",
+    "llama-index-core>=0.13.0,<0.15",
+    "numpy",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.vector_stores.cockroachdb"
+
+[tool.llamahub.class_authors]
+CockroachDBVectorStore = "amineelkouhen"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+filterwarnings = ["ignore::DeprecationWarning:"]
+markers = ["asyncio"]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/tests/conftest.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/tests/conftest.py
@@ -1,0 +1,131 @@
+"""Pytest fixtures: spin up a CockroachDB v25.2+ container with vector enabled.
+
+Two paths:
+
+1. **Local container** (default): start a fresh ``cockroachdb/cockroach`` insecure
+   single-node via testcontainers, enable ``feature.vector_index.enabled``, hand
+   back connection params.
+2. **External instance**: set ``CRDB_TEST_URL=postgresql://user:pass@host:port/db``
+   to skip the container and reuse an existing cluster (useful for CI matrices
+   running against multiple CRDB versions).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import psycopg2
+import pytest
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+CRDB_IMAGE = os.environ.get("CRDB_IMAGE", "cockroachdb/cockroach:latest-v25.2")
+
+
+def _params_from_env() -> dict[str, Any] | None:
+    url = os.environ.get("CRDB_TEST_URL")
+    if not url:
+        return None
+    from urllib.parse import urlparse
+
+    p = urlparse(url)
+    return {
+        "host": p.hostname,
+        "port": p.port or 26257,
+        "user": p.username or "root",
+        "password": p.password,
+        "database": (p.path or "/defaultdb").lstrip("/") or "defaultdb",
+    }
+
+
+@pytest.fixture(scope="session")
+def crdb_params() -> Generator[dict[str, Any], None, None]:
+    env = _params_from_env()
+    if env is not None:
+        yield env
+        return
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.waiting_utils import wait_for_logs
+
+    container = (
+        DockerContainer(CRDB_IMAGE)
+        .with_command("start-single-node --insecure --accept-sql-without-tls")
+        .with_exposed_ports(26257, 8080)
+    )
+    container.start()
+    try:
+        wait_for_logs(container, "node startup completed", timeout=60)
+        host = container.get_container_host_ip()
+        port = int(container.get_exposed_port(26257))
+        params = {
+            "host": host,
+            "port": port,
+            "user": "root",
+            "password": None,
+            "database": "defaultdb",
+        }
+        _enable_vector_feature(params)
+        yield params
+    finally:
+        container.stop()
+
+
+def _enable_vector_feature(params: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute("SET CLUSTER SETTING feature.vector_index.enabled = true")
+    conn.close()
+
+
+@pytest.fixture()
+def fresh_db(crdb_params: dict[str, Any]) -> Generator[dict[str, Any], None, None]:
+    """Create a per-test database, drop it after."""
+    db_name = f"t_{uuid.uuid4().hex[:12]}"
+    admin = dict(crdb_params)
+    conn = psycopg2.connect(
+        host=admin["host"],
+        port=admin["port"],
+        user=admin["user"],
+        password=admin["password"],
+        dbname=admin["database"],
+        sslmode="disable",
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE DATABASE {db_name}")
+    conn.close()
+
+    test_params = dict(crdb_params)
+    test_params["database"] = db_name
+    yield test_params
+
+    # Best-effort drop; tolerate races.
+    for _ in range(3):
+        try:
+            conn = psycopg2.connect(
+                host=admin["host"],
+                port=admin["port"],
+                user=admin["user"],
+                password=admin["password"],
+                dbname=admin["database"],
+                sslmode="disable",
+            )
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            with conn.cursor() as cur:
+                cur.execute(f"DROP DATABASE IF EXISTS {db_name} CASCADE")
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.5)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/tests/test_vector_store.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-cockroachdb/tests/test_vector_store.py
@@ -1,0 +1,159 @@
+"""Integration tests for CockroachDBVectorStore against a live CRDB."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.core.vector_stores.types import (
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+)
+
+from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore
+
+EMBED_DIM = 4
+
+
+def _vec(seed: float) -> list[float]:
+    return [seed, 1.0, 1.0, 1.0]
+
+
+def _make_node(node_id: str, text: str, seed: float, **metadata: Any) -> TextNode:
+    n = TextNode(id_=node_id, text=text, metadata=metadata)
+    n.embedding = _vec(seed)
+    n.relationships = {
+        NodeRelationship.SOURCE: RelatedNodeInfo(node_id=metadata.get("doc_id", node_id))
+    }
+    return n
+
+
+@pytest.fixture()
+def store(fresh_db: dict[str, Any]) -> CockroachDBVectorStore:
+    s = CockroachDBVectorStore.from_params(
+        host=fresh_db["host"],
+        port=fresh_db["port"],
+        user=fresh_db["user"],
+        password=fresh_db["password"] or "",
+        database=fresh_db["database"],
+        table_name="testidx",
+        embed_dim=EMBED_DIM,
+        distance_metric="cosine",
+        cspann_kwargs={"min_partition_size": 4, "max_partition_size": 16},
+        sslmode="disable",
+    )
+    yield s
+
+
+def test_add_and_query_default(store: CockroachDBVectorStore) -> None:
+    nodes = [
+        _make_node("a", "alpha", 1.0, doc_id="d1"),
+        _make_node("b", "beta", 0.5, doc_id="d2"),
+        _make_node("c", "gamma", 0.0, doc_id="d3"),
+    ]
+    ids = store.add(nodes)
+    assert sorted(ids) == ["a", "b", "c"]
+
+    q = VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=2)
+    res = store.query(q)
+    assert len(res.nodes) == 2
+    assert res.ids[0] == "a"
+
+
+def test_metadata_filter(store: CockroachDBVectorStore) -> None:
+    store.add(
+        [
+            _make_node("a", "alpha", 1.0, category="x"),
+            _make_node("b", "beta", 0.9, category="y"),
+            _make_node("c", "gamma", 0.8, category="x"),
+        ]
+    )
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="category", value="x", operator=FilterOperator.EQ)]
+    )
+    res = store.query(
+        VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=5, filters=filters)
+    )
+    returned_ids = set(res.ids)
+    assert returned_ids == {"a", "c"}
+
+
+def test_delete_by_ref_doc(store: CockroachDBVectorStore) -> None:
+    store.add(
+        [
+            _make_node("a", "alpha", 1.0, doc_id="doc1"),
+            _make_node("b", "beta", 0.9, doc_id="doc1"),
+            _make_node("c", "gamma", 0.8, doc_id="doc2"),
+        ]
+    )
+    store.delete("doc1")
+    res = store.query(VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=10))
+    assert res.ids == ["c"]
+
+
+def test_delete_nodes_by_ids(store: CockroachDBVectorStore) -> None:
+    store.add([_make_node(nid, nid, 1.0) for nid in ["a", "b", "c"]])
+    store.delete_nodes(node_ids=["a", "b"])
+    res = store.query(VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=10))
+    assert res.ids == ["c"]
+
+
+def test_clear(store: CockroachDBVectorStore) -> None:
+    store.add([_make_node("a", "alpha", 1.0)])
+    store.clear()
+    res = store.query(VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=10))
+    assert res.ids == []
+
+
+def test_get_nodes_returns_embedding(store: CockroachDBVectorStore) -> None:
+    store.add([_make_node("a", "alpha", 0.3)])
+    nodes = store.get_nodes(node_ids=["a"])
+    assert len(nodes) == 1
+    assert nodes[0].embedding[0] == pytest.approx(0.3)
+
+
+def test_mmr_mode_returns_top_k(store: CockroachDBVectorStore) -> None:
+    store.add(
+        [
+            _make_node("a", "alpha", 1.0),
+            _make_node("b", "beta", 0.95),
+            _make_node("c", "gamma", 0.05),
+        ]
+    )
+    q = VectorStoreQuery(
+        query_embedding=_vec(1.0),
+        similarity_top_k=2,
+        mode=VectorStoreQueryMode.MMR,
+        mmr_threshold=0.2,
+    )
+    res = store.query(q, mmr_prefetch_factor=3.0)
+    assert len(res.nodes) == 2
+
+
+def test_unsupported_mode_raises(store: CockroachDBVectorStore) -> None:
+    store.add([_make_node("a", "alpha", 1.0)])
+    q = VectorStoreQuery(
+        query_embedding=_vec(1.0),
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.HYBRID,
+        query_str="alpha",
+    )
+    with pytest.raises(NotImplementedError):
+        store.query(q)
+
+
+@pytest.mark.asyncio
+async def test_async_add_and_query(store: CockroachDBVectorStore) -> None:
+    await store.async_add(
+        [
+            _make_node("a", "alpha", 1.0),
+            _make_node("b", "beta", 0.5),
+        ]
+    )
+    res = await store.aquery(VectorStoreQuery(query_embedding=_vec(1.0), similarity_top_k=1))
+    assert res.ids == ["a"]
+    await store.close()


### PR DESCRIPTION
## Summary

Adds seven sibling packages under `llama-index-integrations` giving CockroachDB feature parity with the postgres family:

| Package | Class | Notes |
|---|---|---|
| `llama-index-vector-stores-cockroachdb` | `CockroachDBVectorStore` | `BasePydanticVectorStore` on CRDB v25.2+ native `VECTOR(n)` + C-SPANN distributed ANN index. Sync + async, DEFAULT and MMR query modes, JSONB metadata filters, per-query `vector_search_beam_size` tuning. |
| `llama-index-readers-cockroachdb` | `CockroachDBReader` | Load existing CRDB rows into `Document` objects via raw query or table+columns shorthand. |
| `llama-index-retrievers-cockroachdb` | `CockroachDBRetriever` | Standalone `BaseRetriever` wrapping the vector store. |
| `llama-index-storage-kvstore-cockroachdb` | `CockroachDBKVStore` | `BaseKVStore` via `sqlalchemy-cockroachdb`. Sync + async, JSONB value column, per-collection upserts via `INSERT ... ON CONFLICT`. |
| `llama-index-storage-docstore-cockroachdb` | `CockroachDBDocumentStore` | Thin `KVDocumentStore` wrapper. |
| `llama-index-storage-index-store-cockroachdb` | `CockroachDBIndexStore` | Thin `KVIndexStore` wrapper. |
| `llama-index-storage-chat-store-cockroachdb` | `CockroachDBChatStore` | `BaseChatStore`. CRDB doesn't yet support `ARRAY(JSON)` as a column type ([crdb#23468](https://github.com/cockroachdb/cockroach/issues/23468)), so each session's messages live in a single `JSONB` column holding a JSON array; appends use the JSONB `||` operator inside `INSERT ... ON CONFLICT DO UPDATE` for atomic retry-safe writes. |

### Why a new package vs. extending `llama-index-vector-stores-postgres`

`llama-index-vector-stores-postgres` depends on the pgvector extension, which is not available in CockroachDB. CRDB ships its own vector primitives (native `VECTOR(n)` type, `CREATE VECTOR INDEX ... WITH (min_partition_size, max_partition_size)` DDL, and a `vector_search_beam_size` session var) so a dedicated integration is required.

The four storage backends use the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects rather than the plain `postgresql+*` ones, so retries on `SERIALIZATION_FAILURE` are transparent.

### Documentation

- Notebooks under `docs/examples/{vector_stores,docstore,chat_store}/`.
- New entries in `docs/src/content/docs/framework/community/integrations/vector_stores.md` and `docs/src/content/docs/framework/module_guides/storing/{docstores,chat_stores}.md`.

## Test plan

- [x] 26 integration tests across the seven packages, all green against CRDB v25.2 via testcontainers (`CRDB_TEST_URL` override for external clusters).
- [x] Tests cover sync + async paths, JSONB metadata filters, MMR mode, beam-size tuning, idempotent upserts, collection isolation, chat-history atomic appends, delete-by-index, and delete-last.
- [x] A bundled standalone package `llama-index-cockroachdb` containing all seven classes is already published to PyPI and used in production: https://pypi.org/project/llama-index-cockroachdb/

## Related history

This is a fresh, clean re-submission of an earlier PR (#21811) that was auto-closed by the integrations bot. The branch and history have been rebuilt from scratch under the contributor's identity only.