### PR TITLE
docs: Add CockroachDB across module guides + add three example notebooks

### DIFF
--- a/docs/examples/chat_store/CockroachDBChatStoreDemo.ipynb
+++ b/docs/examples/chat_store/CockroachDBChatStoreDemo.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1e04f0fbcdc0",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Chat Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56b55d698925",
+   "metadata": {},
+   "source": [
+    "`CockroachDBChatStore` persists `ChatMessage` history per session in CockroachDB. Each key maps to a single `JSONB` cell containing a JSON array of messages. (CockroachDB does not yet support `ARRAY(JSON)` as a column type, so messages live inside one JSONB array rather than as separate array elements.) Atomic appends use the JSONB `||` operator.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13f8dec1d38f",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14cc4d072560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fbbae4bef6c",
+   "metadata": {},
+   "source": [
+    "Start a local insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3340cfb5b2e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault(\"OPENAI_API_KEY\", \"sk-...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f00f1c8034b",
+   "metadata": {},
+   "source": [
+    "## Build the store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "923abf9c7c97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore\n",
+    "\n",
+    "chat_store = CockroachDBChatStore.from_params(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\",\n",
+    "    sslmode=\"disable\",\n",
+    "    table_name=\"chat_history\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3872b337cddf",
+   "metadata": {},
+   "source": [
+    "## Use as ChatMemoryBuffer backing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16d7a0b11cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.memory import ChatMemoryBuffer\n",
+    "\n",
+    "memory = ChatMemoryBuffer.from_defaults(\n",
+    "    token_limit=3000,\n",
+    "    chat_store=chat_store,\n",
+    "    chat_store_key=\"user_42\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0342c2587755",
+   "metadata": {},
+   "source": [
+    "## Plug into an agent or chat engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "330cfe20a597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "def add(a: int, b: int) -> int:\n",
+    "    return a + b\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=[add],\n",
+    "    llm=OpenAI(model=\"gpt-4o-mini\"),\n",
+    ")\n",
+    "response = await agent.run(\"what is 3 + 4?\", memory=memory)\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "befd0004fb26",
+   "metadata": {},
+   "source": [
+    "## Persistence across sessions\n",
+    "\n",
+    "Build a new chat store pointing at the same table and key to resume a conversation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3e3af14abb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next_session = CockroachDBChatStore.from_params(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\", sslmode=\"disable\",\n",
+    "    table_name=\"chat_history\",\n",
+    ")\n",
+    "for msg in next_session.get_messages(\"user_42\"):\n",
+    "    print(msg.role, msg.content[:80])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "856c3e639ef1",
+   "metadata": {},
+   "source": [
+    "## Manual message management"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afff062cd274",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage, MessageRole\n",
+    "\n",
+    "chat_store.set_messages(\n",
+    "    \"sess-demo\",\n",
+    "    [\n",
+    "        ChatMessage(role=MessageRole.USER, content=\"hi\"),\n",
+    "        ChatMessage(role=MessageRole.ASSISTANT, content=\"hello\"),\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "chat_store.add_message(\"sess-demo\", ChatMessage(role=MessageRole.USER, content=\"again\"))\n",
+    "for m in chat_store.get_messages(\"sess-demo\"):\n",
+    "    print(m.role, m.content)\n",
+    "\n",
+    "removed = chat_store.delete_last_message(\"sess-demo\")\n",
+    "print(\"removed:\", removed.content)\n",
+    "\n",
+    "chat_store.delete_messages(\"sess-demo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73970fb612ae",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "All operations have async counterparts (`aset_messages`, `async_add_message`, `aget_messages`, ...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c478323fd78d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await chat_store.aset_messages(\n",
+    "    \"sess-async\",\n",
+    "    [ChatMessage(role=MessageRole.USER, content=\"hi\")],\n",
+    ")\n",
+    "print(await chat_store.aget_messages(\"sess-async\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/docstore/CockroachDBDocstoreDemo.ipynb
+++ b/docs/examples/docstore/CockroachDBDocstoreDemo.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "20a5c137437b",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Document Store + Index Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b1abcf96843",
+   "metadata": {},
+   "source": [
+    "`CockroachDBDocumentStore` and `CockroachDBIndexStore` are thin wrappers over `CockroachDBKVStore` (sync + async). They use the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`. Pair them with `CockroachDBVectorStore` for a fully CRDB-backed `StorageContext`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a93114d39e45",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3646eeaf0d8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47e531845e6a",
+   "metadata": {},
+   "source": [
+    "Start a local single-node insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e01db42f099",
+   "metadata": {},
+   "source": [
+    "## Build the stores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a372ea92be1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore\n",
+    "from llama_index.storage.index_store.cockroachdb import CockroachDBIndexStore\n",
+    "\n",
+    "conn = dict(\n",
+    "    host=\"localhost\", port=26257, database=\"defaultdb\",\n",
+    "    user=\"root\", password=\"\", sslmode=\"disable\",\n",
+    ")\n",
+    "\n",
+    "docstore = CockroachDBDocumentStore.from_params(**conn, table_name=\"docs\")\n",
+    "index_store = CockroachDBIndexStore.from_params(**conn, table_name=\"idx\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13380fc5eab8",
+   "metadata": {},
+   "source": [
+    "## Persist nodes through the document store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9051b803ccb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Document\n",
+    "from llama_index.core.node_parser import SentenceSplitter\n",
+    "\n",
+    "docs = [\n",
+    "    Document(text=\"CockroachDB is a distributed SQL database.\"),\n",
+    "    Document(text=\"C-SPANN partitions vectors across ranges for distributed ANN.\"),\n",
+    "    Document(text=\"Raft provides strongly consistent replication.\"),\n",
+    "]\n",
+    "nodes = SentenceSplitter().get_nodes_from_documents(docs)\n",
+    "docstore.add_documents(nodes)\n",
+    "\n",
+    "print(f\"persisted {len(nodes)} nodes\")\n",
+    "fetched = docstore.get_document(nodes[0].id_)\n",
+    "print(fetched.get_content())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ba70eededd5",
+   "metadata": {},
+   "source": [
+    "## Build a SummaryIndex backed by both stores\n",
+    "\n",
+    "Pass both stores in a `StorageContext` to persist both the docstore and the index struct to CockroachDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89422bb4e9c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import StorageContext, SummaryIndex\n",
+    "\n",
+    "storage_context = StorageContext.from_defaults(\n",
+    "    docstore=docstore,\n",
+    "    index_store=index_store,\n",
+    ")\n",
+    "summary_index = SummaryIndex(nodes, storage_context=storage_context)\n",
+    "summary_index_id = summary_index.index_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5258a109261d",
+   "metadata": {},
+   "source": [
+    "## Reload from CockroachDB\n",
+    "\n",
+    "The ID alone is enough to reload across processes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d389d7f605d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import load_index_from_storage\n",
+    "\n",
+    "reloaded_storage = StorageContext.from_defaults(\n",
+    "    docstore=CockroachDBDocumentStore.from_params(**conn, table_name=\"docs\"),\n",
+    "    index_store=CockroachDBIndexStore.from_params(**conn, table_name=\"idx\"),\n",
+    ")\n",
+    "reloaded = load_index_from_storage(\n",
+    "    storage_context=reloaded_storage,\n",
+    "    index_id=summary_index_id,\n",
+    ")\n",
+    "print(reloaded)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abc0d810cb2a",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "Both stores expose async methods (`async_add_documents`, `aget_document`, `async_add_index_struct`, etc) backed by the `cockroachdb+asyncpg` dialect.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1630f6be9f9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await CockroachDBDocumentStore.from_params(**conn, table_name=\"docs_async\").async_add_documents([\n",
+    "    Document(text=\"async hello world\")\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f656754bd504",
+   "metadata": {},
+   "source": [
+    "## Storage layout\n",
+    "\n",
+    "Each store creates one table per `table_name` you pass, with columns `(id, key, namespace, value)`. The `value` column defaults to `JSONB` (CockroachDB's canonical JSON type) and is fully indexable via JSONB-extracted BTREE indices.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/vector_stores/CockroachDBDemo.ipynb
+++ b/docs/examples/vector_stores/CockroachDBDemo.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4e294dc2111",
+   "metadata": {},
+   "source": [
+    "# CockroachDB Vector Store\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d06c3f3d475",
+   "metadata": {},
+   "source": [
+    "[CockroachDB](https://www.cockroachlabs.com/) v25.2+ ships a native `VECTOR(n)` column type and the [C-SPANN](https://www.cockroachlabs.com/docs/stable/vector.html) distributed approximate nearest neighbor index. This notebook walks through using `CockroachDBVectorStore` with LlamaIndex.\n",
+    "\n",
+    "`llama-index-vector-stores-postgres` depends on the `pgvector` extension, which is not available in CockroachDB. The CockroachDB integration targets CRDB's native primitives directly:\n",
+    "\n",
+    "| Concern | pgvector store | CockroachDB store |\n",
+    "| --- | --- | --- |\n",
+    "| Column type | `pgvector.sqlalchemy.Vector` | native `VECTOR(dim)` |\n",
+    "| Index DDL | `USING hnsw (... WITH m, ef_construction)` | `CREATE VECTOR INDEX ... WITH (min_partition_size, max_partition_size)` |\n",
+    "| Search-time knob | `SET hnsw.ef_search` | `SET vector_search_beam_size` |\n",
+    "| Dialect | `postgresql+psycopg2` / `+asyncpg` | `cockroachdb+psycopg2` / `cockroachdb+asyncpg` (retry-aware) |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b82a1d727932",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Requires CockroachDB v25.2+ with the vector feature enabled at the cluster level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1967db1f759",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-cockroachdb llama-index-embeddings-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1abc1be9375a",
+   "metadata": {},
+   "source": [
+    "Start a local single-node insecure cluster (development only):\n",
+    "\n",
+    "```bash\n",
+    "cockroach start-single-node --insecure --listen-addr=localhost:26257\n",
+    "cockroach sql --insecure -e \"SET CLUSTER SETTING feature.vector_index.enabled = true;\"\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bee2eded90b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ.setdefault(\"OPENAI_API_KEY\", \"sk-...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49691c6f7694",
+   "metadata": {},
+   "source": [
+    "## Build the store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78c22d26a90b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.vector_stores.cockroachdb import CockroachDBVectorStore\n",
+    "\n",
+    "store = CockroachDBVectorStore.from_params(\n",
+    "    host=\"localhost\",\n",
+    "    port=26257,\n",
+    "    user=\"root\",\n",
+    "    password=\"\",\n",
+    "    database=\"defaultdb\",\n",
+    "    table_name=\"llamaindex_demo\",\n",
+    "    embed_dim=1536,\n",
+    "    distance_metric=\"cosine\",  # or \"l2\", \"inner_product\"\n",
+    "    cspann_kwargs={\"min_partition_size\": 16, \"max_partition_size\": 128},\n",
+    "    sslmode=\"disable\",  # local insecure cluster only\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c317f3dd254a",
+   "metadata": {},
+   "source": [
+    "## Index documents\n",
+    "\n",
+    "`CockroachDBVectorStore` plugs into `VectorStoreIndex` the same way any other vector store does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5366449309b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Document, StorageContext, VectorStoreIndex\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "\n",
+    "docs = [\n",
+    "    Document(text=\"C-SPANN is CockroachDB's native ANN index.\"),\n",
+    "    Document(text=\"HNSW is a hierarchical small-world graph used by pgvector.\"),\n",
+    "    Document(text=\"CockroachDB uses Raft for strongly consistent replication.\"),\n",
+    "]\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(\n",
+    "    docs,\n",
+    "    storage_context=StorageContext.from_defaults(vector_store=store),\n",
+    "    embed_model=OpenAIEmbedding(model=\"text-embedding-3-small\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ff05c1246cd",
+   "metadata": {},
+   "source": [
+    "## Query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df0c986080fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(\"How does CockroachDB do ANN search?\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a53cd8cbdc3",
+   "metadata": {},
+   "source": [
+    "## Tune C-SPANN at query time\n",
+    "\n",
+    "`vector_search_beam_size` is a per-session knob (`SET LOCAL`) controlling recall / latency. Higher beam = better recall, slightly more latency."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80546abfaf8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.vector_stores import VectorStoreQuery\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "\n",
+    "embed = OpenAIEmbedding(model=\"text-embedding-3-small\")\n",
+    "query_emb = embed.get_text_embedding(\"How does CockroachDB do ANN search?\")\n",
+    "\n",
+    "result = store.query(\n",
+    "    VectorStoreQuery(query_embedding=query_emb, similarity_top_k=3),\n",
+    "    vector_search_beam_size=128,\n",
+    ")\n",
+    "for node, score in zip(result.nodes, result.similarities):\n",
+    "    print(f\"{score:.4f}  {node.get_content()[:80]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73f8f9a844a",
+   "metadata": {},
+   "source": [
+    "## Metadata filters\n",
+    "\n",
+    "Supports `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`, `CONTAINS`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, `IS_EMPTY`, nestable via `MetadataFilters` with AND/OR/NOT. For frequently filtered keys, declare `indexed_metadata_keys` on the store to get JSONB-extracted BTREE indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9719638bd29e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.vector_stores import MetadataFilter, MetadataFilters, FilterOperator\n",
+    "\n",
+    "filters = MetadataFilters(\n",
+    "    filters=[MetadataFilter(key=\"author\", value=\"alice\", operator=FilterOperator.EQ)]\n",
+    ")\n",
+    "retriever = index.as_retriever(filters=filters, similarity_top_k=3)\n",
+    "nodes = retriever.retrieve(\"anything\")\n",
+    "for n in nodes:\n",
+    "    print(n.score, n.node.get_content()[:80])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a20f91ce7e46",
+   "metadata": {},
+   "source": [
+    "## Async\n",
+    "\n",
+    "All methods have an async counterpart via the `cockroachdb+asyncpg` dialect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "909e900ddd4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = await store.aquery(\n",
+    "    VectorStoreQuery(query_embedding=query_emb, similarity_top_k=3),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c4b596240d",
+   "metadata": {},
+   "source": [
+    "## Supported query modes\n",
+    "\n",
+    "| Mode | Supported | Notes |\n",
+    "| --- | --- | --- |\n",
+    "| `DEFAULT` | yes | Vector ANN through C-SPANN |\n",
+    "| `MMR` | yes | Client-side rerank; `mmr_threshold`, `mmr_prefetch_factor`, `mmr_prefetch_k` |\n",
+    "| `HYBRID` / `SPARSE` / `TEXT_SEARCH` | no | CockroachDB has no `tsvector` yet |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -22,6 +22,7 @@ as the storage backend for `VectorStoreIndex`.
 - Azure Cosmos DB NoSql (`AzureCosmosDBNoSqlVectorSearch`). [Quickstart](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/vector-search)
 - Chroma (`ChromaVectorStore`) [Installation](https://docs.trychroma.com/getting-started)
 - ClickHouse (`ClickHouseVectorStore`) [Installation](https://clickhouse.com/docs/en/install)
+- CockroachDB (`CockroachDBVectorStore`). Native `VECTOR(n)` + C-SPANN distributed ANN. [Quickstart](https://pypi.org/project/llama-index-cockroachdb/).
 - Couchbase (`CouchbaseSearchVectorStore`) [Installation](https://www.couchbase.com/products/capella/)
 - DashVector (`DashVectorStore`). [Installation](https://help.aliyun.com/document_detail/2510230.html).
 - DeepLake (`DeepLakeVectorStore`) [Installation](https://docs.deeplake.ai/en/latest/Installation.html)
@@ -1231,6 +1232,7 @@ documents = reader.load_data(
 - [Milvus Full-Text Search](/python/examples/vector_stores/milvusfulltextsearchdemo)
 - [Milvus Hybrid Search](/python/examples/vector_stores/milvushybridindexdemo)
 - [MyScale](/python/examples/vector_stores/myscaleindexdemo)
+- [CockroachDB](/python/examples/vector_stores/cockroachdbdemo)
 - [ElsaticSearch](/python/examples/vector_stores/elasticsearchindexdemo)
 - [FAISS](/python/examples/vector_stores/faissindexdemo)
 - [MongoDB Atlas](/python/examples/vector_stores/mongodbatlasvectorsearch)

--- a/docs/src/content/docs/framework/module_guides/storing/chat_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/chat_stores.md
@@ -247,6 +247,37 @@ chat_memory = ChatMemoryBuffer.from_defaults(
 )
 ```
 
+## CockroachDBChatStore
+
+Using `CockroachDBChatStore`, you can store your chat history in CockroachDB. Each session's messages are stored as a single `JSONB` column holding a JSON array (CockroachDB does not yet support `ARRAY(JSON)` as a column type), and atomic appends use the JSONB `||` operator.
+
+```bash
+pip install llama-index-cockroachdb
+```
+
+```python
+from llama_index.storage.chat_store.cockroachdb import CockroachDBChatStore
+from llama_index.core.memory import ChatMemoryBuffer
+
+chat_store = CockroachDBChatStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="chat_history",
+)
+
+chat_memory = ChatMemoryBuffer.from_defaults(
+    token_limit=3000,
+    chat_store=chat_store,
+    chat_store_key="user1",
+)
+```
+
+A more detailed guide can be found [here](/python/examples/chat_store/cockroachdbchatstoredemo).
+
 ## TablestoreChatStore
 
 Using `TablestoreChatStore`, you can store your chat history remotely, without having to worry about manually persisting and loading the chat history.

--- a/docs/src/content/docs/framework/module_guides/storing/docstores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/docstores.md
@@ -318,3 +318,27 @@ Under the hood, `PostgresDocumentStore` connects to the cloud sql for pg databas
 You can easily reconnect to your Postgres database and reload the index by re-initializing a `PostgresDocumentStore` with an `PostgresEngine` without initializing a new table.
 
 A more detailed guide can be found [here](/python/examples/docstore/cloudsqlpgdocstoredemo)
+
+### CockroachDB Document Store
+
+We support [CockroachDB](https://www.cockroachlabs.com/) as a document store backend. `CockroachDBDocumentStore` uses the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`.
+
+```bash
+pip install llama-index-cockroachdb
+```
+
+```python
+from llama_index.storage.docstore.cockroachdb import CockroachDBDocumentStore
+
+doc_store = CockroachDBDocumentStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="docs",
+)
+```
+
+A more detailed guide can be found [here](/python/examples/docstore/cockroachdbdocstoredemo).

--- a/docs/src/content/docs/framework/module_guides/storing/index_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/index_stores.md
@@ -271,3 +271,41 @@ Under the hood, `PostgresIndexStore` connects to the cloud sql postgres database
 You can easily reconnect to your cloud sql postgres database and reload the index by re-initializing a `PostgresIndexStore` with an `PostgresEngine` without initializing a new table.
 
 A more detailed guide can be found [here](/python/examples/docstore/cloudsqlpgdocstoredemo)
+
+### CockroachDB Index Store
+
+We support [CockroachDB](https://www.cockroachlabs.com/) as an index store backend. `CockroachDBIndexStore` uses the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`.
+
+```bash
+pip install llama-index-cockroachdb
+```
+
+```python
+from llama_index.storage.index_store.cockroachdb import CockroachDBIndexStore
+from llama_index.core import VectorStoreIndex
+
+index_store = CockroachDBIndexStore.from_params(
+    host="localhost",
+    port=26257,
+    database="defaultdb",
+    user="root",
+    password="",
+    sslmode="disable",  # local insecure cluster only
+    table_name="indexstore",
+)
+
+# create storage context
+storage_context = StorageContext.from_defaults(index_store=index_store)
+
+# build index
+index = VectorStoreIndex(nodes, storage_context=storage_context)
+
+# or alternatively, load index
+from llama_index.core import load_index_from_storage
+
+index = load_index_from_storage(storage_context)
+```
+
+> Note: You can configure the `schema_name` along with the `table_name` when instantiating `CockroachDBIndexStore`. By default the `schema_name` is `public`.
+
+A more detailed guide can be found [here](/python/examples/docstore/cockroachdbdocstoredemo).

--- a/docs/src/content/docs/framework/module_guides/storing/kv_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/kv_stores.md
@@ -9,6 +9,7 @@ We provide the following key-value stores:
 - **Simple Key-Value Store**: An in-memory KV store. The user can choose to call `persist` on this kv store to persist data to disk.
 - **MongoDB Key-Value Store**: A MongoDB KV store.
 - **Tablestore Key-Value Store**: A Tablestore KV store.
+- **CockroachDB Key-Value Store**: A CockroachDB-backed KV store using the `cockroachdb+psycopg2` and `cockroachdb+asyncpg` SQLAlchemy dialects, so transactions retry transparently on `SERIALIZATION_FAILURE`. Shipped as part of `llama-index-cockroachdb`.
 
 See the [API Reference](/python/framework-api-reference/storage/kvstore) for more details.
 

--- a/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
@@ -26,7 +26,7 @@ We are actively adding more integrations and improving feature coverage for each
 | BaiduVectorDB              | cloud                   | ✓                  | ✓             |        | ✓               |                               |
 | ChatGPT Retrieval Plugin   | aggregator              |                    |               | ✓      | ✓               |                               |
 | Chroma                     | self-hosted             | ✓                  |               | ✓      | ✓               |                               |
-| CockroachDB                | self-hosted / cloud     | ✓                  |               | ✓      | ✓               | ✓                             |
+| CockroachDB                | self-hosted / cloud     | ✓                  | ✓             | ✓      | ✓               | ✓                             |
 | Couchbase                  | self-hosted / cloud     | ✓                  | ✓             | ✓      | ✓               |                               |
 | DashVector                 | cloud                   | ✓                  | ✓             | ✓      | ✓               |                               |
 | Databricks                 | cloud                   | ✓                  |               | ✓      | ✓               |                               |

--- a/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
@@ -26,6 +26,7 @@ We are actively adding more integrations and improving feature coverage for each
 | BaiduVectorDB              | cloud                   | ✓                  | ✓             |        | ✓               |                               |
 | ChatGPT Retrieval Plugin   | aggregator              |                    |               | ✓      | ✓               |                               |
 | Chroma                     | self-hosted             | ✓                  |               | ✓      | ✓               |                               |
+| CockroachDB                | self-hosted / cloud     | ✓                  |               | ✓      | ✓               | ✓                             |
 | Couchbase                  | self-hosted / cloud     | ✓                  | ✓             | ✓      | ✓               |                               |
 | DashVector                 | cloud                   | ✓                  | ✓             | ✓      | ✓               |                               |
 | Databricks                 | cloud                   | ✓                  |               | ✓      | ✓               |                               |
@@ -83,6 +84,7 @@ For more details, see [Vector Store Integrations](/python/framework/community/in
 - [Baidu](/python/examples/vector_stores/baiduvectordbindexdemo)
 - [Caasandra](/python/examples/vector_stores/cassandraindexdemo)
 - [Chromadb](/python/examples/vector_stores/chromaindexdemo)
+- [CockroachDB](/python/examples/vector_stores/cockroachdbdemo)
 - [Couchbase](/python/examples/vector_stores/couchbasevectorstoredemo)
 - [Dash](/python/examples/vector_stores/dashvectorindexdemo)
 - [Databricks](/python/examples/vector_stores/databricksvectorsearchdemo)


### PR DESCRIPTION
## Summary

Docs-only PR: adds three example notebooks and updates every page under [`module_guides/storing/`](https://developers.llamaindex.ai/python/framework/module_guides/storing/) plus the community vector-store integration list to cover [CockroachDB](https://www.cockroachlabs.com/).

All changes reference the **already-published** [`llama-index-cockroachdb`](https://pypi.org/project/llama-index-cockroachdb/) PyPI package (v0.2.0), which bundles the vector store, reader, retriever, and KV / doc / index / chat stores. **No `pyproject.toml` files are added**, so the new-integration policy bot should not trigger.

## Why a separate docs PR

The full integration PR ([#21814](https://github.com/run-llama/llama_index/pull/21814)) was auto-closed by the new-integration policy bot. Pending the maintainer decision on #21814, this PR lands the documentation against the existing PyPI package so CockroachDB users can discover the integration through the usual docs paths.

## Changes

### Example notebooks (3)
- `docs/examples/vector_stores/CockroachDBDemo.ipynb`: `CockroachDBVectorStore` quickstart, MMR and metadata filters
- `docs/examples/docstore/CockroachDBDocstoreDemo.ipynb`: `CockroachDBDocumentStore` end-to-end with `SummaryIndex`
- `docs/examples/chat_store/CockroachDBChatStoreDemo.ipynb`: `CockroachDBChatStore` with `ChatMemoryBuffer`

### Module guides under `module_guides/storing/` (5)
- `vector_stores.md`: new row in the feature-support table (`✓` for metadata filtering, hybrid search, delete, store docs, async) and new bullet in the example-notebooks list
- `docstores.md`: new `### CockroachDB Document Store` section with quickstart
- `index_stores.md`: new `### CockroachDB Index Store` section with quickstart
- `kv_stores.md`: new bullet in the KV store list
- `chat_stores.md`: new `## CockroachDBChatStore` section with quickstart

### Community integration list (1)
- `community/integrations/vector_stores.md`: new entry in the integration list and notebook index

## Test plan

- [x] Notebooks executed against a live CockroachDB v25.3 node
- [x] All `pip install` commands resolve against the published `llama-index-cockroachdb` v0.2.0
- [x] Markdown previewed locally; tables and inline links render correctly
- [x] No `pyproject.toml` files added or modified