### PR TITLE
fix(core): add opt-in empty context chat fallback

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -11,6 +11,7 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.base.response.schema import (
     AsyncStreamingResponse,
+    RESPONSE_TYPE,
     StreamingResponse,
 )
 from llama_index.core.callbacks import CallbackManager, trace_method
@@ -102,6 +103,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
+        respond_with_llm_on_empty_context: bool = False,
     ):
         self._retriever = retriever
         self._llm = llm
@@ -133,6 +135,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         self._token_counter = TokenCounter()
         self._verbose = verbose
+        self._respond_with_llm_on_empty_context = respond_with_llm_on_empty_context
 
     @classmethod
     def from_defaults(
@@ -148,6 +151,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         skip_condense: bool = False,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         verbose: bool = False,
+        respond_with_llm_on_empty_context: bool = False,
         **kwargs: Any,
     ) -> "CondensePlusContextChatEngine":
         """Initialize a CondensePlusContextChatEngine from default parameters."""
@@ -170,6 +174,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             node_postprocessors=node_postprocessors,
             system_prompt=system_prompt,
             verbose=verbose,
+            respond_with_llm_on_empty_context=respond_with_llm_on_empty_context,
         )
 
     def _condense_question(
@@ -319,13 +324,37 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         return response_synthesizer, context_source, context_nodes
 
+    def _synthesize(
+        self,
+        synthesizer: CompactAndRefine,
+        message: str,
+        context_nodes: List[NodeWithScore],
+    ) -> RESPONSE_TYPE:
+        if context_nodes or not self._respond_with_llm_on_empty_context:
+            return synthesizer.synthesize(message, context_nodes)
+
+        response = synthesizer.get_response(query_str=message, text_chunks=[""])
+        return synthesizer._prepare_response_output(response, [])
+
+    async def _asynthesize(
+        self,
+        synthesizer: CompactAndRefine,
+        message: str,
+        context_nodes: List[NodeWithScore],
+    ) -> RESPONSE_TYPE:
+        if context_nodes or not self._respond_with_llm_on_empty_context:
+            return await synthesizer.asynthesize(message, context_nodes)
+
+        response = await synthesizer.aget_response(query_str=message, text_chunks=[""])
+        return synthesizer._prepare_response_output(response, [])
+
     @trace_method("chat")
     def chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
         synthesizer, context_source, context_nodes = self._run_c3(message, chat_history)
 
-        response = synthesizer.synthesize(message, context_nodes)
+        response = self._synthesize(synthesizer, message, context_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -348,7 +377,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = synthesizer.synthesize(message, context_nodes)
+        response = self._synthesize(synthesizer, message, context_nodes)
         assert isinstance(response, StreamingResponse)
 
         self._memory.put(ChatMessage(content=message, role=MessageRole.USER))
@@ -384,7 +413,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        response = await self._asynthesize(synthesizer, message, context_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -407,7 +436,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        response = await self._asynthesize(synthesizer, message, context_nodes)
         assert isinstance(response, AsyncStreamingResponse)
 
         await self._memory.aput(ChatMessage(content=message, role=MessageRole.USER))

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -26,6 +26,27 @@ def chat_engine() -> CondensePlusContextChatEngine:
     )
 
 
+@pytest.fixture()
+def empty_chat_engine() -> CondensePlusContextChatEngine:
+    index = VectorStoreIndex.from_documents([], embed_model=MockEmbedding(embed_dim=3))
+    retriever = index.as_retriever()
+    return CondensePlusContextChatEngine.from_defaults(
+        retriever, llm=MockLLM(), system_prompt=SYSTEM_PROMPT
+    )
+
+
+@pytest.fixture()
+def empty_chat_engine_with_llm_fallback() -> CondensePlusContextChatEngine:
+    index = VectorStoreIndex.from_documents([], embed_model=MockEmbedding(embed_dim=3))
+    retriever = index.as_retriever()
+    return CondensePlusContextChatEngine.from_defaults(
+        retriever,
+        llm=MockLLM(),
+        system_prompt=SYSTEM_PROMPT,
+        respond_with_llm_on_empty_context=True,
+    )
+
+
 def test_chat(chat_engine: CondensePlusContextChatEngine):
     response = chat_engine.chat("Hello World!")
     assert SYSTEM_PROMPT in str(response)
@@ -37,6 +58,44 @@ def test_chat(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_empty_context_returns_empty_response_by_default(
+    empty_chat_engine: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine.chat("Hello World!")
+
+    assert str(response) == "Empty Response"
+    assert response.source_nodes == []
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+def test_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine_with_llm_fallback.chat("Hello World!")
+
+    assert str(response) != "Empty Response"
+    assert SYSTEM_PROMPT in str(response)
+    assert "Hello World!" in str(response)
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
+
+
+def test_stream_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine_with_llm_fallback.stream_chat("Hello World!")
+
+    full_response = ""
+    for token in response.response_gen:
+        full_response += token
+
+    assert full_response != "Empty Response"
+    assert SYSTEM_PROMPT in full_response
+    assert "Hello World!" in full_response
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
 
 
 def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
@@ -82,6 +141,51 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     assert response.is_done
     assert len(chat_engine.chat_history) == 2
     assert chat_engine.chat_history[1].role == MessageRole.ASSISTANT
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_empty_context_returns_empty_response_by_default(
+    empty_chat_engine: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine.astream_chat("Hello World!")
+
+    full_response = ""
+    async for token in response.async_response_gen():
+        full_response += token
+
+    assert full_response == "Empty Response"
+    assert response.source_nodes == []
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine_with_llm_fallback.astream_chat("Hello World!")
+
+    full_response = ""
+    async for token in response.async_response_gen():
+        full_response += token
+
+    assert full_response != "Empty Response"
+    assert SYSTEM_PROMPT in full_response
+    assert "Hello World!" in full_response
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_achat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine_with_llm_fallback.achat("Hello World!")
+
+    assert str(response) != "Empty Response"
+    assert SYSTEM_PROMPT in str(response)
+    assert "Hello World!" in str(response)
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `respond_with_llm_on_empty_context` to `CondensePlusContextChatEngine`.
- Keeps the default empty-context `Empty Response` behavior unchanged.
- When enabled, runs the existing synthesizer prompt path with an empty context chunk instead of taking the empty-node short-circuit.
- Keeps fallback responses ungrounded by source, with `source_nodes=[]`.

Fixes #20894

## Tests
- `uv run --project llama-index-core pytest llama-index-core/tests/chat_engine/test_condense_plus_context.py -q`
- `uv run --project llama-index-core pytest llama-index-core/tests/chat_engine -q`
- `cd llama-index-core && uv run pytest -q`
- `uv run --project llama-index-core ruff check llama-index-core/llama_index llama-index-core/tests`
- `uv run --project llama-index-core ruff format --check llama-index-core/llama_index/core/chat_engine/condense_plus_context.py llama-index-core/tests/chat_engine/test_condense_plus_context.py`
- `cd llama-index-core && uv run mypy llama_index/core/chat_engine/condense_plus_context.py`