### PR TITLE
Document Tuning Engines with OpenAILike

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
@@ -21,3 +21,17 @@ llm = OpenAILike(
     is_function_calling_model=False,
 )
 ```
+
+You can also point `OpenAILike` at a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/):
+
+```python
+llm = OpenAILike(
+    model="gpt-4o-mini",
+    api_base="https://api.tuningengines.com/v1",
+    api_key="your-tuning-engines-key",
+    is_chat_model=True,
+    is_function_calling_model=True,
+)
+```
+
+LlamaIndex continues to own indexing, retrieval, and query orchestration while the gateway centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
