### PR TITLE
fix(ollama): preserve streaming thinking chunks

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -472,15 +472,17 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             for r in response:
-                if r["message"]["content"] is None:
+                message = r["message"]
+                if message["content"] is None and not message.get("thinking"):
                     continue
 
                 r = dict(r)
+                message = r["message"]
 
-                response_txt += r["message"].get("content", "") or ""
-                thinking_txt += r["message"].get("thinking", "") or ""
+                response_txt += message.get("content", "") or ""
+                thinking_txt += message.get("thinking", "") or ""
 
-                new_tool_calls = [dict(t) for t in r["message"].get("tool_calls") or []]
+                new_tool_calls = [dict(t) for t in message.get("tool_calls") or []]
                 for tool_call in new_tool_calls:
                     if (
                         str(tool_call["function"]["name"]),
@@ -517,12 +519,12 @@ class Ollama(FunctionCallingLLM):
                 yield ChatResponse(
                     message=ChatMessage(
                         blocks=output_blocks,
-                        role=r["message"].get("role", MessageRole.ASSISTANT),
+                        role=message.get("role", MessageRole.ASSISTANT),
                     ),
-                    delta=r["message"].get("content", ""),
+                    delta=message.get("content") or "",
                     raw=r,
                     additional_kwargs={
-                        "thinking_delta": r["message"].get("thinking", None),
+                        "thinking_delta": message.get("thinking", None),
                     },
                 )
 
@@ -556,15 +558,17 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             async for r in response:
-                if r["message"]["content"] is None:
+                message = r["message"]
+                if message["content"] is None and not message.get("thinking"):
                     continue
 
                 r = dict(r)
+                message = r["message"]
 
-                response_txt += r["message"].get("content", "") or ""
-                thinking_txt += r["message"].get("thinking", "") or ""
+                response_txt += message.get("content", "") or ""
+                thinking_txt += message.get("thinking", "") or ""
 
-                new_tool_calls = [dict(t) for t in r["message"].get("tool_calls") or []]
+                new_tool_calls = [dict(t) for t in message.get("tool_calls") or []]
                 for tool_call in new_tool_calls:
                     if (
                         str(tool_call["function"]["name"]),
@@ -601,12 +605,12 @@ class Ollama(FunctionCallingLLM):
                 yield ChatResponse(
                     message=ChatMessage(
                         blocks=output_blocks,
-                        role=r["message"].get("role", MessageRole.ASSISTANT),
+                        role=message.get("role", MessageRole.ASSISTANT),
                     ),
-                    delta=r["message"].get("content", ""),
+                    delta=message.get("content") or "",
                     raw=r,
                     additional_kwargs={
-                        "thinking_delta": r["message"].get("thinking", None),
+                        "thinking_delta": message.get("thinking", None),
                     },
                 )
 

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from ollama import Client
-from typing import Annotated
+from typing import Annotated, Any, AsyncIterator
 
 from llama_index.core.base.llms.types import ThinkingBlock, TextBlock, ToolCallBlock
 from llama_index.core.base.llms.base import BaseLLM
@@ -46,6 +46,36 @@ def generate_song(
 
 
 tool = FunctionTool.from_defaults(fn=generate_song)
+
+
+class StreamClient:
+    def __init__(self, chunks: list[dict[str, Any]]) -> None:
+        self.chunks = chunks
+
+    def chat(self, **_: Any) -> list[dict[str, Any]]:
+        return self.chunks
+
+
+class AsyncStreamClient:
+    def __init__(self, chunks: list[dict[str, Any]]) -> None:
+        self.chunks = chunks
+
+    async def chat(self, **_: Any) -> AsyncIterator[dict[str, Any]]:
+        async def gen() -> AsyncIterator[dict[str, Any]]:
+            for chunk in self.chunks:
+                yield chunk
+
+        return gen()
+
+
+def thinking_chunk(content: str | None, thinking: str | None) -> dict[str, Any]:
+    return {
+        "message": {
+            "role": "assistant",
+            "content": content,
+            "thinking": thinking,
+        }
+    }
 
 
 def test_embedding_class() -> None:
@@ -130,6 +160,54 @@ async def test_ollama_async_stream_chat() -> None:
         assert r is not None
         assert r.delta is not None
         assert str(r).strip() != ""
+
+
+def test_stream_chat_preserves_thinking_only_chunks() -> None:
+    llm = Ollama(
+        model="deepseek-r1",
+        context_window=8192,
+        client=StreamClient(
+            [
+                thinking_chunk(None, "thinking step"),
+                thinking_chunk("answer", None),
+            ]
+        ),  # type: ignore[arg-type]
+    )
+
+    chunks = list(llm.stream_chat([ChatMessage(role="user", content="Hello!")]))
+
+    assert chunks[0].delta == ""
+    assert chunks[0].additional_kwargs["thinking_delta"] == "thinking step"
+    assert any(
+        isinstance(block, ThinkingBlock) and block.content == "thinking step"
+        for block in chunks[0].message.blocks
+    )
+    assert chunks[-1].message.content == "answer"
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_preserves_thinking_only_chunks() -> None:
+    llm = Ollama(
+        model="deepseek-r1",
+        context_window=8192,
+        async_client=AsyncStreamClient(
+            [
+                thinking_chunk(None, "thinking step"),
+                thinking_chunk("answer", None),
+            ]
+        ),  # type: ignore[arg-type]
+    )
+
+    response = await llm.astream_chat([ChatMessage(role="user", content="Hello!")])
+    chunks = [chunk async for chunk in response]
+
+    assert chunks[0].delta == ""
+    assert chunks[0].additional_kwargs["thinking_delta"] == "thinking step"
+    assert any(
+        isinstance(block, ThinkingBlock) and block.content == "thinking step"
+        for block in chunks[0].message.blocks
+    )
+    assert chunks[-1].message.content == "answer"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
﻿## Summary
- Preserve Ollama streaming chunks that carry `thinking` but no `content`.
- Keep empty/heartbeat chunks skipped when they contain neither text nor thinking.
- Add sync and async regression coverage for thinking-only streaming chunks.

Fixes #21232

## To verify
- python -m pytest -q tests/test_llms_ollama.py
- python -m ruff check llama_index/llms/ollama/base.py tests/test_llms_ollama.py
- python -m ruff format --check llama_index/llms/ollama/base.py tests/test_llms_ollama.py
- python -m compileall -q llama_index/llms/ollama tests/test_llms_ollama.py
