### PR TITLE
fix(security): SQL injection in llama-index-vector-stores-mariadb MetadataFilter handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-mariadb/llama_index/vector_stores/mariadb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-mariadb/llama_index/vector_stores/mariadb/base.py
@@ -2,10 +2,15 @@
 
 import json
 import logging
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+import re
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import quote_plus
 
 import sqlalchemy
+
+# Allow only safe identifier characters in metadata-filter keys to prevent
+# SQL injection via the JSON path embedded in the WHERE clause.
+_SAFE_METADATA_KEY = re.compile(r"^[A-Za-z0-9_]+$")
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.vector_stores.types import (
@@ -331,23 +336,35 @@ class MariaDBVectorStore(BasePydanticVectorStore):
             _logger.warning("Unsupported operator: %s, fallback to '='", operator)
             return "="
 
-    def _build_filter_clause(self, filter_: MetadataFilter) -> str:
-        filter_value = filter_.value
+    def _build_filter_clause(
+        self, filter_: MetadataFilter, params: Dict[str, Any]
+    ) -> str:
+        if not _SAFE_METADATA_KEY.match(filter_.key or ""):
+            raise ValueError(
+                f"Unsafe metadata filter key {filter_.key!r}; "
+                f"must match {_SAFE_METADATA_KEY.pattern}"
+            )
+
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
-            values = []
+            placeholders = []
             for v in filter_.value:
-                if isinstance(v, str):
-                    value = f"'{v}'"
+                name = f"f_{len(params)}"
+                params[name] = v
+                placeholders.append(f":{name}")
+            filter_value = f"({', '.join(placeholders)})"
+        else:
+            name = f"f_{len(params)}"
+            params[name] = filter_.value
+            filter_value = f":{name}"
 
-                values.append(value)
-            filter_value = ", ".join(values)
-            filter_value = f"({filter_value})"
-        elif isinstance(filter_.value, str):
-            filter_value = f"'{filter_.value}'"
+        return (
+            f"JSON_VALUE(metadata, '$.{filter_.key}') "
+            f"{self._to_mariadb_operator(filter_.operator)} {filter_value}"
+        )
 
-        return f"JSON_VALUE(metadata, '$.{filter_.key}') {self._to_mariadb_operator(filter_.operator)} {filter_value}"
-
-    def _filters_to_where_clause(self, filters: MetadataFilters) -> str:
+    def _filters_to_where_clause(
+        self, filters: MetadataFilters, params: Dict[str, Any]
+    ) -> str:
         conditions = {
             FilterCondition.OR: "OR",
             FilterCondition.AND: "AND",
@@ -361,11 +378,11 @@ class MariaDBVectorStore(BasePydanticVectorStore):
         clauses: List[str] = []
         for filter_ in filters.filters:
             if isinstance(filter_, MetadataFilter):
-                clauses.append(self._build_filter_clause(filter_))
+                clauses.append(self._build_filter_clause(filter_, params))
                 continue
 
             if isinstance(filter_, MetadataFilters):
-                subfilters = self._filters_to_where_clause(filter_)
+                subfilters = self._filters_to_where_clause(filter_, params)
                 if subfilters:
                     clauses.append(f"({subfilters})")
                 continue
@@ -411,9 +428,10 @@ class MariaDBVectorStore(BasePydanticVectorStore):
             VEC_DISTANCE_COSINE(embedding, VEC_FromText('{query.query_embedding}')) AS distance
         FROM `{self.table_name}`"""
 
+        filter_params: Dict[str, Any] = {}
         if query.filters:
             stmt += f"""
-        WHERE {self._filters_to_where_clause(query.filters)}"""
+        WHERE {self._filters_to_where_clause(query.filters, filter_params)}"""
 
         stmt += f"""
         ORDER BY distance
@@ -421,7 +439,7 @@ class MariaDBVectorStore(BasePydanticVectorStore):
         """
 
         with self._engine.connect() as connection:
-            result = connection.execute(sqlalchemy.text(stmt))
+            result = connection.execute(sqlalchemy.text(stmt), filter_params)
 
         results = []
         for item in result:


### PR DESCRIPTION
**Title:** `fix(security): SQL injection in llama-index-vector-stores-mariadb MetadataFilter handling`

## Summary

`MariaDBVectorStore.query()` builds a raw SQL `WHERE` clause from `MetadataFilter.key` and `MetadataFilter.value` via string interpolation, then executes it through `sqlalchemy.text()` with **no** bind parameters. Both the `key` and the `value` flow unescaped into the statement:

```python
# llama_index/vector_stores/mariadb/base.py (pre-fix)
filter_value = f"'{filter_.value}'"  # no quote escaping
return f"JSON_VALUE(metadata, '$.{filter_.key}') {op} {filter_value}"
...
result = connection.execute(sqlalchemy.text(stmt))  # no params
```

A caller that lets metadata-filter contents derive (even transitively) from user input or LLM tool-call output enables SQL injection against the configured MariaDB instance: schema disclosure, data exfiltration / modification, and — depending on DB privileges — file write via `SELECT ... INTO OUTFILE`. This matches the threat model of the previously-fixed couchbase / clickhouse / lantern siblings (CVE-2025-1793, GHSA-v3c8-3pr6-gr7p).

## Fix

Minimal, scoped to `_build_filter_clause` / `_filters_to_where_clause` / `query`:

1. Allow-list `filter.key` with `^[A-Za-z0-9_]+$` (same shape `oracledb` already uses at `base.py:529`).
2. Bind `filter.value` (including each element of `IN` / `NIN` lists) via SQLAlchemy named parameters; pass the params dict into `connection.execute()`.

No other files modified. No public API change (the `_build_filter_clause` / `_filters_to_where_clause` signatures pick up a `params: Dict[str, Any]` argument; they are underscore-prefixed and not part of the public surface).

## Affected versions

`llama-index-vector-stores-mariadb` 0.5.0 and earlier (vulnerable function present since the initial commit).

## CWE / CVSS

- CWE-89 (SQL Injection)
- CVSS 3.1 AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H = **8.8 High**

## Disclosure

Filed as a huntr report by Vael (2026-05-30). This PR is the proposed remediation; per huntr's program rules the fix-bounty is awarded to whoever ships the accepted patch alongside the report.

## Test notes

A regression test exercising `query()` with a `MetadataFilter` whose `key` or `value` contains a SQL quote / control character is recommended. Not added in this PR to keep the diff minimal and review-friendly.

🤖 Co-authored by Vael (Claude CLI) — security-V of the Velisyl Constellation
