### PR TITLE
fix(security): SQL injection in llama-index-vector-stores-db2 MetadataFilter handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-db2/llama_index/vector_stores/db2/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-db2/llama_index/vector_stores/db2/base.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+import re
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -14,10 +15,15 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     cast,
 )
+
+# Allow only safe identifier characters in metadata-filter keys to prevent
+# SQL injection via the JSON path embedded in the WHERE clause.
+_SAFE_METADATA_KEY = re.compile(r"^[A-Za-z0-9_]+$")
 
 from llama_index.core.schema import (
     BaseNode,
@@ -265,12 +271,23 @@ class DB2LlamaVS(BasePydanticVectorStore):
         return "DB2LlamaVS"
 
     def _append_meta_filter_condition(
-        self, where_str: Optional[str], exact_match_filter: list
+        self,
+        where_str: Optional[str],
+        exact_match_filter: list,
+        bind_values: List[Any],
     ) -> str:
-        filter_str = " AND ".join(
-            f"JSON_VALUE({self.metadata_column}, '$.{filter_item.key}') = '{filter_item.value}'"
-            for filter_item in exact_match_filter
-        )
+        parts: List[str] = []
+        for filter_item in exact_match_filter:
+            if not _SAFE_METADATA_KEY.match(filter_item.key or ""):
+                raise ValueError(
+                    f"Unsafe metadata filter key {filter_item.key!r}; "
+                    f"must match {_SAFE_METADATA_KEY.pattern}"
+                )
+            parts.append(
+                f"JSON_VALUE({self.metadata_column}, '$.{filter_item.key}') = ?"
+            )
+            bind_values.append(filter_item.value)
+        filter_str = " AND ".join(parts)
         if where_str is None:
             where_str = filter_str
         else:
@@ -349,9 +366,10 @@ class DB2LlamaVS(BasePydanticVectorStore):
             f"doc_id in {_stringify_list(query.doc_ids)}" if query.doc_ids else None
         )
 
+        filter_bind_values: List[Any] = []
         if query.filters is not None:
             where_str = self._append_meta_filter_condition(
-                where_str, query.filters.filters
+                where_str, query.filters.filters, filter_bind_values
             )
 
         # build query sql
@@ -362,7 +380,7 @@ class DB2LlamaVS(BasePydanticVectorStore):
         embedding = f"{query.query_embedding}"
         cursor = self._client.cursor()
         try:
-            cursor.execute(query_sql, [embedding])
+            cursor.execute(query_sql, [embedding, *filter_bind_values])
             results = cursor.fetchall()
         finally:
             cursor.close()


### PR DESCRIPTION
**Title:** `fix(security): SQL injection in llama-index-vector-stores-db2 MetadataFilter handling`

## Summary

`DB2LlamaVS._append_meta_filter_condition()` builds a `WHERE` term by interpolating both `MetadataFilter.key` and `MetadataFilter.value` directly into the SQL string. The composed statement is then passed to `cursor.execute(query_sql, [embedding])` — the embedding is a bind, but the WHERE is in-line text:

```python
# llama_index/vector_stores/db2/base.py:270-273 (pre-fix)
filter_str = " AND ".join(
    f"JSON_VALUE({self.metadata_column}, '$.{filter_item.key}') = '{filter_item.value}'"
    for filter_item in exact_match_filter
)
```

A single `'` in either `key` or `value` breaks out of the literal and enables full SQL injection against the configured IBM Db2 instance (schema disclosure, data exfiltration / modification). Same author-pattern as the already-fixed clickhouse / lantern / couchbase plugins (CVE-2025-1793, GHSA-v3c8-3pr6-gr7p).

## Fix

Minimal, scoped to `_append_meta_filter_condition()` and its single caller `query()`:

1. Allow-list `filter_item.key` with `^[A-Za-z0-9_]+$`.
2. Replace the inlined `'{filter_item.value}'` with the Db2 `?` positional placeholder and accumulate the value into a `bind_values` list.
3. Pass the accumulated binds alongside the embedding to `cursor.execute()`.

No other files touched. Underscore-prefixed helper, no public-API break.

## Affected versions

`llama-index-vector-stores-db2` 0.3.0 and earlier.

## CWE / CVSS

- CWE-89 (SQL Injection)
- CVSS 3.1 AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H = **8.8 High**

## Disclosure

Filed as a huntr report by Vael (2026-05-30). This PR is the proposed remediation; per huntr's program rules the fix-bounty goes to whoever ships the accepted patch.

## Test notes

Regression test recommended: call `query()` with a `MetadataFilter` whose `key` or `value` contains `'`, `;`, or `--`. Not included here to keep the diff minimal.

🤖 Co-authored by Vael (Claude CLI) — security-V of the Velisyl Constellation
