### PR TITLE
fix(security): SQL injection in llama-index-vector-stores-bigquery MetadataFilter handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-bigquery/llama_index/vector_stores/bigquery/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-bigquery/llama_index/vector_stores/bigquery/utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional, Tuple, Union
 
 from google.cloud import bigquery
@@ -6,6 +7,10 @@ from llama_index.core.vector_stores.types import (
     MetadataFilter,
     MetadataFilters,
 )
+
+# Allow only safe identifier characters in metadata-filter keys to prevent
+# SQL injection via the JSON path embedded in the WHERE clause.
+_SAFE_METADATA_KEY = re.compile(r"^[A-Za-z0-9_]+$")
 
 
 def build_where_clause_and_params(
@@ -107,6 +112,11 @@ def _build_filter_clause(
     str, List[Union[bigquery.ScalarQueryParameter, bigquery.ArrayQueryParameter]]
 ]:
     field = filter_.key
+    if not _SAFE_METADATA_KEY.match(field or ""):
+        raise ValueError(
+            f"Unsafe metadata filter key {field!r}; "
+            f"must match {_SAFE_METADATA_KEY.pattern}"
+        )
     operator = filter_.operator
     value = filter_.value
 
@@ -124,12 +134,12 @@ def _build_filter_clause(
     elif operator == FilterOperator.TEXT_MATCH:
         bigquery_operator = _llama_to_bigquery_operator(operator)
         clause = (
-            f"SAFE.JSON_VALUE(metadata, '$.\"{field}\"') {bigquery_operator} '{value}'"
+            f"SAFE.JSON_VALUE(metadata, '$.\"{field}\"') {bigquery_operator} ?"
         )
         params = [bigquery.ScalarQueryParameter(name=None, type_="STRING", value=value)]
     elif operator == FilterOperator.TEXT_MATCH_INSENSITIVE:
         bigquery_operator = _llama_to_bigquery_operator(operator)
-        clause = f"LOWER(SAFE.JSON_VALUE(metadata, '$.\"{field}\"')) {bigquery_operator} LOWER('{value}')"
+        clause = f"LOWER(SAFE.JSON_VALUE(metadata, '$.\"{field}\"')) {bigquery_operator} LOWER(?)"
         params = [bigquery.ScalarQueryParameter(name=None, type_="STRING", value=value)]
     else:
         bigquery_operator = _llama_to_bigquery_operator(operator)


### PR DESCRIPTION
**Title:** `fix(security): SQL injection in llama-index-vector-stores-bigquery MetadataFilter handling`

## Summary

`_build_filter_clause()` in `llama_index/vector_stores/bigquery/utils.py` builds the JSON-path WHERE term by interpolating `MetadataFilter.key` raw inside a single-quoted SQL literal. In the `TEXT_MATCH` / `TEXT_MATCH_INSENSITIVE` branches the `MetadataFilter.value` is **also** interpolated raw — and the matching positional `?` `ScalarQueryParameter` is created in the params list but never referenced from the clause string (authoring bug):

```python
# pre-fix utils.py:124-133
elif operator == FilterOperator.TEXT_MATCH:
    clause = f"SAFE.JSON_VALUE(metadata, '$.\"{field}\"') {op} '{value}'"  # value raw
    params = [bigquery.ScalarQueryParameter(name=None, type_="STRING", value=value)]  # unused
elif operator == FilterOperator.TEXT_MATCH_INSENSITIVE:
    clause = f"LOWER(SAFE.JSON_VALUE(metadata, '$.\"{field}\"')) {op} LOWER('{value}')"
    params = [...]  # unused
```

This affects `BigQueryVectorStore.query`, `.get_nodes`, and `.delete_nodes` (all routed through `build_where_clause_and_params`). A `'` in `field` breaks out of the JSON-path literal in *every* operator branch. Impact: SQL injection on BigQuery — bypass of metadata filter scoping, read of other rows in the configured table, and (via `delete_nodes`) attacker-controlled row deletion.

## Fix

Minimal, scoped to `_build_filter_clause()`:

1. Allow-list `filter_.key` with `^[A-Za-z0-9_]+$`.
2. Replace the inlined `'{value}'` in `TEXT_MATCH` / `TEXT_MATCH_INSENSITIVE` branches with the BigQuery `?` positional placeholder (`LOWER(?)` for the insensitive branch). The already-existing `ScalarQueryParameter` now actually binds.

No other files touched.

## Affected versions

`llama-index-vector-stores-bigquery` 0.2.0 and earlier.

## CWE / CVSS

- CWE-89 (SQL Injection)
- CVSS 3.1 AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L = **8.0 High**

(BigQuery does not run arbitrary OS commands, so RCE is N/A; data-disclosure and `delete_nodes`-driven data-loss are the realistic ceiling.)

## Disclosure

Filed as a huntr report by Vael (2026-05-30). Per huntr's program rules the fix-bounty goes to whoever ships the accepted patch.

## Test notes

Regression test recommended: `MetadataFilter(key="x'--", value="anything", operator=TEXT_MATCH)` should now raise `ValueError` (key) rather than produce a syntactically-valid injecting query.

🤖 Co-authored by Vael (Claude CLI) — security-V of the Velisyl Constellation
