### PR TITLE
fix(security): SQL injection in llama-index-vector-stores-alibabacloud-mysql MetadataFilter key handling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-alibabacloud-mysql/llama_index/vector_stores/alibabacloud_mysql/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-alibabacloud-mysql/llama_index/vector_stores/alibabacloud_mysql/base.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, List, NamedTuple, Optional, Literal, Sequence
 from urllib.parse import quote_plus
 
 import sqlalchemy
+
+# Allow only safe identifier characters in metadata-filter keys to prevent
+# SQL injection via the JSON path embedded in the WHERE clause.
+_SAFE_METADATA_KEY = re.compile(r"^[A-Za-z0-9_]+$")
 import sqlalchemy.ext.asyncio
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode
@@ -346,6 +350,11 @@ class AlibabaCloudMySQLVectorStore(BasePydanticVectorStore):
     def _build_filter_clause(
         self, filter_: MetadataFilter, global_param_counter: List[int]
     ) -> tuple[str, dict]:
+        if not _SAFE_METADATA_KEY.match(filter_.key or ""):
+            raise ValueError(
+                f"Unsafe metadata filter key {filter_.key!r}; "
+                f"must match {_SAFE_METADATA_KEY.pattern}"
+            )
         params = {}
 
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:


### PR DESCRIPTION
**Title:** `fix(security): SQL injection in llama-index-vector-stores-alibabacloud-mysql MetadataFilter key handling`

## Summary

`AlibabaCloudMySQLVectorStore._build_filter_clause()` correctly parameterizes `MetadataFilter.value` via named SQLAlchemy parameters (`:param_N`) but interpolates `MetadataFilter.key` raw into the JSON-path literal:

```python
# llama_index/vector_stores/alibabacloud_mysql/base.py:376 (pre-fix)
clause = f"JSON_VALUE(metadata, '$.{filter_.key}') {op} {filter_value}"
```

A single `'` in `key` breaks out of the surrounding JSON-path literal and yields SQL injection against the configured Alibaba RDS MySQL instance. Narrower than the mariadb sibling (value is already bound) but still sufficient for arbitrary `SELECT`.

## Fix

One-line allow-list guard at the top of `_build_filter_clause()`: reject any `filter_.key` not matching `^[A-Za-z0-9_]+$` with a `ValueError`.

No other files touched. No public API change.

## Affected versions

`llama-index-vector-stores-alibabacloud-mysql` 0.2.0 and earlier.

## CWE / CVSS

- CWE-89 (SQL Injection)
- CVSS 3.1 AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H = **8.8 High**

## Disclosure

Filed as a huntr report by Vael (2026-05-30). Per huntr's program rules the fix-bounty goes to whoever ships the accepted patch.

## Test notes

Regression test recommended: `MetadataFilter(key="x' OR 1=1--", value="v")` should raise `ValueError` before any SQL is composed.

🤖 Co-authored by Vael (Claude CLI) — security-V of the Velisyl Constellation
