### PR TITLE
fix(core): improve error message for unrecognized embedding model names

### DIFF
--- a/llama-index-core/llama_index/core/embeddings/loading.py
+++ b/llama-index-core/llama_index/core/embeddings/loading.py
@@ -44,6 +44,10 @@ def load_embed_model(data: dict) -> BaseEmbedding:
     if name is None:
         raise ValueError("Embedding loading requires a class_name")
     if name not in RECOGNIZED_EMBEDDINGS:
-        raise ValueError(f"Invalid Embedding name: {name}")
+        available = ", ".join(sorted(RECOGNIZED_EMBEDDINGS.keys()))
+        raise ValueError(
+            f"Invalid Embedding name: {name}. "
+            f"Available embeddings: {available}"
+        )
 
     return RECOGNIZED_EMBEDDINGS[name].from_dict(data)

--- a/llama-index-core/tests/embeddings/test_loading.py
+++ b/llama-index-core/tests/embeddings/test_loading.py
@@ -1,0 +1,40 @@
+"""Tests for load_embed_model in loading.py."""
+
+import pytest
+
+from llama_index.core.embeddings.loading import (
+    RECOGNIZED_EMBEDDINGS,
+    load_embed_model,
+)
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+
+
+def test_load_embed_model_missing_class_name() -> None:
+    """Raises ValueError when class_name key is absent."""
+    with pytest.raises(ValueError, match="Embedding loading requires a class_name"):
+        load_embed_model({})
+
+
+def test_load_embed_model_invalid_name_shows_available() -> None:
+    """Error message for an unrecognized name must list all available embeddings."""
+    with pytest.raises(ValueError) as exc_info:
+        load_embed_model({"class_name": "NonExistentEmbedding"})
+
+    error_msg = str(exc_info.value)
+    assert "Invalid Embedding name: NonExistentEmbedding" in error_msg
+    assert "Available embeddings:" in error_msg
+    for key in sorted(RECOGNIZED_EMBEDDINGS):
+        assert key in error_msg
+
+
+def test_load_embed_model_with_valid_mock() -> None:
+    """MockEmbedding (always present in the registry) round-trips correctly."""
+    model = load_embed_model(MockEmbedding(embed_dim=8).to_dict())
+    assert isinstance(model, MockEmbedding)
+
+
+def test_load_embed_model_passes_through_instance() -> None:
+    """If data is already a BaseEmbedding instance, return it directly."""
+    instance = MockEmbedding(embed_dim=4)
+    result = load_embed_model(instance)  # type: ignore[arg-type]
+    assert result is instance


### PR DESCRIPTION
## Description

When an unrecognized embedding name is passed to `load_embed_model()`, the error message now includes the sorted list of available embedding names so users can quickly find the correct one.

Before:
```
ValueError: Invalid Embedding name: MyEmbedding
```

After:
```
ValueError: Invalid Embedding name: MyEmbedding. Available embeddings: AzureOpenAIEmbedding, HuggingFaceInferenceAPIEmbedding, MockEmbedding, OpenAIEmbedding
```

Fixes #21597

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added 4 tests in `tests/embeddings/test_loading.py`:
- Missing `class_name` key raises proper error
- Invalid name error includes all available embedding names
- Valid `MockEmbedding` round-trips correctly
- Passing an existing `BaseEmbedding` instance returns it directly

All 15 tests in `tests/embeddings/` pass with no regressions.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes