### PR TITLE
docs: remove stale download_loader references

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/chatgpt_plugins.md
+++ b/docs/src/content/docs/framework/community/integrations/chatgpt_plugins.md
@@ -25,12 +25,12 @@ Here is a sample code snippet of showing how to load a document from LlamaHub
 into the JSON format that `/upsert` expects:
 
 ```python
-from llama_index.core import download_loader, Document
+from llama_index.core import Document
+from llama_index.readers.web import SimpleWebPageReader
 from typing import Dict, List
 import json
 
-# download loader, load documents
-from llama_index.readers.web import SimpleWebPageReader
+# load documents
 
 loader = SimpleWebPageReader(html_to_text=True)
 url = "http://www.paulgraham.com/worked.html"

--- a/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/index.mdx
@@ -26,8 +26,6 @@ LlamaHub is an open-source repository containing data loaders that you can easil
 Get started with:
 
 ```python
-from llama_index.core import download_loader
-
 from llama_index.readers.google import GoogleDocsReader
 
 loader = GoogleDocsReader()

--- a/docs/src/content/docs/framework/module_guides/loading/connector/usage_pattern.md
+++ b/docs/src/content/docs/framework/module_guides/loading/connector/usage_pattern.md
@@ -4,13 +4,12 @@ title: Usage Pattern
 
 ## Get Started
 
-Each data loader contains a "Usage" section showing how that loader can be used. At the core of using each loader is a `download_loader` function, which
-downloads the loader file into a module that you can use within your application.
+Each data loader contains a "Usage" section showing how that loader can be used. Install the relevant reader package and import the reader class directly in your application.
 
 Example usage:
 
 ```python
-from llama_index.core import VectorStoreIndex, download_loader
+from llama_index.core import VectorStoreIndex
 
 from llama_index.readers.google import GoogleDocsReader
 

--- a/docs/src/content/docs/framework/understanding/rag/loading/index.md
+++ b/docs/src/content/docs/framework/understanding/rag/loading/index.md
@@ -33,8 +33,6 @@ Because there are so many possible places to get data, they are not all built-in
 In this example LlamaIndex downloads and installs the connector called [DatabaseReader](https://llamahub.ai/l/readers/llama-index-readers-database), which runs a query against a SQL database and returns every row of the results as a `Document`:
 
 ```python
-from llama_index.core import download_loader
-
 from llama_index.readers.database import DatabaseReader
 
 reader = DatabaseReader(

--- a/docs/src/content/docs/framework/understanding/rag/loading/llamahub.md
+++ b/docs/src/content/docs/framework/understanding/rag/loading/llamahub.md
@@ -12,8 +12,6 @@ LlamaHub contains a registry of open-source data connectors that you can easily 
 Get started with:
 
 ```python
-from llama_index.core import download_loader
-
 from llama_index.readers.google import GoogleDocsReader
 
 loader = GoogleDocsReader()

--- a/llama-index-core/llama_index/core/command_line/mappings.json
+++ b/llama-index-core/llama_index/core/command_line/mappings.json
@@ -43,7 +43,6 @@
   "SQLContextBuilder": "llama_index.core",
   "PromptHelper": "llama_index.core",
   "IndexStructType": "llama_index.core",
-  "download_loader": "llama_index.core",
   "load_graph_from_storage": "llama_index.core",
   "load_index_from_storage": "llama_index.core",
   "load_indices_from_storage": "llama_index.core",

--- a/llama-index-integrations/readers/README.md
+++ b/llama-index-integrations/readers/README.md
@@ -9,7 +9,7 @@ pip install llama-index-readers-google
 For example, see the code snippets below using the Google Docs Loader.
 
 ```python
-from llama_index.core import VectorStoreIndex, download_loader
+from llama_index.core import VectorStoreIndex
 from llama_index.readers.google import GoogleDocsReader
 
 gdoc_ids = ["1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec"]


### PR DESCRIPTION
Fixes #21703 - download_loader import error by removing stale references. Changes: removed download_loader mapping from mappings.json, updated documentation to use direct reader imports. Rationale: In LlamaIndex v0.10+, integrations were split into standalone packages. The download_loader helper was deprecated in favor of installing specific reader packages and importing directly.