### PR TITLE
fix(mcp): convert prompt resource content blocks

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,3 +1,5 @@
+import base64
+import mimetypes
 import warnings
 import logging
 import io
@@ -27,7 +29,14 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.base.llms.types import ContentBlock
+from llama_index.core.llms import (
+    AudioBlock,
+    ChatMessage,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
 
 
 class StreamingHandler(logging.Handler):
@@ -64,6 +73,74 @@ def enable_sse(command_or_url: str) -> bool:
     elif "/sse/" in url.path:
         return True
     return False
+
+
+def _decode_mcp_base64(data: str) -> bytes:
+    return base64.b64decode(data, validate=True)
+
+
+def _mime_type_to_format(mime_type: Optional[str]) -> Optional[str]:
+    if not mime_type:
+        return None
+
+    mime_type = mime_type.split(";", 1)[0].strip()
+    guessed_extension = mimetypes.guess_extension(mime_type)
+    if guessed_extension:
+        return guessed_extension.lstrip(".")
+    if "/" in mime_type:
+        return mime_type.split("/", 1)[1]
+    return None
+
+
+def _blob_resource_to_llama_block(
+    data: str, mime_type: Optional[str], title: Optional[str] = None
+) -> ContentBlock:
+    decoded_data = _decode_mcp_base64(data)
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(image=decoded_data, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(audio=decoded_data, format=_mime_type_to_format(mime_type))
+    return DocumentBlock(data=decoded_data, document_mimetype=mime_type, title=title)
+
+
+def _resource_link_to_llama_block(content: types.ResourceLink) -> ContentBlock:
+    uri = str(content.uri)
+    title = content.title or content.name
+    mime_type = content.mimeType
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(url=uri, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(url=uri, format=_mime_type_to_format(mime_type))
+    return DocumentBlock(url=uri, document_mimetype=mime_type, title=title)
+
+
+def _mcp_content_to_llama_block(content: Any) -> ContentBlock:
+    if isinstance(content, types.TextContent):
+        return TextBlock(text=content.text)
+    if isinstance(content, types.ImageContent):
+        return ImageBlock(
+            image=_decode_mcp_base64(content.data),
+            image_mimetype=content.mimeType,
+        )
+    if isinstance(content, types.AudioContent):
+        return AudioBlock(
+            audio=_decode_mcp_base64(content.data),
+            format=_mime_type_to_format(content.mimeType),
+        )
+    if isinstance(content, types.ResourceLink):
+        return _resource_link_to_llama_block(content)
+    if isinstance(content, types.EmbeddedResource):
+        resource = content.resource
+        if isinstance(resource, types.TextResourceContents):
+            return TextBlock(text=resource.text)
+        if isinstance(resource, types.BlobResourceContents):
+            return _blob_resource_to_llama_block(
+                resource.blob,
+                resource.mimeType,
+                title=str(resource.uri),
+            )
+
+    raise ValueError(f"Unsupported content type: {type(content)}")
 
 
 class DefaultInMemoryTokenStorage(TokenStorage):
@@ -379,32 +456,11 @@ class BasicMCPClient(ClientSession):
             prompt = await session.get_prompt(prompt_name, arguments)
             llama_messages = []
             for message in prompt.messages:
-                if isinstance(message.content, types.TextContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[TextBlock(text=message.content.text)],
-                        )
+                llama_messages.append(
+                    ChatMessage(
+                        role=message.role,
+                        blocks=[_mcp_content_to_llama_block(message.content)],
                     )
-                elif isinstance(message.content, types.ImageContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[
-                                ImageBlock(
-                                    image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
-                                )
-                            ],
-                        )
-                    )
-                elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported content type: {type(message.content)}"
-                    )
+                )
 
             return llama_messages

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,7 +1,12 @@
+import base64
 import os
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
 from httpx import AsyncClient
 import pytest
 
+from llama_index.core.llms import AudioBlock, DocumentBlock, ImageBlock, TextBlock
 from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp.client import enable_sse
 from mcp import types
@@ -117,6 +122,112 @@ async def test_get_prompts(client: BasicMCPClient):
     result = await client.get_prompt("analyze_data", {"data": "1,2,3,4,5"})
     assert len(result) > 1
     assert any("1,2,3,4,5" in msg.content for msg in result)
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_converts_mcp_content_blocks(monkeypatch):
+    """Test converting all MCP prompt content block variants."""
+    image_data = b"image-bytes"
+    audio_data = b"audio-bytes"
+    document_data = b"document-bytes"
+
+    class FakeSession:
+        async def get_prompt(self, prompt_name, arguments=None):
+            return SimpleNamespace(
+                messages=[
+                    types.PromptMessage(
+                        role="user",
+                        content=types.TextContent(type="text", text="plain text"),
+                    ),
+                    types.PromptMessage(
+                        role="user",
+                        content=types.ImageContent(
+                            type="image",
+                            data=base64.b64encode(image_data).decode(),
+                            mimeType="image/png",
+                        ),
+                    ),
+                    types.PromptMessage(
+                        role="assistant",
+                        content=types.AudioContent(
+                            type="audio",
+                            data=base64.b64encode(audio_data).decode(),
+                            mimeType="audio/wav",
+                        ),
+                    ),
+                    types.PromptMessage(
+                        role="user",
+                        content=types.EmbeddedResource(
+                            type="resource",
+                            resource=types.TextResourceContents(
+                                uri="config://app",
+                                text="embedded text",
+                                mimeType="text/plain",
+                            ),
+                        ),
+                    ),
+                    types.PromptMessage(
+                        role="user",
+                        content=types.EmbeddedResource(
+                            type="resource",
+                            resource=types.BlobResourceContents(
+                                uri="file:///doc.pdf",
+                                blob=base64.b64encode(document_data).decode(),
+                                mimeType="application/pdf",
+                            ),
+                        ),
+                    ),
+                    types.PromptMessage(
+                        role="user",
+                        content=types.ResourceLink(
+                            type="resource_link",
+                            name="linked-doc",
+                            title="Linked Doc",
+                            uri="file:///linked.pdf",
+                            mimeType="application/pdf",
+                        ),
+                    ),
+                ]
+            )
+
+    @asynccontextmanager
+    async def fake_run_session():
+        yield FakeSession()
+
+    client = BasicMCPClient("python")
+    monkeypatch.setattr(client, "_run_session", fake_run_session)
+
+    result = await client.get_prompt("mixed_content")
+
+    text_block = result[0].blocks[0]
+    assert isinstance(text_block, TextBlock)
+    assert text_block.text == "plain text"
+
+    image_block = result[1].blocks[0]
+    assert isinstance(image_block, ImageBlock)
+    assert image_block.image == base64.b64encode(image_data)
+    assert image_block.image_mimetype == "image/png"
+
+    audio_block = result[2].blocks[0]
+    assert isinstance(audio_block, AudioBlock)
+    assert audio_block.audio == base64.b64encode(audio_data)
+    assert audio_block.format == "wav"
+
+    embedded_text_block = result[3].blocks[0]
+    assert isinstance(embedded_text_block, TextBlock)
+    assert embedded_text_block.text == "embedded text"
+
+    document_block = result[4].blocks[0]
+    assert isinstance(document_block, DocumentBlock)
+    assert document_block.data == base64.b64encode(document_data)
+    assert document_block.document_mimetype == "application/pdf"
+    assert document_block.title == "file:///doc.pdf"
+
+    link_block = result[5].blocks[0]
+    assert isinstance(link_block, DocumentBlock)
+    assert str(link_block.url) == "file:///linked.pdf"
+    assert link_block.document_mimetype == "application/pdf"
+    assert link_block.title == "Linked Doc"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- convert MCP prompt `AudioContent`, `EmbeddedResource`, and `ResourceLink` results into LlamaIndex content blocks instead of raising
- decode MCP base64 payloads before constructing image/audio/document blocks
- add coverage for mixed MCP prompt content block conversion

Fixes #21270

## Validation
- `uv run -- pytest tests/test_client.py::test_get_prompt_converts_mcp_content_blocks -q`
- `uv run -- pytest tests/test_client.py::test_get_prompts -q`
- `uv run -- pytest tests/test_client.py::test_list_tools -q`
- `uv run ruff check llama_index/tools/mcp/client.py tests/test_client.py`
- `uv run ruff format --check llama_index/tools/mcp/client.py tests/test_client.py`

Note: I used AI assistance to draft the conversion helper and test, then manually reviewed and validated the behavior above.