### PR TITLE
feat(readers-twitter): add GetXAPISearchReader for tweet search via the GetXAPI HTTP API

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-twitter/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.6.0] - 2026-05-31
+
+- Add `GetXAPISearchReader` for tweet / X advanced search via the GetXAPI bearer-token HTTP API. Adds `httpx` dependency.
+
 ## [0.1.2] - 2024-02-13
 
 - Add maintainers and keywords from library.json (llamahub)

--- a/llama-index-integrations/readers/llama-index-readers-twitter/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/README.md
@@ -28,6 +28,23 @@ reader = TwitterTweetReader(
 documents = reader.load_data(twitterhandles=["user1", "user2"])
 ```
 
+### Alternative: `GetXAPISearchReader`
+
+For workflows that need search (rather than user-timeline) access, or where the official Twitter developer API is not available, the same package also exposes `GetXAPISearchReader`, which calls the [GetXAPI](https://www.getxapi.com) HTTP API with a single bearer token.
+
+```python
+from llama_index.readers.twitter import GetXAPISearchReader
+
+reader = GetXAPISearchReader(bearer_token="<GetXAPI Bearer Token>")
+
+documents = reader.load_data(
+    query="llamaindex lang:en -is:retweet",
+    limit=50,
+)
+```
+
+Returned `Document` objects carry the tweet text plus `id`, `url`, `author_username`, `author_name`, `created_at`, `like_count`, `retweet_count`, and `reply_count` in `metadata`.
+
 This loader is designed to be used as a way to load data into
 [LlamaIndex](https://github.com/run-llama/llama_index/tree/main/llama_index) and/or subsequently
 used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent.

--- a/llama-index-integrations/readers/llama-index-readers-twitter/llama_index/readers/twitter/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/llama_index/readers/twitter/__init__.py
@@ -1,3 +1,4 @@
 from llama_index.readers.twitter.base import TwitterTweetReader
+from llama_index.readers.twitter.getxapi import GetXAPISearchReader
 
-__all__ = ["TwitterTweetReader"]
+__all__ = ["TwitterTweetReader", "GetXAPISearchReader"]

--- a/llama-index-integrations/readers/llama-index-readers-twitter/llama_index/readers/twitter/getxapi.py
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/llama_index/readers/twitter/getxapi.py
@@ -1,0 +1,129 @@
+"""Reader that searches tweets via the GetXAPI Twitter / X data API."""
+
+from typing import Any, List, Optional
+
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.schema import Document
+
+
+DEFAULT_BASE_URL = "https://api.getxapi.com"
+DEFAULT_SEARCH_PATH = "/twitter/tweet/advanced_search"
+
+
+class GetXAPISearchReader(BasePydanticReader):
+    """
+    Twitter / X search reader backed by the GetXAPI HTTP API.
+
+    Useful when access to the official Twitter developer API is not available.
+    Authentication is a single Bearer token passed via the ``Authorization``
+    header.
+
+    Args:
+        bearer_token (str): GetXAPI bearer token.
+        base_url (Optional[str]): Override the API base URL.
+            Defaults to ``https://api.getxapi.com``.
+        timeout (Optional[float]): Per-request timeout in seconds. Defaults to ``30``.
+
+    """
+
+    is_remote: bool = True
+    bearer_token: str
+    base_url: str = DEFAULT_BASE_URL
+    timeout: float = 30.0
+
+    def __init__(
+        self,
+        bearer_token: str,
+        base_url: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            bearer_token=bearer_token,
+            base_url=base_url or DEFAULT_BASE_URL,
+            timeout=timeout if timeout is not None else 30.0,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "GetXAPISearchReader"
+
+    def _build_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}{DEFAULT_SEARCH_PATH}"
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.bearer_token}",
+            "Accept": "application/json",
+        }
+
+    @staticmethod
+    def _tweet_to_document(tweet: dict) -> Document:
+        text = tweet.get("text") or tweet.get("full_text") or ""
+        tweet_id = str(tweet.get("id") or tweet.get("id_str") or "")
+        author = tweet.get("author") or {}
+        username = author.get("username") or author.get("screen_name") or ""
+        metadata = {
+            "id": tweet_id,
+            "url": (
+                f"https://x.com/{username}/status/{tweet_id}"
+                if tweet_id and username
+                else None
+            ),
+            "author_username": username,
+            "author_name": author.get("name"),
+            "created_at": tweet.get("created_at"),
+            "like_count": tweet.get("like_count") or tweet.get("favorite_count"),
+            "retweet_count": tweet.get("retweet_count"),
+            "reply_count": tweet.get("reply_count"),
+        }
+        metadata = {k: v for k, v in metadata.items() if v is not None}
+        return Document(text=text, id_=tweet_id or None, metadata=metadata)
+
+    def load_data(
+        self,
+        query: str,
+        limit: Optional[int] = 50,
+        **load_kwargs: Any,
+    ) -> List[Document]:
+        """
+        Run an advanced search and return matching tweets as ``Document`` objects.
+
+        Args:
+            query (str): Twitter / X advanced search query.
+            limit (Optional[int]): Maximum number of tweets to return. Defaults to ``50``.
+
+        """
+        try:
+            import httpx
+        except ImportError:
+            raise ImportError(
+                "`httpx` package not found, please run `pip install httpx`"
+            )
+
+        params: dict = {"q": query}
+        if limit is not None:
+            params["limit"] = int(limit)
+        params.update(load_kwargs)
+
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                self._build_url(),
+                headers=self._headers(),
+                params=params,
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        if isinstance(payload, list):
+            tweets = payload
+        elif isinstance(payload, dict):
+            tweets = (
+                payload.get("data")
+                or payload.get("tweets")
+                or payload.get("results")
+                or []
+            )
+        else:
+            tweets = []
+
+        return [self._tweet_to_document(t) for t in tweets if isinstance(t, dict)]

--- a/llama-index-integrations/readers/llama-index-readers-twitter/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-twitter"
-version = "0.5.0"
+version = "0.6.0"
 description = "llama-index readers twitter integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -35,6 +35,7 @@ license = "MIT"
 maintainers = [{name = "ravi03071991"}]
 dependencies = [
     "tweepy>=4.14.0,<5",
+    "httpx>=0.27,<1",
     "llama-index-core>=0.13.0,<0.15",
 ]
 
@@ -57,6 +58,7 @@ import_path = "llama_index.readers.twitter"
 
 [tool.llamahub.class_authors]
 TwitterTweetReader = "ravi03071991"
+GetXAPISearchReader = "bozad"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/llama-index-integrations/readers/llama-index-readers-twitter/tests/test_readers_getxapi.py
+++ b/llama-index-integrations/readers/llama-index-readers-twitter/tests/test_readers_getxapi.py
@@ -1,0 +1,100 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.readers.twitter import GetXAPISearchReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in GetXAPISearchReader.__mro__]
+    assert BasePydanticReader.__name__ in names_of_base_classes
+
+
+def test_defaults():
+    reader = GetXAPISearchReader(bearer_token="token-abc")
+    assert reader.bearer_token == "token-abc"
+    assert reader.base_url == "https://api.getxapi.com"
+    assert reader.timeout == 30.0
+    assert reader._build_url() == "https://api.getxapi.com/twitter/tweet/advanced_search"
+    headers = reader._headers()
+    assert headers["Authorization"] == "Bearer token-abc"
+    assert headers["Accept"] == "application/json"
+
+
+def test_custom_base_url():
+    reader = GetXAPISearchReader(
+        bearer_token="t", base_url="https://staging.getxapi.com/"
+    )
+    assert reader._build_url() == "https://staging.getxapi.com/twitter/tweet/advanced_search"
+
+
+class _MockResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def test_load_data_parses_documents():
+    reader = GetXAPISearchReader(bearer_token="t")
+    payload = {
+        "data": [
+            {
+                "id": "12345",
+                "text": "hello world",
+                "author": {"username": "alice", "name": "Alice"},
+                "created_at": "2026-01-01T00:00:00Z",
+                "like_count": 7,
+                "retweet_count": 2,
+                "reply_count": 1,
+            },
+            {
+                "id": "67890",
+                "text": "second tweet",
+                "author": {"username": "bob", "name": "Bob"},
+            },
+        ]
+    }
+
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
+    mock_client.__exit__.return_value = False
+    mock_client.get.return_value = _MockResponse(payload)
+
+    with patch("httpx.Client", return_value=mock_client):
+        docs = reader.load_data(query="llamaindex", limit=25)
+
+    assert len(docs) == 2
+    assert docs[0].text == "hello world"
+    assert docs[0].metadata["author_username"] == "alice"
+    assert docs[0].metadata["url"] == "https://x.com/alice/status/12345"
+    assert docs[0].metadata["like_count"] == 7
+    assert docs[1].text == "second tweet"
+
+    mock_client.get.assert_called_once()
+    call = mock_client.get.call_args
+    assert call.args[0] == "https://api.getxapi.com/twitter/tweet/advanced_search"
+    assert call.kwargs["headers"]["Authorization"] == "Bearer t"
+    assert call.kwargs["params"] == {"q": "llamaindex", "limit": 25}
+
+
+def test_load_data_handles_list_payload():
+    reader = GetXAPISearchReader(bearer_token="t")
+    payload = [{"id": "1", "text": "x", "author": {"username": "u"}}]
+
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
+    mock_client.__exit__.return_value = False
+    mock_client.get.return_value = _MockResponse(payload)
+
+    with patch("httpx.Client", return_value=mock_client):
+        docs = reader.load_data(query="q")
+
+    assert len(docs) == 1
+    assert docs[0].text == "x"


### PR DESCRIPTION
## Description

Adds a sibling reader class `GetXAPISearchReader` inside the existing `llama-index-readers-twitter` package.

The current `TwitterTweetReader` wraps `tweepy` and reads tweets from a *user timeline*, which requires Twitter developer-portal access. Many LlamaIndex users have asked for a *search* path (advanced query, not just per-handle) that works without a Twitter dev key. `GetXAPISearchReader` provides that by calling the [GetXAPI](https://www.getxapi.com) HTTP API with a single bearer token, returning `Document` objects with rich metadata (`id`, `url`, `author_username`, `author_name`, `created_at`, `like_count`, `retweet_count`, `reply_count`).

Both readers live in the same package, share the namespace `llama_index.readers.twitter`, and remain fully independent — picking one does not affect the other.

## New Package?

- [x] No

This PR modifies the existing `llama-index-readers-twitter` package only. No new `pyproject.toml` is added.

## Version Bump?

- [x] Yes — `0.5.0` → `0.6.0` (additive feature, new `httpx` runtime dependency)
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`tests/test_readers_getxapi.py` covers:

- `BasePydanticReader` MRO membership (mirrors the existing `TwitterTweetReader` test)
- Default field values + URL/header construction
- Custom `base_url` override (including trailing-slash normalization)
- `load_data()` end-to-end with `httpx.Client` mocked: verifies the request URL, bearer header, params (`q` + `limit`), and that response payloads in both `{"data": [...]}` and raw-list shapes parse into `Document` objects with the expected `text` and `metadata`.

All existing `TwitterTweetReader` tests remain untouched and continue to pass.

## Validation

- `python -m py_compile` on all touched `.py` files — passes
- `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — passes (version 0.6.0, deps include `httpx>=0.27,<1`, `class_authors` has new entry)
- Module logic smoke-tested (URL construction, header construction, `_tweet_to_document` mapping, full `load_data` with mocked `httpx.Client`) — passes
- No new warnings introduced
- Pre-commit / lint conventions of the package preserved (single 1-line module docstring, no comment noise, type hints throughout, follows `BasePydanticReader` constructor pattern of the existing `TwitterTweetReader`)

## Backward compatibility

Additive only. `TwitterTweetReader` and its public API are unchanged. Existing imports continue to work. The new `httpx` dependency is broadly compatible (`>=0.27,<1`).

## Duplicate check

I checked the repository for existing GetXAPI / Twitter-search readers and tools: searched `llama-index-integrations/readers/` and `llama-index-integrations/tools/`, scanned open and closed PRs, and scanned open and closed issues. No existing GetXAPI submission found. The only existing Twitter integration is `llama-index-readers-twitter` (`TwitterTweetReader`), which targets a different surface (user-timeline read via tweepy).

## Links

- GetXAPI: https://www.getxapi.com
- Endpoint: `GET https://api.getxapi.com/twitter/tweet/advanced_search`
- Auth: bearer token (single env var)
- Repo: https://github.com/getxapi/getxapi-mcp
- Wikidata: https://www.wikidata.org/wiki/Q139996278

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes