### PR TITLE
Avoid logging chat-engine conversation content

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -180,7 +180,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             return latest_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         llm_input = self._condense_prompt_template.format(
             chat_history=chat_history_str, question=latest_message
@@ -196,7 +196,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             return latest_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         llm_input = self._condense_prompt_template.format(
             chat_history=chat_history_str, question=latest_message
@@ -266,7 +266,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         # Condense conversation history and latest message to a standalone question
         condensed_question = self._condense_question(chat_history, message)  # type: ignore
-        logger.info(f"Condensed question: {condensed_question}")
+        logger.info("Generated condensed question")
         if self._verbose:
             print(f"Condensed question: {condensed_question}")
 
@@ -299,7 +299,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         # Condense conversation history and latest message to a standalone question
         condensed_question = await self._acondense_question(chat_history, message)  # type: ignore
-        logger.info(f"Condensed question: {condensed_question}")
+        logger.info("Generated condensed question")
         if self._verbose:
             print(f"Condensed question: {condensed_question}")
 

--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -125,7 +125,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             return last_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         return self._llm.predict(
             self._condense_question_prompt,
@@ -144,7 +144,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
             return last_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         return await self._llm.apredict(
             self._condense_question_prompt,
@@ -179,7 +179,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
 
-        log_str = f"Querying with: {condensed_question}"
+        log_str = "Querying with condensed question"
         logger.info(log_str)
         if self._verbose:
             print(log_str)
@@ -224,7 +224,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
 
-        log_str = f"Querying with: {condensed_question}"
+        log_str = "Querying with condensed question"
         logger.info(log_str)
         if self._verbose:
             print(log_str)
@@ -282,7 +282,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)
 
-        log_str = f"Querying with: {condensed_question}"
+        log_str = "Querying with condensed question"
         logger.info(log_str)
         if self._verbose:
             print(log_str)
@@ -327,7 +327,7 @@ class CondenseQuestionChatEngine(BaseChatEngine):
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)
 
-        log_str = f"Querying with: {condensed_question}"
+        log_str = "Querying with condensed question"
         logger.info(log_str)
         if self._verbose:
             print(log_str)

--- a/llama-index-core/llama_index/core/chat_engine/multi_modal_condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/multi_modal_condense_plus_context.py
@@ -138,7 +138,7 @@ class MultiModalCondensePlusContextChatEngine(BaseChatEngine):
             return latest_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         llm_input = self._condense_prompt_template.format(
             chat_history=chat_history_str, question=latest_message
@@ -154,7 +154,7 @@ class MultiModalCondensePlusContextChatEngine(BaseChatEngine):
             return latest_message
 
         chat_history_str = messages_to_history_str(chat_history)
-        logger.debug(chat_history_str)
+        logger.debug("Condensing chat history for standalone question")
 
         llm_input = self._condense_prompt_template.format(
             chat_history=chat_history_str, question=latest_message
@@ -194,7 +194,7 @@ class MultiModalCondensePlusContextChatEngine(BaseChatEngine):
 
         # Condense conversation history and latest message to a standalone question
         condensed_question = self._condense_question(chat_history, message)  # type: ignore
-        logger.info(f"Condensed question: {condensed_question}")
+        logger.info("Generated condensed question")
         if self._verbose:
             print(f"Condensed question: {condensed_question}")
 
@@ -221,7 +221,7 @@ class MultiModalCondensePlusContextChatEngine(BaseChatEngine):
 
         # Condense conversation history and latest message to a standalone question
         condensed_question = await self._acondense_question(chat_history, message)  # type: ignore
-        logger.info(f"Condensed question: {condensed_question}")
+        logger.info("Generated condensed question")
         if self._verbose:
             print(f"Condensed question: {condensed_question}")
 

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import pytest
@@ -37,6 +38,24 @@ def test_chat(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_logs_omit_chat_content(
+    chat_engine: CondensePlusContextChatEngine, caplog
+):
+    chat_engine.chat("remember secret-token-123")
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG):
+        chat_engine.chat("use secret-token-456")
+
+    chat_engine_logs = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "llama_index.core.chat_engine.condense_plus_context"
+    )
+    assert "secret-token-123" not in chat_engine_logs
+    assert "secret-token-456" not in chat_engine_logs
 
 
 def test_chat_stream(chat_engine: CondensePlusContextChatEngine):

--- a/llama-index-core/tests/chat_engine/test_condense_question.py
+++ b/llama-index-core/tests/chat_engine/test_condense_question.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 from llama_index.core.base.base_query_engine import BaseQueryEngine
@@ -48,6 +49,26 @@ def test_condense_question_chat_engine_with_init_history(patch_llm_predictor) ->
         "{'question': 'new human message', 'chat_history': 'user: test human "
         "message\\nassistant: test ai message'}"
     )
+
+
+def test_condense_question_logs_omit_chat_content(caplog, patch_llm_predictor) -> None:
+    query_engine = Mock(spec=BaseQueryEngine)
+    query_engine.query.side_effect = lambda x: Response(response=x)
+    engine = CondenseQuestionChatEngine.from_defaults(query_engine=query_engine)
+
+    engine.chat("remember secret-token-123")
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG):
+        engine.chat("use secret-token-456")
+
+    chat_engine_logs = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "llama_index.core.chat_engine.condense_question"
+    )
+    assert "secret-token-123" not in chat_engine_logs
+    assert "secret-token-456" not in chat_engine_logs
 
 
 def test_stream_chat_history_write_completes_on_early_exit() -> None:

--- a/llama-index-core/tests/chat_engine/test_mm_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_mm_condense_plus_context.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import pytest
@@ -70,6 +71,27 @@ def test_chat(chat_engine: MultiModalCondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_logs_omit_chat_content(
+    chat_engine: MultiModalCondensePlusContextChatEngine, caplog
+):
+    chat_engine.chat("remember secret-token-123")
+    caplog.clear()
+
+    with caplog.at_level(logging.DEBUG):
+        chat_engine.chat("use secret-token-456")
+
+    chat_engine_logs = "\n".join(
+        record.getMessage()
+        for record in caplog.records
+        if (
+            record.name
+            == "llama_index.core.chat_engine.multi_modal_condense_plus_context"
+        )
+    )
+    assert "secret-token-123" not in chat_engine_logs
+    assert "secret-token-456" not in chat_engine_logs
 
 
 def test_chat_stream(chat_engine: MultiModalCondensePlusContextChatEngine):


### PR DESCRIPTION
## Summary

This avoids writing full chat history or condensed user questions to the chat-engine loggers. The affected condense chat engines still log that condensation/querying happened, but the log messages no longer include conversation text.

## Why

Chat history and condensed questions can contain private user input. Emitting that content through DEBUG/INFO logs makes it easier for sensitive conversation data to end up in application logs when these loggers are enabled.

## Tests

- `uv run --project llama-index-core python -m pytest tests\chat_engine\test_condense_question.py tests\chat_engine\test_condense_plus_context.py tests\chat_engine\test_mm_condense_plus_context.py`
- `uv run --project llama-index-core ruff check llama_index\core\chat_engine\condense_question.py llama_index\core\chat_engine\condense_plus_context.py llama_index\core\chat_engine\multi_modal_condense_plus_context.py tests\chat_engine\test_condense_question.py tests\chat_engine\test_condense_plus_context.py tests\chat_engine\test_mm_condense_plus_context.py`