### PR TITLE
fix(llms-openai): exclude sampling params from OpenAIResponses when reasoning active

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -104,6 +104,17 @@ if TYPE_CHECKING:
 
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
 
+# Reasoning models (o-series, and any model with reasoning_options set) reject
+# sampling parameters with a 400 Bad Request. These are stripped from the
+# request payload when reasoning is active.
+# See: https://github.com/run-llama/llama_index/issues/20459
+_REASONING_UNSUPPORTED_SAMPLING_PARAMS = (
+    "top_p",
+    "temperature",
+    "presence_penalty",
+    "frequency_penalty",
+)
+
 
 def llm_retry_decorator(f: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(f)
@@ -424,21 +435,18 @@ class OpenAIResponses(FunctionCallingLLM):
         if self.model in O1_MODELS and self.reasoning_options is not None:
             model_kwargs["reasoning"] = self.reasoning_options
 
-        if self.reasoning_options is not None or self.model in O1_MODELS:
-            params_to_exclude_for_reasoning = {
-                "top_p",
-                "temperature",
-                "presence_penalty",
-                "frequency_penalty",
-            }
-            for param in params_to_exclude_for_reasoning:
-                model_kwargs.pop(param, None)
-
         # priority is class args > additional_kwargs > runtime args
         model_kwargs.update(self.additional_kwargs)
 
         kwargs = kwargs or {}
         model_kwargs.update(kwargs)
+
+        # Strip sampling params AFTER merging additional_kwargs and runtime kwargs
+        # so they cannot be re-introduced through those paths and re-trigger the
+        # 400 from reasoning models. See issue #20459.
+        if self.reasoning_options is not None or self.model in O1_MODELS:
+            for param in _REASONING_UNSUPPORTED_SAMPLING_PARAMS:
+                model_kwargs.pop(param, None)
 
         return model_kwargs
 

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.9"
+version = "0.7.10"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -114,6 +114,82 @@ def test_get_model_kwargs_excludes_params_with_reasoning(default_responses_llm):
         assert "reasoning" not in kwargs
 
 
+_REASONING_SAMPLING_PARAMS = (
+    "top_p",
+    "temperature",
+    "presence_penalty",
+    "frequency_penalty",
+)
+
+
+def test_reasoning_options_strips_sampling_params_from_class_args(
+    default_responses_llm,
+):
+    """Sampling params set as class args are absent when reasoning_options is set."""
+    llm = default_responses_llm
+    llm.reasoning_options = {"effort": "low"}
+    llm.temperature = 0.7
+    llm.top_p = 0.5
+
+    kwargs = llm._get_model_kwargs()
+
+    for param in _REASONING_SAMPLING_PARAMS:
+        assert param not in kwargs, f"{param} must be absent when reasoning is set"
+
+
+def test_reasoning_options_strips_sampling_params_from_additional_kwargs(
+    default_responses_llm,
+):
+    """additional_kwargs must not re-introduce sampling params (after-merge strip).
+
+    Regression test for #20459: the strip must run after additional_kwargs are
+    merged, otherwise a user-supplied top_p/penalty re-triggers the 400.
+    """
+    llm = default_responses_llm
+    llm.reasoning_options = {"effort": "low"}
+    llm.additional_kwargs = {
+        "top_p": 0.5,
+        "presence_penalty": 0.2,
+        "frequency_penalty": 0.3,
+    }
+
+    kwargs = llm._get_model_kwargs()
+
+    for param in _REASONING_SAMPLING_PARAMS:
+        assert param not in kwargs, f"{param} re-introduced via additional_kwargs"
+
+
+def test_reasoning_options_strips_sampling_params_from_runtime_kwargs(
+    default_responses_llm,
+):
+    """Runtime kwargs must not re-introduce sampling params (after-merge strip)."""
+    llm = default_responses_llm
+    llm.reasoning_options = {"effort": "low"}
+
+    kwargs = llm._get_model_kwargs(
+        top_p=0.9, temperature=0.1, presence_penalty=0.4, frequency_penalty=0.5
+    )
+
+    for param in _REASONING_SAMPLING_PARAMS:
+        assert param not in kwargs, f"{param} re-introduced via runtime kwargs"
+
+
+def test_no_reasoning_options_preserves_sampling_params(default_responses_llm):
+    """No behavior change when reasoning is inactive (gpt-4o-mini, no options)."""
+    llm = default_responses_llm
+    assert llm.reasoning_options is None
+    assert llm.model not in O1_MODELS
+
+    llm.temperature = 0.7
+    llm.top_p = 0.5
+
+    kwargs = llm._get_model_kwargs(presence_penalty=0.2)
+
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.5
+    assert kwargs["presence_penalty"] == 0.2
+
+
 def test_get_model_kwargs_with_tools_none(default_responses_llm):
     """Test model kwargs generation when tools is explicitly None.
 


### PR DESCRIPTION
@
## what wrong
Reasoning model no like sampling param. `top_p` `temperature` `presence_penalty` `frequency_penalty` make API throw 400.

`OpenAIResponses._get_model_kwargs` pop those param, but pop happen BEFORE merge `additional_kwargs` and runtime `kwargs`. So user pass `top_p` that way -> param come back -> 400 again. Fix no work for those path.

## what fix
Move pop to AFTER both merge. Now param cannot sneak back in. Put param set in module-level constant.

No change when reasoning off (`reasoning_options is None` and model not reasoning) -> payload same as before.

## how test
- New unit test on `_get_model_kwargs`: param gone when set via class arg, `additional_kwargs`, AND runtime kwargs.
- Negative test: param kept when reasoning off.
- Sync + async share `_get_model_kwargs`, both covered.
- Full package suite green, ruff clean. No live API call.

Closes #20459
@