### PR TITLE
feat(llms-minimax): upgrade default model to MiniMax-M3

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-minimax/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/README.md
@@ -21,11 +21,11 @@ print(response)
 
 ### Available Models
 
-| Model                    | Context Window | Description                                              |
-| ------------------------ | -------------- | -------------------------------------------------------- |
-| `MiniMax-M3`             | 524,288        | Latest flagship model, default                           |
+| Model                    | Context Window | Description                                                |
+| ------------------------ | -------------- | ---------------------------------------------------------- |
+| `MiniMax-M3`             | 524,288        | Latest flagship model, default                             |
 | `MiniMax-M2.7`           | 204,800        | Previous-generation model, kept for backward compatibility |
-| `MiniMax-M2.7-highspeed` | 204,800        | High-speed variant of M2.7 for low-latency scenarios     |
+| `MiniMax-M2.7-highspeed` | 204,800        | High-speed variant of M2.7 for low-latency scenarios       |
 
 ### Environment Variables
 

--- a/llama-index-integrations/llms/llama-index-llms-minimax/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/README.md
@@ -13,7 +13,7 @@ pip install llama-index-llms-minimax
 ```python
 from llama_index.llms.minimax import MiniMax
 
-llm = MiniMax(model="MiniMax-M2.7", api_key="your-api-key")
+llm = MiniMax(model="MiniMax-M3", api_key="your-api-key")
 
 response = llm.complete("Explain the importance of low latency LLMs")
 print(response)
@@ -21,14 +21,11 @@ print(response)
 
 ### Available Models
 
-| Model                    | Description                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `MiniMax-M2.7`           | Latest flagship model with enhanced reasoning and coding |
-| `MiniMax-M2.7-highspeed` | High-speed version of M2.7 for low-latency scenarios     |
-| `MiniMax-M2.5`           | Peak Performance. Ultimate Value. Master the Complex.    |
-| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile.                 |
-
-Both models support a 204,800-token context window.
+| Model                    | Context Window | Description                                              |
+| ------------------------ | -------------- | -------------------------------------------------------- |
+| `MiniMax-M3`             | 524,288        | Latest flagship model, default                           |
+| `MiniMax-M2.7`           | 204,800        | Previous-generation model, kept for backward compatibility |
+| `MiniMax-M2.7-highspeed` | 204,800        | High-speed variant of M2.7 for low-latency scenarios     |
 
 ### Environment Variables
 
@@ -41,7 +38,7 @@ export MINIMAX_API_KEY="your-api-key"
 ```python
 from llama_index.llms.minimax import MiniMax
 
-llm = MiniMax(model="MiniMax-M2.7")
+llm = MiniMax(model="MiniMax-M3")
 ```
 
 ### Custom Base URL
@@ -50,7 +47,7 @@ For users in mainland China, use the domestic API endpoint:
 
 ```python
 llm = MiniMax(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     api_base="https://api.minimaxi.com/v1",
 )
 ```

--- a/llama-index-integrations/llms/llama-index-llms-minimax/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/README.md
@@ -47,10 +47,10 @@ llm = MiniMax(model="MiniMax-M3")
 
 The `MiniMax` class uses the OpenAI-compatible API. MiniMax publishes matching OpenAI-compatible and Anthropic-compatible endpoints in both regions:
 
-| Region         | OpenAI-compatible base URL    | Anthropic-compatible base URL           | Documentation                        |
-| -------------- | ----------------------------- | --------------------------------------- | ------------------------------------ |
-| Global         | `https://api.minimax.io/v1`   | `https://api.minimax.io/anthropic/v1`   | `https://platform.minimax.io/docs`   |
-| Mainland China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic/v1` | `https://platform.minimaxi.com/docs` |
+| Region         | OpenAI-compatible base URL    | Anthropic-compatible base URL        | Documentation                        |
+| -------------- | ----------------------------- | ------------------------------------ | ------------------------------------ |
+| Global         | `https://api.minimax.io/v1`   | `https://api.minimax.io/anthropic`   | `https://platform.minimax.io/docs`   |
+| Mainland China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | `https://platform.minimaxi.com/docs` |
 
 The global OpenAI-compatible URL is the default. To use the mainland China OpenAI-compatible endpoint, pass it as `api_base`:
 

--- a/llama-index-integrations/llms/llama-index-llms-minimax/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/README.md
@@ -23,9 +23,11 @@ print(response)
 
 | Model                    | Context Window | Description                                                |
 | ------------------------ | -------------- | ---------------------------------------------------------- |
-| `MiniMax-M3`             | 524,288        | Latest flagship model, default                             |
+| `MiniMax-M3`             | 1,000,000      | Latest flagship model, default                             |
 | `MiniMax-M2.7`           | 204,800        | Previous-generation model, kept for backward compatibility |
 | `MiniMax-M2.7-highspeed` | 204,800        | High-speed variant of M2.7 for low-latency scenarios       |
+| `MiniMax-M2.5`           | 204,800        | Existing model retained for backward compatibility         |
+| `MiniMax-M2.5-highspeed` | 204,800        | High-speed variant retained for backward compatibility     |
 
 ### Environment Variables
 
@@ -41,9 +43,16 @@ from llama_index.llms.minimax import MiniMax
 llm = MiniMax(model="MiniMax-M3")
 ```
 
-### Custom Base URL
+### Regional Base URLs
 
-For users in mainland China, use the domestic API endpoint:
+The `MiniMax` class uses the OpenAI-compatible API. MiniMax publishes matching OpenAI-compatible and Anthropic-compatible endpoints in both regions:
+
+| Region         | OpenAI-compatible base URL    | Anthropic-compatible base URL           | Documentation                        |
+| -------------- | ----------------------------- | --------------------------------------- | ------------------------------------ |
+| Global         | `https://api.minimax.io/v1`   | `https://api.minimax.io/anthropic/v1`   | `https://platform.minimax.io/docs`   |
+| Mainland China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic/v1` | `https://platform.minimaxi.com/docs` |
+
+The global OpenAI-compatible URL is the default. To use the mainland China OpenAI-compatible endpoint, pass it as `api_base`:
 
 ```python
 llm = MiniMax(

--- a/llama-index-integrations/llms/llama-index-llms-minimax/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/README.md
@@ -29,6 +29,19 @@ print(response)
 | `MiniMax-M2.5`           | 204,800        | Existing model retained for backward compatibility         |
 | `MiniMax-M2.5-highspeed` | 204,800        | High-speed variant retained for backward compatibility     |
 
+### Thinking Control
+
+`MiniMax-M3` supports `adaptive` and `disabled` thinking modes. Pass the provider-specific request field through the OpenAI SDK's `extra_body` parameter:
+
+```python
+llm = MiniMax(
+    model="MiniMax-M3",
+    additional_kwargs={
+        "extra_body": {"thinking": {"type": "adaptive"}},
+    },
+)
+```
+
 ### Environment Variables
 
 You can set the `MINIMAX_API_KEY` environment variable instead of passing `api_key` directly:
@@ -59,4 +72,21 @@ llm = MiniMax(
     model="MiniMax-M3",
     api_base="https://api.minimaxi.com/v1",
 )
+```
+
+For Anthropic-compatible calls, use the Anthropic SDK with the base URL for the desired region. Pass the base URL ending in `/anthropic`; the SDK appends `/v1/messages`:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    api_key="your-api-key",
+    base_url="https://api.minimax.io/anthropic",
+)
+message = client.messages.create(
+    model="MiniMax-M3",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(message.content[0].text)
 ```

--- a/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/base.py
@@ -5,14 +5,14 @@ from llama_index.llms.openai_like import OpenAILike
 from llama_index.llms.minimax.utils import get_context_window, FUNCTION_CALLING_MODELS
 
 DEFAULT_API_BASE = "https://api.minimax.io/v1"
-DEFAULT_MODEL = "MiniMax-M2.7"
+DEFAULT_MODEL = "MiniMax-M3"
 
 
 class MiniMax(OpenAILike):
     """
     MiniMax LLM.
 
-    MiniMax offers powerful language models with up to 204,800 tokens context window
+    MiniMax offers powerful language models with up to 524,288 tokens context window
     through an OpenAI-compatible API.
 
     Examples:
@@ -22,7 +22,7 @@ class MiniMax(OpenAILike):
         from llama_index.llms.minimax import MiniMax
 
         # Set up the MiniMax class with the required model and API key
-        llm = MiniMax(model="MiniMax-M2.7", api_key="your_api_key")
+        llm = MiniMax(model="MiniMax-M3", api_key="your_api_key")
 
         # Call the complete method with a query
         response = llm.complete("Explain the importance of low latency LLMs")

--- a/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/base.py
@@ -12,7 +12,7 @@ class MiniMax(OpenAILike):
     """
     MiniMax LLM.
 
-    MiniMax offers powerful language models with up to 524,288 tokens context window
+    MiniMax offers powerful language models with up to 1,000,000 tokens context window
     through an OpenAI-compatible API.
 
     Examples:

--- a/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/utils.py
@@ -1,13 +1,17 @@
 MINIMAX_MODEL_TO_CONTEXT_WINDOW = {
-    "MiniMax-M3": 524288,
+    "MiniMax-M3": 1000000,
     "MiniMax-M2.7": 204800,
     "MiniMax-M2.7-highspeed": 204800,
+    "MiniMax-M2.5": 204800,
+    "MiniMax-M2.5-highspeed": 204800,
 }
 
 FUNCTION_CALLING_MODELS = {
     "MiniMax-M3",
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
+    "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
 }
 
 

--- a/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/llama_index/llms/minimax/utils.py
@@ -1,15 +1,13 @@
 MINIMAX_MODEL_TO_CONTEXT_WINDOW = {
+    "MiniMax-M3": 524288,
     "MiniMax-M2.7": 204800,
     "MiniMax-M2.7-highspeed": 204800,
-    "MiniMax-M2.5": 204800,
-    "MiniMax-M2.5-highspeed": 204800,
 }
 
 FUNCTION_CALLING_MODELS = {
+    "MiniMax-M3",
     "MiniMax-M2.7",
     "MiniMax-M2.7-highspeed",
-    "MiniMax-M2.5",
-    "MiniMax-M2.5-highspeed",
 }
 
 

--- a/llama-index-integrations/llms/llama-index-llms-minimax/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-minimax"
-version = "0.1.0"
+version = "0.2.0"
 description = "llama-index llms minimax integration"
 authors = [{name = "MiniMax"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-minimax/tests/test_llms_minimax.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/tests/test_llms_minimax.py
@@ -12,38 +12,49 @@ def test_llm_class():
     assert BaseLLM.__name__ in names_of_base_classes
 
 
-def test_default_model_is_m27():
-    """Default model should be MiniMax-M2.7."""
+def test_default_model_is_m3():
+    """Default model should be MiniMax-M3."""
     llm = MiniMax(api_key="test-key")
-    assert llm.model == "MiniMax-M2.7"
+    assert llm.model == "MiniMax-M3"
 
 
-def test_model_list_contains_m27():
-    """Both M2.7 models should be in the context window map."""
+def test_model_list_contains_m3():
+    """M3 should be in the context window map."""
+    assert "MiniMax-M3" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
+
+
+def test_m3_in_function_calling_models():
+    """M3 should support function calling."""
+    assert "MiniMax-M3" in FUNCTION_CALLING_MODELS
+
+
+def test_m3_appears_before_m27():
+    """M3 should appear before M2.7 in the model list."""
+    keys = list(MINIMAX_MODEL_TO_CONTEXT_WINDOW.keys())
+    m3_idx = keys.index("MiniMax-M3")
+    m27_idx = keys.index("MiniMax-M2.7")
+    assert m3_idx < m27_idx
+
+
+def test_m27_legacy_still_available():
+    """M2.7 models should remain available for backward compatibility."""
     assert "MiniMax-M2.7" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
     assert "MiniMax-M2.7-highspeed" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
-
-
-def test_m27_in_function_calling_models():
-    """Both M2.7 models should support function calling."""
     assert "MiniMax-M2.7" in FUNCTION_CALLING_MODELS
     assert "MiniMax-M2.7-highspeed" in FUNCTION_CALLING_MODELS
 
 
-def test_m27_appears_before_m25():
-    """M2.7 models should appear before M2.5 in the model list."""
-    keys = list(MINIMAX_MODEL_TO_CONTEXT_WINDOW.keys())
-    m27_idx = keys.index("MiniMax-M2.7")
-    m25_idx = keys.index("MiniMax-M2.5")
-    assert m27_idx < m25_idx
+def test_older_models_removed():
+    """Older M2.5 models should no longer be present."""
+    assert "MiniMax-M2.5" not in MINIMAX_MODEL_TO_CONTEXT_WINDOW
+    assert "MiniMax-M2.5-highspeed" not in MINIMAX_MODEL_TO_CONTEXT_WINDOW
+    assert "MiniMax-M2.5" not in FUNCTION_CALLING_MODELS
+    assert "MiniMax-M2.5-highspeed" not in FUNCTION_CALLING_MODELS
 
 
-def test_legacy_models_still_available():
-    """Old M2.5 models should still be present."""
-    assert "MiniMax-M2.5" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
-    assert "MiniMax-M2.5-highspeed" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
-    assert "MiniMax-M2.5" in FUNCTION_CALLING_MODELS
-    assert "MiniMax-M2.5-highspeed" in FUNCTION_CALLING_MODELS
+def test_context_window_for_m3():
+    """M3 should return the 524,288 context window."""
+    assert get_context_window("MiniMax-M3") == 524288
 
 
 def test_context_window_for_m27():

--- a/llama-index-integrations/llms/llama-index-llms-minimax/tests/test_llms_minimax.py
+++ b/llama-index-integrations/llms/llama-index-llms-minimax/tests/test_llms_minimax.py
@@ -44,17 +44,17 @@ def test_m27_legacy_still_available():
     assert "MiniMax-M2.7-highspeed" in FUNCTION_CALLING_MODELS
 
 
-def test_older_models_removed():
-    """Older M2.5 models should no longer be present."""
-    assert "MiniMax-M2.5" not in MINIMAX_MODEL_TO_CONTEXT_WINDOW
-    assert "MiniMax-M2.5-highspeed" not in MINIMAX_MODEL_TO_CONTEXT_WINDOW
-    assert "MiniMax-M2.5" not in FUNCTION_CALLING_MODELS
-    assert "MiniMax-M2.5-highspeed" not in FUNCTION_CALLING_MODELS
+def test_legacy_models_still_available():
+    """Existing models should remain available for backward compatibility."""
+    assert "MiniMax-M2.5" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
+    assert "MiniMax-M2.5-highspeed" in MINIMAX_MODEL_TO_CONTEXT_WINDOW
+    assert "MiniMax-M2.5" in FUNCTION_CALLING_MODELS
+    assert "MiniMax-M2.5-highspeed" in FUNCTION_CALLING_MODELS
 
 
 def test_context_window_for_m3():
-    """M3 should return the 524,288 context window."""
-    assert get_context_window("MiniMax-M3") == 524288
+    """M3 should return the 1,000,000-token context window."""
+    assert get_context_window("MiniMax-M3") == 1000000
 
 
 def test_context_window_for_m27():


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary

- Register `MiniMax-M3` as the default model with a 1,000,000-token context window.
- Keep the existing model catalog available and update the usage examples.
- Document both global and mainland China regional endpoint sets.
- Explain MiniMax-M3 thinking configuration and Anthropic-compatible SDK setup.
- Bump the integration package version to `0.2.0`.

## Testing

- `.venv/bin/pytest -q` - 9 passed
- `.venv/bin/python -m compileall -q llama_index tests`
- Changed-file pre-commit hooks - passed
- Loopback request capture for `/v1/chat/completions` and `/anthropic/v1/messages` - passed
