### PR TITLE
Document Foundry Local for OpenAILike

### DIFF
--- a/docs/examples/llm/foundry_local.ipynb
+++ b/docs/examples/llm/foundry_local.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/llm/foundry_local.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Foundry Local"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Foundry Local](https://github.com/microsoft/Foundry-Local) from Microsoft exposes an OpenAI-compatible API for running local models. LlamaIndex can use it directly through the `OpenAILike` integration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "1. Install `llama-index-llms-openai-like` and the Foundry Local SDK (`foundry-local-sdk-winml` on Windows, `foundry-local-sdk` on macOS/Linux).\n",
+    "2. Use the Foundry Local SDK to download/load a model and start the optional local OpenAI-compatible web service.\n",
+    "3. `OpenAILike` needs an HTTP endpoint, so point it at `f\"{manager.urls[0]}/v1\"` and use `model.id` so requests target the exact loaded variant.\n",
+    "4. Foundry Local itself is SDK-first and does not require the web service outside OpenAI-compatible integrations.\n",
+    "5. Increase `timeout` if your hardware takes longer to generate the first response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Windows, replace foundry-local-sdk with foundry-local-sdk-winml\n",
+    "%pip install llama-index-llms-openai-like foundry-local-sdk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from foundry_local_sdk import Configuration, FoundryLocalManager\n",
+    "from llama_index.llms.openai_like import OpenAILike"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FoundryLocalManager.initialize(Configuration(app_name=\"llamaindex-foundry-local\"))\n",
+    "manager = FoundryLocalManager.instance\n",
+    "\n",
+    "model = manager.catalog.get_model(\"qwen2.5-0.5b\")\n",
+    "model.download()\n",
+    "model.load()\n",
+    "manager.start_web_service()\n",
+    "\n",
+    "llm = OpenAILike(\n",
+    "    model=model.id,\n",
+    "    api_base=f\"{manager.urls[0].rstrip('/')}/v1\",\n",
+    "    api_key=\"fake\",\n",
+    "    context_window=32768,\n",
+    "    is_chat_model=True,\n",
+    "    is_function_calling_model=False,\n",
+    "    timeout=120.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = llm.complete(\"Reply with: Foundry Local is working.\")\n",
+    "print(str(response))"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
@@ -2,7 +2,9 @@
 
 `pip install llama-index-llms-openai-like`
 
-This package is a thin wrapper around the OpenAI API. It is designed to be used with the OpenAI API, but can be used with any OpenAI-compatible API.
+This package is a thin wrapper around the OpenAI API. It is designed to be used
+with the OpenAI API, but can be used with any OpenAI-compatible API, including
+Foundry Local.
 
 ## Usage
 
@@ -21,3 +23,44 @@ llm = OpenAILike(
     is_function_calling_model=False,
 )
 ```
+
+## Foundry Local
+
+Install `llama-index-llms-openai-like` and the Foundry Local SDK for your platform:
+
+```bash
+# Windows
+pip install llama-index-llms-openai-like foundry-local-sdk-winml
+
+# macOS/Linux
+pip install llama-index-llms-openai-like foundry-local-sdk
+```
+
+```python
+from foundry_local_sdk import Configuration, FoundryLocalManager
+from llama_index.llms.openai_like import OpenAILike
+
+FoundryLocalManager.initialize(Configuration(app_name="llamaindex-foundry-local"))
+manager = FoundryLocalManager.instance
+
+model = manager.catalog.get_model("qwen2.5-0.5b")
+model.download()
+model.load()
+manager.start_web_service()
+
+llm = OpenAILike(
+    model=model.id,
+    api_base=f"{manager.urls[0].rstrip('/')}/v1",
+    api_key="fake",
+    context_window=32768,
+    is_chat_model=True,
+    is_function_calling_model=False,
+    timeout=120.0,
+)
+```
+
+Foundry Local itself is SDK-first and does not need to run as a web server unless
+you are connecting it to an OpenAI-compatible HTTP client like `OpenAILike`. This
+example uses the optional local `/v1` endpoint only for that compatibility layer.
+Foundry Local 1.2 also exposes the OpenAI Responses API from the same `/v1`
+endpoint, but `OpenAILike` continues to use the chat-completions surface.


### PR DESCRIPTION
## Summary
- refresh the `OpenAILike` README example for Foundry Local
- update the notebook to use `FoundryLocalManager`, `model.id`, and `manager.urls[0]/v1`
- make it explicit that the local endpoint is optional in general and only used here because `OpenAILike` expects an OpenAI-compatible HTTP endpoint