### PR TITLE
fix(core): replace deprecated get_doc_id() calls with id_ property in tests

### DIFF
--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-gel/tests/test_gel.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-gel/tests/test_gel.py
@@ -76,12 +76,12 @@ def test_gel_docstore(
     assert len(ds.docs) == 2
 
     # test getting documents
-    doc0 = ds.get_document(documents[0].get_doc_id())
+    doc0 = ds.get_document(documents[0].id_)
     assert doc0 is not None
     assert documents[0].get_content() == doc0.get_content()
 
     # test deleting documents
-    ds.delete_document(documents[0].get_doc_id())
+    ds.delete_document(documents[0].id_)
     assert len(ds.docs) == 1
 
 

--- a/llama-index-integrations/storage/docstore/llama-index-storage-docstore-tablestore/tests/test_storage_docstore_tablestore.py
+++ b/llama-index-integrations/storage/docstore/llama-index-storage-docstore-tablestore/tests/test_storage_docstore_tablestore.py
@@ -70,12 +70,12 @@ def test_tablestore_doc_store(
     assert len(ds.docs) == 2
 
     # test getting documents
-    doc0 = ds.get_document(documents[0].get_doc_id())
+    doc0 = ds.get_document(documents[0].id_)
     assert doc0 is not None
     assert documents[0].get_content() == doc0.get_content()
 
     # test deleting documents
-    ds.delete_document(documents[0].get_doc_id())
+    ds.delete_document(documents[0].id_)
     assert len(ds.docs) == 1
 
 


### PR DESCRIPTION
This PR fixes deprecation warnings caused by internal test code calling the deprecated `get_doc_id()` method instead of accessing the `id_` property directly.

The deprecation warning appears when users call `VectorStoreIndex.from_documents()` because test files in the docstore integrations were still using the old API. The deprecated method was marked for removal in version 0.12.2, but test code in two integration packages (gel and tablestore) continued using it.

Changed `documents[0].get_doc_id()` to `documents[0].id_` in:
- `llama-index-integrations/storage/docstore/llama-index-storage-docstore-gel/tests/test_gel.py`
- `llama-index-integrations/storage/docstore/llama-index-storage-docstore-tablestore/tests/test_storage_docstore_tablestore.py`

This eliminates the deprecation warnings and aligns the test code with the recommended API.

Fixes #18852
