### PR TITLE
[codex] Add codebase learning assistant example

### DIFF
--- a/docs/examples/usecases/codebase_learning_assistant.ipynb
+++ b/docs/examples/usecases/codebase_learning_assistant.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9f0c4a4b",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/usecases/codebase_learning_assistant.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d90a2f2",
+   "metadata": {},
+   "source": [
+    "# Codebase Learning Assistant\n",
+    "\n",
+    "This notebook shows how to build a small codebase learning assistant with LlamaIndex. The goal is not only to answer questions over code chunks, but also to help a new contributor form a staged learning path through an unfamiliar repository.\n",
+    "\n",
+    "The pattern is useful when you want to:\n",
+    "\n",
+    "- ingest source files from a repository or local project,\n",
+    "- preserve metadata such as file path, extension, and module,\n",
+    "- retrieve relevant implementation details, and\n",
+    "- synthesize a contributor-friendly learning roadmap."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa7f24d3",
+   "metadata": {},
+   "source": [
+    "If you are opening this notebook in Colab, install LlamaIndex first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c11b5831",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad21e762",
+   "metadata": {},
+   "source": [
+    "## Create a tiny sample repository\n",
+    "\n",
+    "To keep the notebook self-contained, we create a toy repository. In a real workflow, replace `sample_repo` with a cloned GitHub repository or a local project directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "341b0c42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "repo_dir = Path(\"sample_repo\").resolve()\n",
+    "(repo_dir / \"app\").mkdir(parents=True, exist_ok=True)\n",
+    "(repo_dir / \"tests\").mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "(repo_dir / \"README.md\").write_text(\n",
+    "    \"\"\"# TaskFlow\\n\\nTaskFlow is a small FastAPI service that accepts tasks, stores them in memory, and exposes a worker loop for processing pending work.\\n\"\"\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "(repo_dir / \"app\" / \"models.py\").write_text(\n",
+    "    \"\"\"from pydantic import BaseModel\\n\\n\\nclass Task(BaseModel):\\n    id: str\\n    title: str\\n    status: str = \\\"pending\\\"\\n\"\"\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "(repo_dir / \"app\" / \"store.py\").write_text(\n",
+    "    \"\"\"from .models import Task\\n\\n\\nclass TaskStore:\\n    def __init__(self):\\n        self._tasks: dict[str, Task] = {}\\n\\n    def add(self, task: Task) -> Task:\\n        self._tasks[task.id] = task\\n        return task\\n\\n    def pending(self) -> list[Task]:\\n        return [task for task in self._tasks.values() if task.status == \\\"pending\\\"]\\n\"\"\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "(repo_dir / \"app\" / \"main.py\").write_text(\n",
+    "    \"\"\"from fastapi import FastAPI\\n\\nfrom .models import Task\\nfrom .store import TaskStore\\n\\napp = FastAPI()\\nstore = TaskStore()\\n\\n\\n@app.post(\\\"/tasks\\\")\\ndef create_task(task: Task) -> Task:\\n    return store.add(task)\\n\\n\\n@app.get(\\\"/tasks/pending\\\")\\ndef list_pending() -> list[Task]:\\n    return store.pending()\\n\"\"\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "(repo_dir / \"tests\" / \"test_store.py\").write_text(\n",
+    "    \"\"\"from app.models import Task\\nfrom app.store import TaskStore\\n\\n\\ndef test_pending_tasks():\\n    store = TaskStore()\\n    store.add(Task(id=\\\"1\\\", title=\\\"write docs\\\"))\\n    assert len(store.pending()) == 1\\n\"\"\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09b5c50b",
+   "metadata": {},
+   "source": [
+    "## Load code files with metadata\n",
+    "\n",
+    "`SimpleDirectoryReader` can load local files and attach metadata. For code repositories, path-like metadata is important because contributors often ask questions about modules, entry points, and tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf26a33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import SimpleDirectoryReader\n",
+    "\n",
+    "\n",
+    "def file_metadata(file_path: str) -> dict:\n",
+    "    path = Path(file_path).resolve()\n",
+    "    relative_path = path.relative_to(repo_dir)\n",
+    "    return {\n",
+    "        \"file_path\": str(relative_path),\n",
+    "        \"extension\": path.suffix,\n",
+    "        \"module\": relative_path.parts[0] if len(relative_path.parts) > 1 else \"root\",\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "documents = SimpleDirectoryReader(\n",
+    "    input_dir=str(repo_dir),\n",
+    "    recursive=True,\n",
+    "    required_exts=[\".py\", \".md\"],\n",
+    "    file_metadata=file_metadata,\n",
+    ").load_data()\n",
+    "\n",
+    "for document in documents:\n",
+    "    print(document.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7793eecc",
+   "metadata": {},
+   "source": [
+    "## Build an index\n",
+    "\n",
+    "Use a splitter that keeps source files small enough for retrieval while preserving metadata on every node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c1b7fd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Settings, VectorStoreIndex\n",
+    "from llama_index.core.node_parser import SentenceSplitter\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "Settings.llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "Settings.node_parser = SentenceSplitter(chunk_size=512, chunk_overlap=64)\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(documents)\n",
+    "query_engine = index.as_query_engine(similarity_top_k=6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6101e",
+   "metadata": {},
+   "source": [
+    "## Ask contributor-oriented questions\n",
+    "\n",
+    "The first set of questions should map the project before asking for implementation details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa7ac410",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    query_engine.query(\n",
+    "        \"What is the main purpose of this repository? Mention the key files a new contributor should inspect first.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72f1e4d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    query_engine.query(\n",
+    "        \"Trace the main execution flow from the API layer to the storage layer. Include file paths.\"\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4087af8a",
+   "metadata": {},
+   "source": [
+    "## Generate a staged learning path\n",
+    "\n",
+    "A learning assistant can turn retrieved context into a roadmap. This makes the output useful for onboarding, not just question answering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88bd9dd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learning_path_prompt = \"\"\"\n",
+    "Create a four-stage learning path for a new contributor to this repository.\n",
+    "\n",
+    "Use this structure:\n",
+    "1. First map the project: purpose, folders, and entry points.\n",
+    "2. Run the main flow: how data moves through the system.\n",
+    "3. Study the core implementation patterns: abstractions and tradeoffs.\n",
+    "4. Apply one lesson: a small exercise the contributor can implement.\n",
+    "\n",
+    "For each stage, include the files to inspect and one concrete question to answer.\n",
+    "\"\"\"\n",
+    "\n",
+    "print(query_engine.query(learning_path_prompt))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4d47720",
+   "metadata": {},
+   "source": [
+    "## Production notes\n",
+    "\n",
+    "For a larger repository, this baseline can be extended with:\n",
+    "\n",
+    "- a code parser that extracts symbols, imports, and call relationships,\n",
+    "- a property graph index for module and symbol relationships,\n",
+    "- metadata filters for language, folder, or test files,\n",
+    "- reranking for high-signal code snippets, and\n",
+    "- separate prompts for architecture overview, execution flow, implementation patterns, and reusable takeaways."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds a tutorial-style notebook that shows how to build a small codebase learning assistant with LlamaIndex.

The example demonstrates how to:

- ingest source files from a local repository-like directory
- preserve file path, extension, and module metadata
- build a `VectorStoreIndex` over code and README content
- ask contributor-oriented repository understanding questions
- synthesize a staged learning path for onboarding to an unfamiliar codebase

## Why

Developers often use RAG to ask isolated questions over code chunks. This example focuses on a structured onboarding workflow: first map the project, then trace the main flow, study implementation patterns, and apply one concrete lesson.

## Validation

- Verified the notebook JSON is valid with `python -m json.tool docs/examples/usecases/codebase_learning_assistant.ipynb`
- Kept the change scoped to docs/examples only

I did not execute the LLM-backed cells because they require an OpenAI API key.