### PR TITLE
fix: remove deprecated Hugging Face Hub inference extra

### DIFF
--- a/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
@@ -35,7 +35,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.19.0",
+    "huggingface-hub>=0.19.0",
 ]
 
 [tool.codespell]

--- a/llama-index-utils/llama-index-utils-huggingface/uv.lock
+++ b/llama-index-utils/llama-index-utils-huggingface/uv.lock
@@ -1917,7 +1917,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", extras = ["inference"], specifier = ">=0.19.0" },
+    { name = "huggingface-hub", specifier = ">=0.19.0" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
 ]
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `huggingface-hub[inference]` extra from the Hugging Face utils package dependency
- Keep the same `huggingface-hub>=0.19.0` version constraint
- Update the package lock metadata to match `pyproject.toml`

Closes #21549

## Verification

- Confirmed `huggingface-hub[inference]` no longer appears under `llama-index-utils/llama-index-utils-huggingface`
- Parsed `pyproject.toml` and `uv.lock` with Python `tomllib`
- `git diff --check`
