### PR TITLE
fix(chat-engine): avoid ValueError when writing multi-block message to history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -32,6 +33,31 @@ dispatcher = instrument.get_dispatcher(__name__)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
+
+
+def _set_message_text(message: ChatMessage, text: str) -> None:
+    """Safely update the text content of a ChatMessage.
+
+    Uses the blocks list directly so it works correctly when the message
+    contains multiple or non-text blocks (e.g. image blocks in a multi-modal
+    response).  In that case the legacy .content setter would raise a
+    ValueError.
+
+    Args:
+        message: The ChatMessage whose text content should be updated.
+        text: The new text to set.
+
+    """
+    text_blocks = [b for b in message.blocks if isinstance(b, TextBlock)]
+    non_text_blocks = [b for b in message.blocks if not isinstance(b, TextBlock)]
+
+    if text_blocks:
+        # Update the first TextBlock in-place; discard any subsequent text
+        # blocks that accumulated during streaming.
+        text_blocks[0].text = text
+        message.blocks = [text_blocks[0]] + non_text_blocks
+    else:
+        message.blocks = [TextBlock(text=text)]
 
 
 def is_function(message: ChatMessage) -> bool:
@@ -191,7 +217,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_text(chat.message, final_text.strip())  # final message
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +275,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_text(chat.message, final_text.strip())  # final message
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -130,3 +130,61 @@ def test_simple_chat_engine_astream_exception_handling():
         pytest.fail(
             "Exception was not correctly handled - ended up in asyncio cleanup performed during garbage collection"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _set_message_text (fix for issue #21679)
+# ---------------------------------------------------------------------------
+def test_set_message_text_single_text_block() -> None:
+    """_set_message_text updates a single-TextBlock message without error."""
+    from llama_index.core.chat_engine.types import _set_message_text
+    from llama_index.core.base.llms.types import TextBlock
+
+    msg = ChatMessage(role=MessageRole.ASSISTANT, content="original text")
+    _set_message_text(msg, "updated text")
+
+    assert msg.content == "updated text"
+    assert len(msg.blocks) == 1
+    assert isinstance(msg.blocks[0], TextBlock)
+
+
+def test_set_message_text_multi_block_no_error() -> None:
+    """_set_message_text must NOT raise ValueError on a multi-block message.
+
+    This is the regression test for issue #21679: the legacy .content setter
+    raises ValueError when called on a ChatMessage with more than one block.
+    """
+    from llama_index.core.chat_engine.types import _set_message_text
+    from llama_index.core.base.llms.types import TextBlock, ImageBlock
+
+    # Build a message that simulates a multi-modal response:
+    # one image block followed by one text block.
+    img_block = ImageBlock(url="https://example.com/img.png")
+    txt_block = TextBlock(text="caption")
+    msg = ChatMessage(role=MessageRole.ASSISTANT)
+    msg.blocks = [img_block, txt_block]
+
+    # Must not raise; previously this raised ValueError.
+    _set_message_text(msg, "final streamed text")
+
+    # The text block should be updated; non-text blocks preserved.
+    text_blocks = [b for b in msg.blocks if isinstance(b, TextBlock)]
+    non_text_blocks = [b for b in msg.blocks if not isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert text_blocks[0].text == "final streamed text"
+    assert len(non_text_blocks) == 1  # image block still present
+
+
+def test_set_message_text_empty_blocks() -> None:
+    """_set_message_text creates a TextBlock when the message has no blocks."""
+    from llama_index.core.chat_engine.types import _set_message_text
+    from llama_index.core.base.llms.types import TextBlock
+
+    msg = ChatMessage(role=MessageRole.ASSISTANT)
+    msg.blocks = []
+
+    _set_message_text(msg, "new text")
+
+    assert len(msg.blocks) == 1
+    assert isinstance(msg.blocks[0], TextBlock)
+    assert msg.blocks[0].text == "new text"


### PR DESCRIPTION
## Description

Fixes #21679

Both  and  in  finalize the accumulated streaming text via the legacy  setter. That setter raises  whenever  has more than one entry (e.g. a text block plus an image block in a multi-modal response):



This causes  to crash at the history-writeback stage, after the entire response has already been generated.

## Fix

Introduce a private  helper that operates on  directly:

- If the message already has s, the first one is updated in-place; any subsequent text blocks are dropped. Non-text blocks (images, documents) are preserved.
- If the message has no s, a new one is inserted.

Both  and  are updated to use the helper.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Three unit tests added to :
-  - baseline single-block case
-  - regression: image+text must not raise ValueError
-  - no blocks case

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
