### PR TITLE
feat(openai-like): accept direct extra_body

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/llama_index/llms/openai_like/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -53,6 +53,9 @@ class OpenAILike(OpenAI):
             Default is 0.1.
         additional_kwargs (dict):
             Specify additional parameters to the request body.
+        extra_body (dict):
+            Extra OpenAI-compatible request body fields, such as provider-specific
+            reasoning controls.
         max_retries (int):
             How many times to retry the API call if it fails.
             Defaults to 3.
@@ -120,9 +123,29 @@ class OpenAILike(OpenAI):
             " disables inference of max_tokens."
         ),
     )
+    extra_body: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Extra OpenAI-compatible request body fields.",
+    )
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
+        if self.extra_body is not None:
+            additional_kwargs = dict(self.additional_kwargs or {})
+            existing_extra_body = additional_kwargs.get("extra_body")
+            if existing_extra_body is None:
+                additional_kwargs["extra_body"] = dict(self.extra_body)
+            elif isinstance(existing_extra_body, dict):
+                additional_kwargs["extra_body"] = {
+                    **existing_extra_body,
+                    **self.extra_body,
+                }
+            else:
+                raise ValueError(
+                    "additional_kwargs['extra_body'] must be a dict if provided."
+                )
+            self.additional_kwargs = additional_kwargs
+
         if isinstance(self.tokenizer, str):
             try:
                 import transformers  # noqa: F401

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/tests/test_openai_like.py
@@ -41,6 +41,32 @@ def test_interfaces() -> None:
     assert llm.model == STUB_MODEL_NAME
 
 
+def test_extra_body_is_forwarded_through_additional_kwargs() -> None:
+    extra_body = {"thinking": {"type": "disabled"}}
+
+    llm = OpenAILike(
+        model=STUB_MODEL_NAME,
+        api_key=STUB_API_KEY,
+        extra_body=extra_body,
+    )
+
+    assert llm.additional_kwargs["extra_body"] == extra_body
+
+
+def test_extra_body_merges_with_existing_extra_body() -> None:
+    llm = OpenAILike(
+        model=STUB_MODEL_NAME,
+        api_key=STUB_API_KEY,
+        additional_kwargs={"extra_body": {"provider": {"order": ["deepseek"]}}},
+        extra_body={"thinking": {"type": "disabled"}},
+    )
+
+    assert llm.additional_kwargs["extra_body"] == {
+        "provider": {"order": ["deepseek"]},
+        "thinking": {"type": "disabled"},
+    }
+
+
 def mock_chat_completion(text: str) -> ChatCompletion:
     return ChatCompletion(
         id="chatcmpl-abc123",


### PR DESCRIPTION
## Summary
- add a direct `extra_body` argument on `OpenAILike`
- merge it into the existing `additional_kwargs["extra_body"]` request path
- keep existing `additional_kwargs` support and allow provider-specific fields to coexist

Fixes #21634.

## To verify
- `.venv\\Scripts\\python.exe -m pytest llama-index-integrations\\llms\\llama-index-llms-openai-like\\tests\\test_openai_like.py -q`
- `.venv\\Scripts\\python.exe -m py_compile llama-index-integrations\\llms\\llama-index-llms-openai-like\\llama_index\\llms\\openai_like\\base.py llama-index-integrations\\llms\\llama-index-llms-openai-like\\tests\\test_openai_like.py`
- `.venv\\Scripts\\python.exe -m ruff check llama-index-integrations\\llms\\llama-index-llms-openai-like\\llama_index\\llms\\openai_like\\base.py llama-index-integrations\\llms\\llama-index-llms-openai-like\\tests\\test_openai_like.py`
- `.venv\\Scripts\\python.exe -m ruff format --check llama-index-integrations\\llms\\llama-index-llms-openai-like\\llama_index\\llms\\openai_like\\base.py llama-index-integrations\\llms\\llama-index-llms-openai-like\\tests\\test_openai_like.py`