### PR TITLE
fix(llama-index-llms-google-genai): accept assistant role in ROLES_FROM_GEMINI

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -68,10 +68,15 @@ ROLES_TO_GEMINI: dict[MessageRole, MessageRole] = {
 }
 
 ROLES_FROM_GEMINI: dict[str, MessageRole] = {
-    ## Gemini has user, model and function roles.
+    ## Gemini natively uses user, model, and function roles.
     "user": MessageRole.USER,
     "model": MessageRole.ASSISTANT,
     "function": MessageRole.TOOL,
+    ## Gemini-compatible MaaS endpoints (e.g. `gemma-4-26b-a4b-it-maas` via
+    ## Vertex Model Garden) may return `assistant` instead of `model` in the
+    ## role field; accepting it here avoids a `KeyError` when reading the
+    ## response (#21799).
+    "assistant": MessageRole.ASSISTANT,
 }
 
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -2048,3 +2048,35 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+def test_chat_from_gemini_response_accepts_assistant_role() -> None:
+    """Regression for #21799: Gemini-compatible MaaS endpoints (e.g.
+    `gemma-4-26b-a4b-it-maas`) may return `assistant` instead of the
+    Gemini-native `model` role. `ROLES_FROM_GEMINI` must accept it so
+    `chat_from_gemini_response` doesn't raise `KeyError: 'assistant'`."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "assistant"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Hello from gemma"
+    mock_response.candidates[0].content.parts[0].thought = False
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].function_call.id = ""
+    mock_response.candidates[0].content.parts[0].function_call.name = ""
+    mock_response.candidates[0].content.parts[0].function_call.args = {}
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.candidates[0].grounding_metadata = None
+    mock_response.candidates[0].model_dump.return_value = {
+        "finish_reason": types.FinishReason.STOP,
+        "content": {"role": "assistant", "parts": [{"text": "Hello from gemma"}]},
+    }
+    mock_response.prompt_feedback = None
+    mock_response.usage_metadata = None
+    mock_response.function_calls = None
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.message.role == MessageRole.ASSISTANT
+    assert chat_response.message.blocks[0].text == "Hello from gemma"


### PR DESCRIPTION
## Summary

Closes #21799.

Gemini-compatible MaaS endpoints (e.g. `gemma-4-26b-a4b-it-maas` via Vertex Model Garden) return `assistant` in the role field instead of Gemini's native `model`. Today `chat_from_gemini_response()` does:

```python
role = ROLES_FROM_GEMINI[top_candidate.content.role or 'model']
```

at [`utils.py:242`](llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py#L242) and [`:266`](llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py#L266) — a direct dict lookup with no default. When the response role is `assistant`, this raises `KeyError: 'assistant'` and the entire response is discarded.

## Fix shape

Add `assistant` → `MessageRole.ASSISTANT` to `ROLES_FROM_GEMINI` alongside the existing native Gemini roles (`user`, `model`, `function`). One-line dict addition, no behavior change for responses that already use Gemini-native roles.

## Test plan

- [x] New `test_chat_from_gemini_response_accepts_assistant_role` exercises the previously-failing path: mock response with `role='assistant'` no longer raises and produces `MessageRole.ASSISTANT` on the parsed `ChatResponse`.
- [x] Full `tests/test_llms_google_genai.py` passes locally (26 passed, 42 skipped — skipped ones need live API keys).

## Note

The issue body also mentioned a second symptom — `client.models.get(model="gemma-4-26b-a4b-it-maas")` failing at construction — which is a separate Gemini API-side issue (the model isn't returned by `models.get`). Reproducing/fixing that would require a different change (catching the failure and falling back to a default model_meta); happy to do that in a follow-up if maintainers want both addressed.