### PR TITLE
Validate AG-UI static tool names

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -24,6 +24,25 @@ from llama_index.protocols.ag_ui.utils import (
 )
 
 
+def _validate_unique_static_tool_names(
+    frontend_tools: List[BaseTool], backend_tools: List[BaseTool]
+) -> None:
+    seen: Dict[str, str] = {}
+    for tool_group, tools in (
+        ("frontend_tools", frontend_tools),
+        ("backend_tools", backend_tools),
+    ):
+        for tool in tools:
+            name = tool.metadata.name
+            if name in seen:
+                raise ValueError(
+                    f"AG-UI tool name {name!r} appears in both {seen[name]} "
+                    f"and {tool_group}; tool names must be unique across "
+                    "frontend_tools and backend_tools."
+                )
+            seen[name] = tool_group
+
+
 def _ag_ui_tool_to_llama_index(tool: AGUITool) -> BaseTool:
     """
     Convert an AG-UI Tool definition to a LlamaIndex FunctionTool.
@@ -129,6 +148,9 @@ class AGUIChatWorkflow(Workflow):
         validated_backend_tools: List[BaseTool] = [
             validate_tool(tool) for tool in backend_tools or []
         ]
+        _validate_unique_static_tool_names(
+            validated_frontend_tools, validated_backend_tools
+        )
 
         self.frontend_tools = {
             tool.metadata.name: tool for tool in validated_frontend_tools

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_agent_tool_names.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_agent_tool_names.py
@@ -1,0 +1,49 @@
+import pytest
+
+from llama_index.core.llms.mock import MockFunctionCallingLLM
+from llama_index.core.tools import FunctionTool
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow
+
+
+def _tool(name: str) -> FunctionTool:
+    def tool_fn() -> str:
+        return name
+
+    return FunctionTool.from_defaults(fn=tool_fn, name=name)
+
+
+def test_ag_ui_workflow_rejects_frontend_backend_tool_name_collision() -> None:
+    frontend_tool = _tool("shared_tool")
+    backend_tool = _tool("shared_tool")
+
+    with pytest.raises(ValueError, match="shared_tool"):
+        AGUIChatWorkflow(
+            llm=MockFunctionCallingLLM(),
+            frontend_tools=[frontend_tool],
+            backend_tools=[backend_tool],
+        )
+
+
+def test_ag_ui_workflow_rejects_duplicate_static_tool_names_in_same_group() -> None:
+    with pytest.raises(ValueError, match="shared_tool"):
+        AGUIChatWorkflow(
+            llm=MockFunctionCallingLLM(),
+            frontend_tools=[_tool("shared_tool"), _tool("shared_tool")],
+        )
+
+    with pytest.raises(ValueError, match="shared_tool"):
+        AGUIChatWorkflow(
+            llm=MockFunctionCallingLLM(),
+            backend_tools=[_tool("shared_tool"), _tool("shared_tool")],
+        )
+
+
+def test_ag_ui_workflow_accepts_unique_frontend_and_backend_tool_names() -> None:
+    workflow = AGUIChatWorkflow(
+        llm=MockFunctionCallingLLM(),
+        frontend_tools=[_tool("frontend_tool")],
+        backend_tools=[_tool("backend_tool")],
+    )
+
+    assert set(workflow.frontend_tools) == {"frontend_tool"}
+    assert set(workflow.backend_tools) == {"backend_tool"}


### PR DESCRIPTION
## Summary

- validate static AG-UI tool names before building the workflow tool maps
- reject duplicate names within `frontend_tools`, within `backend_tools`, or across both groups
- add focused regression coverage for duplicate and unique static tool names

## Rationale

`AGUIChatWorkflow` stores static frontend and backend tools in dictionaries keyed by `tool.metadata.name`. If two static tools share the same name, one entry can silently shadow the other during workflow construction.

This PR validates the names before those dictionaries are built, so ambiguous static tool routing fails early with a clear error.

## Tests

From `llama-index-integrations/protocols/llama-index-protocols-ag-ui`:

- `uv run --python 3.11 pytest tests/test_agent_tool_names.py -q`
- `uv run --python 3.11 ruff check llama_index/protocols/ag_ui/agent.py tests/test_agent_tool_names.py`
- `uv run --python 3.11 python -m py_compile llama_index/protocols/ag_ui/agent.py tests/test_agent_tool_names.py`
- `git diff --check`
