### PR TITLE
fix(vector-stores-azureaisearch): preserve falsy metadata values

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,9 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            # Use an explicit None check so falsy values (0, "", [], False)
+            # are preserved instead of being silently stored as None (#21385).
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -503,3 +503,57 @@ def test_close_does_not_call_external_client_close() -> None:
 
     # Verify close was NOT called on the external search client
     search_client.close.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_default_index_mapping_preserves_falsy_metadata_values() -> None:
+    """Regression for #21385: `_default_index_mapping` previously used a truthy
+    test (`if metadata_value`) to decide whether to copy a metadata field into
+    the index document. Falsy values that are still legitimate data — `0`,
+    `""`, `[]`, `False` — were silently dropped (stored as `None` on retrieval).
+    Switch to `if metadata_value is not None` so only genuinely absent values
+    are skipped."""
+    search_client = mock_client_with_user_agent("search")
+    vector_store = AzureAISearchVectorStore(
+        search_or_index_client=search_client,
+        id_field_key="id",
+        chunk_field_key="content",
+        embedding_field_key="embedding",
+        metadata_string_field_key="metadata",
+        doc_id_field_key="doc_id",
+        filterable_metadata_field_keys=[
+            "count",
+            "label",
+            "tags",
+            "enabled",
+        ],
+        index_management=IndexManagement.NO_VALIDATION,
+        embedding_dimensionality=2,
+    )
+
+    # `_field_mapping` keys are the canonical field names (id/chunk/embedding/metadata/doc_id),
+    # not the user-supplied column names.
+    enriched_doc = {
+        "id": "doc-1",
+        "chunk": "x",
+        "embedding": [0.5, 0.5],
+        "metadata": "{}",
+        "doc_id": "doc-1",
+    }
+    metadata = {
+        "count": 0,
+        "label": "",
+        "tags": [],
+        "enabled": False,
+        "absent": None,  # must still be skipped
+    }
+
+    index_doc = vector_store._default_index_mapping(enriched_doc, metadata)
+
+    assert index_doc["count"] == 0
+    assert index_doc["label"] == ""
+    assert index_doc["tags"] == []
+    assert index_doc["enabled"] is False
+    assert "absent" not in index_doc


### PR DESCRIPTION
## Summary

Closes #21385.

`_default_index_mapping` in `AzureAISearchVectorStore` used a truthy test (`if metadata_value`) to decide whether to copy a metadata field into the index document. Falsy values that are still legitimate data — `0`, `""`, `[]`, `False` — were silently dropped, then surfaced as `None` on retrieval. The reporter pointed at the exact site (`base.py:899`) and recommended this fix.

## Fix

Switch to `if metadata_value is not None` so only genuinely absent fields are skipped while every legitimate falsy value is preserved.

## Test plan

- [x] New `test_default_index_mapping_preserves_falsy_metadata_values` asserts `0` / `""` / `[]` / `False` round-trip correctly through `_default_index_mapping`, while a `None`-valued field is still skipped.
- [x] Existing `tests/test_azureaisearch.py` passes locally.