### PR TITLE
fix(llms-ollama): keep thinking-only chunks in stream_chat/astream_chat

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -472,7 +472,12 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             for r in response:
-                if r["message"]["content"] is None:
+                # Skip chunks that carry neither content nor thinking — but
+                # keep thinking-only chunks (e.g. from gpt-oss/DeepSeek-R1/QwQ)
+                # so reasoning text isn't silently dropped on the stream (#21232).
+                if r["message"]["content"] is None and not r["message"].get(
+                    "thinking"
+                ):
                     continue
 
                 r = dict(r)
@@ -556,7 +561,10 @@ class Ollama(FunctionCallingLLM):
             all_tool_calls = []
 
             async for r in response:
-                if r["message"]["content"] is None:
+                # Same as stream_chat above: keep thinking-only chunks (#21232).
+                if r["message"]["content"] is None and not r["message"].get(
+                    "thinking"
+                ):
                     continue
 
                 r = dict(r)

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -493,3 +493,72 @@ async def test_chat_methods_with_tool_input() -> None:
         ablocks.extend(r.message.blocks)
     assert len([block for block in ablocks if isinstance(block, TextBlock)]) > 0
     assert len([block for block in ablocks if isinstance(block, ToolCallBlock)]) == 0
+
+
+def test_stream_chat_keeps_thinking_only_chunks() -> None:
+    """Regression for #21232: thinking-only chunks (content=None, thinking=...)
+    from reasoning models (e.g. DeepSeek-R1, QwQ, gpt-oss) were dropped by the
+    `if content is None: continue` guard in `stream_chat`, so reasoning text
+    never reached the consumer. Only chunks with neither content nor thinking
+    should be skipped now."""
+    from unittest.mock import MagicMock
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = iter(
+        [
+            {"message": {"role": "assistant", "content": None, "thinking": "let me think..."}},
+            {"message": {"role": "assistant", "content": None, "thinking": " step 1"}},
+            {"message": {"role": "assistant", "content": "answer ", "thinking": ""}},
+            {"message": {"role": "assistant", "content": "is 42", "thinking": ""}},
+            {"message": {"role": "assistant", "content": None, "thinking": None}},  # skipped
+        ]
+    )
+
+    llm = Ollama(model="test-thinking-model", client=fake_client, async_client=MagicMock())
+
+    chunks = list(llm.stream_chat([ChatMessage(role="user", content="hi")]))
+
+    thinking_deltas = [
+        c.additional_kwargs.get("thinking_delta") for c in chunks
+    ]
+    assert "let me think..." in thinking_deltas
+    assert " step 1" in thinking_deltas
+    # Final accumulated thinking content survives onto the last yielded chunk's ThinkingBlock.
+    last_blocks = chunks[-1].message.blocks
+    thinking_blocks = [b for b in last_blocks if isinstance(b, ThinkingBlock)]
+    assert thinking_blocks and thinking_blocks[0].content == "let me think... step 1"
+    text_blocks = [b for b in last_blocks if isinstance(b, TextBlock)]
+    assert text_blocks and text_blocks[0].text == "answer is 42"
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_keeps_thinking_only_chunks() -> None:
+    """Async sibling of `test_stream_chat_keeps_thinking_only_chunks` (#21232)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    async def _agen():
+        for r in [
+            {"message": {"role": "assistant", "content": None, "thinking": "thinking-only"}},
+            {"message": {"role": "assistant", "content": "done", "thinking": ""}},
+            {"message": {"role": "assistant", "content": None, "thinking": None}},
+        ]:
+            yield r
+
+    fake_async_client = MagicMock()
+    fake_async_client.chat = AsyncMock(return_value=_agen())
+
+    llm = Ollama(
+        model="test-thinking-model",
+        client=MagicMock(),
+        async_client=fake_async_client,
+    )
+
+    chunks = []
+    async for c in await llm.astream_chat([ChatMessage(role="user", content="hi")]):
+        chunks.append(c)
+
+    last_blocks = chunks[-1].message.blocks
+    thinking_blocks = [b for b in last_blocks if isinstance(b, ThinkingBlock)]
+    assert thinking_blocks and thinking_blocks[0].content == "thinking-only"
+    text_blocks = [b for b in last_blocks if isinstance(b, TextBlock)]
+    assert text_blocks and text_blocks[0].text == "done"


### PR DESCRIPTION
## Summary

Closes #21232.

When streaming from Ollama reasoning models (DeepSeek-R1, QwQ, gpt-oss, etc.), chunks where `content=None` but `thinking` is populated were silently dropped by the guard at the top of both `stream_chat` and `astream_chat`:

```python
if r["message"]["content"] is None:
    continue
```

The non-streaming `chat`/`achat` paths already handled thinking-only chunks correctly, so the asymmetry meant **all** reasoning text was lost on every streaming call even though `think=True` was correctly forwarded to the Ollama API.

## Fix

Skip only when both content and thinking are absent:

```python
if r["message"]["content"] is None and not r["message"].get("thinking"):
    continue
```

Thinking-only chunks now flow through, accumulate into `thinking_txt`, and surface as a `ThinkingBlock` plus `thinking_delta` on each yielded `ChatResponse`.

## Test plan

- [x] `test_stream_chat_keeps_thinking_only_chunks` — sync path, mocked `client.chat` returns a sequence interleaving thinking-only and content chunks; asserts `thinking_delta` per chunk + final `ThinkingBlock`+`TextBlock` shape.
- [x] `test_astream_chat_keeps_thinking_only_chunks` — async sibling.
- [x] Chunks with neither content nor thinking are still skipped (verified in both tests with a trailing `{"content": None, "thinking": None}` chunk).