### PR TITLE
fix(readers-microsoft-onedrive): sanitize server-supplied filename in _download_file_by_url

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -269,11 +269,31 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         file_download_url = item["@microsoft.graph.downloadUrl"]
         file_name = item["name"]
 
+        # Strip any directory components from the server-supplied name and
+        # confirm the resolved destination stays inside `local_dir`. The
+        # Microsoft Graph API can in principle return a filename containing
+        # `..` or absolute-path components; without this guard a downloaded
+        # file could land outside the caller-supplied download directory
+        # (CWE-22 / path traversal — #21867).
+        sanitized_name = os.path.basename(file_name)
+        if not sanitized_name or sanitized_name in (os.curdir, os.pardir):
+            raise ValueError(
+                f"Refusing to download file with unsafe name: {file_name!r}"
+            )
+        file_path = os.path.join(local_dir, sanitized_name)
+        resolved_dir = os.path.realpath(local_dir)
+        resolved_path = os.path.realpath(file_path)
+        if (
+            os.path.commonpath([resolved_dir, resolved_path]) != resolved_dir
+        ):  # pragma: no cover -- defense-in-depth after basename strip
+            raise ValueError(
+                f"Refusing to download file that escapes local_dir: {file_name!r}"
+            )
+
         # Download the file.
         file_data = requests.get(file_download_url)
 
         # Save the downloaded file to the specified local directory.
-        file_path = os.path.join(local_dir, file_name)
         with open(file_path, "wb") as f:
             f.write(file_data.content)
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -60,3 +60,75 @@ def test_mixins(real_onedrive_reader: OneDriveReader):
     file_content = real_onedrive_reader.read_file_content(resource)
     assert file_content is not None
     assert len(file_content) == resource_info["file_size"]
+
+
+def test_download_file_by_url_rejects_path_traversal_filename(tmp_path, monkeypatch):
+    """Regression for #21867: server-supplied `item['name']` is used to build
+    the local destination path, so a traversal sequence (`../...`) would
+    write outside the caller-supplied download directory. We sanitize via
+    `os.path.basename` and additionally verify the resolved path stays
+    inside `local_dir`.
+    """
+    import os
+
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+
+    # Stub out the network call so the test doesn't depend on a real URL.
+    class _StubResponse:
+        content = b"x"
+
+    monkeypatch.setattr(
+        "llama_index.readers.microsoft_onedrive.base.requests.get",
+        lambda *_a, **_kw: _StubResponse(),
+    )
+
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    sentinel_outside = tmp_path / "escaped.txt"
+
+    # Filename with a `..` component must be rejected.
+    with pytest.raises(ValueError, match="unsafe name"):
+        reader._download_file_by_url(
+            {"@microsoft.graph.downloadUrl": "http://example.invalid", "name": ".."},
+            str(download_dir),
+        )
+
+    # Filename containing a traversal sequence is sanitized to its basename
+    # and lands inside `download_dir`, never at `sentinel_outside`.
+    written = reader._download_file_by_url(
+        {
+            "@microsoft.graph.downloadUrl": "http://example.invalid",
+            "name": "../escaped.txt",
+        },
+        str(download_dir),
+    )
+    assert not sentinel_outside.exists()
+    assert os.path.realpath(written).startswith(os.path.realpath(str(download_dir)))
+
+
+def test_download_file_by_url_preserves_normal_filename(tmp_path, monkeypatch):
+    """Sibling control test: a benign filename must still round-trip cleanly."""
+    import os
+
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+
+    class _StubResponse:
+        content = b"hello"
+
+    monkeypatch.setattr(
+        "llama_index.readers.microsoft_onedrive.base.requests.get",
+        lambda *_a, **_kw: _StubResponse(),
+    )
+
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+
+    written = reader._download_file_by_url(
+        {
+            "@microsoft.graph.downloadUrl": "http://example.invalid",
+            "name": "report.txt",
+        },
+        str(download_dir),
+    )
+    assert os.path.basename(written) == "report.txt"
+    assert open(written, "rb").read() == b"hello"


### PR DESCRIPTION
## Summary

Closes #21867.

`OneDriveReader._download_file_by_url` joined the caller-supplied `local_dir` with the server-supplied `item['name']` from the Microsoft Graph API without sanitization. A filename containing path-traversal components (`../escaped.txt`) or absolute-path components would cause the downloaded file to be written **outside** the caller-supplied download directory — breaking the documented `load_data` contract that everything lands within the temporary directory. This is a CWE-22 / Zip-Slip-class path-traversal sink.

## Fix

- Strip directory components from the server-supplied name with `os.path.basename`.
- Reject empty / `.` / `..` names with a clear `ValueError`.
- Defense-in-depth: verify the resolved destination stays inside `local_dir` via `os.path.realpath` + `os.path.commonpath`.

No behavior change for well-formed filenames (which is every name a real Graph API response returns in practice).

## Test plan

- [x] `test_download_file_by_url_rejects_path_traversal_filename` — `..` raises `ValueError("unsafe name")`; `../escaped.txt` gets sanitized to `escaped.txt` and lands inside the download dir (never at the parent-directory location).
- [x] `test_download_file_by_url_preserves_normal_filename` — control: a benign `report.txt` still round-trips cleanly with the expected content.