### PR TITLE
fix(onedrive): sanitize remote filenames to prevent path traversal

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -267,13 +267,19 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         """
         # Extract download URL and filename from the provided item.
         file_download_url = item["@microsoft.graph.downloadUrl"]
-        file_name = item["name"]
+        file_name = os.path.basename(item["name"].replace("\\", "/"))
 
         # Download the file.
         file_data = requests.get(file_download_url)
 
         # Save the downloaded file to the specified local directory.
-        file_path = os.path.join(local_dir, file_name)
+        # Verify the resolved path stays within local_dir to prevent
+        # path traversal via crafted filenames (e.g. "../secret.txt").
+        file_path = os.path.normpath(os.path.join(local_dir, file_name))
+        if not file_path.startswith(os.path.normpath(local_dir) + os.sep) and file_path != os.path.normpath(local_dir):
+            raise ValueError(
+                f"Refusing to write file outside download directory: {file_name!r}"
+            )
         with open(file_path, "wb") as f:
             f.write(file_data.content)
 


### PR DESCRIPTION
## Problem

`_download_file_by_url()` uses the raw `item["name"]` field from the Microsoft Graph API response to construct a local file path without sanitization. When the remote filename contains path traversal sequences (e.g. `../test.txt`), downloaded files are written outside the intended download directory.

This is the same pattern as internetarchive CVE-2025-1060 — unsanitized remote metadata used to construct local file paths.

Fixes #21867

## Fix

Two defenses applied:

1. **Strip directory components**: `os.path.basename(item["name"].replace("\\", "/"))` removes any path separators, keeping only the filename
2. **Path boundary check**: After `os.path.join`, verify the resolved path stays within `local_dir` using `os.path.normpath` + `startswith`. Raises `ValueError` if the path would escape.

This is backwards-compatible: legitimate filenames are unaffected. Only filenames attempting directory traversal are rejected.