### PR TITLE
fix: keep OneDrive downloads inside local dir

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -267,13 +267,18 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         """
         # Extract download URL and filename from the provided item.
         file_download_url = item["@microsoft.graph.downloadUrl"]
-        file_name = item["name"]
+        file_name = os.path.basename(str(item["name"]).replace("\\", "/"))
+        if file_name in ("", ".", ".."):
+            raise ValueError(f"Invalid OneDrive file name: {item['name']!r}")
 
         # Download the file.
         file_data = requests.get(file_download_url)
 
         # Save the downloaded file to the specified local directory.
-        file_path = os.path.join(local_dir, file_name)
+        local_dir = os.path.abspath(local_dir)
+        file_path = os.path.abspath(os.path.join(local_dir, file_name))
+        if os.path.commonpath([local_dir, file_path]) != local_dir:
+            raise ValueError(f"Refusing to write outside download directory: {file_name!r}")
         with open(file_path, "wb") as f:
             f.write(file_data.content)
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.microsoft_onedrive import OneDriveReader
@@ -31,6 +33,34 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+@pytest.mark.parametrize("remote_name", ["../proof.txt", "..\\proof.txt"])
+def test_download_file_by_url_keeps_remote_name_inside_local_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, remote_name: str
+):
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+
+    class Response:
+        content = b"downloaded"
+
+    monkeypatch.setattr("requests.get", lambda _: Response())
+
+    downloaded_path = Path(
+        reader._download_file_by_url(
+            {
+                "name": remote_name,
+                "@microsoft.graph.downloadUrl": "https://example.com/file",
+            },
+            str(download_dir),
+        )
+    )
+
+    assert downloaded_path == download_dir.resolve() / "proof.txt"
+    assert downloaded_path.read_bytes() == b"downloaded"
+    assert not (tmp_path / "proof.txt").exists()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- sanitize OneDrive item names before writing downloaded files
- normalize both `/` and `\` separators so remote metadata cannot escape the local download directory
- add a regression test for traversal-style filenames

Fixes #21867.

## To verify
- `.venv\Scripts\python -m pytest llama-index-integrations\readers\llama-index-readers-microsoft-onedrive\tests\test_readers_microsoft_onedrive.py -q`
- `.venv\Scripts\python -m py_compile llama-index-integrations\readers\llama-index-readers-microsoft-onedrive\llama_index\readers\microsoft_onedrive\base.py llama-index-integrations\readers\llama-index-readers-microsoft-onedrive\tests\test_readers_microsoft_onedrive.py`
- `git diff --check`
