### PR TITLE
fix: sanitize item name in OneDrive reader to prevent path traversal

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -268,6 +268,11 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         # Extract download URL and filename from the provided item.
         file_download_url = item["@microsoft.graph.downloadUrl"]
         file_name = item["name"]
+        
+        # Sanitize file name to prevent path traversal
+        file_name = os.path.basename(file_name.replace("\\", "/"))
+        if not file_name or file_name in (".", ".."):
+            raise ValueError(f"Invalid file name: {item['name']}")
 
         # Download the file.
         file_data = requests.get(file_download_url)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -33,6 +33,22 @@ def test_serialize():
     assert new_reader.required_exts == reader.required_exts
 
 
+def test_download_file_by_url_path_traversal():
+    import os
+    from unittest.mock import MagicMock, patch
+    reader = OneDriveReader(client_id="dummy", tenant_id="dummy")
+    item = {
+        "@microsoft.graph.downloadUrl": "https://example.com/download",
+        "name": "../../path_traversal_test.txt"
+    }
+    with patch("llama_index.readers.microsoft_onedrive.base.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(content=b"file content")
+        with patch("llama_index.readers.microsoft_onedrive.base.open", create=True) as mock_open:
+            result_path = reader._download_file_by_url(item, "/tmp/allowed_dir")
+            expected_path = os.path.join("/tmp/allowed_dir", "path_traversal_test.txt")
+            assert os.path.normpath(result_path) == os.path.normpath(expected_path)
+
+
 @pytest.fixture()
 def real_onedrive_reader():
     raise pytest.skip("Fill in redacted values to run this test")


### PR DESCRIPTION
In `llama-index-readers-microsoft-onedrive`, the `_download_file_by_url` method constructs local download paths using the raw `item["name"]` directly. If a filename contains backslashes or traversal characters, it could allow downloading files outside the target directory.

This PR adds path sanitization to construct the local file path safely using `os.path.basename` after normalizing slashes. A unit test verifying this security fix is included.