### PR TITLE
[Docs] add Spanlens integration to observability docs

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -898,6 +898,34 @@ openlit.init()
 
 - [OpenLIT's Official Documentation](https://docs.openlit.io/latest/integrations/llama-index)
 
+### Spanlens
+
+[Spanlens](https://spanlens.io) is an open-source LLM observability platform (MIT, [github.com/spanlens/Spanlens](https://github.com/spanlens/Spanlens)). The LlamaIndex integration is a `BaseCallbackHandler` subclass that maps every `CBEventType` (LLM, RETRIEVE, EMBEDDING, FUNCTION_CALL, QUERY) to a typed span, so the dashboard trace tree mirrors your RAG topology 1:1 with token usage, cost, and parent/child linkage from the framework's per-event UUIDs.
+
+#### Install
+
+```shell
+pip install "spanlens[llama-index]"
+```
+
+#### Usage Pattern
+
+```python
+import os
+from llama_index.core import Settings
+from spanlens import SpanlensClient
+from spanlens.integrations.llama_index import SpanlensCallbackHandler
+
+client = SpanlensClient(api_key=os.environ["SPANLENS_API_KEY"])
+Settings.callback_manager.add_handler(SpanlensCallbackHandler(client=client))
+```
+
+Every query engine, agent, or workflow created after this gets full trace capture with no further code changes.
+
+#### Guides
+
+- [Spanlens LlamaIndex docs](https://www.spanlens.io/docs/integrations/llamaindex)
+
 ### AgentOps
 
 [AgentOps](https://github.com/AgentOps-AI/agentops) helps developers build, evaluate,


### PR DESCRIPTION
## Description

Adds a Spanlens integration entry to `docs/src/content/docs/framework/module_guides/observability/index.md`.

[Spanlens](https://spanlens.io) ([github.com/spanlens/Spanlens](https://github.com/spanlens/Spanlens), MIT) is an open-source LLM observability platform. The LlamaIndex integration is a `BaseCallbackHandler` subclass (`spanlens.integrations.llama_index.SpanlensCallbackHandler`) that maps every `CBEventType` to a typed span with token usage and parent/child linkage from the framework's per-event UUIDs. Published on PyPI as `spanlens[llama-index]`.

Follows the structure of the existing observability entries (e.g. OpenLIT, Langtrace, SigNoz): one section with `#### Install`, `#### Usage Pattern`, `#### Guides`.

## Fixes # (issue)

N/A — purely additive docs entry.

## New Package?

- [ ] Yes
- [x] No — **no new package added.** Spanlens is published independently on PyPI (`pip install "spanlens[llama-index]"`), per the CONTRIBUTING guidance against new integration packages in this repo. Single-file docs change only.

## Version Bump?

- [ ] Yes
- [x] No — no `pyproject.toml` touched.

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — docs entry for a new observability integration

## How Has This Been Tested?

Markdown-only change. Covered by the existing docs build.

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

The handler itself is covered by 7 unit tests and an end-to-end integration smoke test in the `spanlens` repo, exercised against the real `CallbackManager` + `CBEventType` + `EventPayload` from `llama-index-core 0.14.22` and a live ingest server.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation