### PR TITLE
Update Vearch demo notebook imports

### DIFF
--- a/docs/examples/vector_stores/VearchDemo.ipynb
+++ b/docs/examples/vector_stores/VearchDemo.ipynb
@@ -73,8 +73,8 @@
    ],
    "source": [
     "from llama_index import ServiceContext\n",
-    "from llama_index.embeddings import HuggingFaceEmbedding\n",
-    "from llama_index.vector_stores import VearchVectorStore\n",
+    "from llama_index.embeddings.huggingface import HuggingFaceEmbedding\n",
+    "from llama_index.vector_stores.vearch import VearchVectorStore\n",
     "\n",
     "\"\"\"\n",
     "vearch cluster\n",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/examples/VearchDemo.ipynb
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/examples/VearchDemo.ipynb
@@ -73,8 +73,8 @@
    ],
    "source": [
     "from llama_index import ServiceContext\n",
-    "from llama_index.embeddings import HuggingFaceEmbedding\n",
-    "from llama_index.vector_stores import VearchVectorStore\n",
+    "from llama_index.embeddings.huggingface import HuggingFaceEmbedding\n",
+    "from llama_index.vector_stores.vearch import VearchVectorStore\n",
     "\n",
     "\"\"\"\n",
     "vearch cluster\n",


### PR DESCRIPTION
# Description

Updates the Vearch demo notebooks to use the current integration import paths for HuggingFace embeddings and the Vearch vector store.

Fixes # N/A

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Validation performed:

- `python -m json.tool` on both notebooks
- `git diff --check` on both notebooks
- Verified old imports are absent and new imports are present