### PR TITLE
fix(openrouter): support llama-index-llms-openai-like 0.7

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openrouter/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openrouter/pyproject.toml
@@ -26,15 +26,15 @@ dev = [
 
 [project]
 name = "llama-index-llms-openrouter"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms openrouter integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "llama-index-llms-openai-like>=0.5.0,<0.7",
-    "llama-index-core>=0.13.0,<0.15",
+    "llama-index-llms-openai-like>=0.7.0,<0.8",
+    "llama-index-core>=0.14.3,<0.15",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/llms/llama-index-llms-openrouter/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-openrouter/uv.lock
@@ -1936,33 +1936,33 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-openai"
-version = "0.6.26"
+version = "0.7.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
     { name = "openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/5e/a7a47d46dc2eb30953d83654112c8af6f61821ca78ef3ea22e30729aac3a/llama_index_llms_openai-0.6.26.tar.gz", hash = "sha256:3474602ecbc30c88a8b585cfd5737891d45da78251a5e067c4dbc2d3cc3d08db", size = 27262, upload-time = "2026-03-05T02:53:50.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/85/f07466d0f5c3f1e1f295a60f2d2e9d32163635ba39ae2fda22ce2fbac1c9/llama_index_llms_openai-0.7.9.tar.gz", hash = "sha256:f54a24b717134c86e724007057a06a84394f019d1f01e918b624894e208a86df", size = 27564, upload-time = "2026-05-29T15:32:37.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/8a/f46f59279c078b001374813f69987b43b7c3bd9df01981af545cf2d954d7/llama_index_llms_openai-0.6.26-py3-none-any.whl", hash = "sha256:2062ef505676d0a1c7c116c138c2f890aa7653619fc3ca697e47df7bd2ef8b3f", size = 28330, upload-time = "2026-03-05T02:53:40.421Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c2/cfa341cff00154b58abed3fc559fb43c2531d5dd70eefb75f230704d4c3c/llama_index_llms_openai-0.7.9-py3-none-any.whl", hash = "sha256:0bc8f59faddf8dbc9f90c5576127ab2fa6d368be5078885dc7e611af129b5a79", size = 28648, upload-time = "2026-05-29T15:32:35.997Z" },
 ]
 
 [[package]]
 name = "llama-index-llms-openai-like"
-version = "0.6.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-core" },
     { name = "llama-index-llms-openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/ae4f56a95c926b6c6c030ec4a235147824a11f8979076173fdd6c90a875f/llama_index_llms_openai_like-0.6.0.tar.gz", hash = "sha256:6938cfed62c77876ba43f26519aabf555775fd8e0e7e1af2ddf37a9fc91dca32", size = 5178, upload-time = "2026-01-30T21:13:11.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a3/16410b28d131aa113ada79f856b78cb68a8e92a1e27255ea9c36c27a5dec/llama_index_llms_openai_like-0.7.2.tar.gz", hash = "sha256:ed9ff73f975dce470f98ac61c982151ba78eedfa3fb9b03894bc1d1312b213ff", size = 5389, upload-time = "2026-04-23T23:05:32.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/19/018966087d11cab287cb3a37e53c79a045b6ae8442d9eb325d1b5accb70a/llama_index_llms_openai_like-0.6.0-py3-none-any.whl", hash = "sha256:6d97260787ea5a2e6ad15fb547ec5c606b87775dcf9903a698e4c7e9893b367e", size = 4860, upload-time = "2026-01-30T21:13:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0c/fdddaee5391d915d3d568d2d8dbdb7c95647e65bb94d4ddb31d47cef5daf/llama_index_llms_openai_like-0.7.2-py3-none-any.whl", hash = "sha256:1f45a7b1cec8fb3f5997684327ffe6c19f93e789c2fff35dc5522465850faf0b", size = 6602, upload-time = "2026-04-23T23:05:31.708Z" },
 ]
 
 [[package]]
 name = "llama-index-llms-openrouter"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1993,8 +1993,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "llama-index-llms-openai-like", specifier = ">=0.5.0,<0.7" },
+    { name = "llama-index-core", specifier = ">=0.14.3,<0.15" },
+    { name = "llama-index-llms-openai-like", specifier = ">=0.7.0,<0.8" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

`llama-index-llms-openrouter` 0.5.0 caps `llama-index-llms-openai-like<0.7`, which transitively pins `llama-index-llms-openai<0.6` and blocks upgrading `llama-index` in environments that pull the openrouter integration (#21860).

This PR widens the cap to `>=0.7.0,<0.8` (matching the current 0.7.x release line of `openai-like`, which itself requires `llama-index-llms-openai>=0.7.0,<0.8`) and bumps the `llama-index-core` lower bound to `>=0.14.3` to match `openai-like`'s floor. The package version is patched from `0.5.0` to `0.5.1`.

`OpenRouter` is a thin `OpenAILike` subclass that only sets a default API base and a few `additional_kwargs` for provider routing. The `OpenAILike.__init__` keyword arguments used here are stable across the 0.5 → 0.7 jump, so no code changes are required.

Fixes #21860

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New Integration

## How Has This Been Tested?

- `uv sync` resolves cleanly with the new constraints in `llama-index-integrations/llms/llama-index-llms-openrouter`.
- `uv run --group dev -- pytest tests/` — both existing tests pass (`test_embedding_class`, `test_provider_routing_settings_injected`); the latter exercises the inherited `OpenAILike` constructor end-to-end.
- `uv run --group dev -- ruff check .` — clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (n/a — dependency-only change)
- [x] I have added tests that prove my fix is effective (existing tests cover the integration; no new behavior introduced)
- [x] New and existing unit tests pass locally with my changes

## Version Bump?

- [x] Yes — `llama-index-llms-openrouter` `0.5.0` → `0.5.1` (patch, dependency-only).

## New Package?

- [ ] No.