### PR TITLE
fix: escape vector store filter values

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-alibabacloud-opensearch/llama_index/vector_stores/alibabacloud_opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-alibabacloud-opensearch/llama_index/vector_stores/alibabacloud_opensearch/base.py
@@ -294,7 +294,8 @@ class AlibabaCloudOpenSearchStore(BasePydanticVectorStore):
             ref_doc_id (str): The doc_id of the document to delete.
 
         """
-        filter = f"{DEFAULT_DOC_ID_KEY}='{ref_doc_id}'"
+        escaped_ref_doc_id = str(ref_doc_id).replace("'", "''")
+        filter = f"{DEFAULT_DOC_ID_KEY}='{escaped_ref_doc_id}'"
         request = models.FetchRequest(table_name=self._config.table_name, filter=filter)
 
         response = self._client.fetch(request)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-analyticdb/llama_index/vector_stores/analyticdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-analyticdb/llama_index/vector_stores/analyticdb/base.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+import re
 from typing import Any, List, Union
 
 from llama_index.core.bridge.pydantic import PrivateAttr
@@ -40,16 +41,31 @@ OPERATOR_MAP = {
 }
 
 
+def _validate_metadata_key(key: str) -> str:
+    # The key becomes part of the SQL/JSON-path text; allow a safe identifier charset only.
+    if not re.fullmatch(r"[A-Za-z0-9_]+", str(key)):
+        raise ValueError(f"Invalid metadata filter key: {key!r}")
+    return str(key)
+
+
+def _escape_sql_str(value: Any) -> str:
+    # The filter is sent to AnalyticDB as a raw SQL string (the request `filter` field has
+    # no bind-parameter support), so single quotes in values must be escaped.
+    return str(value).replace("'", "''")
+
+
 def _build_filter_clause(filter_: MetadataFilter) -> str:
     adb_operator = OPERATOR_MAP.get(filter_.operator)
+    key = _validate_metadata_key(filter_.key)
     if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
-        return f"metadata_->>'{filter_.key}' {adb_operator} {tuple(filter_.value)}"
+        values = ", ".join(f"'{_escape_sql_str(v)}'" for v in filter_.value)
+        return f"metadata_->>'{key}' {adb_operator} ({values})"
     elif filter_.operator == FilterOperator.CONTAINS:
         return (
-            f"metadata_::jsonb->'{filter_.key}' {adb_operator} '[\"{filter_.value}\"]'"
+            f"metadata_::jsonb->'{key}' {adb_operator} '[\"{_escape_sql_str(filter_.value)}\"]'"
         )
     else:
-        return f"metadata_->>'{filter_.key}' {adb_operator} '{filter_.value}'"
+        return f"metadata_->>'{key}' {adb_operator} '{_escape_sql_str(filter_.value)}'"
 
 
 def _recursively_parse_adb_filter(filters: MetadataFilters) -> Union[str, None]:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -1052,7 +1052,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             return
 
         # Locate documents to delete
-        filter = f"{self._field_mapping['doc_id']} eq '{ref_doc_id}'"
+        escaped_ref_doc_id = str(ref_doc_id).replace("'", "''")
+        filter = f"{self._field_mapping['doc_id']} eq '{escaped_ref_doc_id}'"
         batch_size = 1000
 
         while True:
@@ -1083,7 +1084,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             return
 
         # Locate documents to delete
-        filter = f"{self._field_mapping['doc_id']} eq '{ref_doc_id}'"
+        escaped_ref_doc_id = str(ref_doc_id).replace("'", "''")
+        filter = f"{self._field_mapping['doc_id']} eq '{escaped_ref_doc_id}'"
         batch_size = 1000
 
         while True:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/llama_index/vector_stores/azurecosmosnosql/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/llama_index/vector_stores/azurecosmosnosql/base.py
@@ -312,7 +312,11 @@ class AzureCosmosDBNoSqlVectorSearch(BasePydanticVectorStore):
 
         """
         items = self._container.query_items(
-            query=f"SELECT c.id, c.id AS partitionKey FROM c WHERE c.{self._metadata_key}.ref_doc_id = '{ref_doc_id}'",
+            query=(
+                "SELECT c.id, c.id AS partitionKey FROM c "
+                f"WHERE c.{self._metadata_key}.ref_doc_id = @ref_doc_id"
+            ),
+            parameters=[{"name": "@ref_doc_id", "value": ref_doc_id}],
             enable_cross_partition_query=True,
         )
         for item in items:


### PR DESCRIPTION
## Summary
- parameterize Azure Cosmos NoSQL delete lookup by ref_doc_id
- escape string literals used in Azure AI Search and Alibaba Cloud OpenSearch delete filters
- validate AnalyticDB metadata filter keys and escape SQL string values

## Test plan
- python poc/poc_azurecosmosnosql_injection.py
- python poc/poc_azureaisearch_injection.py
- python poc/poc_analyticdb_sqli.py
- python poc/poc_alibabacloud_opensearch_injection.py