### PR TITLE
feat(tools-mcp): add TWZRD Agent Intel remote MCP example notebook

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/examples/twzrd_agent_intel.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/examples/twzrd_agent_intel.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# TWZRD Agent Intel \u2014 Remote MCP Server with LlamaIndex\n",
+    "\n",
+    "This notebook demonstrates using **[TWZRD Agent Intel](https://intel.twzrd.xyz)** \u2014 a production remote Streamable-HTTP MCP server \u2014 with LlamaIndex agents.\n",
+    "\n",
+    "TWZRD Agent Intel trust-scores Solana wallets before agents make HTTP 402 micropayments. No local server setup required \u2014 the MCP endpoint is live at `https://intel.twzrd.xyz/mcp`.\n",
+    "\n",
+    "## Tools available\n",
+    "\n",
+    "| Tool | Cost | Description |\n",
+    "|------|------|-------------|\n",
+    "| `score_agent` | Free | On-chain trust score (0\u2013100) for a Solana wallet |\n",
+    "| `preflight_check` | Free | Boolean readiness \u2014 is this wallet safe to pay? |\n",
+    "| `get_trust_receipt` | Paid (x402) | Signed `twzrd.receipt.v5` via USDC micropayment |\n",
+    "\n",
+    "## Installation\n",
+    "\n",
+    "```bash\n",
+    "pip install llama-index-tools-mcp llama-index-llms-openai\n",
+    "export OPENAI_API_KEY=<your_key>\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1c2d3e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "%pip install llama-index-tools-mcp llama-index-llms-openai -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "source": [
+    "## Setup \u2014 connect to TWZRD Agent Intel MCP server\n",
+    "\n",
+    "The `BasicMCPClient` connects to any Streamable-HTTP MCP endpoint. TWZRD's endpoint requires no authentication for the free tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1e2f3a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient, McpToolSpec\n",
+    "\n",
+    "TWZRD_MCP_URL = \"https://intel.twzrd.xyz/mcp\"\n",
+    "\n",
+    "mcp_client = BasicMCPClient(TWZRD_MCP_URL)\n",
+    "mcp_tool_spec = McpToolSpec(client=mcp_client)\n",
+    "\n",
+    "# List available tools\n",
+    "tools = await mcp_tool_spec.to_tool_list_async()\n",
+    "for t in tools:\n",
+    "    print(f\"  {t.metadata.name}: {t.metadata.description}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "source": [
+    "## Example 1: Direct tool call \u2014 score a Solana wallet\n",
+    "\n",
+    "Call `score_agent` directly to get a trust score for a wallet address."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1a2b3c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call score_agent directly\n",
+    "wallet = \"4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf\"\n",
+    "\n",
+    "score_tool = next(t for t in tools if t.metadata.name == \"score_agent\")\n",
+    "result = await score_tool.acall(wallet=wallet)\n",
+    "print(f\"Trust score for {wallet}:\\n{result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b3c4d5",
+   "metadata": {},
+   "source": [
+    "## Example 2: FunctionAgent \u2014 trust-gated payment decision\n",
+    "\n",
+    "Build a LlamaIndex `FunctionAgent` that uses TWZRD tools to decide whether to approve a USDC payment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\", api_key=os.environ[\"OPENAI_API_KEY\"])\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    name=\"TrustGateAgent\",\n",
+    "    description=\"An agent that verifies Solana wallet trust before approving payments.\",\n",
+    "    tools=tools,\n",
+    "    llm=llm,\n",
+    "    system_prompt=(\n",
+    "        \"You are a payment safety agent. Before approving any USDC transfer, \"\n",
+    "        \"you MUST call preflight_check on the recipient wallet. \"\n",
+    "        \"If preflight passes, also call score_agent and include the trust score in your response. \"\n",
+    "        \"If preflight fails, decline the payment and explain why.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "wallet = \"4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf\"\n",
+    "response = await agent.run(\n",
+    "    f\"I want to send 5 USDC to {wallet}. Is it safe to proceed?\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2d3e4f5",
+   "metadata": {},
+   "source": [
+    "## Example 3: Filter to free tools only\n",
+    "\n",
+    "The `get_trust_receipt` tool requires a paid x402 USDC micropayment. For a free-only setup, filter to just the scoring tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import McpToolSpec\n",
+    "\n",
+    "# Use only the free tools\n",
+    "free_tool_spec = McpToolSpec(\n",
+    "    client=mcp_client,\n",
+    "    allowed_tools=[\"score_agent\", \"preflight_check\"],\n",
+    ")\n",
+    "free_tools = await free_tool_spec.to_tool_list_async()\n",
+    "print(f\"Free tools loaded: {[t.metadata.name for t in free_tools]}\")\n",
+    "\n",
+    "agent_free = FunctionAgent(\n",
+    "    name=\"FreeTrustAgent\",\n",
+    "    description=\"Trust scoring agent using only free TWZRD tools.\",\n",
+    "    tools=free_tools,\n",
+    "    llm=llm,\n",
+    "    system_prompt=\"Check the trust score of Solana wallets before payments.\",\n",
+    ")\n",
+    "\n",
+    "wallet2 = \"DJsfAHjRomMhE7tTfQnFyGKhVVNQHBBXoHF3Rq1uKkVz\"\n",
+    "response2 = await agent_free.run(\n",
+    "    f\"What is the trust score for wallet {wallet2}?\"\n",
+    ")\n",
+    "print(response2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2f3a4b5",
+   "metadata": {},
+   "source": [
+    "## MCP server configuration\n",
+    "\n",
+    "To use TWZRD Agent Intel in any MCP-compatible client:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"mcpServers\": {\n",
+    "    \"twzrd-agent-intel\": {\n",
+    "      \"url\": \"https://intel.twzrd.xyz/mcp\"\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "## Resources\n",
+    "\n",
+    "- Website: https://intel.twzrd.xyz\n",
+    "- MCP endpoint: https://intel.twzrd.xyz/mcp\n",
+    "- OpenAPI: https://intel.twzrd.xyz/openapi.json\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds an example notebook `twzrd_agent_intel.ipynb` to `llama-index-tools-mcp/examples/` demonstrating how to use `McpToolSpec` with a **production remote Streamable-HTTP MCP server** — [TWZRD Agent Intel](https://intel.twzrd.xyz).

The existing `mcp.ipynb` example requires running a local server first. This example uses a live remote endpoint (no local setup), making it a useful reference for teams building agents that connect to third-party MCP services.

### What the notebook covers

1. **Direct tool call** — invoke `score_agent` to get a trust score for a Solana wallet
2. **FunctionAgent** — trust-gated payment decision using `preflight_check` + `score_agent`  
3. **Filtered tool spec** — using `allowed_tools` to expose only free tools

### About TWZRD Agent Intel

[TWZRD Agent Intel](https://intel.twzrd.xyz) is a Solana trust-scoring MCP server for x402 agent payment workflows:

| Tool | Cost | Description |
|------|------|-------------|
| `score_agent` | Free | On-chain trust score (0–100) for a Solana wallet |
| `preflight_check` | Free | Boolean readiness check before sending a payment |
| `get_trust_receipt` | Paid (HTTP 402) | Signed receipt via USDC micropayment |

MCP endpoint: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP, no API key required for free tools)

```python
from llama_index.tools.mcp import BasicMCPClient, McpToolSpec

mcp_client = BasicMCPClient("https://intel.twzrd.xyz/mcp")
mcp_tool_spec = McpToolSpec(client=mcp_client)
tools = await mcp_tool_spec.to_tool_list_async()
```

## Type of change

- [ ] Bug fix
- [x] New feature / example
- [ ] Breaking change
- [ ] Documentation update