### PR TITLE
fix: lazy init Google rerank async client

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/llama_index/postprocessor/google_rerank/base.py
@@ -1,5 +1,6 @@
 """Google Rerank postprocessor using Discovery Engine Ranking API."""
 
+import asyncio
 import os
 from typing import Any, List, Optional
 
@@ -53,7 +54,9 @@ class GoogleRerank(BaseNodePostprocessor):
     )
 
     _client: Any = PrivateAttr()
-    _async_client: Any = PrivateAttr()
+    _async_client: Any = PrivateAttr(default=None)
+    _async_client_loop: Any = PrivateAttr(default=None)
+    _credentials: Any = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -82,9 +85,7 @@ class GoogleRerank(BaseNodePostprocessor):
             self.project_id = resolved_project
 
         self._client = discoveryengine.RankServiceClient(credentials=credentials)
-        self._async_client = discoveryengine.RankServiceAsyncClient(
-            credentials=credentials
-        )
+        self._credentials = credentials
 
     @classmethod
     def class_name(cls) -> str:
@@ -107,6 +108,15 @@ class GoogleRerank(BaseNodePostprocessor):
                 )
             )
         return records
+
+    def _get_async_client(self) -> Any:
+        current_loop = asyncio.get_running_loop()
+        if self._async_client is None or self._async_client_loop is not current_loop:
+            self._async_client = discoveryengine.RankServiceAsyncClient(
+                credentials=self._credentials
+            )
+            self._async_client_loop = current_loop
+        return self._async_client
 
     @dispatcher.span
     def _postprocess_nodes(
@@ -185,7 +195,7 @@ class GoogleRerank(BaseNodePostprocessor):
             records=records,
         )
 
-        response = await self._async_client.rank(request=request)
+        response = await self._get_async_client().rank(request=request)
 
         new_nodes = []
         for record in response.records:

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-google-rerank/tests/test_postprocessor_google_rerank.py
@@ -80,6 +80,18 @@ def test_google_rerank():
     reranker._client.rank.assert_called_once()
 
 
+def test_google_rerank_async_client_is_lazy():
+    with mock.patch(
+        "llama_index.postprocessor.google_rerank.base.discoveryengine",
+        create=True,
+    ) as mock_discoveryengine:
+        with mock.patch("google.auth.default", return_value=(None, "test-project")):
+            GoogleRerank(project_id="test-project")
+
+    mock_discoveryengine.RankServiceClient.assert_called_once()
+    mock_discoveryengine.RankServiceAsyncClient.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_google_rerank_async():
     reranker = _create_reranker(top_n=2)
@@ -90,24 +102,31 @@ async def test_google_rerank_async():
             {"index": 0, "score": 0.70},
         ]
     )
-    reranker._async_client.rank = AsyncMock(return_value=mock_response)
 
     input_nodes = [
         NodeWithScore(node=TextNode(id_="1", text="hello world")),
         NodeWithScore(node=TextNode(id_="2", text="goodbye world")),
     ]
 
+    async_client = MagicMock()
+    async_client.rank = AsyncMock(return_value=mock_response)
+
     query_bundle = QueryBundle(query_str="goodbye")
-    actual_nodes = await reranker.apostprocess_nodes(
-        input_nodes, query_bundle=query_bundle
-    )
+    with mock.patch(
+        "llama_index.postprocessor.google_rerank.base.discoveryengine.RankServiceAsyncClient",
+        return_value=async_client,
+    ) as mock_async_client_cls:
+        actual_nodes = await reranker.apostprocess_nodes(
+            input_nodes, query_bundle=query_bundle
+        )
 
     assert len(actual_nodes) == 2
     assert actual_nodes[0].node.get_content() == "goodbye world"
     assert actual_nodes[0].score == pytest.approx(0.90)
     assert actual_nodes[1].node.get_content() == "hello world"
     assert actual_nodes[1].score == pytest.approx(0.70)
-    reranker._async_client.rank.assert_called_once()
+    mock_async_client_cls.assert_called_once()
+    async_client.rank.assert_called_once()
 
 
 def test_google_rerank_empty_nodes():


### PR DESCRIPTION
## Summary

Fixes #21150.

`GoogleRerank` currently creates `RankServiceAsyncClient` in `__init__`. In production apps that construct the reranker outside the request loop and later call `apostprocess_nodes()` inside another event loop, that eager async client can be bound to the wrong async context.

This keeps the async implementation, but initializes the async Discovery Engine client lazily from the running event loop. If the reranker is reused from a different loop later, it creates a fresh async client for that loop.

This is intentionally different from the older closed #21184 approach: it does not remove `_apostprocess_nodes()` or fall back to the sync path in a worker thread.

## Validation

```text
python -m pytest llama-index-integrations\postprocessor\llama-index-postprocessor-google-rerank\tests\test_postprocessor_google_rerank.py -q
# 7 passed

python -m py_compile llama-index-integrations\postprocessor\llama-index-postprocessor-google-rerank\llama_index\postprocessor\google_rerank\base.py llama-index-integrations\postprocessor\llama-index-postprocessor-google-rerank\tests\test_postprocessor_google_rerank.py

python -m ruff check llama-index-integrations\postprocessor\llama-index-postprocessor-google-rerank\llama_index\postprocessor\google_rerank\base.py llama-index-integrations\postprocessor\llama-index-postprocessor-google-rerank\tests\test_postprocessor_google_rerank.py
# All checks passed

git diff --check
```
