### PR TITLE
fix: omit unset best_of for vLLM sampling params

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -254,6 +254,8 @@ class Vllm(LLM):
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
+        if self.best_of is None:
+            base_kwargs.pop("best_of")
         return {**base_kwargs}
 
     @atexit.register

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
@@ -28,3 +28,19 @@ def test_server_callback() -> None:
     )
     assert remote.callback_manager == callback_manager
     del remote
+
+
+def test_model_kwargs_omit_default_best_of() -> None:
+    from llama_index.llms.vllm import VllmServer
+
+    remote = VllmServer(api_url="http://localhost:8000")
+
+    assert "best_of" not in remote._model_kwargs
+
+
+def test_model_kwargs_include_explicit_best_of() -> None:
+    from llama_index.llms.vllm import VllmServer
+
+    remote = VllmServer(api_url="http://localhost:8000", best_of=2)
+
+    assert remote._model_kwargs["best_of"] == 2


### PR DESCRIPTION
## Summary

Fixes #21371.

`Vllm._model_kwargs` currently includes `best_of: None` by default. Recent vLLM versions no longer accept `best_of` in `SamplingParams`, so local `.complete()` calls can fail with `TypeError: Unexpected keyword argument 'best_of'` even when the user did not configure `best_of`.

This change omits `best_of` only when it is unset, while preserving explicit `best_of` values for older/compatible vLLM setups.

## Validation

From `llama-index-integrations/llms/llama-index-llms-vllm`:

- `uv run pytest tests/test_llms_vllm.py -q`
- `uv run pytest -q`
- `uv run ruff check llama_index/llms/vllm/base.py tests/test_llms_vllm.py`
- `uv run ruff format --check llama_index/llms/vllm/base.py tests/test_llms_vllm.py`

## AI assistance

I used AI assistance to help inspect the issue, prepare this small patch, and draft the regression tests. I reviewed the final diff and validated it locally with the commands above.
