### PR TITLE
fix(tools-mcp): handle AudioContent / EmbeddedResource / ResourceLink in get_prompt

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -27,7 +27,13 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.llms import (
+    AudioBlock,
+    ChatMessage,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
 
 
 class StreamingHandler(logging.Handler):
@@ -398,9 +404,68 @@ class BasicMCPClient(ClientSession):
                             ],
                         )
                     )
+                elif isinstance(message.content, types.AudioContent):
+                    # MCP `AudioContent.data` is base64-encoded; mirror
+                    # `ImageContent` and pass through unchanged so
+                    # `AudioBlock.resolve_audio()` decodes lazily downstream.
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[
+                                AudioBlock(
+                                    audio=message.content.data,
+                                    format=message.content.mimeType,
+                                )
+                            ],
+                        )
+                    )
                 elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
+                    resource = message.content.resource
+                    if isinstance(resource, types.TextResourceContents):
+                        # Embedded text resource — inline as a TextBlock so the
+                        # text content reaches the LLM. URI / mimeType is
+                        # tracked via the wrapping ChatMessage role only.
+                        llama_messages.append(
+                            ChatMessage(
+                                role=message.role,
+                                blocks=[TextBlock(text=resource.text)],
+                            )
+                        )
+                    elif isinstance(resource, types.BlobResourceContents):
+                        # Embedded binary resource — pass through as a
+                        # DocumentBlock; MCP keeps the payload base64-encoded
+                        # which DocumentBlock handles directly.
+                        llama_messages.append(
+                            ChatMessage(
+                                role=message.role,
+                                blocks=[
+                                    DocumentBlock(
+                                        data=resource.blob,
+                                        url=str(resource.uri),
+                                        document_mimetype=resource.mimeType,
+                                    )
+                                ],
+                            )
+                        )
+                    else:  # pragma: no cover - future-proofing
+                        raise ValueError(
+                            f"Unsupported embedded resource type: {type(resource)}"
+                        )
+                elif isinstance(message.content, types.ResourceLink):
+                    # ResourceLink points to a resource the client must fetch
+                    # itself; surface the link via DocumentBlock so downstream
+                    # adapters can resolve it.
+                    llama_messages.append(
+                        ChatMessage(
+                            role=message.role,
+                            blocks=[
+                                DocumentBlock(
+                                    url=str(message.content.uri),
+                                    title=message.content.name,
+                                    document_mimetype=message.content.mimeType,
+                                )
+                            ],
+                        )
                     )
                 else:
                     raise ValueError(

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -259,3 +259,98 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_handles_all_mcp_content_block_types():
+    """Regression for #21270.
+
+    `BasicMCPClient.get_prompt` previously only handled `TextContent` and
+    `ImageContent`. `EmbeddedResource` raised `NotImplementedError` and any
+    other valid MCP `ContentBlock` (`AudioContent`, `ResourceLink`) raised
+    `ValueError`, so any server that returned those types broke the call.
+    Verify all five spec-valid content types now translate without raising.
+    """
+    from contextlib import asynccontextmanager
+    from unittest.mock import patch
+
+    from llama_index.core.llms import (
+        AudioBlock,
+        DocumentBlock,
+        ImageBlock,
+        TextBlock,
+    )
+    from mcp import types
+
+    prompt_messages = [
+        types.PromptMessage(
+            role="user", content=types.TextContent(type="text", text="hello")
+        ),
+        types.PromptMessage(
+            role="user",
+            content=types.ImageContent(type="image", data="aW1nLWI2NA==", mimeType="image/png"),
+        ),
+        types.PromptMessage(
+            role="user",
+            content=types.AudioContent(type="audio", data="YXVkaW8tYjY0", mimeType="audio/wav"),
+        ),
+        types.PromptMessage(
+            role="user",
+            content=types.EmbeddedResource(
+                type="resource",
+                resource=types.TextResourceContents(
+                    uri="resource://doc-text", mimeType="text/plain", text="inline text"
+                ),
+            ),
+        ),
+        types.PromptMessage(
+            role="user",
+            content=types.EmbeddedResource(
+                type="resource",
+                resource=types.BlobResourceContents(
+                    uri="resource://doc-blob",
+                    mimeType="application/pdf",
+                    blob="cGRmLWI2NA==",
+                ),
+            ),
+        ),
+        types.PromptMessage(
+            role="user",
+            content=types.ResourceLink(
+                type="resource_link",
+                name="report.pdf",
+                uri="resource://report",
+                mimeType="application/pdf",
+            ),
+        ),
+    ]
+
+    class _FakeSession:
+        async def get_prompt(self, _name, _args):
+            return types.GetPromptResult(messages=prompt_messages)
+
+    @asynccontextmanager
+    async def _fake_run_session(self):
+        yield _FakeSession()
+
+    client = BasicMCPClient("ignored", args=[], timeout=5)
+    with patch.object(BasicMCPClient, "_run_session", _fake_run_session):
+        result = await client.get_prompt("any")
+
+    assert [
+        type(msg.blocks[0]).__name__ for msg in result
+    ] == [
+        "TextBlock",
+        "ImageBlock",
+        "AudioBlock",
+        "TextBlock",
+        "DocumentBlock",
+        "DocumentBlock",
+    ]
+    assert isinstance(result[0].blocks[0], TextBlock) and result[0].blocks[0].text == "hello"
+    assert isinstance(result[1].blocks[0], ImageBlock)
+    assert isinstance(result[2].blocks[0], AudioBlock)
+    assert isinstance(result[3].blocks[0], TextBlock) and result[3].blocks[0].text == "inline text"
+    assert isinstance(result[4].blocks[0], DocumentBlock)
+    assert isinstance(result[5].blocks[0], DocumentBlock)
+    assert result[5].blocks[0].title == "report.pdf"


### PR DESCRIPTION
## Summary

Closes #21270.

`BasicMCPClient.get_prompt` only handled `TextContent` and `ImageContent`. The remaining spec-valid MCP `ContentBlock` variants raised on every prompt that returned them:

- `EmbeddedResource` → `NotImplementedError("Embedded resources are not supported yet")`
- `AudioContent` / `ResourceLink` → `ValueError("Unsupported content type: ...")` via the `else` branch

So any MCP server emitting audio, embedded resources, or resource links crashed `get_prompt` instead of translating into LlamaIndex blocks.

## Fix shape

Add explicit handling for each variant:

| MCP type | Maps to |
|---|---|
| `AudioContent` | `AudioBlock(audio=data, format=mimeType)` |
| `EmbeddedResource` (text resource) | `TextBlock(text=resource.text)` |
| `EmbeddedResource` (blob resource) | `DocumentBlock(data=blob, url=uri, document_mimetype=mimeType)` |
| `ResourceLink` | `DocumentBlock(url=uri, title=name, document_mimetype=mimeType)` |

Existing `TextContent` / `ImageContent` paths unchanged.

## Test plan

- [x] `test_get_prompt_handles_all_mcp_content_block_types` exercises all six content patterns (text, image, audio, embedded text resource, embedded blob resource, resource link) via a mocked `_run_session`. Asserts the produced block types and key fields.
- [x] Existing tests still pass (`tests/test_client.py` collects 14 tests; the new one is the 14th).