### PR TITLE
fix(bedrock-converse): retry async stream setup

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -934,9 +934,12 @@ async def converse_with_retry_async(
                 return await c.converse(**kwargs)
 
         @retry_decorator
+        async def _converse_stream_with_retry(c: Any, **kwargs: Any) -> Any:
+            return await c.converse_stream(**kwargs)
+
         async def _conversion_stream_with_retry(**kwargs: Any) -> Any:
             if client is not None:
-                response = await client.converse_stream(**kwargs)
+                response = await _converse_stream_with_retry(client, **kwargs)
                 async for event in response["stream"]:
                     yield event
             else:
@@ -945,7 +948,7 @@ async def converse_with_retry_async(
                     config=config,
                     **_boto_client_kwargs,
                 ) as c:
-                    response = await c.converse_stream(**kwargs)
+                    response = await _converse_stream_with_retry(c, **kwargs)
                     async for event in response["stream"]:
                         yield event
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -4,6 +4,8 @@ from typing import Literal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_none
+import llama_index.llms.bedrock_converse.utils as bedrock_utils
 from llama_index.core.base.llms.types import (
     AudioBlock,
     CacheControl,
@@ -913,6 +915,117 @@ async def test_converse_with_retry_async_uses_provided_client_streaming():
         async for _ in response_gen:
             pass
         patched_stream.assert_called_once()
+
+
+class TransientStreamSetupError(Exception):
+    pass
+
+
+class AsyncStreamSetupRetryClient:
+    def __init__(self, fail_on_calls: int = 1) -> None:
+        self.calls = 0
+        self.fail_on_calls = fail_on_calls
+
+    async def converse_stream(self, **kwargs):
+        self.calls += 1
+        if self.calls <= self.fail_on_calls:
+            raise TransientStreamSetupError("temporary setup failure")
+
+        async def stream_generator():
+            yield {
+                "contentBlockDelta": {
+                    "delta": {"text": "retried"},
+                    "contentBlockIndex": 0,
+                }
+            }
+
+        return {"stream": stream_generator()}
+
+
+class AsyncMidStreamFailureClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def converse_stream(self, **kwargs):
+        self.calls += 1
+
+        async def stream_generator():
+            yield {
+                "contentBlockDelta": {
+                    "delta": {"text": "first"},
+                    "contentBlockIndex": 0,
+                }
+            }
+            raise TransientStreamSetupError("mid-stream failure")
+
+        return {"stream": stream_generator()}
+
+
+@pytest.mark.asyncio
+async def test_converse_with_retry_async_retries_stream_setup(monkeypatch):
+    monkeypatch.setattr(bedrock_utils, "HAS_AIOBOTO3", True)
+    monkeypatch.setattr(
+        bedrock_utils,
+        "_create_retry_decorator_async",
+        lambda max_retries: retry(
+            reraise=True,
+            stop=stop_after_attempt(max_retries),
+            wait=wait_none(),
+            retry=retry_if_exception_type(TransientStreamSetupError),
+        ),
+    )
+    async_client = AsyncStreamSetupRetryClient()
+
+    response_gen = await converse_with_retry_async(
+        client=async_client,
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+        messages=[],
+        stream=True,
+        max_retries=2,
+        session=object(),
+        config=object(),
+    )
+
+    events = [event async for event in response_gen]
+
+    assert async_client.calls == 2
+    assert events[0]["contentBlockDelta"]["delta"]["text"] == "retried"
+
+
+@pytest.mark.asyncio
+async def test_converse_with_retry_async_does_not_retry_mid_stream_errors(
+    monkeypatch,
+):
+    monkeypatch.setattr(bedrock_utils, "HAS_AIOBOTO3", True)
+    monkeypatch.setattr(
+        bedrock_utils,
+        "_create_retry_decorator_async",
+        lambda max_retries: retry(
+            reraise=True,
+            stop=stop_after_attempt(max_retries),
+            wait=wait_none(),
+            retry=retry_if_exception_type(TransientStreamSetupError),
+        ),
+    )
+    async_client = AsyncMidStreamFailureClient()
+
+    response_gen = await converse_with_retry_async(
+        client=async_client,
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+        messages=[],
+        stream=True,
+        max_retries=2,
+        session=object(),
+        config=object(),
+    )
+
+    events = []
+    with pytest.raises(TransientStreamSetupError):
+        async for event in response_gen:
+            events.append(event)
+
+    assert async_client.calls == 1
+    assert events[0]["contentBlockDelta"]["delta"]["text"] == "first"
 
 
 def test_thinking_dict_enabled_requires_budget():


### PR DESCRIPTION
## Summary

Fixes #21346.

Move the async Bedrock Converse streaming retry boundary from the async generator body to the awaitable `converse_stream()` setup call. This makes retryable setup failures retry as intended while still allowing mid-stream failures to propagate without replaying a partially consumed stream.

## Changes

- Add a retry-wrapped async helper for the initial `converse_stream()` call.
- Use that helper in both provided-client and session-created async streaming paths.
- Keep iteration over `response["stream"]` outside the retry wrapper so already-yielded chunks are not replayed.
- Add regression coverage for retrying a transient setup failure and for not retrying a mid-stream failure.

## Verification

From `llama-index-integrations/llms/llama-index-llms-bedrock-converse`:

```bash
uv run -- pytest tests/test_bedrock_converse_utils.py -q -k 'retries_stream_setup'
uv run -- pytest tests/test_bedrock_converse_utils.py -q -k 'stream_setup or mid_stream_errors'
uv run -- pytest tests/test_bedrock_converse_utils.py -q -k 'converse_with_retry_async'
uv run -- pytest tests/test_bedrock_converse_utils.py -q
uv run -- ruff check llama_index/llms/bedrock_converse/utils.py tests/test_bedrock_converse_utils.py
uv run -- ruff format --check llama_index/llms/bedrock_converse/utils.py tests/test_bedrock_converse_utils.py
```

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

AI assistance was used to help prepare this small patch and test coverage. I reviewed the implementation and validated the commands above.
