### PR TITLE
fix(cerebras): bump llama-index-llms-openai-like to >=0.6.0,<0.9

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-cerebras"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index llms cerebras integration"
 authors = [{name = "Cerebras", email = "support@cerebras.ai"}]
 requires-python = ">=3.10,<4.0"
@@ -34,7 +34,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.13.0,<0.15",
-    "llama-index-llms-openai-like>=0.5.0,<0.6",
+    "llama-index-llms-openai-like>=0.6.0,<0.9",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
## Description

`llama-index-llms-cerebras` pins `llama-index-llms-openai-like>=0.5.0,<0.6`, but the current released version is **0.7.2**. This makes it impossible to install `llama-index-llms-cerebras` alongside any `llama-index>=0.14.18` release, which requires `openai-like>=0.6`.

This PR bumps the constraint to `>=0.6.0,<0.9` so users can install Cerebras alongside the current llama-index release series.

The `Cerebras` class is a thin `OpenAILike` subclass that only adds `__init__` and `class_name()`. The `OpenAILike` import path is unchanged in `0.6`/`0.7`, so no code changes are required.

Fixes #21100

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No (updating existing package)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes — bumped `llama-index-llms-cerebras` from `0.4.0` to `0.4.1`