### PR TITLE
fix: keep doc numbers and relevances aligned in choice-select answer parsing

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -148,13 +148,11 @@ def default_parse_choice_select_answer_fn(
                 )
         if answer_num > num_choices:
             continue
-        answer_nums.append(answer_num)
         # extract just the first digits after the colon.
         try:
             _answer_relevance = re.findall(
                 r"\d+", line_tokens[1].split(":")[1].strip()
             )[0]
-            answer_relevances.append(float(_answer_relevance))
         except (IndexError, ValueError) as e:
             if not raise_error:
                 continue
@@ -164,6 +162,10 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
+        # only keep the doc number once we know its relevance parsed, so the
+        # two lists stay parallel (callers zip them together)
+        answer_nums.append(answer_num)
+        answer_relevances.append(float(_answer_relevance))
     return answer_nums, answer_relevances
 
 

--- a/llama-index-core/tests/indices/test_utils.py
+++ b/llama-index-core/tests/indices/test_utils.py
@@ -34,3 +34,15 @@ def test_default_parse_choice_select_answer_fn(answer):
     answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
     assert answer_nums == [2, 4]
     assert answer_relevances == [8, 6]
+
+
+def test_default_parse_choice_select_answer_fn_unparseable_relevance():
+    """A valid doc with an unparseable relevance must not desync the two lists."""
+    from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
+
+    # second line has no digits in the relevance field -> relevance parse fails
+    answer = "Doc: 1, Relevance: 8\nDoc: 2, Relevance: high"
+    answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
+    assert answer_nums == [1]
+    assert answer_relevances == [8]
+    assert len(answer_nums) == len(answer_relevances)


### PR DESCRIPTION
`default_parse_choice_select_answer_fn` returns two parallel lists, `answer_nums` and `answer_relevances`, and callers like `SummaryIndexLLMRetriever` zip them together to score nodes.

The doc number was appended to `answer_nums` before the relevance was parsed. If a line has a valid doc number but a relevance with no digits (e.g. an LLM returning `Doc: 2, Relevance: high`), the relevance parse raises and the loop `continue`s — leaving `answer_nums` longer than `answer_relevances`. After that the two lists are misaligned: relevance scores get attached to the wrong nodes and the final choice is silently dropped. The retriever's `relevances or [...]` fallback only kicks in when the list is completely empty, so a partial mismatch slips through unnoticed.

Fix is to append the doc number only after its relevance has parsed successfully, so the lists always stay in lockstep. Added a regression test covering the unparseable-relevance case.