### PR TITLE
fix(openai): GPT-5 chat variants are not reasoning models — respect custom temperature

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -60,10 +60,10 @@ O1_MODELS: Dict[str, int] = {
     "o4-mini": 200000,
     "o4-mini-2025-04-16": 200000,
     # gpt-5 is a reasoning model, putting it in the o models list
+    # NOTE: the gpt-5* chat variants (e.g. gpt-5.2-chat-latest) are standard chat
+    # models, not reasoning models — they belong in GPT4_MODELS instead (see #20154)
     "gpt-5": 400000,
     "gpt-5-2025-08-07": 400000,
-    "gpt-5-chat": 128000,
-    "gpt-5-chat-latest": 128000,
     "gpt-5-mini": 400000,
     "gpt-5-mini-2025-08-07": 400000,
     "gpt-5-nano": 400000,
@@ -72,17 +72,13 @@ O1_MODELS: Dict[str, int] = {
     "gpt-5-pro-2025-10-06": 400000,
     "gpt-5.1": 400000,
     "gpt-5.1-2025-11-13": 400000,
-    "gpt-5.1-chat-latest": 128000,
     "gpt-5.2": 400000,
     "gpt-5.2-2025-12-11": 400000,
-    "gpt-5.2-chat-latest": 128000,
     "gpt-5.3": 400000,
-    "gpt-5.3-chat-latest": 128000,
     "gpt-5.4": 1050000,
     "gpt-5.4-2026-03-05": 1050000,
     "gpt-5.4-mini": 400000,
     "gpt-5.4-nano": 400000,
-    "gpt-5.4-chat-latest": 128000,
     "gpt-5.5": 1050000,
     "gpt-5.5-2026-04-23": 1050000,
 }
@@ -144,8 +140,14 @@ GPT4_MODELS: Dict[str, int] = {
     "gpt-4.1-2025-04-14": 1047576,
     "gpt-4.1-mini-2025-04-14": 1047576,
     "gpt-4.1-nano-2025-04-14": 1047576,
-    # Latest GPT-5-chat supports setting temperature, so putting it here
+    # GPT-5 chat variants are standard chat models (not reasoning models): they
+    # support setting temperature and must not be treated as O1_MODELS (#20154)
+    "gpt-5-chat": 128000,
     "gpt-5-chat-latest": 128000,
+    "gpt-5.1-chat-latest": 128000,
+    "gpt-5.2-chat-latest": 128000,
+    "gpt-5.3-chat-latest": 128000,
+    "gpt-5.4-chat-latest": 128000,
 }
 
 AZURE_TURBO_MODELS: Dict[str, int] = {

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.9"
+version = "0.7.10"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -27,6 +27,7 @@ from llama_index.llms.openai import OpenAI
 from llama_index.llms.openai.utils import (
     ALL_AVAILABLE_MODELS,
     CHAT_MODELS,
+    O1_MODELS,
     from_openai_completion_logprobs,
     from_openai_message_dicts,
     from_openai_messages,
@@ -446,10 +447,19 @@ def test_is_json_schema_supported_unsupported_models() -> None:
         )
 
 
-def test_gpt_5_chat_latest_model_support() -> None:
-    """Test that gpt-5-chat-latest is properly supported."""
-    model_name = "gpt-5-chat-latest"
+GPT_5_CHAT_VARIANTS = [
+    "gpt-5-chat",
+    "gpt-5-chat-latest",
+    "gpt-5.1-chat-latest",
+    "gpt-5.2-chat-latest",
+    "gpt-5.3-chat-latest",
+    "gpt-5.4-chat-latest",
+]
 
+
+@pytest.mark.parametrize("model_name", GPT_5_CHAT_VARIANTS)
+def test_gpt_5_chat_variants_model_support(model_name: str) -> None:
+    """Test that the GPT-5 chat variants are properly supported as chat models."""
     # Test that model is in available models
     assert model_name in ALL_AVAILABLE_MODELS, (
         f"{model_name} should be in ALL_AVAILABLE_MODELS"
@@ -473,6 +483,25 @@ def test_gpt_5_chat_latest_model_support() -> None:
 
     # Test that model is in CHAT_MODELS
     assert model_name in CHAT_MODELS, f"{model_name} should be in CHAT_MODELS"
+
+    # Chat variants are not reasoning models: they must not be in O1_MODELS,
+    # which forces temperature to 1.0 (regression guard for #20154 / #20156)
+    assert model_name not in O1_MODELS, f"{model_name} should not be in O1_MODELS"
+
+
+@pytest.mark.parametrize("model_name", GPT_5_CHAT_VARIANTS)
+def test_gpt_5_chat_variants_respect_temperature(model_name: str) -> None:
+    """GPT-5 chat variants accept a custom temperature (#20154)."""
+    llm = OpenAI(model=model_name, temperature=0.2, api_key="fake")
+    assert llm.temperature == 0.2, (
+        f"{model_name} should respect a custom temperature, got {llm.temperature}"
+    )
+
+
+def test_reasoning_models_force_temperature() -> None:
+    """True reasoning models still force temperature to 1.0."""
+    llm = OpenAI(model="o3", temperature=0.2, api_key="fake")
+    assert llm.temperature == 1.0
 
 
 def test_is_chatcomp_api_supported() -> None:


### PR DESCRIPTION
# Description

The GPT-5 chat variants are standard (non-reasoning) chat models, but they are currently listed in `O1_MODELS`, so the `OpenAI` class treats them as reasoning models. The most visible effect: `temperature` is force-overridden to `1.0` at construction (`base.py`), silently discarding the user's value. `O1_MODELS` membership also forwards `reasoning_effort` (which these models don't accept) and demotes the system role.

This is a regression of #20156: that PR moved `gpt-5-chat-latest` out of `O1_MODELS` into `GPT4_MODELS` to fix #20154 ("gpt-5-chat-latest does not accept custom temperature"), but a later model-family addition re-added it to `O1_MODELS`. The regression wasn't caught because the test from #20156 checks chat-model classification but never asserts `model not in O1_MODELS`. The newer chat variants (`gpt-5-chat`, `gpt-5.1-chat-latest`, `gpt-5.2-chat-latest`, `gpt-5.3-chat-latest`, `gpt-5.4-chat-latest`) were added directly to `O1_MODELS` and inherited the same bug.

This PR:
- moves all 6 GPT-5 chat variants from `O1_MODELS` to `GPT4_MODELS` (same approach as #20156), preserving their 128k context sizes
- parametrizes the existing `gpt-5-chat-latest` support test over all chat variants and adds the missing regression guard (`model not in O1_MODELS`)
- adds behavioral tests: chat variants keep a custom `temperature`; true reasoning models (`o3`) still force `1.0`

Fixes #20154 (regressed)

## New Package?

- [ ] No

## Version Bump?

- [x] Yes (`llama-index-llms-openai` 0.7.9 → 0.7.10)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Full package suite: `pytest tests/` → 124 passed, 14 skipped (no failures). New parametrized tests fail on `main` and pass with this change.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I added new unit tests to cover this change
- [x] I ran `make format; make lint` to appease the lint gods
