### PR TITLE
fix(openai): mark o1-pro, o3-pro and gpt-5-pro as Responses-API-only

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -88,6 +88,16 @@ O1_MODELS: Dict[str, int] = {
 }
 
 RESPONSES_API_ONLY_MODELS = {
+    # Per OpenAI's model pages, the pro reasoning models are "available in the
+    # Responses API only". The o1-pro/o3-pro/gpt-5-pro entries stay in O1_MODELS
+    # too so context-window lookup and reasoning handling keep working for
+    # OpenAIResponses; membership here only gates the Chat Completions class.
+    "o1-pro": 200000,
+    "o1-pro-2025-03-19": 200000,
+    "o3-pro": 200000,
+    "o3-pro-2025-06-10": 200000,
+    "gpt-5-pro": 400000,
+    "gpt-5-pro-2025-10-06": 400000,
     "gpt-5.2-pro": 400000,
     "gpt-5.2-pro-2025-12-11": 400000,
     "gpt-5.4-pro": 1050000,

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.9"
+version = "0.7.10"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_utils.py
@@ -480,6 +480,24 @@ def test_is_chatcomp_api_supported() -> None:
     assert not is_chatcomp_api_supported("gpt-5.2-pro")
     assert is_chatcomp_api_supported("gpt-5.4")
     assert not is_chatcomp_api_supported("gpt-5.4-pro")
+    # The older pro reasoning models are Responses-API-only too
+    assert not is_chatcomp_api_supported("o1-pro")
+    assert not is_chatcomp_api_supported("o1-pro-2025-03-19")
+    assert not is_chatcomp_api_supported("o3-pro")
+    assert not is_chatcomp_api_supported("o3-pro-2025-06-10")
+    assert not is_chatcomp_api_supported("gpt-5-pro")
+    assert not is_chatcomp_api_supported("gpt-5-pro-2025-10-06")
+    # ...but their non-pro siblings remain chat-completions-supported
+    assert is_chatcomp_api_supported("o1")
+    assert is_chatcomp_api_supported("o3")
+    assert is_chatcomp_api_supported("gpt-5")
+
+
+def test_responses_only_pro_models_raise_helpful_error() -> None:
+    """Constructing the Chat Completions class with a Responses-only model raises."""
+    for model_name in ["o1-pro", "o3-pro", "gpt-5-pro"]:
+        with pytest.raises(ValueError, match="only supported by the Responses API"):
+            OpenAI(model=model_name, api_key="fake")
 
 
 def test_gpt_5_chat_model_support() -> None:


### PR DESCRIPTION
# Description

`RESPONSES_API_ONLY_MODELS` currently lists only `gpt-5.2-pro` and `gpt-5.4-pro`, so the helpful constructor guard in `OpenAI.__init__` ("Cannot use model X as it is only supported by the Responses API. Use the OpenAIResponses class for it.") never fires for the older pro reasoning models. `OpenAI(model="o3-pro")` (or `o1-pro` / `gpt-5-pro`) constructs fine and then fails at request time with a confusing upstream API error instead.

Per OpenAI's model pages for [o1-pro](https://developers.openai.com/api/docs/models/o1-pro), [o3-pro](https://developers.openai.com/api/docs/models/o3-pro), and [gpt-5-pro](https://developers.openai.com/api/docs/models/gpt-5-pro), each is *"available in the Responses API only to enable support for multi-turn model interactions"* — the same situation the existing `gpt-5.2-pro`/`gpt-5.4-pro` entries handle.

This PR adds `o1-pro`, `o3-pro`, `gpt-5-pro` (and their dated snapshots) to `RESPONSES_API_ONLY_MODELS`. They deliberately stay in `O1_MODELS` as well, so context-window lookup (`ALL_AVAILABLE_MODELS`) and the reasoning-model handling in `OpenAIResponses` are unchanged — membership in `RESPONSES_API_ONLY_MODELS` only gates the Chat Completions class.

One consideration for reviewers: if Azure deployments expose any of these models via chat completions (the `AzureOpenAI` subclass shares this guard), that would be a reason to scope the guard differently — happy to adjust.

Note: bumps the package version to 0.7.10; may need a trivial rebase depending on the order this lands relative to #21921.

## New Package?

- [ ] No

## Version Bump?

- [x] Yes (`llama-index-llms-openai` 0.7.9 → 0.7.10)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`pytest tests/` → 113 passed, 14 skipped (no failures). New tests: `is_chatcomp_api_supported` negatives for all six pro entries (plus positives guarding `o1`/`o3`/`gpt-5` stay supported), and a constructor test asserting the helpful `ValueError` is raised for `o1-pro`/`o3-pro`/`gpt-5-pro`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I added new unit tests to cover this change
- [x] I ran `make format; make lint` to appease the lint gods
