### PR TITLE
docs: clarify pandas query engine usage

### DIFF
--- a/docs/examples/query_engine/pandas_query_engine.ipynb
+++ b/docs/examples/query_engine/pandas_query_engine.ipynb
@@ -20,6 +20,8 @@
     "\n",
     "The input to the `PandasQueryEngine` is a Pandas dataframe, and the output is a response. The LLM infers dataframe operations to perform in order to retrieve the result.\n",
     "\n",
+    "`PandasQueryEngine` lives in `llama-index-experimental`, so install `llama-index-experimental` and import it with `from llama_index.experimental.query_engine import PandasQueryEngine`. Legacy imports from `llama_index.core.query_engine` are deprecated.\n",
+    "\n",
     "**WARNING:** This tool provides the LLM access to the `eval` function.\n",
     "Arbitrary code execution is possible on the machine running this tool.\n",
     "While some level of filtering is done on code, this tool is not recommended \n",


### PR DESCRIPTION
## What
Adds a note to the Pandas Query Engine notebook clarifying that `PandasQueryEngine` lives in `llama-index-experimental`.

## Why
Users following the notebook try `from llama_index.core.query_engine import PandasQueryEngine` and get an `ImportError`. The correct package (`llama-index-experimental`) and import path are not mentioned before the code cells.

## What changed
- `docs/examples/query_engine/pandas_query_engine.ipynb`: Added a one-line note specifying the correct install (`llama-index-experimental`) and import path (`from llama_index.experimental.query_engine import PandasQueryEngine`), and that legacy core imports are deprecated.