### PR TITLE
Add BuyWhere MCP product search example notebook

### DIFF
--- a/docs/examples/tools/buywhere_mcp.ipynb
+++ b/docs/examples/tools/buywhere_mcp.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LlamaIndex + BuyWhere MCP: Product Search Agent\n",
+    "\n",
+    "This notebook demonstrates how to use the [BuyWhere MCP server](https://github.com/BuyWhere/buywhere-mcp) with LlamaIndex to build an AI agent that can search and compare products across Singapore, SEA, and US e-commerce platforms.\n",
+    "\n",
+    "BuyWhere provides access to 3M+ products across Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and 20+ other platforms.\n",
+    "\n",
+    "We use the `llama-index-tools-mcp` package to connect to the BuyWhere MCP server via stdio transport."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-tools-mcp llama-index-llms-openai llama-index-core"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"  # replace with your OpenAI API key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load BuyWhere MCP Tools\n",
+    "\n",
+    "The BuyWhere MCP server runs via `npx @buywhere/mcp-server` (requires Node.js 18+). LlamaIndex connects to it via stdio transport using `get_tools_from_mcp_url`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import get_tools_from_mcp_url\n",
+    "\n",
+    "# Connect to BuyWhere MCP server via stdio\n",
+    "# The server is launched automatically via npx\n",
+    "tools = await get_tools_from_mcp_url(\n",
+    "    \"stdio://npx @buywhere/mcp-server\"\n",
+    ")\n",
+    "\n",
+    "print(f\"Loaded {len(tools)} tools from BuyWhere MCP server:\")\n",
+    "for tool in tools:\n",
+    "    print(f\"  - {tool.metadata.name}: {tool.metadata.description[:80]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a Product Search Agent\n",
+    "\n",
+    "Now we create a LlamaIndex `ReActAgent` that uses the BuyWhere tools to answer product search queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent import ReActAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "\n",
+    "agent = ReActAgent.from_tools(\n",
+    "    tools,\n",
+    "    llm=llm,\n",
+    "    verbose=True,\n",
+    "    max_iterations=10,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example Queries\n",
+    "\n",
+    "### Search for products across Singapore platforms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.achat(\n",
+    "    \"Find me the best deals on air purifiers in Singapore under SGD 300. \"\n",
+    "    \"Compare prices across Shopee, Lazada, and FairPrice.\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cross-border price comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.achat(\n",
+    "    \"I want to buy a MacBook Pro M3. Compare prices between Singapore \"\n",
+    "    \"and US Amazon, and tell me where it's cheaper after accounting for \"\n",
+    "    \"typical import duties.\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resources\n",
+    "\n",
+    "- [BuyWhere MCP GitHub](https://github.com/BuyWhere/buywhere-mcp)\n",
+    "- [BuyWhere API docs](https://buywhere.ai)\n",
+    "- [llama-index-tools-mcp docs](https://docs.llamaindex.ai/en/stable/examples/tools/mcp/)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a new example notebook demonstrating how to use the [BuyWhere MCP server](https://github.com/BuyWhere/buywhere-mcp) with LlamaIndex for AI-powered product search.

**What it shows:**
- Connecting to the BuyWhere MCP server via stdio using `llama-index-tools-mcp`
- Building a `ReActAgent` with BuyWhere product search tools
- Querying 3M+ products across Singapore, SEA, and US e-commerce platforms (Shopee, Lazada, Amazon, Walmart, FairPrice)
- Cross-border price comparison

**Why:** BuyWhere is a production MCP server for e-commerce product search. This notebook provides a practical example of using MCP tools with LlamaIndex agents in a real-world use case.

**File:** `docs/examples/tools/buywhere_mcp.ipynb`

**Prerequisites:** Node.js 18+, `pip install llama-index-tools-mcp`