### PR TITLE
Add llama-index-tools-mint (MINT Protocol work attestation)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mint/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-mint/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) FoundryNet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-mint/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-mint/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-mint/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mint/README.md
@@ -1,0 +1,106 @@
+# LlamaIndex Tools Integration: MINT Protocol
+
+This tool connects to [MINT Protocol](https://mint.foundrynet.io) to give your
+agent **universal work attestation**: it can attest a completed unit of work to a
+tamper-evident, on-chain (Solana) record, verify any actor's trust profile,
+discover trusted agents and services by capability, and rate or recommend other
+actors to build portable reputation across the agent economy.
+
+All blockchain interaction happens server-side, so your agent never touches a
+wallet or signs a transaction — every tool is a plain authenticated HTTPS call.
+The same service is also available as an MCP server on
+[Smithery](https://smithery.ai/server/@foundrynet/mint-protocol).
+
+## Installation
+
+```bash
+pip install llama-index llama-index-core llama-index-tools-mint
+```
+
+## Authentication
+
+Get a `fnet_` API key at [mint.foundrynet.io](https://mint.foundrynet.io) and
+pass it as `api_key` (or set the `MINT_API_KEY` environment variable). Reads
+(`verify_trust`, `discover_actors`) are free and need no key.
+
+## Usage
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.mint import MintToolSpec
+
+mint_tool = MintToolSpec(api_key="your-fnet-api-key", name="my-agent")
+
+agent = FunctionAgent(
+    tools=mint_tool.to_tool_list(),
+    llm=OpenAI(model="gpt-4.1"),
+)
+
+response = await agent.run(
+    "Attest that you completed a code_review, then show me my trust profile."
+)
+print(response)
+```
+
+## Features
+
+The MINT Protocol tool provides the following capabilities:
+
+### Attest Work
+
+- `attest_work`: Attest a completed unit of work. Anchors a tamper-evident record
+  on Solana mainnet and returns a receipt with a public `verify_url`. Inputs and
+  outputs are hashed client-side, never sent in the clear.
+
+```python
+receipt = mint_tool.attest_work(
+    work_type="code_review",
+    summary="Reviewed PR #1234",
+    input_data={"pr": 1234},
+    output_data={"verdict": "approved", "findings": 2},
+    duration_seconds=42,
+)
+print(receipt["verify_url"])
+```
+
+### Verify Trust
+
+- `verify_trust`: Look up any actor's trust profile (trust score, attestation
+  count, average rating, recommendations). Free.
+
+```python
+profile = mint_tool.verify_trust(actor_name="some-other-agent")
+print(profile["trust_score"])
+```
+
+### Discover Actors
+
+- `discover_actors`: Trust-ranked search of the actor directory by capability.
+  Free.
+
+```python
+candidates = mint_tool.discover_actors(
+    capability="telemetry normalization",
+    min_trust=70,
+    limit=5,
+)
+```
+
+### Rate & Recommend
+
+- `rate_attestation`: Rate a completed attestation 1-5, updating the rated actor's
+  trust score.
+- `recommend_actor`: Endorse another actor in a named context 1-5.
+
+```python
+mint_tool.rate_attestation(
+    attestation_id="att_...",
+    rated_mint_id="MINT-abc123",
+    score=5,
+    comment="Fast and accurate.",
+)
+```
+
+For more information, visit the [MINT Protocol documentation](https://mint.foundrynet.io)
+or the [`mint-attest` SDK on PyPI](https://pypi.org/project/mint-attest/).

--- a/llama-index-integrations/tools/llama-index-tools-mint/llama_index/tools/mint/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-mint/llama_index/tools/mint/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.mint.base import MintToolSpec
+
+__all__ = ["MintToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-mint/llama_index/tools/mint/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mint/llama_index/tools/mint/base.py
@@ -1,0 +1,204 @@
+"""MINT Protocol tool spec for LlamaIndex."""
+
+from typing import Any, List, Optional
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+
+class MintToolSpec(BaseToolSpec):
+    """MINT Protocol tool spec.
+
+    Gives an agent universal *work attestation*: attest a completed unit of work
+    to a tamper-evident, on-chain (Solana) record, verify any actor's trust
+    profile, discover trusted agents/services by capability, and rate or
+    recommend other actors to build portable reputation across the agent economy.
+
+    Thin wrapper over the ``mint-attest`` SDK
+    (https://pypi.org/project/mint-attest/). All blockchain interaction happens
+    server-side, so the agent never touches a wallet or signs a transaction — every
+    method is a plain authenticated HTTPS call. The same service is also available
+    as an MCP server (https://smithery.ai/server/@foundrynet/mint-protocol).
+    """
+
+    spec_functions = [
+        "attest_work",
+        "verify_trust",
+        "discover_actors",
+        "rate_attestation",
+        "recommend_actor",
+    ]
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        name: Optional[str] = None,
+        capabilities: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Initialize the MINT client.
+
+        Args:
+            api_key (Optional[str]): Your MINT ``fnet_`` API key. Falls back to the
+                ``MINT_API_KEY`` environment variable. Get one at
+                https://mint.foundrynet.io.
+            endpoint (Optional[str]): Override the MINT server endpoint (defaults to
+                the hosted MINT service / ``MINT_ENDPOINT``).
+            name (Optional[str]): Display name for this agent's MINT identity, used
+                when the agent auto-registers on its first attestation.
+            capabilities (Optional[List[str]]): Capability tags advertised for this
+                agent in the discovery directory, e.g. ``["code_review", "rag"]``.
+
+        """
+        from mint_attest import MintClient
+
+        self.client = MintClient(
+            api_key=api_key,
+            endpoint=endpoint,
+            name=name,
+            capabilities=capabilities,
+        )
+
+    def attest_work(
+        self,
+        work_type: str,
+        summary: Optional[str] = None,
+        input_data: Optional[Any] = None,
+        output_data: Optional[Any] = None,
+        duration_seconds: Optional[float] = None,
+    ) -> dict:
+        """
+        Attest a completed unit of work.
+
+        Anchors a tamper-evident record on Solana mainnet and returns a receipt
+        containing the attestation id, data hash, transaction signature, and a
+        public ``verify_url``. The agent auto-registers on its first attestation.
+
+        Args:
+            work_type (str): What kind of work was done, e.g. ``"code_review"``,
+                ``"generation"``, ``"data_extraction"``.
+            summary (Optional[str]): Short human-readable summary of the work.
+            input_data (Optional[Any]): The work's input — hashed client-side, never
+                sent in the clear.
+            output_data (Optional[Any]): The work's output — hashed client-side.
+            duration_seconds (Optional[float]): How long the work took.
+
+        Returns:
+            dict: The attestation receipt (attestation_id, data_hash,
+            tx_signature, verify_url, ...).
+
+        """
+        receipt = self.client.attest(
+            work_type=work_type,
+            summary=summary,
+            input_data=input_data,
+            output_data=output_data,
+            duration_seconds=duration_seconds,
+        )
+        return receipt.raw or {"attestation_id": receipt.attestation_id}
+
+    def verify_trust(
+        self,
+        mint_id: Optional[str] = None,
+        actor_name: Optional[str] = None,
+    ) -> dict:
+        """
+        Look up an actor's trust profile.
+
+        Args:
+            mint_id (Optional[str]): The actor's MINT id. Defaults to this agent's
+                own identity when neither argument is given.
+            actor_name (Optional[str]): Look the actor up by name instead of id.
+
+        Returns:
+            dict: The trust profile (trust_score, total_attestations, avg_rating,
+            recommendations, work_types, ...).
+
+        """
+        return self.client.verify(mint_id=mint_id, actor_name=actor_name).raw
+
+    def discover_actors(
+        self,
+        capability: Optional[str] = None,
+        actor_type: Optional[str] = None,
+        min_trust: float = 0,
+        limit: int = 10,
+    ) -> List[dict]:
+        """
+        Search the directory for trusted actors, best first.
+
+        Args:
+            capability (Optional[str]): Capability or keyword to search for, e.g.
+                ``"telemetry normalization"``.
+            actor_type (Optional[str]): Filter by type — ``"ai_agent"``,
+                ``"machine"``, ``"iot_device"``, or ``"service"``.
+            min_trust (float): Only return actors at or above this trust score
+                (0-100).
+            limit (int): Maximum number of results (1-50).
+
+        Returns:
+            List[dict]: Matching actors, ranked by trust score.
+
+        """
+        results = self.client.discover(
+            capability=capability,
+            actor_type=actor_type,
+            min_trust=min_trust,
+            limit=limit,
+        )
+        return [d.raw for d in results]
+
+    def rate_attestation(
+        self,
+        attestation_id: str,
+        rated_mint_id: str,
+        score: int,
+        comment: Optional[str] = None,
+    ) -> dict:
+        """
+        Rate a completed attestation 1-5, updating the rated actor's trust score.
+
+        Args:
+            attestation_id (str): The attestation being rated.
+            rated_mint_id (str): The actor that did the work.
+            score (int): A rating from 1 to 5.
+            comment (Optional[str]): Optional free-text feedback.
+
+        Returns:
+            dict: The rating result.
+
+        """
+        return self.client.rate(
+            attestation_id=attestation_id,
+            rated_mint_id=rated_mint_id,
+            score=score,
+            comment=comment,
+        ).raw
+
+    def recommend_actor(
+        self,
+        recommended_mint_id: str,
+        context: str,
+        score: int,
+        note: Optional[str] = None,
+    ) -> dict:
+        """
+        Endorse another actor in a named context 1-5, updating their trust score.
+
+        Args:
+            recommended_mint_id (str): The actor you're endorsing.
+            context (str): What you're endorsing them for, e.g.
+                ``"cross-oem normalization"``.
+            score (int): A score from 1 to 5.
+            note (Optional[str]): Optional free-text note.
+
+        Returns:
+            dict: The recommendation result.
+
+        """
+        return self.client.recommend(
+            recommended_mint_id=recommended_mint_id,
+            context=context,
+            score=score,
+            note=note,
+        ).raw

--- a/llama-index-integrations/tools/llama-index-tools-mint/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mint/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-tools-mint"
+version = "0.1.0"
+description = "llama-index tools MINT Protocol integration"
+authors = [{name = "FoundryNet", email = "hello@foundrynet.io"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "foundrynet"}]
+keywords = ["attestation", "trust", "reputation", "verification", "agent", "mint"]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "mint-attest>=0.3.1",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.mint"
+
+[tool.llamahub.class_authors]
+MintToolSpec = "foundrynet"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-mint/tests/test_tools_mint.py
+++ b/llama-index-integrations/tools/llama-index-tools-mint/tests/test_tools_mint.py
@@ -1,0 +1,33 @@
+import unittest
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.mint import MintToolSpec
+
+
+class TestMintToolSpec(unittest.TestCase):
+    def test_class_inheritance(self):
+        """MintToolSpec should inherit from BaseToolSpec."""
+        names_of_base_classes = [b.__name__ for b in MintToolSpec.__mro__]
+        self.assertIn(BaseToolSpec.__name__, names_of_base_classes)
+
+    def test_spec_functions(self):
+        """All advertised tool functions should be defined on the spec."""
+        expected = [
+            "attest_work",
+            "verify_trust",
+            "discover_actors",
+            "rate_attestation",
+            "recommend_actor",
+        ]
+        self.assertEqual(MintToolSpec.spec_functions, expected)
+        for fn in expected:
+            self.assertTrue(callable(getattr(MintToolSpec, fn)))
+
+    def test_initialization(self):
+        """The spec should construct a MINT client carrying the given key."""
+        tool = MintToolSpec(api_key="fnet_test_key", name="test-agent")
+        self.assertEqual(tool.client.api_key, "fnet_test_key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds a new tool integration package, **`llama-index-tools-mint`**, exposing [MINT Protocol](https://mint.foundrynet.io) — universal work attestation for AI agents — as a LlamaIndex `ToolSpec`.

`MintToolSpec` gives an agent five tools:
- `attest_work` — anchor a tamper-evident record of completed work on Solana mainnet (inputs/outputs hashed client-side) and get a public `verify_url`
- `verify_trust` — look up any actor's trust profile (free)
- `discover_actors` — trust-ranked directory search by capability (free)
- `rate_attestation` / `recommend_actor` — build portable reputation across the agent economy

It's a thin wrapper over the [`mint-attest`](https://pypi.org/project/mint-attest/) SDK; all blockchain interaction happens server-side, so the agent only makes authenticated HTTPS calls. The same service is also available as an MCP server on [Smithery](https://smithery.ai/server/@foundrynet/mint-protocol).

Follows the standard `llama-index-integrations/tools/` package layout (`pyproject.toml` with `[tool.llamahub]`, `base.py` `ToolSpec`, README, Makefile, tests).

## New Package?

- [x] Yes

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change — `tests/test_tools_mint.py` (inheritance, advertised `spec_functions`, client construction). `pytest tests/` passes (3 passed) with `mint-attest` and `llama-index-core` installed.

## Suggested Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (package README)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works