### PR TITLE
fix(google-genai): handle MaaS role alias and models.get failure

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -244,7 +244,13 @@ class GoogleGenAI(FunctionCallingLLM):
 
         # only get model meta data if max_tokens or context_window is not specified
         if max_tokens is None or context_window is None:
-            model_meta = client.models.get(model=model)
+            try:
+                model_meta = client.models.get(model=model)
+            except Exception:
+                # Some endpoints (e.g. Google Cloud MaaS) do not expose the
+                # models.get API; fall back to None so callers must supply
+                # max_tokens and context_window explicitly.
+                model_meta = None
         else:
             model_meta = None
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -69,8 +69,10 @@ ROLES_TO_GEMINI: dict[MessageRole, MessageRole] = {
 
 ROLES_FROM_GEMINI: dict[str, MessageRole] = {
     ## Gemini has user, model and function roles.
+    ## Some Google Cloud MaaS endpoints return "assistant" instead of "model".
     "user": MessageRole.USER,
     "model": MessageRole.ASSISTANT,
+    "assistant": MessageRole.ASSISTANT,
     "function": MessageRole.TOOL,
 }
 


### PR DESCRIPTION
## Summary

- `ROLES_FROM_GEMINI` in `utils.py` was missing the `assistant` key. Google Cloud MaaS endpoints (e.g. `gemma-4-26b-a4b-it-maas`) can return `role=assistant` instead of `role=model`, causing a `KeyError` on every response.
- `client.models.get(model=model)` in `base.py` raises an exception for MaaS deployments that don't expose the models metadata API, crashing `__init__`. The call is now wrapped in a `try/except` that falls back to `model_meta = None` (the same code path already taken when both `max_tokens` and `context_window` are supplied explicitly).

Fixes #21799

## Changes

- `llama_index/llms/google_genai/utils.py`: add `assistant: MessageRole.ASSISTANT` to `ROLES_FROM_GEMINI`
- `llama_index/llms/google_genai/base.py`: wrap `client.models.get()` in `try/except` with graceful fallback