### PR TITLE
fix(github-reader): add asyncio_mode=auto to unblock async tests in CI

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -4,26 +4,26 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-  "ipython==8.10.0",
-  "jupyter>=1.0.0,<2",
-  "mypy==0.991",
-  "pre-commit==3.2.0",
-  "pylint==2.15.10",
-  "pytest==9.0.3",
-  "pytest-asyncio",
-  "pytest-mock==3.11.1",
-  "ruff==0.11.11",
-  "types-Deprecated>=0.1.0",
-  "types-PyYAML>=6.0.12.12,<7",
-  "types-protobuf>=4.24.0.4,<5",
-  "types-redis==4.5.5.0",
-  "types-requests==2.28.11.8",
-  "types-setuptools==67.1.0.0",
-  "black[jupyter]>=23.7.0,<=26.5.1",
-  "codespell[toml]>=v2.2.6",
-  "diff-cover>=9.2.0",
-  "pytest-cov>=6.1.1",
-  "PyJWT[crypto]>=2.8.0"
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==9.0.3",
+    "pytest-asyncio",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]>=23.7.0,<=26.5.1",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "PyJWT[crypto]>=2.8.0",
 ]
 
 [project]
@@ -35,29 +35,29 @@ requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [
-  {name = "ahmetkca"},
-  {name = "moncho"},
-  {name = "rwood-97"}
+    {name = "ahmetkca"},
+    {name = "moncho"},
+    {name = "rwood-97"},
 ]
 keywords = [
-  "code",
-  "collaborators",
-  "git",
-  "github",
-  "issues",
-  "placeholder",
-  "repository",
-  "source code"
+    "code",
+    "collaborators",
+    "git",
+    "github",
+    "issues",
+    "placeholder",
+    "repository",
+    "source code",
 ]
 dependencies = [
-  "llama-index-embeddings-openai>=0.6.0,<0.7",
-  "httpx>=0.26.0",
-  "llama-index-core>=0.13.0,<0.15"
+    "llama-index-embeddings-openai>=0.6.0,<0.7",
+    "httpx>=0.26.0",
+    "llama-index-core>=0.13.0,<0.15",
 ]
 
 [project.optional-dependencies]
 github-app = [
-  "PyJWT[crypto]>=2.8.0"
+    "PyJWT[crypto]>=2.8.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -82,6 +82,9 @@ GitHubRepositoryCollaboratorsReader = "rwood-97"
 GitHubRepositoryIssuesReader = "moncho"
 GithubRepositoryReader = "ahmetkca"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.mypy]
 disallow_untyped_defs = true
 exclude = ["_static", "build", "examples", "notebooks", "venv"]

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -4,26 +4,26 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "ipython==8.10.0",
-    "jupyter>=1.0.0,<2",
-    "mypy==0.991",
-    "pre-commit==3.2.0",
-    "pylint==2.15.10",
-    "pytest==9.0.3",
-    "pytest-asyncio",
-    "pytest-mock==3.11.1",
-    "ruff==0.11.11",
-    "types-Deprecated>=0.1.0",
-    "types-PyYAML>=6.0.12.12,<7",
-    "types-protobuf>=4.24.0.4,<5",
-    "types-redis==4.5.5.0",
-    "types-requests==2.28.11.8",
-    "types-setuptools==67.1.0.0",
-    "black[jupyter]>=23.7.0,<=26.5.1",
-    "codespell[toml]>=v2.2.6",
-    "diff-cover>=9.2.0",
-    "pytest-cov>=6.1.1",
-    "PyJWT[crypto]>=2.8.0",
+  "ipython==8.10.0",
+  "jupyter>=1.0.0,<2",
+  "mypy==0.991",
+  "pre-commit==3.2.0",
+  "pylint==2.15.10",
+  "pytest==9.0.3",
+  "pytest-asyncio",
+  "pytest-mock==3.11.1",
+  "ruff==0.11.11",
+  "types-Deprecated>=0.1.0",
+  "types-PyYAML>=6.0.12.12,<7",
+  "types-protobuf>=4.24.0.4,<5",
+  "types-redis==4.5.5.0",
+  "types-requests==2.28.11.8",
+  "types-setuptools==67.1.0.0",
+  "black[jupyter]>=23.7.0,<=26.5.1",
+  "codespell[toml]>=v2.2.6",
+  "diff-cover>=9.2.0",
+  "pytest-cov>=6.1.1",
+  "PyJWT[crypto]>=2.8.0"
 ]
 
 [project]
@@ -35,29 +35,29 @@ requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
 maintainers = [
-    {name = "ahmetkca"},
-    {name = "moncho"},
-    {name = "rwood-97"},
+  {name = "ahmetkca"},
+  {name = "moncho"},
+  {name = "rwood-97"}
 ]
 keywords = [
-    "code",
-    "collaborators",
-    "git",
-    "github",
-    "issues",
-    "placeholder",
-    "repository",
-    "source code",
+  "code",
+  "collaborators",
+  "git",
+  "github",
+  "issues",
+  "placeholder",
+  "repository",
+  "source code"
 ]
 dependencies = [
-    "llama-index-embeddings-openai>=0.6.0,<0.7",
-    "httpx>=0.26.0",
-    "llama-index-core>=0.13.0,<0.15",
+  "llama-index-embeddings-openai>=0.6.0,<0.7",
+  "httpx>=0.26.0",
+  "llama-index-core>=0.13.0,<0.15"
 ]
 
 [project.optional-dependencies]
 github-app = [
-    "PyJWT[crypto]>=2.8.0",
+  "PyJWT[crypto]>=2.8.0"
 ]
 
 [tool.codespell]
@@ -82,11 +82,11 @@ GitHubRepositoryCollaboratorsReader = "rwood-97"
 GitHubRepositoryIssuesReader = "moncho"
 GithubRepositoryReader = "ahmetkca"
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-
 [tool.mypy]
 disallow_untyped_defs = true
 exclude = ["_static", "build", "examples", "notebooks", "venv"]
 ignore_missing_imports = true
 python_version = "3.8"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

The `unit_test.yml` CI matrix was failing for the `llama-index-readers-github` package because pytest-asyncio 0.21+ defaults to `strict` mode and requires async test methods inside classes to have an explicit asyncio configuration. Three tests in `test_github_app_auth.py` were failing with `Failed: async def functions are not natively supported`:

- `TestGitHubAppAuth::test_get_installation_token_uses_cache`
- `TestGithubClientWithAppAuth::test_get_auth_headers_with_pat`
- `TestGithubClientWithAppAuth::test_get_auth_headers_with_github_app`

## Changes

- `llama-index-readers-github/pyproject.toml`: add `[tool.pytest.ini_options]` section with `asyncio_mode = auto`, matching the configuration already present in other packages such as `llama-index-embeddings-voyageai`.

Refs #21607