### PR TITLE
fix(vertexai-search): use asyncio.to_thread in _aretrieve to avoid blocking event loop

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
@@ -8,6 +8,7 @@ Vertex AI Search is a part of Vertex AI Agent Builder.
 """
 
 from __future__ import annotations
+import asyncio
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 import json
@@ -390,4 +391,4 @@ class VertexAISearchRetriever(BaseRetriever):
 
     async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
         """Asynchronously retrieve from the platform."""
-        return self._retrieve(query_bundle=query_bundle)
+        return await asyncio.to_thread(self._retrieve, query_bundle)


### PR DESCRIPTION
## Summary

`VertexAISearchRetriever._aretrieve()` was calling the synchronous `_retrieve()` directly without offloading to a thread, causing it to block the asyncio event loop for the full duration of each Discovery Engine gRPC call. Under concurrent `aretrieve()` calls, this effectively serialized all retrieval work and could delay unrelated asyncio tasks by multiple seconds.

The fix wraps `_retrieve` with `asyncio.to_thread()`, which runs the synchronous work in a thread-pool executor and keeps the event loop free.

Fixes #21934

## Changes

- `llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py`: add `import asyncio`; change `_aretrieve` to `await asyncio.to_thread(self._retrieve, query_bundle)`