### PR TITLE
fix(vertexai-search): populate id_ and metadata in structured data store results

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
@@ -267,7 +267,9 @@ class VertexAISearchRetriever(BaseRetriever):
             note_with_score.append(
                 NodeWithScore(
                     node=TextNode(
-                        text=json.dumps(document_dict.get("struct_data", {}))
+                        text=json.dumps(document_dict.get("struct_data", {})),
+                        id_=document_dict.get("id", ""),
+                        metadata={"document_name": document_dict.get("name", "")},
                     ),
                     score=score,
                 )


### PR DESCRIPTION
## Summary

`VertexAISearchRetriever._convert_structured_datastore_response()` was creating `TextNode` objects with only the `struct_data` payload. The Discovery Engine document identity fields (`id` and `name`) were silently discarded, so callers had no way to trace returned nodes back to their source documents.

This adds two lines to the `TextNode` constructor:
- `id_` — set from `document.id` (the short document ID, e.g. `"li-meta-gamma"`)
- `metadata["document_name"]` — set from `document.name` (full resource path, e.g. `"projects/.../documents/li-meta-gamma"`)

No behavior change for unstructured or website data store paths.

Fixes #21933

## Changes

- `llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py`: set `id_` and `metadata` on `TextNode` in `_convert_structured_datastore_response`