### PR TITLE
fix(azureaisearch): build valid NOT filter expressions

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -1255,7 +1255,8 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
         elif metadata_filters.condition == FilterCondition.OR:
             odata_expr = " or ".join(odata_filter)
         elif metadata_filters.condition == FilterCondition.NOT:
-            odata_expr = f"not ({odata_filter})"
+            inner_filter = " and ".join(odata_filter)
+            odata_expr = f"not ({inner_filter})"
         else:
             raise ValueError(
                 f"Unsupported filter condition {metadata_filters.condition}"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -6,10 +6,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
-from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode
+from llama_index.core.vector_stores.types import (
+    FilterCondition,
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+    VectorStoreQuery,
+    VectorStoreQueryMode,
+)
 from llama_index.vector_stores.azureaisearch import (
     AzureAISearchVectorStore,
     IndexManagement,
+    MetadataIndexFieldType,
 )
 
 try:
@@ -427,6 +435,49 @@ def test_azureaisearch_query_ignores_conflicting_kwargs_and_forwards_extras_for_
         assert called["top"] != extras["top"]
         assert called["select"] != extras["select"]
         assert called["filter"] != extras["filter"]
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_azureaisearch_not_filter_builds_valid_odata_expression() -> None:
+    search_client = mock_client_with_user_agent("search")
+    search_client.search.return_value = []
+    vector_store = AzureAISearchVectorStore(
+        search_or_index_client=search_client,
+        id_field_key="id",
+        chunk_field_key="content",
+        embedding_field_key="embedding",
+        metadata_string_field_key="metadata",
+        doc_id_field_key="doc_id",
+        filterable_metadata_field_keys={
+            "relative_path": ("relative_path", MetadataIndexFieldType.STRING),
+        },
+        hidden_field_keys=["embedding"],
+        index_management=IndexManagement.NO_VALIDATION,
+        embedding_dimensionality=2,
+    )
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="relative_path",
+                value="Base/samp.docx",
+                operator=FilterOperator.EQ,
+            )
+        ],
+        condition=FilterCondition.NOT,
+    )
+    query = VectorStoreQuery(
+        query_embedding=[0.1, 0.2],
+        similarity_top_k=1,
+        mode=VectorStoreQueryMode.DEFAULT,
+        filters=filters,
+    )
+
+    vector_store.query(query)
+
+    called = search_client.search.call_args[1]
+    assert called["filter"] == "not (relative_path eq 'Base/samp.docx')"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Fixes the Azure AI Search vector store's OData generation for `MetadataFilters(condition=FilterCondition.NOT)`.

Before this change, `_create_odata_filter()` formatted the internal Python list directly:

```python
not (["relative_path eq 'Base/samp.docx'"])
```

That is not a valid Azure AI Search OData expression. This change joins the generated child filter expressions first, then wraps them in `not (...)`:

```python
not (relative_path eq 'Base/samp.docx')
```

## Why

`NOT` filters are useful when a RAG app needs to exclude a folder, tenant, document family, or source class while preserving strict retrieval scoping. Generating a Python list string makes that filter unusable by Azure AI Search.

This is related to the broader metadata filtering and retrieval scoping concerns discussed in #19370, but it does not attempt to change `odata_filters` passthrough behavior.

## Changes

- Build the inner NOT filter expression from the generated child OData clauses instead of interpolating the Python list.
- Add a unit test that verifies the `filter` argument passed to `search_client.search()` is valid OData for a `FilterCondition.NOT` query.

## Validation

- `python -m pytest llama-index-integrations\vector_stores\llama-index-vector-stores-azureaisearch\tests\test_azureaisearch.py -q`
  - `15 passed`
- `python -m py_compile llama-index-integrations\vector_stores\llama-index-vector-stores-azureaisearch\llama_index\vector_stores\azureaisearch\base.py llama-index-integrations\vector_stores\llama-index-vector-stores-azureaisearch\tests\test_azureaisearch.py`
- `git diff --check`