### PR TITLE
feat: extract Markdown frontmatter metadata

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-file/README.md
@@ -135,6 +135,14 @@ documents = SimpleDirectoryReader(
     "./data", file_extractor=file_extractor
 ).load_data()
 
+# Markdown Reader with YAML frontmatter metadata
+parser = MarkdownReader(extract_frontmatter=True)
+file_extractor = {".md": parser}
+documents = SimpleDirectoryReader(
+    "./data", file_extractor=file_extractor
+).load_data()
+print(documents[0].metadata)
+
 # Mbox Reader example
 parser = MboxReader()
 file_extractor = {".mbox": parser}

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/markdown/base.py
@@ -6,11 +6,33 @@ Contains parser for md files.
 """
 
 import re
+from typing import Any, Dict, List, Optional, Tuple
+
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
-from typing import Any, Dict, List, Optional, Tuple
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
+import yaml
+
+
+_FRONTMATTER_PATTERN = re.compile(
+    r"\A---[ \t]*\r?\n(?P<frontmatter>.*?)(?:\r?\n)---[ \t]*(?:\r?\n|$)",
+    re.DOTALL,
+)
+
+
+class _FrontmatterLoader(yaml.SafeLoader):
+    """Safe YAML loader that keeps date-like scalars as metadata strings."""
+
+
+_FrontmatterLoader.yaml_implicit_resolvers = {
+    key: [
+        (tag, regexp)
+        for tag, regexp in resolvers
+        if tag != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
 
 
 class MarkdownReader(BaseReader):
@@ -28,6 +50,7 @@ class MarkdownReader(BaseReader):
         remove_hyperlinks: bool = True,
         remove_images: bool = True,
         separator: str = " ",
+        extract_frontmatter: bool = False,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -35,6 +58,7 @@ class MarkdownReader(BaseReader):
         self._remove_hyperlinks = remove_hyperlinks
         self._remove_images = remove_images
         self._separator = separator
+        self._extract_frontmatter = extract_frontmatter
 
     def markdown_to_tups(self, markdown_text: str) -> List[Tuple[Optional[str], str]]:
         """Convert a markdown file to a list of tuples containing header and text."""
@@ -114,6 +138,46 @@ class MarkdownReader(BaseReader):
         """Initialize the parser with the config."""
         return {}
 
+    def _read_content(
+        self, filepath: str, fs: Optional[AbstractFileSystem] = None
+    ) -> str:
+        """Read markdown file content."""
+        fs = fs or LocalFileSystem()
+        with fs.open(filepath, encoding="utf-8") as f:
+            return f.read().decode(encoding="utf-8")
+
+    def _parse_content(
+        self, content: str
+    ) -> Tuple[List[Tuple[Optional[str], str]], Dict[str, Any]]:
+        """Parse markdown content into tuples and extracted metadata."""
+        content, frontmatter = self.extract_frontmatter(content)
+        if self._remove_hyperlinks:
+            content = self.remove_hyperlinks(content)
+        if self._remove_images:
+            content = self.remove_images(content)
+        return self.markdown_to_tups(content), frontmatter
+
+    def extract_frontmatter(self, content: str) -> Tuple[str, Dict[str, Any]]:
+        """Extract YAML frontmatter from markdown content."""
+        if not self._extract_frontmatter:
+            return content, {}
+
+        match = _FRONTMATTER_PATTERN.match(content)
+        if not match:
+            return content, {}
+
+        try:
+            frontmatter = yaml.load(
+                match.group("frontmatter"), Loader=_FrontmatterLoader
+            ) or {}
+        except yaml.YAMLError:
+            return content, {}
+
+        if not isinstance(frontmatter, dict):
+            return content, {}
+
+        return content[match.end() :], frontmatter
+
     def parse_tups(
         self,
         filepath: str,
@@ -121,14 +185,9 @@ class MarkdownReader(BaseReader):
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Tuple[Optional[str], str]]:
         """Parse file into tuples."""
-        fs = fs or LocalFileSystem()
-        with fs.open(filepath, encoding="utf-8") as f:
-            content = f.read().decode(encoding="utf-8")
-        if self._remove_hyperlinks:
-            content = self.remove_hyperlinks(content)
-        if self._remove_images:
-            content = self.remove_images(content)
-        return self.markdown_to_tups(content)
+        content = self._read_content(filepath, fs=fs)
+        tups, _ = self._parse_content(content)
+        return tups
 
     def load_data(
         self,
@@ -137,14 +196,16 @@ class MarkdownReader(BaseReader):
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
         """Parse file into string."""
-        tups = self.parse_tups(file, fs=fs)
+        content = self._read_content(file, fs=fs)
+        tups, frontmatter = self._parse_content(content)
         results = []
+        metadata = {**frontmatter, **(extra_info or {})}
 
         for header, text in tups:
             if header is None:
-                results.append(Document(text=text, metadata=extra_info or {}))
+                results.append(Document(text=text, metadata=metadata))
             else:
                 results.append(
-                    Document(text=f"\n\n{header}\n{text}", metadata=extra_info or {})
+                    Document(text=f"\n\n{header}\n{text}", metadata=metadata)
                 )
         return results

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     "pandas>=2.0.0,<3",
     "llama-index-core>=0.13.0,<0.15",
     "defusedxml>=0.7.1",
+    "PyYAML>=6.0.1",
 ]
 
 [project.optional-dependencies]

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_markdown.py
@@ -1,6 +1,71 @@
 from llama_index.readers.file.markdown.base import MarkdownReader
 
 
+def test_extract_frontmatter_default_disabled() -> None:
+    reader = MarkdownReader()
+    content = "---\nticker: AAPL\n---\n# Thesis\nRevenue improved."
+
+    parsed_content, metadata = reader.extract_frontmatter(content)
+
+    assert parsed_content == content
+    assert metadata == {}
+
+
+def test_load_data_extracts_frontmatter_metadata(tmp_path) -> None:
+    path = tmp_path / "note.md"
+    path.write_text(
+        "---\n"
+        "ticker: AAPL\n"
+        "date: 2026-06-12\n"
+        "rating_score: 4\n"
+        "source: earnings_call\n"
+        "tags:\n"
+        "  - guidance\n"
+        "---\n"
+        "# Thesis\n"
+        "Revenue guidance improved.\n",
+        encoding="utf-8",
+    )
+    reader = MarkdownReader(extract_frontmatter=True)
+
+    documents = reader.load_data(
+        str(path),
+        extra_info={"source": "directory", "file_path": str(path)},
+    )
+
+    assert len(documents) == 1
+    assert "Revenue guidance improved." in documents[0].text
+    assert "ticker: AAPL" not in documents[0].text
+    assert documents[0].metadata["ticker"] == "AAPL"
+    assert documents[0].metadata["date"] == "2026-06-12"
+    assert documents[0].metadata["rating_score"] == 4
+    assert documents[0].metadata["source"] == "directory"
+    assert documents[0].metadata["tags"] == ["guidance"]
+    assert documents[0].metadata["file_path"] == str(path)
+
+
+def test_load_data_keeps_frontmatter_as_content_by_default(tmp_path) -> None:
+    path = tmp_path / "note.md"
+    path.write_text("---\nticker: AAPL\n---\n# Thesis\n", encoding="utf-8")
+    reader = MarkdownReader()
+
+    documents = reader.load_data(str(path))
+
+    assert len(documents) == 2
+    assert "ticker: AAPL" in documents[0].text
+    assert "ticker" not in documents[0].metadata
+
+
+def test_extract_frontmatter_invalid_yaml_keeps_content() -> None:
+    reader = MarkdownReader(extract_frontmatter=True)
+    content = "---\nticker: [AAPL\n---\n# Thesis\nRevenue improved."
+
+    parsed_content, metadata = reader.extract_frontmatter(content)
+
+    assert parsed_content == content
+    assert metadata == {}
+
+
 def test_parse_markdown_starting_with_header() -> None:
     reader = MarkdownReader()
     markdown_text = "# ABC\nabc\n# DEF\ndef"

--- a/llama-index-integrations/readers/llama-index-readers-file/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-file/uv.lock
@@ -1904,6 +1904,7 @@ dependencies = [
     { name = "llama-index-core" },
     { name = "pandas" },
     { name = "pypdf" },
+    { name = "pyyaml" },
     { name = "striprtf" },
 ]
 


### PR DESCRIPTION
## Summary

Adds optional YAML frontmatter extraction to `MarkdownReader` in `llama-index-readers-file`.

When `extract_frontmatter=True`, Markdown files beginning with `--- ... ---` are parsed with PyYAML. Mapping values are added to every generated `Document.metadata`, and the frontmatter block is removed before header-based parsing. The default remains unchanged, so existing users keep frontmatter in document text unless they opt in.

Metadata precedence is frontmatter < `extra_info`, preserving the existing file-level metadata supplied by callers such as `SimpleDirectoryReader`. Date-like YAML scalars are kept as strings so note fields like `date: 2026-06-12` remain safe metadata values.

This helps Markdown and Obsidian-style RAG ingestion pipelines carry fields like ticker, report date, source, author, event type, or document id into retrievable/filterable metadata instead of burying them in content.

## Changes

- Adds `extract_frontmatter` to `MarkdownReader`.
- Keeps invalid or non-mapping frontmatter as content instead of failing ingestion.
- Adds PyYAML as an explicit readers-file dependency and updates the local lock entry.
- Documents the new usage in the readers-file README.
- Adds regression coverage for default behavior, extracted metadata, metadata precedence, date string preservation, and invalid YAML fallback.

## Tests

- `python -m pytest llama-index-integrations\readers\llama-index-readers-file\tests\test_markdown.py -q`
- `python -m py_compile llama-index-integrations\readers\llama-index-readers-file\llama_index\readers\file\markdown\base.py llama-index-integrations\readers\llama-index-readers-file\tests\test_markdown.py`
- `python -m ruff check llama-index-integrations\readers\llama-index-readers-file\llama_index\readers\file\markdown\base.py llama-index-integrations\readers\llama-index-readers-file\tests\test_markdown.py`
- `git diff --check`