### PR TITLE
feat(core): add F-beta retrieval evaluation metric

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -272,6 +272,80 @@ class Recall(BaseRetrievalMetric):
         return RetrievalMetricResult(score=recall)
 
 
+class FBeta(BaseRetrievalMetric):
+    """
+    F-beta score metric.
+
+    Combines precision and recall into a single score via their weighted
+    harmonic mean. ``beta`` controls the trade-off: ``beta == 1`` yields the
+    F1 score, ``beta > 1`` weights recall more heavily, and ``beta < 1``
+    weights precision more heavily.
+
+    Attributes:
+        metric_name (str): The name of the metric.
+        beta (float): Weight of recall relative to precision. Defaults to 1.0 (F1).
+
+    """
+
+    metric_name: ClassVar[str] = "fbeta"
+    beta: float = Field(
+        default=1.0,
+        description="Weight of recall relative to precision. beta=1 yields the F1 score.",
+    )
+
+    def compute(
+        self,
+        query: Optional[str] = None,
+        expected_ids: Optional[List[str]] = None,
+        retrieved_ids: Optional[List[str]] = None,
+        expected_texts: Optional[List[str]] = None,
+        retrieved_texts: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> RetrievalMetricResult:
+        """
+        Compute the F-beta score based on the provided inputs.
+
+        Parameters
+        ----------
+            query (Optional[str]): The query string (not used in the current implementation).
+            expected_ids (Optional[List[str]]): Expected document IDs.
+            retrieved_ids (Optional[List[str]]): Retrieved document IDs.
+            expected_texts (Optional[List[str]]): Expected texts (not used in the current implementation).
+            retrieved_texts (Optional[List[str]]): Retrieved texts (not used in the current implementation).
+
+        Raises
+        ------
+            ValueError: If the necessary IDs are not provided.
+
+        Returns
+        -------
+            RetrievalMetricResult: The result with the computed F-beta score.
+
+        """
+        # Checking for the required arguments
+        if (
+            retrieved_ids is None
+            or expected_ids is None
+            or not retrieved_ids
+            or not expected_ids
+        ):
+            raise ValueError("Retrieved ids and expected ids must be provided")
+
+        retrieved_set = set(retrieved_ids)
+        expected_set = set(expected_ids)
+        num_relevant = len(retrieved_set & expected_set)
+        precision = num_relevant / len(retrieved_set)
+        recall = num_relevant / len(expected_set)
+
+        beta_squared = self.beta**2
+        denominator = beta_squared * precision + recall
+        if denominator == 0.0:
+            return RetrievalMetricResult(score=0.0)
+
+        fbeta = (1 + beta_squared) * precision * recall / denominator
+        return RetrievalMetricResult(score=fbeta)
+
+
 class AveragePrecision(BaseRetrievalMetric):
     """
     Average Precision (AP) metric.
@@ -498,6 +572,7 @@ METRIC_REGISTRY: Dict[str, Type[BaseRetrievalMetric]] = {
     "mrr": MRR,
     "precision": Precision,
     "recall": Recall,
+    "fbeta": FBeta,
     "ap": AveragePrecision,
     "ndcg": NDCG,
     "cohere_rerank_relevancy": CohereRerankRelevancyMetric,

--- a/llama-index-core/tests/evaluation/test_metrics.py
+++ b/llama-index-core/tests/evaluation/test_metrics.py
@@ -3,6 +3,7 @@ from math import log2
 import pytest
 from llama_index.core.evaluation.retrieval.metrics import (
     AveragePrecision,
+    FBeta,
     HitRate,
     MRR,
     NDCG,
@@ -108,6 +109,65 @@ def test_recall(expected_ids, retrieved_ids, expected_result):
     recall = Recall()
     result = recall.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
     assert result.score == pytest.approx(expected_result)
+
+
+@pytest.mark.parametrize(
+    ("expected_ids", "retrieved_ids", "beta", "expected_result"),
+    [
+        # F1 (beta=1): precision 3/4, recall 3/3
+        (
+            ["id1", "id2", "id3"],
+            ["id3", "id1", "id2", "id4"],
+            1.0,
+            2 * (3 / 4) * (3 / 3) / ((3 / 4) + (3 / 3)),
+        ),
+        # F1: precision 1/2, recall 1/4
+        (
+            ["id1", "id2", "id3", "id4"],
+            ["id5", "id1"],
+            1.0,
+            2 * (1 / 2) * (1 / 4) / ((1 / 2) + (1 / 4)),
+        ),
+        # no overlap -> precision and recall are both 0 -> F-beta 0
+        (["id1", "id2"], ["id3", "id4"], 1.0, 0.0),
+        # F1: precision 2/3, recall 2/2
+        (
+            ["id1", "id2"],
+            ["id2", "id1", "id7"],
+            1.0,
+            2 * (2 / 3) * (2 / 2) / ((2 / 3) + (2 / 2)),
+        ),
+        # F2 weights recall more heavily: precision 3/4, recall 3/3
+        (
+            ["id1", "id2", "id3"],
+            ["id3", "id1", "id2", "id4"],
+            2.0,
+            (1 + 2**2) * (3 / 4) * (3 / 3) / ((2**2) * (3 / 4) + (3 / 3)),
+        ),
+        # F0.5 weights precision more heavily: precision 3/4, recall 3/3
+        (
+            ["id1", "id2", "id3"],
+            ["id3", "id1", "id2", "id4"],
+            0.5,
+            (1 + 0.5**2) * (3 / 4) * (3 / 3) / ((0.5**2) * (3 / 4) + (3 / 3)),
+        ),
+    ],
+)
+def test_fbeta(expected_ids, retrieved_ids, beta, expected_result):
+    fbeta = FBeta(beta=beta)
+    result = fbeta.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+    assert result.score == pytest.approx(expected_result)
+
+
+def test_fbeta_default_is_f1():
+    """The default beta=1 must equal an explicit F1 score."""
+    expected_ids = ["id1", "id2", "id3"]
+    retrieved_ids = ["id3", "id1", "id2", "id4"]
+    default = FBeta().compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+    explicit_f1 = FBeta(beta=1.0).compute(
+        expected_ids=expected_ids, retrieved_ids=retrieved_ids
+    )
+    assert default.score == pytest.approx(explicit_f1.score)
 
 
 @pytest.mark.parametrize(
@@ -237,6 +297,10 @@ def test_exceptions(expected_ids, retrieved_ids, use_granular):
     with pytest.raises(ValueError):
         recall = Recall()
         recall.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+
+    with pytest.raises(ValueError):
+        fbeta = FBeta()
+        fbeta.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
 
     with pytest.raises(ValueError):
         ap = AveragePrecision()


### PR DESCRIPTION
## Description

Adds an `FBeta` retrieval evaluation metric to the retrieval metrics module. The
module already provides Precision and Recall, but there was no single metric that
combines them, which is what users need to evaluate the precision-recall tradeoff
(requested in #21706).

`FBeta` computes the weighted harmonic mean of precision and recall:

- `beta == 1` yields the F1 score (the default)
- `beta > 1` weights recall more heavily
- `beta < 1` weights precision more heavily

It follows the existing `BaseRetrievalMetric` pattern, mirrors the input validation
of `Precision`/`Recall`, returns `0.0` when precision and recall are both zero, and is
registered in `METRIC_REGISTRY` as `"fbeta"` so it works with `resolve_metrics` and
`RetrieverEvaluator`.

Relates to #21706.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added parametrized unit tests in `tests/evaluation/test_metrics.py` covering F1,
recall-weighted (beta=2), precision-weighted (beta=0.5), the zero-overlap case, a
default-equals-F1 check, and the missing-ids `ValueError` path. The full
`test_metrics.py` suite passes (49 tests). `ruff format --check` and `ruff check` pass
on the changed files.
