### PR TITLE
feat(protocols/ag-ui): surface LLM reasoning as REASONING_MESSAGE_* events

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -12,6 +13,9 @@ from llama_index.core.workflow import Context, Workflow, step
 from llama_index.core.workflow.events import Event, StartEvent, StopEvent
 from llama_index.protocols.ag_ui.events import (
     MessagesSnapshotWorkflowEvent,
+    ReasoningMessageContentWorkflowEvent,
+    ReasoningMessageEndWorkflowEvent,
+    ReasoningMessageStartWorkflowEvent,
     StateSnapshotWorkflowEvent,
     TextMessageChunkWorkflowEvent,
     ToolCallChunkWorkflowEvent,
@@ -82,6 +86,113 @@ DEFAULT_STATE_PROMPT = """<state>
 
 {user_input}
 """
+
+
+# OpenAI Responses-API event type that carries an incremental reasoning
+# summary delta. Matched by string so we don't import the openai type (the
+# type name has also moved across openai-python releases).
+_RESPONSES_REASONING_DELTA_TYPE = "response.reasoning_summary_text.delta"
+
+# Prefix shared by every Responses-API reasoning event type string
+# (e.g. ``response.reasoning_summary_text.delta``,
+# ``response.reasoning_text.delta``). Used only to detect a reasoning-shaped
+# event we could not parse, so an upstream SDK rename surfaces loudly instead
+# of silently dropping all reasoning.
+_RESPONSES_REASONING_TYPE_PREFIX = "response.reasoning"
+
+_logger = logging.getLogger(__name__)
+
+# One-time-warning dedupe for unmatched reasoning-shaped raw types.
+_warned_unmatched_reasoning_types: set = set()
+
+
+def _warn_unmatched_reasoning_once(raw_type: str) -> None:
+    """
+    Emit a one-time warning for a reasoning-shaped but unparsed raw type.
+
+    Reasoning is strictly additive, so the caller still gets ``""`` and the
+    stream is unaffected. This only makes an OpenAI-SDK event-type rename
+    greppable instead of an invisible regression.
+    """
+    if raw_type in _warned_unmatched_reasoning_types:
+        return
+    _warned_unmatched_reasoning_types.add(raw_type)
+    _logger.warning(
+        "Saw a reasoning-shaped stream event raw_type=%r that does not match "
+        "the known delta type %r (and exposed no extractable delta); dropping "
+        "reasoning for this chunk. The OpenAI SDK may have renamed the "
+        "reasoning event type -- update _RESPONSES_REASONING_DELTA_TYPE.",
+        raw_type,
+        _RESPONSES_REASONING_DELTA_TYPE,
+    )
+
+
+def _extract_reasoning_delta(resp: ChatResponse) -> str:
+    """
+    Pull an incremental reasoning delta off a streamed chat response.
+
+    Handles both LLM transports this package can drive:
+
+    * **Responses API** (``OpenAIResponses`` -- the native-reasoning path for
+      gpt-5, o3, o4-mini, ...). Each yielded ``ChatResponse`` carries the raw
+      ``ResponseStreamEvent`` on ``resp.raw``; a
+      ``response.reasoning_summary_text.delta`` event exposes the incremental
+      summary text on ``.delta``.
+    * **Chat Completions** (legacy ``OpenAI`` LLM, DeepSeek / vLLM
+      ``reasoning_content`` convention). ``resp.raw`` is a
+      ``ChatCompletionChunk`` whose ``delta`` carries ``reasoning_content`` in
+      ``model_extra`` (pydantic) or directly.
+
+    Returns ``""`` when the chunk carries no reasoning delta (or has an
+    unexpected shape) so the caller can treat reasoning as strictly additive.
+    """
+    raw = getattr(resp, "raw", None)
+    if raw is None:
+        return ""
+
+    # --- Responses API: response.reasoning_summary_text.delta -------------
+    raw_type = getattr(raw, "type", None)
+    if raw_type is None and isinstance(raw, dict):
+        raw_type = raw.get("type")
+    if raw_type == _RESPONSES_REASONING_DELTA_TYPE:
+        delta = getattr(raw, "delta", None)
+        if delta is None and isinstance(raw, dict):
+            delta = raw.get("delta")
+        if delta:
+            return str(delta)
+        _warn_unmatched_reasoning_once(str(raw_type))
+        return ""
+
+    # An unmatched event that still clearly looks like reasoning (the SDK
+    # likely renamed the delta type) -- warn once and drop.
+    if isinstance(raw_type, str) and raw_type.startswith(
+        _RESPONSES_REASONING_TYPE_PREFIX
+    ):
+        _warn_unmatched_reasoning_once(raw_type)
+        return ""
+
+    # --- Chat Completions: delta.reasoning_content ------------------------
+    choices = getattr(raw, "choices", None)
+    if choices is None and isinstance(raw, dict):
+        choices = raw.get("choices")
+    if not choices:
+        return ""
+    first = choices[0]
+    delta = getattr(first, "delta", None)
+    if delta is None and isinstance(first, dict):
+        delta = first.get("delta")
+    if delta is None:
+        return ""
+    # Pydantic model: non-standard fields land in ``model_extra``.
+    extra = getattr(delta, "model_extra", None)
+    if isinstance(extra, dict) and extra.get("reasoning_content"):
+        return str(extra["reasoning_content"])
+    direct = getattr(delta, "reasoning_content", None)
+    if direct:
+        return str(direct)
+    if isinstance(delta, dict) and delta.get("reasoning_content"):
+        return str(delta["reasoning_content"])
+    return ""
 
 
 class InputEvent(StartEvent):
@@ -237,10 +348,43 @@ class AGUIChatWorkflow(Workflow):
         )
 
         resp_id = str(uuid.uuid4())
+        reasoning_msg_id: Optional[str] = None
         resp = ChatResponse(message=ChatMessage(role="assistant", content=""))
 
         async for resp in resp_gen:
+            # Emit reasoning deltas (Responses-API summary deltas or
+            # chat-completions ``reasoning_content``) ahead of any text. The
+            # reasoning message is finalized before the first text chunk so the
+            # AG-UI reasoning channel closes cleanly ahead of the assistant
+            # message.
+            reasoning_delta = _extract_reasoning_delta(resp)
+            # Load-bearing non-empty guard: ReasoningMessageContentEvent.delta
+            # is Field(min_length=1), so emitting an empty delta would raise a
+            # pydantic ValidationError mid-stream.
+            if reasoning_delta:
+                if reasoning_msg_id is None:
+                    reasoning_msg_id = str(uuid.uuid4())
+                    ctx.write_event_to_stream(
+                        ReasoningMessageStartWorkflowEvent(
+                            message_id=reasoning_msg_id,
+                            role="reasoning",
+                        )
+                    )
+                ctx.write_event_to_stream(
+                    ReasoningMessageContentWorkflowEvent(
+                        message_id=reasoning_msg_id,
+                        delta=reasoning_delta,
+                    )
+                )
+
             if resp.delta:
+                if reasoning_msg_id is not None:
+                    ctx.write_event_to_stream(
+                        ReasoningMessageEndWorkflowEvent(
+                            message_id=reasoning_msg_id,
+                        )
+                    )
+                    reasoning_msg_id = None
                 ctx.write_event_to_stream(
                     TextMessageChunkWorkflowEvent(
                         role="assistant",
@@ -249,6 +393,15 @@ class AGUIChatWorkflow(Workflow):
                         message_id=resp_id,
                     )
                 )
+
+        # If the model produced reasoning but no assistant text (pure
+        # tool-call turn), still close the reasoning message.
+        if reasoning_msg_id is not None:
+            ctx.write_event_to_stream(
+                ReasoningMessageEndWorkflowEvent(
+                    message_id=reasoning_msg_id,
+                )
+            )
 
         chat_history.append(resp.message)
         await ctx.store.set("chat_history", chat_history)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/events.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/events.py
@@ -15,6 +15,9 @@ from ag_ui.core.events import (
     MessagesSnapshotEvent,
     RawEvent,
     CustomEvent,
+    ReasoningMessageStartEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
     RunStartedEvent,
     RunFinishedEvent,
     RunErrorEvent,
@@ -75,6 +78,18 @@ class RawWorkflowEvent(RawEvent, Event):
 
 class CustomWorkflowEvent(CustomEvent, Event):
     type: EventType = EventType.CUSTOM
+
+
+class ReasoningMessageStartWorkflowEvent(ReasoningMessageStartEvent, Event):
+    type: EventType = EventType.REASONING_MESSAGE_START
+
+
+class ReasoningMessageContentWorkflowEvent(ReasoningMessageContentEvent, Event):
+    type: EventType = EventType.REASONING_MESSAGE_CONTENT
+
+
+class ReasoningMessageEndWorkflowEvent(ReasoningMessageEndEvent, Event):
+    type: EventType = EventType.REASONING_MESSAGE_END
 
 
 class RunStartedWorkflowEvent(RunStartedEvent, Event):

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
@@ -19,6 +19,9 @@ from llama_index.protocols.ag_ui.events import (
     StateSnapshotWorkflowEvent,
     StateDeltaWorkflowEvent,
     MessagesSnapshotWorkflowEvent,
+    ReasoningMessageStartWorkflowEvent,
+    ReasoningMessageContentWorkflowEvent,
+    ReasoningMessageEndWorkflowEvent,
     RunStartedWorkflowEvent,
     RunFinishedWorkflowEvent,
     RunErrorWorkflowEvent,
@@ -41,6 +44,9 @@ AG_UI_EVENTS = (
     MessagesSnapshotWorkflowEvent,
     TextMessageChunkWorkflowEvent,
     ToolCallChunkWorkflowEvent,
+    ReasoningMessageStartWorkflowEvent,
+    ReasoningMessageContentWorkflowEvent,
+    ReasoningMessageEndWorkflowEvent,
     CustomWorkflowEvent,
 )
 

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.4.0"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_reasoning_extract.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_reasoning_extract.py
@@ -1,0 +1,119 @@
+"""
+Tests for ``_extract_reasoning_delta`` in ``llama_index.protocols.ag_ui.agent``.
+
+These tests cover both LLM transports the AG-UI workflow can drive:
+
+* OpenAI Responses API (``OpenAIResponses``) -- ``resp.raw`` is a
+  ``ResponseStreamEvent`` whose ``type`` is
+  ``response.reasoning_summary_text.delta`` and ``.delta`` carries the
+  incremental summary text.
+* OpenAI Chat Completions (``OpenAI``, DeepSeek, vLLM) -- ``resp.raw`` is a
+  ``ChatCompletionChunk`` whose ``delta`` carries ``reasoning_content`` in
+  either pydantic ``model_extra`` or as a plain attribute / dict key.
+
+Reasoning extraction is strictly additive: any unrecognized shape returns
+``""`` so the surrounding text-streaming path is unaffected.
+"""
+
+from types import SimpleNamespace
+
+from llama_index.core.llms import ChatMessage, ChatResponse
+from llama_index.protocols.ag_ui.agent import (
+    _RESPONSES_REASONING_DELTA_TYPE,
+    _extract_reasoning_delta,
+)
+
+
+def _mk_resp(raw):
+    """Build a minimal ChatResponse with the given ``raw`` payload."""
+    return ChatResponse(
+        message=ChatMessage(role="assistant", content=""),
+        delta="",
+        raw=raw,
+    )
+
+
+# --- Responses API -------------------------------------------------------
+
+
+def test_responses_api_object_with_reasoning_delta() -> None:
+    raw = SimpleNamespace(
+        type=_RESPONSES_REASONING_DELTA_TYPE,
+        delta="step one",
+    )
+    assert _extract_reasoning_delta(_mk_resp(raw)) == "step one"
+
+
+def test_responses_api_dict_with_reasoning_delta() -> None:
+    raw = {"type": _RESPONSES_REASONING_DELTA_TYPE, "delta": "step two"}
+    assert _extract_reasoning_delta(_mk_resp(raw)) == "step two"
+
+
+def test_responses_api_unrelated_event_returns_empty() -> None:
+    raw = SimpleNamespace(type="response.output_text.delta", delta="hi")
+    assert _extract_reasoning_delta(_mk_resp(raw)) == ""
+
+
+def test_responses_api_reasoning_shaped_unknown_type_returns_empty() -> None:
+    """
+    An SDK rename to a different reasoning-shaped type returns ``""``
+    (and warns once via the logger), it must not raise.
+    """
+    raw = SimpleNamespace(type="response.reasoning_text.delta", delta="x")
+    assert _extract_reasoning_delta(_mk_resp(raw)) == ""
+
+
+# --- Chat Completions ----------------------------------------------------
+
+
+def test_chat_completions_reasoning_content_model_extra() -> None:
+    """OpenAI SDK pydantic chunk: non-standard fields land in ``model_extra``."""
+    delta = SimpleNamespace(
+        model_extra={"reasoning_content": "thinking..."},
+        content=None,
+    )
+    raw = SimpleNamespace(
+        type=None,
+        choices=[SimpleNamespace(delta=delta)],
+    )
+    assert _extract_reasoning_delta(_mk_resp(raw)) == "thinking..."
+
+
+def test_chat_completions_reasoning_content_direct_attr() -> None:
+    """Some SDK builds expose ``reasoning_content`` directly on the delta."""
+    delta = SimpleNamespace(reasoning_content="hmm", content=None)
+    raw = SimpleNamespace(
+        type=None,
+        choices=[SimpleNamespace(delta=delta)],
+    )
+    assert _extract_reasoning_delta(_mk_resp(raw)) == "hmm"
+
+
+def test_chat_completions_plain_dict() -> None:
+    """A plain-dict raw chunk (e.g. when SDK has been deserialized through JSON)."""
+    raw = {
+        "type": None,
+        "choices": [{"delta": {"reasoning_content": "ponder"}}],
+    }
+    assert _extract_reasoning_delta(_mk_resp(raw)) == "ponder"
+
+
+def test_chat_completions_no_reasoning_returns_empty() -> None:
+    delta = SimpleNamespace(model_extra={}, content="hello")
+    raw = SimpleNamespace(
+        type=None,
+        choices=[SimpleNamespace(delta=delta)],
+    )
+    assert _extract_reasoning_delta(_mk_resp(raw)) == ""
+
+
+# --- Edge cases ----------------------------------------------------------
+
+
+def test_no_raw_returns_empty() -> None:
+    assert _extract_reasoning_delta(_mk_resp(None)) == ""
+
+
+def test_empty_choices_returns_empty() -> None:
+    raw = SimpleNamespace(type=None, choices=[])
+    assert _extract_reasoning_delta(_mk_resp(raw)) == ""

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_reasoning_workflow.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_reasoning_workflow.py
@@ -1,0 +1,170 @@
+"""
+End-to-end test that ``AGUIChatWorkflow`` emits AG-UI ``REASONING_MESSAGE_*``
+events when the upstream LLM streams a reasoning channel.
+
+Driven by a stub ``FunctionCallingLLM`` whose ``astream_chat_with_tools`` yields
+``ChatResponse`` chunks shaped like the OpenAI Responses-API stream (raw
+``response.reasoning_summary_text.delta`` events followed by plain text
+deltas). This is exactly the shape ``OpenAIResponses`` exposes through
+``ChatResponse.raw``; running it against a stub avoids any network or model
+key dependency.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, List, Sequence
+
+import pytest
+
+from llama_index.core.base.llms.types import LLMMetadata
+from llama_index.core.llms import ChatMessage, ChatResponse
+from llama_index.core.llms.function_calling import FunctionCallingLLM
+from llama_index.protocols.ag_ui.agent import (
+    AGUIChatWorkflow,
+    _RESPONSES_REASONING_DELTA_TYPE,
+)
+from llama_index.protocols.ag_ui.events import (
+    ReasoningMessageContentWorkflowEvent,
+    ReasoningMessageEndWorkflowEvent,
+    ReasoningMessageStartWorkflowEvent,
+    TextMessageChunkWorkflowEvent,
+)
+
+
+class _ReasoningStubLLM(FunctionCallingLLM):
+    """
+    Minimal FunctionCallingLLM that streams a synthetic reasoning+text chunk
+    sequence so the workflow has something to translate.
+    """
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(
+            model_name="stub-reasoning",
+            is_function_calling_model=True,
+            is_chat_model=True,
+        )
+
+    async def astream_chat_with_tools(
+        self,
+        tools: Sequence[Any],
+        chat_history: List[ChatMessage],
+        allow_parallel_tool_calls: bool = True,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatResponse]:
+        async def _gen() -> AsyncIterator[ChatResponse]:
+            # Two reasoning deltas, then two text deltas. The workflow should
+            # emit Start -> Content x2 -> End -> Text x2.
+            for r in ("step ", "one. "):
+                yield ChatResponse(
+                    message=ChatMessage(role="assistant", content=""),
+                    delta="",
+                    raw=SimpleNamespace(
+                        type=_RESPONSES_REASONING_DELTA_TYPE,
+                        delta=r,
+                    ),
+                )
+            for t in ("hello ", "world"):
+                yield ChatResponse(
+                    message=ChatMessage(role="assistant", content=t),
+                    delta=t,
+                    raw=SimpleNamespace(type="response.output_text.delta", delta=t),
+                )
+
+        return _gen()
+
+    def get_tool_calls_from_response(
+        self,
+        response: ChatResponse,
+        error_on_no_tool_call: bool = True,
+        **kwargs: Any,
+    ) -> List[Any]:
+        return []
+
+    # The remaining abstract methods aren't reached by this test, but the
+    # FunctionCallingLLM ABC requires concrete bodies.
+    def chat(self, *args: Any, **kwargs: Any) -> ChatResponse:  # pragma: no cover
+        raise NotImplementedError
+
+    def stream_chat(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    def complete(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    def stream_complete(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    async def achat(
+        self, *args: Any, **kwargs: Any
+    ) -> ChatResponse:  # pragma: no cover
+        raise NotImplementedError
+
+    async def acomplete(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    async def astream_complete(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    async def astream_chat(self, *args: Any, **kwargs: Any):  # pragma: no cover
+        raise NotImplementedError
+
+    def _prepare_chat_with_tools(
+        self, *args: Any, **kwargs: Any
+    ) -> dict:  # pragma: no cover
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_workflow_emits_reasoning_then_text() -> None:
+    from ag_ui.core import RunAgentInput, UserMessage
+
+    workflow = AGUIChatWorkflow(
+        llm=_ReasoningStubLLM(),
+        frontend_tools=[],
+        backend_tools=[],
+        initial_state={},
+        system_prompt=None,
+        timeout=30,
+    )
+
+    run_input = RunAgentInput(
+        thread_id="t1",
+        run_id="r1",
+        messages=[UserMessage(id="m1", role="user", content="hi")],
+        tools=[],
+        context=[],
+        state={},
+        forwarded_props={},
+    )
+
+    handler = workflow.run(input_data=run_input)
+
+    seen: List[Any] = []
+    async for ev in handler.stream_events():
+        seen.append(ev)
+    await handler
+
+    reasoning_start = [
+        e for e in seen if isinstance(e, ReasoningMessageStartWorkflowEvent)
+    ]
+    reasoning_content = [
+        e for e in seen if isinstance(e, ReasoningMessageContentWorkflowEvent)
+    ]
+    reasoning_end = [e for e in seen if isinstance(e, ReasoningMessageEndWorkflowEvent)]
+    text_chunks = [e for e in seen if isinstance(e, TextMessageChunkWorkflowEvent)]
+
+    assert len(reasoning_start) == 1, "exactly one REASONING_MESSAGE_START"
+    assert len(reasoning_end) == 1, "exactly one REASONING_MESSAGE_END"
+    assert len(reasoning_content) == 2, "two reasoning content deltas"
+    assert "".join(e.delta for e in reasoning_content) == "step one. "
+    assert len(text_chunks) == 2, "two text chunks after reasoning closes"
+    assert "".join(e.delta for e in text_chunks) == "hello world"
+
+    # Ordering: REASONING_MESSAGE_END must come before the first
+    # TEXT_MESSAGE_CHUNK so the reasoning slot finalizes ahead of the
+    # assistant text in the AG-UI consumer.
+    reasoning_end_idx = seen.index(reasoning_end[0])
+    first_text_idx = seen.index(text_chunks[0])
+    assert reasoning_end_idx < first_text_idx


### PR DESCRIPTION
# Description

Closes the three independent gaps in `llama-index-protocols-ag-ui==0.3.1` that cause LLM **reasoning** content (OpenAI Responses-API `response.reasoning_summary_text.delta` for gpt-5/o3/o4-mini, or the chat-completions `delta.reasoning_content` convention used by DeepSeek / vLLM / Qwen3) to be silently dropped before reaching the AG-UI consumer:

1. **`events.py`** — add `ReasoningMessage{Start,Content,End}WorkflowEvent`, subclasses of the matching `ag_ui.core.events` types so the encoder serializes them as `REASONING_MESSAGE_*` SSE frames.
2. **`agent.py`** — in `AGUIChatWorkflow.chat`, read a reasoning delta off each chunk's `resp.raw` via the new `_extract_reasoning_delta` helper (handles both Responses-API and chat-completions transports without importing the openai SDK types) and emit `REASONING_MESSAGE_START` → repeated `REASONING_MESSAGE_CONTENT` → `REASONING_MESSAGE_END` ahead of the first text chunk, so the reasoning slot finalizes before the assistant message.
3. **`router.py`** — add the three new event classes to `AG_UI_EVENTS` so the SSE forwarder passes them through.

Strictly additive: any unrecognized chunk shape returns `""` and the existing text/tool-call paths are unaffected. No public API changes.

Fixes #21945

## Why this matters

Without this fix, an AG-UI agent built with `llama_index.protocols.ag_ui` plus a reasoning-capable LLM (e.g. `OpenAIResponses(model="gpt-5", reasoning_options={...})`) cannot surface the model's chain of thought to the frontend — the reasoning channel is dropped at the workflow layer and `REASONING_MESSAGE_*` SSE frames are never emitted. This breaks parity with other AG-UI agent SDKs (langgraph-python in particular) that already implement the reasoning channel.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — bumped `llama-index-protocols-ag-ui` from `0.3.1` → `0.4.0`
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

This package had no `tests/` directory; this PR adds one with two new test files:

* `tests/test_reasoning_extract.py` — 10 unit tests covering `_extract_reasoning_delta` across Responses-API objects/dicts, chat-completions `model_extra` / direct-attr / plain-dict shapes, the SDK-rename fallback, and empty-input edge cases.
* `tests/test_reasoning_workflow.py` — workflow-level test that drives `AGUIChatWorkflow` with a stub `FunctionCallingLLM` streaming a synthetic Responses-API reasoning + text sequence, and asserts the emitted event order is `REASONING_MESSAGE_START` → 2× `REASONING_MESSAGE_CONTENT` → `REASONING_MESSAGE_END` strictly before the first `TEXT_MESSAGE_CHUNK`.

All 11 tests pass locally (`uv run pytest tests/`). Red-baseline confirmed: stashing the `agent.py` change makes `test_reasoning_workflow.py` fail to import (it references the new private constant `_RESPONSES_REASONING_DELTA_TYPE` from the agent module).

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run ruff check` (auto-fixed) and `uv run ruff format`

## Reference Implementation Background

This patch upstreams a workaround we've been carrying in CopilotKit's [LlamaIndex showcase integration](https://github.com/CopilotKit/CopilotKit/blob/main/showcase/integrations/llamaindex/src/agents/_reasoning_router.py), which subclassed `AGUIChatWorkflow` + `AGUIWorkflowRouter` to close the same three gaps externally. That subclass approach proved the design under production load (real OpenAI gpt-5 + the AG-UI protocol's frontend reasoning slot, plus mocked deterministic replay). This PR moves the fix into the package so downstream consumers don't have to vendor it.
