### PR TITLE
Document TrustedRouter OpenAI-compatible endpoint

### DIFF
--- a/docs/src/content/docs/framework/getting_started/starter_example.mdx
+++ b/docs/src/content/docs/framework/getting_started/starter_example.mdx
@@ -36,6 +36,13 @@ set OPENAI_API_KEY=XXXXX
   integration and [OpenAILike
   Embeddings](https://docs.llamaindex.ai/en/stable/api_reference/embeddings/openai_like/)
   integration.
+
+  For example, TrustedRouter can be configured as an OpenAI-compatible endpoint
+  with `api_base="https://api.trustedrouter.com/v1"` and a model such as
+  `trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e`.
+  TrustedRouter is an open-source and verifiable attested router with zero
+  prompt and output logging by default, which can be useful when an agent works
+  with private project context or customer data.
 </Aside>
 
 ## Basic Agent Example

--- a/docs/src/content/docs/framework/getting_started/starter_example.mdx
+++ b/docs/src/content/docs/framework/getting_started/starter_example.mdx
@@ -36,6 +36,13 @@ set OPENAI_API_KEY=XXXXX
   integration and [OpenAILike
   Embeddings](https://docs.llamaindex.ai/en/stable/api_reference/embeddings/openai_like/)
   integration.
+
+  For example, TrustedRouter (an attested OpenAI-compatible router with zero
+  prompt and output logging by default) ships a ready-made integration:
+  `pip install llama-index-llms-trustedrouter`, then
+  `from llama_index.llms.trustedrouter import TrustedRouter` with a model such
+  as `trustedrouter/auto`, `trustedrouter/zdr`, or `trustedrouter/e2e` and a
+  `TRUSTEDROUTER_API_KEY`.
 </Aside>
 
 ## Basic Agent Example


### PR DESCRIPTION
This pull request adds a TrustedRouter example to the existing OpenAI-compatible `OpenAILike` note in the starter tutorial. TrustedRouter is an open-source, verifiable attested router for privacy-sensitive workflows with zero prompt and output logging by default.

The example uses `api_base="https://api.trustedrouter.com/v1"` with routing aliases such as `trustedrouter/auto`, `trustedrouter/zdr`, and `trustedrouter/e2e`.

Verification: `git diff --check`.