### PR TITLE
docs: clarify LlamaCloud embedding auth errors

### DIFF
--- a/docs/src/content/docs/framework/module_guides/indexing/llama_cloud_index.md
+++ b/docs/src/content/docs/framework/module_guides/indexing/llama_cloud_index.md
@@ -59,6 +59,14 @@ index = LlamaCloudIndex.from_documents(
 index = LlamaCloudIndex("my_first_index", project_name="default")
 ```
 
+By default, new indexes use LlamaCloud managed embeddings. If retrieval fails
+with an error like `Error querying data sink: 400: OpenAI Authentication error.
+The OpenAI API key used for the embedding transformation on your index is
+invalid.`, this usually indicates the query reached LlamaCloud successfully, but
+the embedding model configured for that index needs fresh provider credentials.
+Update the embedding model credentials in the LlamaCloud UI, or recreate the
+index with the desired managed embedding configuration, then retry retrieval.
+
 You can also configure a retriever for managed retrieval:
 
 ```python

--- a/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/README.md
+++ b/llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/README.md
@@ -57,6 +57,14 @@ index = LlamaCloudIndex.from_documents(
 index = LlamaCloudIndex("my_first_index", project_name="default")
 ```
 
+If retrieval fails with an error like `Error querying data sink: 400: OpenAI
+Authentication error. The OpenAI API key used for the embedding transformation
+on your index is invalid.`, this usually indicates the query reached LlamaCloud
+successfully, but the embedding model configured for that index needs fresh
+provider credentials. Update the embedding model credentials in the LlamaCloud
+UI, or recreate the index with the desired managed embedding configuration, then
+retry retrieval.
+
 You can also configure a retriever for managed retrieval:
 
 ```python


### PR DESCRIPTION
# Description

Adds troubleshooting guidance for the LlamaCloud managed embedding authentication error reported in #21087. The error is returned after the request reaches LlamaCloud and usually means the index's configured managed embedding provider credentials need to be refreshed or the index should be recreated with the desired managed embedding configuration.

Addresses #21087.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Docs-only verification:

- `git diff --check`
- `uv run --frozen pre-commit run --files docs/src/content/docs/framework/module_guides/indexing/llama_cloud_index.md llama-index-integrations/indices/llama-index-indices-managed-llama-cloud/README.md`
- Characterization grep verified the exact reported error and remediation text are present in both docs entry points.

Note: `uv run make lint` currently fails outside this diff on repo-wide notebook formatting under local Python 3.12/3.14 with `black-jupyter`: `module 'ast' has no attribute 'Str'`. The targeted pre-commit run for the changed files passes.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
