### PR TITLE
feat(memory): add llama-index-memory-recollect integration

### DIFF
--- a/docs/api_reference/api_reference/memory/recollect.md
+++ b/docs/api_reference/api_reference/memory/recollect.md
@@ -1,0 +1,5 @@
+::: llama_index.memory.recollect
+options:
+  members:
+        - RecollectMemory
+        - RecollectContext

--- a/docs/examples/memory/RecollectMemory.ipynb
+++ b/docs/examples/memory/RecollectMemory.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/memory/RecollectMemory.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recollect Memory\n",
+    "\n",
+    "[Recollect](https://github.com/cobusgreyling/recollect) is a self-hosted long-term memory layer for AI agents. It extracts durable facts from conversations, scopes them per user/session, and retrieves them with hybrid search.\n",
+    "\n",
+    "This notebook shows how to use `RecollectMemory` with LlamaIndex chat engines and workflow agents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-memory-recollect recollect-ai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup with Recollect (local, no API keys)\n",
+    "\n",
+    "Use `RecollectConfig.local_dev()` for SQLite storage and a deterministic local embedder—ideal for prototyping without cloud credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.memory.recollect import RecollectMemory\n",
+    "from recollect.config import RecollectConfig\n",
+    "\n",
+    "context = {\"user_id\": \"alice\"}\n",
+    "memory = RecollectMemory.from_config(\n",
+    "    context=context,\n",
+    "    config=RecollectConfig.local_dev().model_dump(),\n",
+    "    search_msg_limit=4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`context` must include at least one of `user_id`, `agent_id`, or `run_id`.\n",
+    "\n",
+    "`search_msg_limit` controls how many recent chat messages are concatenated into the retrieval query (default `5`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recollect for Function Calling Agents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def call_fn(name: str):\n",
+    "    \"\"\"Call the provided name.\"\"\"\n",
+    "    print(f\"Calling... {name}\")\n",
+    "\n",
+    "\n",
+    "def email_fn(name: str):\n",
+    "    \"\"\"Email the provided name.\"\"\"\n",
+    "    print(f\"Emailing... {name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "agent = FunctionAgent(tools=[email_fn, call_fn], llm=llm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\"Hi, my name is Mayank.\", memory=memory)\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\n",
+    "    \"My preferred way of communication is email.\", memory=memory\n",
+    ")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SimpleChatEngine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import SimpleChatEngine\n",
+    "\n",
+    "chat_engine = SimpleChatEngine.from_defaults(llm=llm, memory=memory)\n",
+    "print(chat_engine.chat(\"What do you remember about me?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [Recollect GitHub](https://github.com/cobusgreyling/recollect)\n",
+    "- [LangChain integration guide](https://github.com/cobusgreyling/recollect/blob/main/docs/integrations/langchain.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -324,3 +324,4 @@ You can find a few examples of memory in action below:
 - [Composable Memory](/python/examples/agent/memory/composable_memory)
 - [Vector Memory](/python/examples/agent/memory/vector_memory)
 - [Mem0 Memory](/python/examples/memory/mem0memory)
+- [Recollect Memory](/python/examples/memory/recollectmemory)

--- a/llama-index-integrations/memory/llama-index-memory-recollect/.gitignore
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.pytest_cache/
+.venv/
+dist/
+*.egg-info/

--- a/llama-index-integrations/memory/llama-index-memory-recollect/LICENSE
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Copyright 2026 Cobus Greyling
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/llama-index-integrations/memory/llama-index-memory-recollect/Makefile
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/Makefile
@@ -1,0 +1,4 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+test:	## Run tests via pytest.
+	pytest tests

--- a/llama-index-integrations/memory/llama-index-memory-recollect/README.md
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/README.md
@@ -1,0 +1,33 @@
+# LlamaIndex Memory Integration: Recollect
+
+[Recollect](https://github.com/cobusgreyling/recollect) is a self-hosted long-term memory layer for AI agents. This package provides a LlamaIndex `BaseMemory` adapter.
+
+## Installation
+
+```bash
+pip install llama-index-memory-recollect
+```
+
+## Quickstart (local, no API keys)
+
+```python
+from llama_index.memory.recollect import RecollectMemory
+from recollect.config import RecollectConfig
+
+memory = RecollectMemory.from_config(
+    context={"user_id": "alice"},
+    config=RecollectConfig.local_dev().model_dump(),
+    search_msg_limit=4,
+)
+```
+
+Use with `SimpleChatEngine`, `FunctionAgent`, or `ReActAgent` by passing `memory=memory`.
+
+## Notebook
+
+See [`docs/examples/memory/RecollectMemory.ipynb`](../../../docs/examples/memory/RecollectMemory.ipynb).
+
+## Links
+
+- [Recollect GitHub](https://github.com/cobusgreyling/recollect)
+- [LlamaHub memory integrations](https://llamahub.ai/l/memory)

--- a/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/__init__.py
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.memory.recollect.base import RecollectMemory, RecollectContext
+
+__all__ = ["RecollectMemory", "RecollectContext"]

--- a/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/base.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.memory import BaseMemory
+from llama_index.core.memory import Memory as LlamaIndexMemory
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+from llama_index.memory.recollect.utils import (
+    convert_chat_history_to_dict,
+    convert_memory_to_system_message,
+    convert_messages_to_string,
+)
+from recollect.config import RecollectConfig
+from recollect.memory import Memory
+
+
+class RecollectContext(BaseModel):
+    user_id: str | None = None
+    agent_id: str | None = None
+    run_id: str | None = None
+
+    def validate_provided_context(self) -> None:
+        if all(v is None for v in (self.user_id, self.agent_id, self.run_id)):
+            raise ValueError("Recollect context requires at least one of user_id, agent_id, run_id")
+
+    def build_filter(self) -> dict[str, str]:
+        flt: dict[str, str] = {}
+        if self.user_id is not None:
+            flt["user_id"] = self.user_id
+        if self.agent_id is not None:
+            flt["agent_id"] = self.agent_id
+        if self.run_id is not None:
+            flt["run_id"] = self.run_id
+        return flt
+
+    def scope_kwargs(self) -> dict[str, str]:
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
+class RecollectMemory(BaseMemory):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    primary_memory: LlamaIndexMemory = Field(description="Chat history buffer")
+    context: RecollectContext = Field(default_factory=RecollectContext)
+    search_msg_limit: int = Field(default=5)
+
+    _client: Memory | None = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        context: RecollectContext | dict[str, Any] | None = None,
+        client: Memory | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if "primary_memory" not in kwargs:
+            kwargs["primary_memory"] = LlamaIndexMemory.from_defaults()
+        super().__init__(**kwargs)
+        self._client = client
+        if context is not None:
+            ctx = RecollectContext.model_validate(context)
+            ctx.validate_provided_context()
+            self.context = ctx
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "RecollectMemory"
+
+    @classmethod
+    def from_defaults(cls, **kwargs: Any) -> RecollectMemory:
+        raise NotImplementedError("Use RecollectMemory.from_config()")
+
+    @classmethod
+    def from_config(
+        cls,
+        context: dict[str, Any],
+        config: RecollectConfig | dict[str, Any] | None = None,
+        search_msg_limit: int = 5,
+        **kwargs: Any,
+    ) -> RecollectMemory:
+        ctx = RecollectContext.model_validate(context)
+        ctx.validate_provided_context()
+        if isinstance(config, dict):
+            cfg = RecollectConfig.model_validate(config)
+        elif config is None:
+            cfg = RecollectConfig.local_dev()
+        else:
+            cfg = config
+        client = Memory(cfg)
+        return cls(
+            primary_memory=LlamaIndexMemory.from_defaults(),
+            context=ctx,
+            client=client,
+            search_msg_limit=search_msg_limit,
+            **kwargs,
+        )
+
+    def get(self, input: str | None = None, **kwargs: Any) -> list[ChatMessage]:
+        assert self._client is not None
+        messages = self.primary_memory.get(input=input, **kwargs)
+        query = convert_messages_to_string(messages, input, limit=self.search_msg_limit)
+        result = self._client.search(query, filters=self.context.build_filter())
+        search_results = result.get("results", [])
+        system_message = convert_memory_to_system_message(search_results)
+        if messages and messages[0].role == MessageRole.SYSTEM:
+            system_message = convert_memory_to_system_message(
+                search_results, existing_system_message=messages[0]
+            )
+        messages.insert(0, system_message)
+        return messages
+
+    def get_all(self) -> list[ChatMessage]:
+        return self.primary_memory.get_all()
+
+    def _add_msgs_to_client_memory(self, messages: list[ChatMessage]) -> None:
+        assert self._client is not None
+        self._client.add(
+            convert_chat_history_to_dict(messages),
+            **self.context.scope_kwargs(),
+        )
+
+    def put(self, message: ChatMessage) -> None:
+        self._add_msgs_to_client_memory([message])
+        self.primary_memory.put(message)
+
+    def set(self, messages: list[ChatMessage]) -> None:
+        initial_len = len(self.primary_memory.get_all())
+        self._add_msgs_to_client_memory(messages[initial_len:])
+        self.primary_memory.set(messages)
+
+    def reset(self) -> None:
+        self.primary_memory.reset()

--- a/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/utils.py
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/llama_index/memory/recollect/utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+DEFAULT_INTRO = "Below are relevant memories retrieved for this conversation:"
+DEFAULT_OUTRO = "End of retrieved memories."
+
+
+def convert_memory_to_system_message(
+    response: list[dict[str, Any]],
+    existing_system_message: ChatMessage | None = None,
+) -> ChatMessage:
+    lines = [str(item.get("memory", "")) for item in response]
+    formatted = "\n\n" + DEFAULT_INTRO + "\n"
+    for line in lines:
+        if line:
+            formatted += f"\n- {line}\n"
+    formatted += "\n" + DEFAULT_OUTRO
+    if existing_system_message is not None and existing_system_message.content:
+        base = existing_system_message.content.split(DEFAULT_INTRO)[0]
+        formatted = base + formatted
+    return ChatMessage(content=formatted, role=MessageRole.SYSTEM)
+
+
+def convert_chat_history_to_dict(messages: list[ChatMessage]) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for message in messages:
+        if message.role in (MessageRole.USER, MessageRole.ASSISTANT) and message.content:
+            out.append({"role": message.role.value, "content": message.content})
+    return out
+
+
+def convert_messages_to_string(
+    messages: list[ChatMessage], input: str | None = None, limit: int = 5
+) -> str:
+    recent = messages[-limit:]
+    formatted = [f"{msg.role.value}: {msg.content}" for msg in recent]
+    result = "\n".join(formatted)
+    if input:
+        result += f"\nuser: {input}"
+    return result

--- a/llama-index-integrations/memory/llama-index-memory-recollect/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest==8.4.2",
+    "pytest-mock==3.11.1",
+]
+
+[project]
+name = "llama-index-memory-recollect"
+version = "0.1.0"
+description = "LlamaIndex memory integration for Recollect long-term agent memory"
+authors = [{ name = "Cobus Greyling", email = "cobusgreyling@users.noreply.github.com" }]
+requires-python = "<4.0,>=3.10"
+readme = "README.md"
+license = "Apache-2.0"
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "recollect-ai>=0.2.0,<0.3.0",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.memory.recollect"
+
+[tool.llamahub.class_authors]
+RecollectMemory = "Cobus Greyling"

--- a/llama-index-integrations/memory/llama-index-memory-recollect/tests/test_recollect.py
+++ b/llama-index-integrations/memory/llama-index-memory-recollect/tests/test_recollect.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.memory.recollect import RecollectContext, RecollectMemory
+
+
+def test_recollect_memory_from_config(tmp_path):
+    context = {"user_id": "test_user"}
+    config = {
+        "data_dir": str(tmp_path / "recollect"),
+        "extraction_enabled": False,
+        "embedder": {"provider": "local", "dimensions": 64},
+        "vector_store": {"provider": "sqlite", "embedding_dims": 64},
+    }
+
+    with patch("llama_index.memory.recollect.base.Memory") as MockMemory:
+        mock_client = MockMemory.return_value
+        mock_client.search.return_value = {
+            "results": [{"memory": "User likes hiking", "score": 0.9}]
+        }
+
+        memory = RecollectMemory.from_config(
+            context=context,
+            config=config,
+            search_msg_limit=3,
+        )
+
+        assert isinstance(memory, RecollectMemory)
+        assert isinstance(memory.context, RecollectContext)
+        assert memory.context.user_id == "test_user"
+        assert memory._client == mock_client
+        assert memory.search_msg_limit == 3
+
+
+def test_recollect_memory_get_injects_system_message(tmp_path):
+    config = {
+        "data_dir": str(tmp_path / "recollect"),
+        "extraction_enabled": False,
+        "embedder": {"provider": "local", "dimensions": 64},
+        "vector_store": {"provider": "sqlite", "embedding_dims": 64},
+    }
+    memory = RecollectMemory.from_config(context={"user_id": "bob"}, config=config)
+    assert memory._client is not None
+    memory._client.add("User lives in Cape Town", user_id="bob", infer=False)
+
+    memory.primary_memory.put(ChatMessage(role=MessageRole.USER, content="Where do I live?"))
+    messages = memory.get(input="Where do I live?")
+    assert messages[0].role == MessageRole.SYSTEM
+    assert "Cape Town" in (messages[0].content or "")


### PR DESCRIPTION
## Summary

Adds a LlamaIndex memory integration for [Recollect](https://github.com/cobusgreyling/recollect), a self-hosted long-term memory layer for AI agents.

- New package: `llama-index-integrations/memory/llama-index-memory-recollect`
- `RecollectMemory.from_config()` adapter (mirrors Mem0Memory ergonomics)
- Example notebook: `docs/examples/memory/RecollectMemory.ipynb`
- API reference: `docs/api_reference/api_reference/memory/recollect.md`
- Linked from agent memory guide (`memory.mdx`)

## Install (after publish)

```bash
pip install llama-index-memory-recollect recollect-ai
```

> **Note:** The core library is published on PyPI as **`recollect-ai`** (import name remains `recollect`) because `recollect` is already taken on PyPI.

## LlamaHub

`pyproject.toml` includes `[tool.llamahub]` metadata for `RecollectMemory`.

## Tests

```bash
cd llama-index-integrations/memory/llama-index-memory-recollect
pip install -e . recollect-ai pytest
pytest
```

## Checklist

- [x] Integration package + tests
- [x] Docs notebook + memory guide link
- [x] API reference stub