### PR TITLE
docs(memory): add RecollectMemory notebook (standalone PyPI integration)

### DIFF
--- a/docs/api_reference/api_reference/memory/recollect.md
+++ b/docs/api_reference/api_reference/memory/recollect.md
@@ -1,0 +1,5 @@
+::: llama_index.memory.recollect
+options:
+  members:
+        - RecollectMemory
+        - RecollectContext

--- a/docs/examples/memory/RecollectMemory.ipynb
+++ b/docs/examples/memory/RecollectMemory.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/memory/RecollectMemory.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recollect Memory\n",
+    "\n",
+    "[Recollect](https://github.com/cobusgreyling/recollect) is a self-hosted long-term memory layer for AI agents. It extracts durable facts from conversations, scopes them per user/session, and retrieves them with hybrid search.\n",
+    "\n",
+    "This notebook shows how to use `RecollectMemory` with LlamaIndex chat engines and workflow agents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index llama-index-memory-recollect recollect-ai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup with Recollect (local, no API keys)\n",
+    "\n",
+    "Use `RecollectConfig.local_dev()` for SQLite storage and a deterministic local embedder—ideal for prototyping without cloud credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.memory.recollect import RecollectMemory\n",
+    "from recollect.config import RecollectConfig\n",
+    "\n",
+    "context = {\"user_id\": \"alice\"}\n",
+    "memory = RecollectMemory.from_config(\n",
+    "    context=context,\n",
+    "    config=RecollectConfig.local_dev().model_dump(),\n",
+    "    search_msg_limit=4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`context` must include at least one of `user_id`, `agent_id`, or `run_id`.\n",
+    "\n",
+    "`search_msg_limit` controls how many recent chat messages are concatenated into the retrieval query (default `5`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recollect for Function Calling Agents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def call_fn(name: str):\n",
+    "    \"\"\"Call the provided name.\"\"\"\n",
+    "    print(f\"Calling... {name}\")\n",
+    "\n",
+    "\n",
+    "def email_fn(name: str):\n",
+    "    \"\"\"Email the provided name.\"\"\"\n",
+    "    print(f\"Emailing... {name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "agent = FunctionAgent(tools=[email_fn, call_fn], llm=llm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\"Hi, my name is Mayank.\", memory=memory)\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\n",
+    "    \"My preferred way of communication is email.\", memory=memory\n",
+    ")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SimpleChatEngine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import SimpleChatEngine\n",
+    "\n",
+    "chat_engine = SimpleChatEngine.from_defaults(llm=llm, memory=memory)\n",
+    "print(chat_engine.chat(\"What do you remember about me?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [Recollect GitHub](https://github.com/cobusgreyling/recollect)\n",
+    "- [LangChain integration guide](https://github.com/cobusgreyling/recollect/blob/main/docs/integrations/langchain.md)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -324,3 +324,4 @@ You can find a few examples of memory in action below:
 - [Composable Memory](/python/examples/agent/memory/composable_memory)
 - [Vector Memory](/python/examples/agent/memory/vector_memory)
 - [Mem0 Memory](/python/examples/memory/mem0memory)
+- [Recollect Memory](/python/examples/memory/recollectmemory) — self-hosted memory via [`llama-index-memory-recollect`](https://pypi.org/project/llama-index-memory-recollect/) on PyPI


### PR DESCRIPTION
## Summary

Adds documentation for the **standalone** LlamaIndex memory integration [`llama-index-memory-recollect`](https://pypi.org/project/llama-index-memory-recollect/) (maintained in [cobusgreyling/recollect](https://github.com/cobusgreyling/recollect)).

This PR intentionally **does not** add a new `pyproject.toml` under `llama-index-integrations/` (per current repo policy).

## Changes

- `docs/examples/memory/RecollectMemory.ipynb`
- Memory guide link in `memory.mdx`
- API reference stub: `docs/api_reference/api_reference/memory/recollect.md`

## Install

```bash
pip install llama-index-memory-recollect recollect-ai
```

(`recollect-ai` provides the `recollect` import.)