### PR TITLE
fix: close file handles in HotpotQAEvaluator using context managers

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,20 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
+                with open(
                     os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
-                response = requests.get(url, stream=True)
+                ) as save_file:
+                    response = requests.get(url, stream=True)
 
-                # Define the size of each chunk
-                chunk_size = 1024
+                    # Define the size of each chunk
+                    chunk_size = 1024
 
-                # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                    # Loop over the chunks and parse the JSON data
+                    for chunk in tqdm.tqdm(
+                        response.iter_content(chunk_size=chunk_size)
+                    ):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +73,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.loads(f.read())
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:

--- a/llama-index-core/tests/evaluation/test_hotpotqa.py
+++ b/llama-index-core/tests/evaluation/test_hotpotqa.py
@@ -1,0 +1,227 @@
+"""Tests for HotpotQA benchmark evaluator."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llama_index.core.query_engine.retriever_query_engine import RetrieverQueryEngine
+from llama_index.core.evaluation.benchmarks.hotpotqa import (
+    HotpotQAEvaluator,
+    HotpotQARetriever,
+    exact_match_score,
+    f1_score,
+    normalize_answer,
+)
+from llama_index.core.schema import QueryBundle
+
+
+# ---------------------------------------------------------------------------
+# normalize_answer
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_answer_lowercase():
+    assert normalize_answer("Hello World") == "hello world"
+
+
+def test_normalize_answer_removes_articles():
+    assert normalize_answer("The cat sat on a mat") == "cat sat on mat"
+
+
+def test_normalize_answer_removes_punctuation():
+    assert normalize_answer("Hello, World!") == "hello world"
+
+
+def test_normalize_answer_collapses_whitespace():
+    assert normalize_answer("  hello   world  ") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# exact_match_score
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_score_true():
+    assert exact_match_score("The Cat", "the cat") is True
+
+
+def test_exact_match_score_false():
+    assert exact_match_score("dog", "cat") is False
+
+
+# ---------------------------------------------------------------------------
+# f1_score
+# ---------------------------------------------------------------------------
+
+
+def test_f1_score_perfect_match():
+    f1, precision, recall = f1_score("quick brown fox", "quick brown fox")
+    assert f1 == pytest.approx(1.0)
+    assert precision == pytest.approx(1.0)
+    assert recall == pytest.approx(1.0)
+
+
+def test_f1_score_no_overlap():
+    result = f1_score("cat", "dog")
+    assert result == (0, 0, 0)
+
+
+def test_f1_score_partial_overlap():
+    f1, precision, recall = f1_score("quick brown fox", "quick brown dog")
+    assert precision == pytest.approx(2 / 3)
+    assert recall == pytest.approx(2 / 3)
+
+
+def test_f1_score_yes_no_mismatch():
+    assert f1_score("yes", "no") == (0, 0, 0)
+
+
+def test_f1_score_no_answer():
+    assert f1_score("something else", "noanswer") == (0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# HotpotQARetriever
+# ---------------------------------------------------------------------------
+
+SAMPLE_QUERY_OBJECTS = [
+    {
+        "question": "Who wrote Hamlet?",
+        "answer": "Shakespeare",
+        "context": [
+            ["Source A", ["Shakespeare wrote Hamlet.", "It is a tragedy."]],
+            ["Source B", ["Hamlet is a Danish prince."]],
+        ],
+    }
+]
+
+
+def test_hotpotqa_retriever_returns_nodes():
+    retriever = HotpotQARetriever(SAMPLE_QUERY_OBJECTS)
+    bundle = QueryBundle(
+        query_str="Who wrote Hamlet?",
+        custom_embedding_strs=["Who wrote Hamlet?"],
+    )
+    results = retriever._retrieve(bundle)
+    assert len(results) == 2
+    assert all(r.score == 1.0 for r in results)
+
+
+def test_hotpotqa_retriever_uses_query_str_fallback():
+    retriever = HotpotQARetriever(SAMPLE_QUERY_OBJECTS)
+    bundle = QueryBundle(query_str="Who wrote Hamlet?")
+    results = retriever._retrieve(bundle)
+    assert len(results) == 2
+
+
+def test_hotpotqa_retriever_str():
+    retriever = HotpotQARetriever(SAMPLE_QUERY_OBJECTS)
+    assert str(retriever) == "HotpotQARetriever"
+
+
+def test_hotpotqa_retriever_rejects_non_list():
+    with pytest.raises(AssertionError):
+        HotpotQARetriever("not a list")
+
+
+# ---------------------------------------------------------------------------
+# HotpotQAEvaluator._download_datasets
+# ---------------------------------------------------------------------------
+
+
+def test_download_datasets_returns_path(tmp_path):
+    """_download_datasets returns a dict mapping dataset name to file path."""
+    evaluator = HotpotQAEvaluator()
+
+    mock_response = MagicMock()
+    mock_response.iter_content.return_value = [b"[]"]
+
+    with (
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.get_cache_dir",
+            return_value=str(tmp_path),
+        ),
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.requests.get",
+            return_value=mock_response,
+        ),
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.tqdm.tqdm",
+            side_effect=lambda it, **kw: it,
+        ),
+    ):
+        paths = evaluator._download_datasets()
+
+    assert "hotpot_dev_distractor" in paths
+    assert paths["hotpot_dev_distractor"].endswith("dev_distractor.json")
+
+
+def test_download_datasets_raises_on_network_error(tmp_path):
+    """_download_datasets raises ValueError when download fails."""
+    evaluator = HotpotQAEvaluator()
+
+    with (
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.get_cache_dir",
+            return_value=str(tmp_path),
+        ),
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.requests.get",
+            side_effect=ConnectionError("network down"),
+        ),
+    ):
+        with pytest.raises(ValueError, match="could not download"):
+            evaluator._download_datasets()
+
+
+def test_download_datasets_skips_download_if_file_exists(tmp_path):
+    """If the dataset dir already exists, no network request is made."""
+    dataset_dir = tmp_path / "datasets" / "HotpotQA"
+    dataset_dir.mkdir(parents=True)
+    dataset_file = dataset_dir / "dev_distractor.json"
+    dataset_file.write_text("[]")
+
+    evaluator = HotpotQAEvaluator()
+
+    with (
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.get_cache_dir",
+            return_value=str(tmp_path),
+        ),
+        patch(
+            "llama_index.core.evaluation.benchmarks.hotpotqa.requests.get"
+        ) as mock_get,
+    ):
+        paths = evaluator._download_datasets()
+        mock_get.assert_not_called()
+
+    assert "hotpot_dev_distractor" in paths
+
+
+# ---------------------------------------------------------------------------
+# HotpotQAEvaluator.run
+# ---------------------------------------------------------------------------
+
+
+def test_run_computes_scores(tmp_path):
+    """run() queries the engine and completes without errors."""
+    evaluator = HotpotQAEvaluator()
+
+    dataset_file = tmp_path / "dev_distractor.json"
+    dataset_file.write_text(json.dumps(SAMPLE_QUERY_OBJECTS))
+
+    mock_query_engine = MagicMock(spec=RetrieverQueryEngine)
+    mock_response = MagicMock()
+    mock_response.__str__ = lambda self: "Shakespeare"
+    mock_query_engine.query.return_value = mock_response
+    mock_query_engine.with_retriever.return_value = mock_query_engine
+
+    with patch.object(
+        evaluator,
+        "_download_datasets",
+        return_value={"hotpot_dev_distractor": str(dataset_file)},
+    ):
+        evaluator.run(mock_query_engine, queries=1)
+
+    mock_query_engine.query.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #21956

Two `open()` calls in `HotpotQAEvaluator` never closed their file handles, causing resource leaks:

- `_download_datasets()`: `save_file` was opened in `"wb"` mode but never closed. If an exception occurred mid-download, the file handle would leak and the partial file might not be flushed.
- `run()`: the dataset file `f` was read and immediately abandoned without closing.

Both are replaced with `with open(...) as ...:` so the handle is always released, even on exception.

## Changes

- `llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py` - fix two resource leaks
- `llama-index-core/tests/evaluation/test_hotpotqa.py` - add 19 unit tests (all passing)

## Testing

```bash
cd llama-index-core
uv run pytest tests/evaluation/test_hotpotqa.py -v
# 19 passed, 95% coverage on hotpotqa.py
```

All pre-commit hooks pass (ruff, ruff-format, mypy, black, prettier, codespell).