### PR TITLE
Fix typos in documentation and a code comment

### DIFF
--- a/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
+++ b/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
@@ -81,7 +81,7 @@ You can also skip creation, and connect to an existing knowledge graph using an 
 
 ### Querying
 
-Querying a Property Graph Index is also highly flexible. Retrieval works by using several sub-retrievers and combining results. By default, keyword + synoymn expanasion is used, as well as vector retrieval (if your graph was embedded), to retrieve relevant triples.
+Querying a Property Graph Index is also highly flexible. Retrieval works by using several sub-retrievers and combining results. By default, keyword + synonym expansion is used, as well as vector retrieval (if your graph was embedded), to retrieve relevant triples.
 
 You can also choose to include the source text in addition to the retrieved triples (unavailable for graphs created outside of LlamaIndex).
 

--- a/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
+++ b/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
@@ -83,6 +83,6 @@ You can also skip creation, and connect to an existing knowledge graph using an 
 
 Querying a Property Graph Index is also highly flexible. Retrieval works by using several sub-retrievers and combining results. By default, keyword + synoymn expanasion is used, as well as vector retrieval (if your graph was embedded), to retrieve relevant triples.
 
-You can also chose to include the source text in addition to the retrieved triples (unavailble for graphs created outside of LlamaIndex).
+You can also choose to include the source text in addition to the retrieved triples (unavailable for graphs created outside of LlamaIndex).
 
 See more in the [full guide for Property Graphs](/python/framework/module_guides/indexing/lpg_index_guide).

--- a/docs/src/content/docs/framework/optimizing/building_rag_from_scratch.md
+++ b/docs/src/content/docs/framework/optimizing/building_rag_from_scratch.md
@@ -28,7 +28,7 @@ This tutorial shows you how to build a retriever to query a vector store.
 
 ## Building Ingestion/Retrieval from Scratch (Open-Source/Local Components)
 
-This tutoral shows you how to build an ingestion/retrieval pipeline using only
+This tutorial shows you how to build an ingestion/retrieval pipeline using only
 open-source components.
 
 - [Open Source RAG](/python/examples/low_level/oss_ingestion_retrieval)

--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -777,7 +777,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         # Get entities
         entities = self._get_entities(query_bundle.query_str)
         # Before we enable embedding/semantic search, we need to make sure
-        # we don't miss any entities that's synoynm of the entities we extracted
+        # we don't miss any entities that's synonym of the entities we extracted
         # in string matching based retrieval in following steps, thus we expand
         # synonyms here.
         if len(entities) == 0:
@@ -798,7 +798,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         # Get entities
         entities = await self._aget_entities(query_bundle.query_str)
         # Before we enable embedding/semantic search, we need to make sure
-        # we don't miss any entities that's synoynm of the entities we extracted
+        # we don't miss any entities that's synonym of the entities we extracted
         # in string matching based retrieval in following steps, thus we expand
         # synonyms here.
         if len(entities) == 0:


### PR DESCRIPTION
# Description

Fixes spelling typos in the documentation and one source-code comment. This is a documentation/comment-only change; no functional code is affected, and there are no dependency or API changes.

Changes:

docs/src/content/docs/framework/module_guides/indexing/index_guide.md: `synoymn expanasion` -> `synonym expansion`; `chose` -> `choose`; `unavailble` -> `unavailable`

docs/src/content/docs/framework/optimizing/building_rag_from_scratch.md: `tutoral` -> `tutorial`

llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py: `synoynm` -> `synonym` (inside two code comments only)

No new package; no `pyproject.toml`/dependency changes; no tests needed.
