### PR TITLE
fix: preserve document id/name and metadata in VertexAISearchRetriever structured results

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/llama_index/retrievers/vertexai_search/base.py
@@ -264,14 +264,17 @@ class VertexAISearchRetriever(BaseRetriever):
             document_dict = MessageToDict(
                 result.document._pb, preserving_proto_field_name=True
             )
-            note_with_score.append(
-                NodeWithScore(
-                    node=TextNode(
-                        text=json.dumps(document_dict.get("struct_data", {}))
-                    ),
-                    score=score,
-                )
-            )
+            struct_data = document_dict.get("struct_data", {})
+            metadata = dict(struct_data)
+            for identity_key in ("id", "name"):
+                identity_value = document_dict.get(identity_key)
+                if identity_value is not None:
+                    metadata.setdefault(identity_key, identity_value)
+            node = TextNode(text=json.dumps(struct_data), metadata=metadata)
+            document_id = document_dict.get("id")
+            if document_id is not None:
+                node.id_ = document_id
+            note_with_score.append(NodeWithScore(node=node, score=score))
 
         return note_with_score
 

--- a/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/tests/test_retrievers_vertexai_search.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-vertexai-search/tests/test_retrievers_vertexai_search.py
@@ -1,3 +1,7 @@
+import json
+from types import SimpleNamespace
+
+from google.cloud.discoveryengine_v1.types import Document, SearchResponse
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.retrievers.vertexai_search.base import VertexAISearchRetriever
 
@@ -5,3 +9,39 @@ from llama_index.retrievers.vertexai_search.base import VertexAISearchRetriever
 def test_class():
     names_of_base_classes = [b.__name__ for b in VertexAISearchRetriever.__mro__]
     assert BaseRetriever.__name__ in names_of_base_classes
+
+
+def test_structured_response_preserves_document_identity_and_metadata():
+    """
+    Regression test for #21933.
+
+    Structured data store results must keep the Discovery Engine document identity
+    (`id`/`name`) and the `struct_data` fields, instead of only serializing the struct
+    payload into the node text.
+    """
+    document = Document(
+        id="li-meta-gamma",
+        name=(
+            "projects/PN/locations/global/collections/default_collection/"
+            "dataStores/DS/branches/0/documents/li-meta-gamma"
+        ),
+        struct_data={
+            "case_id": "RUN",
+            "title": "Gamma",
+            "expected_doc_id": "li-meta-gamma",
+        },
+    )
+    result = SearchResponse.SearchResult(id="li-meta-gamma", document=document)
+
+    nodes = VertexAISearchRetriever._convert_structured_datastore_response(
+        SimpleNamespace(), [result]
+    )
+
+    assert len(nodes) == 1
+    node = nodes[0].node
+    assert node.id_ == "li-meta-gamma"
+    assert node.metadata["case_id"] == "RUN"
+    assert node.metadata["title"] == "Gamma"
+    assert node.metadata["id"] == "li-meta-gamma"
+    assert node.metadata["name"].endswith("documents/li-meta-gamma")
+    assert json.loads(node.text)["case_id"] == "RUN"


### PR DESCRIPTION
Fixes #21933

### Description

`VertexAISearchRetriever._convert_structured_datastore_response` built each node with `TextNode(text=json.dumps(struct_data))`, so the Discovery Engine document identity (`id` / `name`) was dropped and the structured fields were not exposed as node metadata. Callers comparing a direct `SearchService.Search` response with the LlamaIndex nodes lost the document id and all `structData` fields.

This sets the node `id_` from the document id and populates `metadata` with the `struct_data` fields plus the document `id` / `name` (without overwriting any same-named `struct_data` keys). The node text is unchanged. Unstructured/website paths are untouched.

### New Package?

- [ ] Yes
- [x] No

### Version Bump?

- [ ] Yes
- [x] No

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Added new unit tests in the package's `tests/` that build a structured `SearchResult` and assert the resulting node carries the document id (`id_`), the document `name`, and the `struct_data` fields in `metadata`.

> This contribution was prepared with the assistance of an AI agent; all changes were reviewed and verified locally (unit tests + ruff).