### PR TITLE
fix(query-engine): offload blocking HTTP in CogniswitchQueryEngine._aquery

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/cogniswitch_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/cogniswitch_query_engine.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict
 
 import requests
@@ -59,7 +60,9 @@ class CogniswitchQueryEngine(BaseQueryEngine):
         return self.query_knowledge(query_bundle.query_str)
 
     async def _aquery(self, query_bundle: QueryBundle) -> Response:
-        return self.query_knowledge(query_bundle.query_str)
+        # query_knowledge issues a blocking requests.post; offload it so awaiting
+        # aquery() does not stall the event loop.
+        return await asyncio.to_thread(self.query_knowledge, query_bundle.query_str)
 
     def _get_prompt_modules(self) -> Dict[str, Any]:
         """Get prompts."""

--- a/llama-index-core/tests/query_engine/test_cogniswitch_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_cogniswitch_query_engine.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 from unittest.mock import patch
 
@@ -6,6 +7,7 @@ from llama_index.core.base.response.schema import Response
 from llama_index.core.query_engine.cogniswitch_query_engine import (
     CogniswitchQueryEngine,
 )
+from llama_index.core.schema import QueryBundle
 
 
 @pytest.fixture()
@@ -35,3 +37,23 @@ def test_query_knowledge_unsuccessful(
     response = query_engine.query_knowledge("what is life?")
     assert isinstance(response, Response)
     assert response.response == "Bad Request"
+
+
+@pytest.mark.asyncio
+@patch("requests.post")
+async def test_aquery_offloads_blocking_call_to_thread(
+    mock_post: Any, query_engine: CogniswitchQueryEngine
+) -> None:
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {"data": {"answer": "42"}}
+
+    with patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy:
+        response = await query_engine._aquery(
+            QueryBundle(query_str="What is the meaning of life?")
+        )
+
+    # The blocking requests.post must run off the event loop via asyncio.to_thread,
+    # while the response is unchanged.
+    spy.assert_called_once()
+    assert isinstance(response, Response)
+    assert response.response == "42"


### PR DESCRIPTION
# Description

`CogniswitchQueryEngine._aquery` is declared `async`, but it called the synchronous `query_knowledge()` directly — which issues a blocking `requests.post()`. So `await query_engine.aquery(...)` stalled the asyncio event loop for the entire Cogniswitch HTTP round-trip, defeating the point of the async API and blocking every other coroutine in a concurrent app for the duration of the request.

This offloads the blocking call with `asyncio.to_thread`, so the async path no longer blocks the loop. The returned `Response` is unchanged.

Found by a static sweep for blocking IO reachable from `async` paths — this was the only such finding in `llama-index-core`.

Fixes # (no tracking issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] No — the change is in `llama-index-core`, which the template exempts from version bumps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `tests/query_engine/test_cogniswitch_query_engine.py::test_aquery_offloads_blocking_call_to_thread`, which asserts `_aquery` routes the blocking call through `asyncio.to_thread` and returns the same `Response`. The full file (3 tests) passes locally, and `ruff check` / `ruff format --check` are clean on both files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
