### PR TITLE
docs: fix broken import in StringIterableReader docstring example

### DIFF
--- a/llama-index-core/llama_index/core/readers/string_iterable.py
+++ b/llama-index-core/llama_index/core/readers/string_iterable.py
@@ -15,7 +15,8 @@ class StringIterableReader(BasePydanticReader):
     Example:
         .. code-block:: python
 
-            from llama_index.core.legacy import StringIterableReader, TreeIndex
+            from llama_index.core import TreeIndex
+            from llama_index.core.readers import StringIterableReader
 
             documents = StringIterableReader().load_data(
                 texts=["I went to the store", "I bought an apple"]


### PR DESCRIPTION
The usage example in the `StringIterableReader` docstring imports from `llama_index.core.legacy`, a module that has been removed, so the snippet raises `ModuleNotFoundError` if copied as-is. This updates the example to import `StringIterableReader` from `llama_index.core.readers` (matching `command_line/mappings.json`) and `TreeIndex` from `llama_index.core`, which are the current public locations. Documentation-only change with no code behavior impact.