### PR TITLE
test(core): cover multimodal image metadata filters

### DIFF
--- a/llama-index-core/tests/indices/multi_modal/test_retriever.py
+++ b/llama-index-core/tests/indices/multi_modal/test_retriever.py
@@ -1,0 +1,60 @@
+import pytest
+
+from llama_index.core import MockEmbedding, StorageContext
+from llama_index.core.embeddings import MockMultiModalEmbedding
+from llama_index.core.indices import MultiModalVectorStoreIndex
+from llama_index.core.schema import ImageNode, QueryBundle
+from llama_index.core.vector_stores.simple import SimpleVectorStore
+from llama_index.core.vector_stores.types import (
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+)
+
+
+@pytest.fixture()
+def image_retriever():
+    matching_node = ImageNode(
+        id_="matching-image",
+        image_path="matching.png",
+        metadata={"category": "keep"},
+    )
+    filtered_node = ImageNode(
+        id_="filtered-image",
+        image_path="filtered.png",
+        metadata={"category": "skip"},
+    )
+    storage_context = StorageContext.from_defaults(image_store=SimpleVectorStore())
+    index = MultiModalVectorStoreIndex(
+        [matching_node, filtered_node],
+        storage_context=storage_context,
+        embed_model=MockEmbedding(embed_dim=3),
+        image_embed_model=MockMultiModalEmbedding(embed_dim=3),
+    )
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.EQ, value="keep")
+        ]
+    )
+    return index.as_retriever(filters=filters, image_similarity_top_k=2)
+
+
+def test_image_to_image_retrieve_applies_filters_for_image_path(image_retriever):
+    results = image_retriever.image_to_image_retrieve("query.png")
+
+    assert [node.node.node_id for node in results] == ["matching-image"]
+
+
+def test_image_to_image_retrieve_applies_filters_for_query_bundle(image_retriever):
+    results = image_retriever.image_to_image_retrieve(
+        QueryBundle(query_str="", image_path="query.png")
+    )
+
+    assert [node.node.node_id for node in results] == ["matching-image"]
+
+
+@pytest.mark.asyncio
+async def test_aimage_to_image_retrieve_applies_filters_for_image_path(image_retriever):
+    results = await image_retriever.aimage_to_image_retrieve("query.png")
+
+    assert [node.node.node_id for node in results] == ["matching-image"]


### PR DESCRIPTION
# Description

Adds regression coverage for `MetadataFilters` on `MultiModalVectorStoreIndex.image_to_image_retrieve()`.

Issue #15165 reported that filtering image nodes worked when passing a `QueryBundle`, but not when passing an image path string. Current `main` routes both sync and async image retrieval through `_build_vector_store_query()`, which includes `filters=self._filters`; this PR locks that behavior down with focused tests using the reported setup shape:

- `StorageContext.from_defaults(image_store=SimpleVectorStore())`
- `ImageNode` objects with metadata
- `index.as_retriever(filters=..., image_similarity_top_k=2)`
- string image path retrieval, `QueryBundle` retrieval, and async string image path retrieval

Refs #15165

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No, test-only change in `llama-index-core`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Commands run:

```bash
uv run --group dev pytest tests/indices/multi_modal/test_retriever.py -q
uv run --group dev ruff format tests/indices/multi_modal/test_retriever.py --check
uv run --group dev ruff check tests/indices/multi_modal/test_retriever.py
uv run --group dev pytest tests/indices/multi_modal/test_retriever.py tests/chat_engine/test_multi_modal_context.py tests/chat_engine/test_mm_condense_plus_context.py -q
```

Pre-commit also ran during commit and passed:

- ruff
- ruff-format
- mypy
- prettier
- codespell

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran focused format/lint checks for the changed test file
