### PR TITLE
fix: prevent file handle leaks in HotpotQAEvaluator

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,18 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
+                with open(
                     os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
-                response = requests.get(url, stream=True)
+                ) as save_file:
+                    response = requests.get(url, stream=True)
 
-                # Define the size of each chunk
-                chunk_size = 1024
+                    # Define the size of each chunk
+                    chunk_size = 1024
 
-                # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                    # Loop over the chunks and parse the JSON data
+                    for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +71,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.loads(f.read())
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:


### PR DESCRIPTION
## Summary

Fixes #21956 - Resource leak in HotpotQAEvaluator

## What I fixed
- Replaced manual `open()` calls with `with open(...) as` context managers
- Ensures file handles are properly closed even if exceptions occur

## Testing
- Syntax validated with `python3 -m py_compile`
- Both file handles now properly closed

## Impact
- Prevents file descriptor leaks on every call
- Better exception safety during download operations