### PR TITLE
fix(llms/rungpt): offload blocking HTTP in acomplete/achat to asyncio.to_thread

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-rungpt/llama_index/llms/rungpt/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-rungpt/llama_index/llms/rungpt/base.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from llama_index.core.base.llms.types import (
@@ -244,7 +245,9 @@ class RunGptLLM(LLM):
         messages: Sequence[ChatMessage],
         **kwargs: Any,
     ) -> ChatResponse:
-        return self.chat(messages, **kwargs)
+        # chat() issues a blocking requests.post; offload it so awaiting achat()
+        # does not stall the event loop.
+        return await asyncio.to_thread(self.chat, messages, **kwargs)
 
     @llm_chat_callback()
     async def astream_chat(
@@ -263,7 +266,9 @@ class RunGptLLM(LLM):
     async def acomplete(
         self, prompt: str, formatted: bool = False, **kwargs: Any
     ) -> CompletionResponse:
-        return self.complete(prompt, **kwargs)
+        # complete() issues a blocking requests.post; offload it so awaiting
+        # acomplete() does not stall the event loop.
+        return await asyncio.to_thread(self.complete, prompt, **kwargs)
 
     @llm_completion_callback()
     async def astream_complete(

--- a/llama-index-integrations/llms/llama-index-llms-rungpt/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-rungpt/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-rungpt"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms rungpt integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-rungpt/tests/test_llms_rungpt.py
+++ b/llama-index-integrations/llms/llama-index-llms-rungpt/tests/test_llms_rungpt.py
@@ -1,7 +1,48 @@
+import asyncio
+from unittest.mock import patch
+
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    CompletionResponse,
+    MessageRole,
+)
 from llama_index.llms.rungpt import RunGptLLM
 
 
 def test_embedding_class():
     names_of_base_classes = [b.__name__ for b in RunGptLLM.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_acomplete_offloads_blocking_call_to_thread():
+    llm = RunGptLLM()
+    with (
+        patch.object(
+            RunGptLLM, "complete", return_value=CompletionResponse(text="hi")
+        ) as mock_complete,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        response = asyncio.run(llm.acomplete("prompt"))
+
+    # complete() issues a blocking requests.post; acomplete must run it off the loop.
+    spy.assert_called_once()
+    mock_complete.assert_called_once()
+    assert response.text == "hi"
+
+
+def test_achat_offloads_blocking_call_to_thread():
+    llm = RunGptLLM()
+    reply = ChatResponse(message=ChatMessage(role=MessageRole.ASSISTANT, content="hi"))
+    with (
+        patch.object(RunGptLLM, "chat", return_value=reply) as mock_chat,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        response = asyncio.run(
+            llm.achat([ChatMessage(role=MessageRole.USER, content="q")])
+        )
+
+    spy.assert_called_once()
+    mock_chat.assert_called_once()
+    assert response.message.content == "hi"


### PR DESCRIPTION
# Description

`RunGptLLM.acomplete` and `achat` are `async`, but they called the synchronous `complete()` / `chat()` directly — each of which issues a blocking `requests.post()`. So `await llm.acomplete(...)` / `await llm.achat(...)` stalled the asyncio event loop for the full RunGPT HTTP round-trip, blocking every other coroutine for the duration.

This offloads the blocking call with `asyncio.to_thread`; the returned response is unchanged.

The streaming async methods (`astream_complete` / `astream_chat`) iterate the sync streaming generators and need an aiohttp-style rewrite to be truly non-blocking — left out of scope here.

Fixes # (no tracking issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-llms-rungpt` 0.5.0 → 0.5.1

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_acomplete_offloads_blocking_call_to_thread` and `test_achat_offloads_blocking_call_to_thread`, which assert `acomplete`/`achat` route through `asyncio.to_thread` and return the same response. The full file (3 tests) passes locally; `ruff check` / `ruff format --check` are clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
