### PR TITLE
fix(readers/onedrive): offload blocking HTTP/file IO in async resource methods

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -1,5 +1,6 @@
 """OneDrive files reader."""
 
+import asyncio
 import logging
 import os
 import tempfile
@@ -808,7 +809,10 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         recursive: bool = True,
         userprincipalname: Optional[str] = None,
     ) -> List[str]:
-        return self.list_resources(
+        # list_resources issues blocking requests; offload so awaiting
+        # alist_resources does not stall the event loop.
+        return await asyncio.to_thread(
+            self.list_resources,
             folder_id=folder_id,
             file_ids=file_ids,
             folder_path=folder_path,
@@ -831,7 +835,9 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
     async def aget_resource_info(
         self, resource_id: str, *args: Any, **kwargs: Any
     ) -> Dict:
-        return self.get_resource_info(resource_id, *args, **kwargs)
+        return await asyncio.to_thread(
+            self.get_resource_info, resource_id, *args, **kwargs
+        )
 
     def load_resource(
         self, resource_id: str, *args: Any, **kwargs: Any
@@ -841,7 +847,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
     async def aload_resource(
         self, resource_id: str, *args: Any, **kwargs: Any
     ) -> List[Document]:
-        return self.load_resource(resource_id, *args, **kwargs)
+        return await asyncio.to_thread(self.load_resource, resource_id, *args, **kwargs)
 
     def read_file_content(self, input_file: Path, **kwargs) -> bytes:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -859,4 +865,4 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
                 return f.read()
 
     async def aread_file_content(self, input_file: Path, **kwargs) -> bytes:
-        return self.read_file_content(input_file, **kwargs)
+        return await asyncio.to_thread(self.read_file_content, input_file, **kwargs)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-onedrive"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers microsoft_onedrive integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,5 +1,10 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
 from llama_index.readers.microsoft_onedrive import OneDriveReader
 
 test_client_id = "test_client_id"
@@ -31,6 +36,71 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+def _reader() -> OneDriveReader:
+    return OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+
+
+def test_alist_resources_offloads_to_thread():
+    reader = _reader()
+    with (
+        patch.object(
+            OneDriveReader, "list_resources", return_value=["a.txt"]
+        ) as mock_sync,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        result = asyncio.run(reader.alist_resources())
+
+    # The async resource API must run the blocking sync call off the event loop.
+    spy.assert_called_once()
+    mock_sync.assert_called_once()
+    assert result == ["a.txt"]
+
+
+def test_aget_resource_info_offloads_to_thread():
+    reader = _reader()
+    info = {"file_path": "a.txt"}
+    with (
+        patch.object(
+            OneDriveReader, "get_resource_info", return_value=info
+        ) as mock_sync,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        result = asyncio.run(reader.aget_resource_info("a.txt"))
+
+    spy.assert_called_once()
+    mock_sync.assert_called_once()
+    assert result == info
+
+
+def test_aload_resource_offloads_to_thread():
+    reader = _reader()
+    docs = [Document(text="hi")]
+    with (
+        patch.object(OneDriveReader, "load_resource", return_value=docs) as mock_sync,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        result = asyncio.run(reader.aload_resource("a.txt"))
+
+    spy.assert_called_once()
+    mock_sync.assert_called_once()
+    assert result == docs
+
+
+def test_aread_file_content_offloads_to_thread():
+    reader = _reader()
+    with (
+        patch.object(
+            OneDriveReader, "read_file_content", return_value=b"data"
+        ) as mock_sync,
+        patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+    ):
+        result = asyncio.run(reader.aread_file_content(Path("a.txt")))
+
+    spy.assert_called_once()
+    mock_sync.assert_called_once()
+    assert result == b"data"
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Description

`OneDriveReader`'s async resource API — `alist_resources`, `aget_resource_info`, `aload_resource`, and `aread_file_content` — each `await`ed nothing and called the synchronous `list_resources` / `get_resource_info` / `load_resource` / `read_file_content` directly. Those issue blocking Microsoft Graph `requests` calls (and local file reads), so `await`ing any of them stalled the asyncio event loop for the entire operation, blocking every other coroutine.

This offloads each delegation with `asyncio.to_thread`; the returned results are unchanged.

Found by a static sweep for blocking IO reachable from `async` paths.

Fixes # (no tracking issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-readers-microsoft-onedrive` 0.5.0 → 0.5.1

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added spy-based regression tests asserting each of `alist_resources` / `aget_resource_info` / `aload_resource` / `aread_file_content` routes through `asyncio.to_thread` and returns the sync result. The suite passes (6 passed, 1 skipped — the live-credentials integration test); `ruff check` / `ruff format` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
