### PR TITLE
Fix/tool resource leaks

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
@@ -226,31 +226,37 @@ class AzureCodeInterpreterToolSpec(BaseToolSpec):
         if data and local_file_path:
             raise ValueError("data and local_file_path cannot be provided together")
 
-        if local_file_path:
-            remote_file_path = f"/mnt/data/{os.path.basename(local_file_path)}"
-            data = open(local_file_path, "rb")
+        opened_file = None
+        try:
+            if local_file_path:
+                remote_file_path = f"/mnt/data/{os.path.basename(local_file_path)}"
+                opened_file = open(local_file_path, "rb")
+                data = opened_file
 
-        access_token = self.access_token_provider()
-        if not remote_file_path.startswith("/mnt/data"):
-            remote_file_path = f"/mnt/data/{remote_file_path}"
-        api_url = self._build_url("files/upload")
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-        }
+            access_token = self.access_token_provider()
+            if not remote_file_path.startswith("/mnt/data"):
+                remote_file_path = f"/mnt/data/{remote_file_path}"
+            api_url = self._build_url("files/upload")
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+            }
 
-        files = [("file", (remote_file_path, data, "application/octet-stream"))]
+            files = [("file", (remote_file_path, data, "application/octet-stream"))]
 
-        response = requests.request("POST", api_url, headers=headers, files=files)
-        response.raise_for_status()
+            response = requests.request("POST", api_url, headers=headers, files=files)
+            response.raise_for_status()
 
-        response_json = response.json()
-        remote_files_metadatas = []
-        for entry in response_json["value"]:
-            if "properties" in entry:
-                remote_files_metadatas.append(
-                    RemoteFileMetadata.from_dict(entry["properties"])
-                )
-        return remote_files_metadatas
+            response_json = response.json()
+            remote_files_metadatas = []
+            for entry in response_json["value"]:
+                if "properties" in entry:
+                    remote_files_metadatas.append(
+                        RemoteFileMetadata.from_dict(entry["properties"])
+                    )
+            return remote_files_metadatas
+        finally:
+            if opened_file is not None:
+                opened_file.close()
 
     def download_file_to_local(
         self, remote_file_path: str, local_file_path: Optional[str] = None

--- a/llama-index-integrations/tools/llama-index-tools-cogniswitch/llama_index/tools/cogniswitch/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-cogniswitch/llama_index/tools/cogniswitch/base.py
@@ -100,16 +100,16 @@ class CogniswitchToolSpec(BaseToolSpec):
             api_url = self.source_file_endpoint
 
             headers = self.headers
-            if file is not None:
-                files = {"file": open(file, "rb")}
-            else:
-                files = None
             data = {
                 "url": url,
                 "documentName": document_name,
                 "documentDescription": document_description,
             }
-            response = requests.post(api_url, headers=headers, data=data, files=files)
+            with open(file, "rb") as f:
+                files = {"file": f}
+                response = requests.post(
+                    api_url, headers=headers, data=data, files=files
+                )
         if response.status_code == 200:
             return response.json()
         else:

--- a/llama-index-integrations/tools/llama-index-tools-python-file/llama_index/tools/python_file/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-python-file/llama_index/tools/python_file/base.py
@@ -8,8 +8,8 @@ class PythonFileToolSpec(BaseToolSpec):
     spec_functions = ["function_definitions", "get_function", "get_functions"]
 
     def __init__(self, file_name: str) -> None:
-        f = open(file_name).read()
-        self.tree = ast.parse(f)
+        with open(file_name) as f:
+            self.tree = ast.parse(f.read())
 
     def function_definitions(self, external: Optional[bool] = True) -> str:
         """


### PR DESCRIPTION
# Description

Fix resource leaks in three tool integrations where `open()` was called without a corresponding `close()`, leaking file descriptors.

**Changes:**
- **PythonFileToolSpec** (`base.py:11`): `open(file_name).read()` → `with open(file_name) as f:`
- **CogniSwitch** (`base.py:104`): `open(file, "rb")` passed to requests without closing → wrapped in `with` statement
- **Azure Code Interpreter** (`base.py:231`): `open(local_file_path, "rb")` for upload without close → added `try/finally` to ensure cleanup

In long-running processes or repeated calls, bare `open()` without close causes file descriptor exhaustion (OS limit ~1024 per process). Same pattern as #21957.

Fixes #21970

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests
- Pre-commit checks passed (ruff, mypy, ruff-format, codespell)
- All three files verified with `ast.parse()` for syntax correctness

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods