### PR TITLE
fix(readers/dashscope): offload blocking upload in DashScopeParse._create_job

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-dashscope/llama_index/readers/dashscope/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-dashscope/llama_index/readers/dashscope/base.py
@@ -158,27 +158,34 @@ class DashScopeParse(BasePydanticReader):
 
         headers = self._get_dashscope_header()
 
-        # load data
-        with open(file_path, "rb") as f:
-            upload_file_lease_result = self.__upload_lease(file_path, headers)
+        # The file open, upload-lease request, and file upload are blocking IO;
+        # run them off the event loop instead of on it.
+        upload_file_lease_result = await asyncio.to_thread(
+            self._upload_file_with_lease, file_path, headers
+        )
 
-            upload_file_lease_result.upload(file_path, f)
-
-            url = f"{self.base_url}/api/v1/datacenter/category/{self.category_id}/add_file"
-            async with httpx.AsyncClient(timeout=self.max_timeout) as client:
-                response = await client.post(
-                    url,
-                    headers=headers,
-                    json={
-                        "lease_id": upload_file_lease_result.lease_id,
-                        "parser": ResultType.DASHSCOPE_DOCMIND.value,
-                    },
-                )
-            add_file_result = dashscope_response_handler(
-                response, "add_file", AddFileResult, url=url
+        url = f"{self.base_url}/api/v1/datacenter/category/{self.category_id}/add_file"
+        async with httpx.AsyncClient(timeout=self.max_timeout) as client:
+            response = await client.post(
+                url,
+                headers=headers,
+                json={
+                    "lease_id": upload_file_lease_result.lease_id,
+                    "parser": ResultType.DASHSCOPE_DOCMIND.value,
+                },
             )
+        add_file_result = dashscope_response_handler(
+            response, "add_file", AddFileResult, url=url
+        )
 
         return add_file_result.file_id
+
+    def _upload_file_with_lease(self, file_path, headers):
+        """Open the file, acquire an upload lease, and upload it (all blocking IO)."""
+        with open(file_path, "rb") as f:
+            upload_file_lease_result = self.__upload_lease(file_path, headers)
+            upload_file_lease_result.upload(file_path, f)
+        return upload_file_lease_result
 
     @retry(
         stop=stop_after_delay(60),

--- a/llama-index-integrations/readers/llama-index-readers-dashscope/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-dashscope/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-dashscope"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers dashscope integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-dashscope/tests/test_readers_dashscope.py
+++ b/llama-index-integrations/readers/llama-index-readers-dashscope/tests/test_readers_dashscope.py
@@ -1,7 +1,61 @@
-from llama_index.readers.dashscope import DashScopeParse
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from llama_index.core.readers.base import BasePydanticReader
+from llama_index.readers.dashscope import DashScopeParse
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in DashScopeParse.__mro__]
     assert BasePydanticReader.__name__ in names_of_base_classes
+
+
+def test_upload_file_with_lease_runs_blocking_upload(tmp_path):
+    parse = DashScopeParse(api_key="k")
+    src = tmp_path / "doc.pdf"
+    src.write_bytes(b"data")
+    fake_lease = MagicMock()
+
+    with patch.object(
+        DashScopeParse, "_DashScopeParse__upload_lease", return_value=fake_lease
+    ):
+        result = parse._upload_file_with_lease(str(src), {})
+
+    assert result is fake_lease
+    fake_lease.upload.assert_called_once()
+
+
+def test_create_job_offloads_blocking_upload():
+    parse = DashScopeParse(api_key="k")
+    fake_lease = MagicMock(lease_id="lease-1")
+
+    async def run():
+        client = MagicMock()
+        client.post = AsyncMock(return_value=MagicMock())
+        with (
+            patch(
+                "llama_index.readers.dashscope.base.UploadFileLeaseResult.is_file_valid"
+            ),
+            patch.object(DashScopeParse, "_get_dashscope_header", return_value={}),
+            patch.object(
+                DashScopeParse, "_upload_file_with_lease", return_value=fake_lease
+            ) as mock_upload,
+            patch(
+                "llama_index.readers.dashscope.base.httpx.AsyncClient"
+            ) as mock_client_cls,
+            patch(
+                "llama_index.readers.dashscope.base.dashscope_response_handler",
+                return_value=MagicMock(file_id="file-1"),
+            ),
+            patch("asyncio.to_thread", wraps=asyncio.to_thread) as spy,
+        ):
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await parse._create_job("doc.pdf")
+
+        # The blocking upload must run off the event loop via asyncio.to_thread.
+        spy.assert_called_once()
+        mock_upload.assert_called_once()
+        assert result == "file-1"
+
+    asyncio.run(run())


### PR DESCRIPTION
# Description

`DashScopeParse._create_job` is `async`, but before the async `add_file` POST it opened the file, requested the upload lease (a **blocking** `httpx.Client` request inside `__upload_lease`), and uploaded the file — all synchronously on the event loop. So `await`ing it (via `aload_data` / `aget_json`) stalled the loop for the entire lease + upload.

This extracts the file open + lease + upload into a sync helper (`_upload_file_with_lease`) and runs it via `asyncio.to_thread`. The async `add_file` request then runs as before using the returned lease, and the file handle no longer stays open across the async POST. Behavior is unchanged.

Found by a static sweep for blocking IO reachable from `async` paths.

Fixes # (no tracking issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-readers-dashscope` 0.5.0 → 0.5.1

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_upload_file_with_lease_runs_blocking_upload` covers the extracted helper, and `test_create_job_offloads_blocking_upload` asserts `_create_job` routes the blocking work through `asyncio.to_thread`. Suite passes (3 passed); `ruff check` / `ruff format` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
