### PR TITLE
fix: use context managers for file handles in integrations

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
@@ -154,9 +154,8 @@ class BGEM3Index(BaseIndex[IndexDict]):
             int(k): v for k, v in index.index_struct.nodes_dict.items()
         }
         index._docs_pos_to_node_id = docs_pos_to_node_id
-        index._multi_embed_store = pickle.load(
-            open(Path(persist_dir) / "multi_embed_store.pkl", "rb")
-        )
+        with open(Path(persist_dir) / "multi_embed_store.pkl", "rb") as f:
+            index._multi_embed_store = pickle.load(f)
         return index
 
     def query(self, query_str: str, top_k: int = 10) -> List[NodeWithScore]:

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
@@ -359,36 +359,37 @@ class VectaraIndex(BaseManagedIndex):
         if filename is None:
             filename = file_path.split("/")[-1]
 
-        files = {"file": (filename, open(file_path, "rb"))}
+        with open(file_path, "rb") as f:
+            files = {"file": (filename, f)}
 
-        if metadata:
-            metadata["framework"] = "llama_index"
-            files["metadata"] = (None, json.dumps(metadata), "application/json")
+            if metadata:
+                metadata["framework"] = "llama_index"
+                files["metadata"] = (None, json.dumps(metadata), "application/json")
 
-        if chunking_strategy:
-            files["chunking_strategy"] = (
-                None,
-                json.dumps(chunking_strategy),
-                "application/json",
+            if chunking_strategy:
+                files["chunking_strategy"] = (
+                    None,
+                    json.dumps(chunking_strategy),
+                    "application/json",
+                )
+
+            if enable_table_extraction:
+                files["table_extraction_config"] = (
+                    None,
+                    json.dumps({"extract_tables": enable_table_extraction}),
+                    "application/json",
+                )
+
+            headers = self._get_post_headers()
+            headers.pop("Content-Type")
+            valid_corpus_key = self._get_corpus_key(corpus_key)
+            response = self._session.post(
+                f"{self._base_url}/v2/corpora/{valid_corpus_key}/upload_file",
+                files=files,
+                verify=True,
+                headers=headers,
+                timeout=self.vectara_api_timeout,
             )
-
-        if enable_table_extraction:
-            files["table_extraction_config"] = (
-                None,
-                json.dumps({"extract_tables": enable_table_extraction}),
-                "application/json",
-            )
-
-        headers = self._get_post_headers()
-        headers.pop("Content-Type")
-        valid_corpus_key = self._get_corpus_key(corpus_key)
-        response = self._session.post(
-            f"{self._base_url}/v2/corpora/{valid_corpus_key}/upload_file",
-            files=files,
-            verify=True,
-            headers=headers,
-            timeout=self.vectara_api_timeout,
-        )
 
         res = response.json()
         if response.status_code == 201:

--- a/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
@@ -1,3 +1,4 @@
+import io
 from typing import Any, Dict, Sequence
 
 from llama_index.core.base.llms.types import (
@@ -94,7 +95,8 @@ class Replicate(CustomLLM):
         }
         if self.image != "":
             try:
-                base_kwargs["image"] = open(self.image, "rb")
+                with open(self.image, "rb") as f:
+                    base_kwargs["image"] = io.BytesIO(f.read())
             except FileNotFoundError:
                 raise FileNotFoundError(
                     "Could not load image file. Please check whether the file exists"

--- a/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
@@ -123,16 +123,17 @@ class SemanticScholarReader(BaseReader):
             # Then, check if it's a valid PDF. If it's not, skip to the next document.
             if file_path:
                 try:
-                    pdf = PdfReader(open(file_path, "rb"))
+                    with open(file_path, "rb") as f:
+                        pdf = PdfReader(f)
+                        text = ""
+                        for page in pdf.pages:
+                            text += page.extract_text()
                 except Exception as e:
                     logging.error(
                         f"Failed to read pdf with exception: {e}. Skipping document..."
                     )
                     continue
 
-                text = ""
-                for page in pdf.pages:
-                    text += page.extract_text()
                 full_text_docs.append(Document(text=text, extra_info=metadata))
 
         return full_text_docs


### PR DESCRIPTION
# Description

Fix resource leaks in four integrations where `open()` was called without a corresponding `close()`, leaking file descriptors.

**Changes:**
- **Vectara** (`base.py:362`): `open(file_path, "rb")` for upload → wrapped in `with` statement
- **Replicate LLM** (`base.py:97`): `open(self.image, "rb")` stored in dict → read into `io.BytesIO` buffer with context manager
- **SemanticScholar** (`base.py:126`): `PdfReader(open(...))` in loop → wrapped in `with` statement
- **BGE-M3** (`base.py:158`): `pickle.load(open(...))` inline → wrapped in `with` statement

Same pattern as #21957 and #21971.

Fixes #21973

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests
- Pre-commit checks passed (ruff, mypy, ruff-format, codespell)
- All four files verified with `ast.parse()` for syntax correctness

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods