### PR TITLE
ci: pin third-party actions to commit SHA (supply-chain hardening)

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -16,12 +16,12 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/close_new_integration_prs.yml
+++ b/.github/workflows/close_new_integration_prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for new pyproject.toml files
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,11 +46,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,7 +63,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -76,6 +76,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/core-typecheck.yml
+++ b/.github/workflows/core-typecheck.yml
@@ -10,12 +10,12 @@ jobs:
   core-typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/coverage_check.yml
+++ b/.github/workflows/coverage_check.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install -y portaudio19-dev
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true

--- a/.github/workflows/issue_classifier.yml
+++ b/.github/workflows/issue_classifier.yml
@@ -8,18 +8,18 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
 
       - name: Classify Issues as Good First Issues
-        uses: run-llama/issue-classifier@v0.2.0
+        uses: run-llama/issue-classifier@d5aa3584e6e0705553a7e4fc5c1f80f99d70bf39 # v0.2.0
         with:
           llama-cloud-api-key: ${{ secrets.LLAMA_CLOUD_API_KEY }}
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/llama_dev_tests.yml
+++ b/.github/workflows/llama_dev_tests.yml
@@ -14,12 +14,12 @@ jobs:
   test-llama-dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -21,12 +21,12 @@ jobs:
     if: github.repository == 'run-llama/llama_index'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Install uv and set python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.10"
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create Release PR
         id: rpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: Prepare release
           signoff: false

--- a/.github/workflows/publish_sub_package.yml
+++ b/.github/workflows/publish_sub_package.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'run-llama/llama_index'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install uv and set the python version
         if: ${{ steps.changed-files.outputs.changed_files != '' }}
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       version: ${{ steps.build-publish-core.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv and set python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.10"
 
@@ -41,7 +41,7 @@ jobs:
           uv run python -c "from llama_index.core.utils import get_tokenizer; print(get_tokenizer('gpt-5-mini'))"
 
       - name: Generate build provenance attestations
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         id: attest
         with:
           subject-path: "llama-index-core/llama_index/core/_static/**/*"
@@ -75,14 +75,14 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
           owner: run-llama
 
       - name: Trigger repository_dispatch
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: run-llama/workflows-py
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv and set python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.10"
 
@@ -120,7 +120,7 @@ jobs:
           uv publish --token ${{ secrets.LLAMA_INDEX_PYPI_TOKEN }}
 
       - name: Generate Release Notes
-        uses: CSchoel/release-notes-from-changelog@v1
+        uses: CSchoel/release-notes-from-changelog@3594292798d8d7eaed04d0a436a5fa2b22e448c7 # v1
         with:
           version: "$(date +'%Y-%m-%d')"
           begin-pattern: "/^## \\[$(date +'%Y-%m-%d')\\]/"

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           # PR configuration
           stale-pr-message: "This PR is stale because it has been open 50 days with no activity. Remove stale label or comment or this will be closed in 10 days."

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repo (llama_index)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Fetch the base commit so git diff works for incremental example conversion
       - name: Fetch base commit for diff
@@ -31,14 +31,14 @@ jobs:
         run: git fetch --depth=1 origin ${{ github.event.before }}
 
       - name: Checkout docs repo (developer hub)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: run-llama/developers
           token: ${{ secrets.DEVELOPER_HUB_TOKEN }}
           path: developer-hub
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y portaudio19-dev
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -43,7 +43,7 @@ jobs:
   test-core-py314:
     runs-on: ubuntu-latest-unit-tester
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y portaudio19-dev
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.14"
           enable-cache: true


### PR DESCRIPTION
## Summary

Pins third-party GitHub Actions to a full commit SHA instead of a moving tag, in line with [GitHub's hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and OpenSSF Scorecard's [Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies).

This is a defense-in-depth / supply-chain reliability change. It does not alter any runtime behavior of llama_index itself.

## Motivation

Tag references in GitHub Actions are mutable: a maintainer (or someone with their token) can re-point a tag to a different commit at any time. The 2025 `tj-actions/changed-files` incident ([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)) — where a malicious commit was published under an existing tag and inherited by every consuming workflow — is the canonical example.

Pinning to an immutable commit SHA closes that window without changing what the workflow does today. The repo already has `.github/dependabot.yml` configured for `package-ecosystem: "github-actions"`, so SHA-pinned actions stay auto-updatable via PR; the cost of adoption is one-time.

OpenSSF Scorecard's `Pinned-Dependencies` check is the standard reference; this change moves llama_index from WARN to PASS on that check.

## Scope

Only `.github/workflows/*.yml` files. No source-code changes. No new dependencies. No CI runtime change.

- **14 workflow files modified**
- **39 `uses:` lines pinned**
- All third-party actions covered (including `actions/*`, `github/codeql-action/*`, `astral-sh/setup-uv`, `peter-evans/*`, `CSchoel/release-notes-from-changelog`, `run-llama/issue-classifier`)

## Files touched

```
.github/workflows/build_package.yml             (2)
.github/workflows/close_new_integration_prs.yml (1)
.github/workflows/codeql.yml                    (4)
.github/workflows/core-typecheck.yml            (2)
.github/workflows/coverage_check.yml            (2)
.github/workflows/issue_classifier.yml          (3)
.github/workflows/lint.yml                      (2)
.github/workflows/llama_dev_tests.yml           (2)
.github/workflows/pre_release.yml               (3)
.github/workflows/publish_sub_package.yml       (2)
.github/workflows/release.yml                   (8)
.github/workflows/stale_bot.yml                 (1)
.github/workflows/sync-docs.yml                 (3)
.github/workflows/unit_test.yml                 (4)
```

## Patch examples

```diff
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
```

```diff
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
```

```diff
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
```

The trailing `# vN` comment preserves human readability and is what Dependabot uses to decide when to open the next update PR. The same pattern is applied to every `uses:` line that points at a third-party action by tag.

`actions/*`-owned actions (checkout, github-script, etc.) are GitHub-maintained and are technically lower risk, but Scorecard still expects them to be SHA-pinned for the check to pass — applying the rule uniformly keeps the policy easy to enforce.

## Keeping pins current

The existing `.github/dependabot.yml` already covers this:

```yaml
- package-ecosystem: "github-actions"
  directory: "/"
  schedule:
    interval: "weekly"
```

Dependabot opens one PR per updated action with the new SHA and matching tag comment; no manual SHA lookups going forward.

## Verification

- All 14 modified files pass `yaml.safe_load`
- Diff is exclusively `uses:` line swaps; no whitespace, indentation, or comment changes elsewhere
- Comment-form (`@<sha> # <tag>`) is recognized by Dependabot's `github-actions` ecosystem for version tracking

## Notes for reviewers

- Happy to split this across multiple smaller PRs (one workflow file per PR) if that's easier to review.
- If the project prefers to keep `actions/*` GitHub-owned actions on tag refs, I'll drop those lines from the diff — just let me know.
- No changes to caching keys, runner images, permissions blocks, or secrets handling are included; those can be follow-up PRs if of interest.

## References

- [GitHub Docs — Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [OpenSSF Scorecard — Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
- [CVE-2025-30066 — tj-actions/changed-files tag re-point incident](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)
