### PR TITLE
fix: add SSRF protection to resolve_binary() for URL-based content blocks

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -3,8 +3,10 @@
 import asyncio
 import base64
 import inspect
+import ipaddress
 import os
 import random
+import socket
 import sys
 import time
 import traceback
@@ -35,7 +37,7 @@ from typing import (
 
 import platformdirs
 import requests
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 if TYPE_CHECKING:
     from nltk.tokenize import PunktSentenceTokenizer
@@ -623,6 +625,60 @@ async def async_unit_generator(x: Any) -> AsyncGenerator[Any, None]:
     yield x
 
 
+_ALLOWED_REMOTE_URL_SCHEMES = {"http", "https"}
+
+
+def _is_disallowed_host(hostname: str) -> bool:
+    """Return True if `hostname` resolves to a loopback/private/link-local/reserved address."""
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        # Can't resolve the host; let requests surface the error.
+        return False
+
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return True
+    return False
+
+
+def _assert_safe_remote_url(url: str) -> None:
+    """Raise ValueError if `url` is not safe to fetch server-side (SSRF guard)."""
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in _ALLOWED_REMOTE_URL_SCHEMES:
+        raise ValueError(f"Unsupported URL scheme for remote fetch: {parsed_url.scheme!r}")
+    if not parsed_url.hostname:
+        raise ValueError("URL is missing a hostname")
+    if _is_disallowed_host(parsed_url.hostname):
+        raise ValueError(f"Refusing to fetch from disallowed host: {parsed_url.hostname!r}")
+
+
+def _fetch_remote_url(url: str, headers: Dict[str, str], max_redirects: int = 5) -> requests.Response:
+    """Fetch `url`, re-validating the SSRF guard on every redirect hop."""
+    for _ in range(max_redirects + 1):
+        _assert_safe_remote_url(url)
+        response = requests.get(url, headers=headers, timeout=(60, 60), allow_redirects=False)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("location")
+            if not location:
+                response.raise_for_status()
+                return response
+            url = urljoin(url, location)
+            continue
+        response.raise_for_status()
+        return response
+
+    raise ValueError("Too many redirects while resolving binary URL")
+
+
 def resolve_binary(
     raw_bytes: Optional[bytes] = None,
     path: Optional[Union[str, Path]] = None,
@@ -701,8 +757,7 @@ def resolve_binary(
         headers = {
             "User-Agent": "LlamaIndex/0.0 (https://llamaindex.ai; info@llamaindex.ai) llama-index-core/0.0"
         }
-        response = requests.get(url, headers=headers, timeout=(60, 60))
-        response.raise_for_status()
+        response = _fetch_remote_url(url, headers)
         if as_base64:
             return BytesIO(base64.b64encode(response.content))
         return BytesIO(response.content)

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -20,6 +20,7 @@ from llama_index.core.utils import (
     get_tokenizer,
     iter_batch,
     print_text,
+    resolve_binary,
     retry_on_exceptions_with_backoff,
     truncate_text,
 )
@@ -353,3 +354,52 @@ def test_get_cache_dir_env_var_precedence(tmp_path, monkeypatch) -> None:
         mock_user_cache_dir.return_value = "/should/not/be/used"
         get_cache_dir()
         mock_user_cache_dir.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://127.0.0.1:8080/admin",
+        "http://localhost/admin",
+        "http://10.0.0.5/internal",
+        "http://192.168.1.1/",
+        "http://[::1]/admin",
+    ],
+)
+def test_resolve_binary_blocks_ssrf_to_internal_hosts(url: str) -> None:
+    with pytest.raises(ValueError, match="disallowed host"):
+        resolve_binary(url=url)
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://example.com/file"])
+def test_resolve_binary_blocks_disallowed_schemes(url: str) -> None:
+    with pytest.raises(ValueError, match="Unsupported URL scheme"):
+        resolve_binary(url=url)
+
+
+def test_resolve_binary_blocks_redirect_to_internal_host() -> None:
+    """A remote redirect must not be able to retarget the fetch at an internal host."""
+
+    class FakeResponse:
+        def __init__(self, redirect_target: Optional[str] = None) -> None:
+            self.is_redirect = redirect_target is not None
+            self.is_permanent_redirect = False
+            self.headers = {"location": redirect_target} if redirect_target else {}
+            self.content = b"ok"
+
+        def raise_for_status(self) -> None:
+            pass
+
+    def fake_get(url, headers=None, timeout=None, allow_redirects=None):
+        if url == "https://public.example.com/img":
+            return FakeResponse(redirect_target="http://169.254.169.254/latest/meta-data/")
+        raise AssertionError(f"unexpected request to {url}")
+
+    with mock.patch("llama_index.core.utils.requests.get", side_effect=fake_get):
+        with pytest.raises(ValueError, match="disallowed host"):
+            resolve_binary(url="https://public.example.com/img")
+
+
+def test_resolve_binary_data_url_still_works() -> None:
+    assert resolve_binary(url="data:text/plain;base64,aGVsbG8=").read() == b"hello"


### PR DESCRIPTION
## Summary

`resolve_binary()` in `llama-index-core/llama_index/core/utils.py` fetches arbitrary URLs via `requests.get()` with no validation when `ImageBlock`/`AudioBlock`/`VideoBlock` content blocks are constructed with a `url` field. Any application that lets a user supply an image/audio/video URL for multimodal chat hands SSRF straight to the LLM pipeline: an attacker can target cloud metadata endpoints (`169.254.169.254`), loopback, or other internal services, with the response returned as base64 to the LLM.

## Fix

- Restrict fetches to `http`/`https` schemes (data: URLs continue to work as before)
- Resolve the hostname and reject loopback/private/link-local/reserved/multicast/unspecified addresses
- Re-validate the SSRF guard on every redirect hop (max 5), so a public host cannot redirect the fetch to an internal address

## Test plan

- Added parametrized tests blocking SSRF to metadata/loopback/private/IPv6-loopback hosts
- Added tests blocking disallowed schemes (`file://`, `ftp://`)
- Added a mocked-redirect test confirming a redirect to an internal host is blocked
- Added a regression test confirming `data:` URLs still resolve correctly

This PR is a minimal, focused security fix with no behavior change for legitimate public URLs.
