### PR TITLE
fix: enable TLS verification by default in Minio reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
@@ -36,6 +36,7 @@ class BotoMinioReader(BaseReader):
         aws_access_secret: Optional[str] = None,
         aws_session_token: Optional[str] = None,
         s3_endpoint_url: Optional[str] = "https://s3.amazonaws.com",
+        verify_ssl: bool = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -62,6 +63,9 @@ class BotoMinioReader(BaseReader):
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.
         s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
+        verify_ssl (bool): verify SSL certificates for S3 connections.
+            Default is True. Set to False only for local development with
+            self-signed certificates.
 
         """
         super().__init__(*args, **kwargs)
@@ -80,6 +84,7 @@ class BotoMinioReader(BaseReader):
         self.aws_access_secret = aws_access_secret
         self.aws_session_token = aws_session_token
         self.s3_endpoint_url = s3_endpoint_url
+        self.verify_ssl = verify_ssl
 
     def load_data(self) -> List[Document]:
         """Load file(s) from S3."""
@@ -92,7 +97,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify_ssl,
         )
         s3 = boto3.resource(
             "s3",
@@ -101,7 +106,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify_ssl,
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# Description

Fix unconditionally disabled TLS certificate verification in `BotoMinioReader`. Both `boto3.client()` and `boto3.resource()` calls had `verify=False` hardcoded, making all S3 connections vulnerable to man-in-the-middle attacks.

**Changes:**
- Added `verify_ssl: bool = True` parameter to `BotoMinioReader.__init__()`
- Replaced hardcoded `verify=False` with `verify=self.verify_ssl` in both boto3 calls
- Default is `True` (secure) - users who need self-signed certs can explicitly pass `verify_ssl=False`

This is a breaking change in behavior (TLS is now verified by default), but the previous behavior was a security bug. Existing users connecting to proper S3/Minio endpoints with valid certificates will see no difference.

Fixes #21978

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Pre-commit checks passed (ruff, mypy, ruff-format, codespell)
- [x] Syntax verified with `ast.parse()`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods