### PR TITLE
docs: add Dynamic Feed keyless-MCP example to llama-index-tools-mcp

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/examples/dynamicfeed_mcp.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/examples/dynamicfeed_mcp.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dynamic Feed \u2014 keyless live data via a remote MCP server\n",
+    "\n",
+    "[Dynamic Feed](https://dynamicfeed.ai) is a keyless remote (Streamable HTTP) MCP server that gives a LlamaIndex agent live, current data its model was never trained on \u2014 weather, CVEs, software versions, hazards, satellites, macro and more (87 tools across 19 verticals). ",
+    "Every datapoint is Ed25519-signed and carries a provenance envelope (source, observed-at, freshness).\n",
+    "\n",
+    "This notebook uses the existing `llama-index-tools-mcp` integration \u2014 no new package, no API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-tools-mcp llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient, McpToolSpec\n",
+    "\n",
+    "# keyless remote MCP endpoint\n",
+    "mcp_client = BasicMCPClient(\"https://dynamicfeed.ai/mcp\")\n",
+    "tools = await McpToolSpec(client=mcp_client).to_tool_list_async()\n",
+    "print(f\"loaded {len(tools)} keyless Dynamic Feed tools\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "agent = FunctionAgent(tools=tools, llm=OpenAI(model=\"gpt-4o\"))\n",
+    "resp = await agent.run(\"What is the latest stable Python, and is lodash 4.17.10 vulnerable?\")\n",
+    "print(resp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each response is **Ed25519-signed** and verifiable against `https://dynamicfeed.ai/.well-known/keys`. ",
+    "The signature is proof-of-existence and tamper-evidence \u2014 it proves Dynamic Feed reported a value at a time and the bytes are unaltered. It is **not** a claim the value is objectively true; your agent still applies judgment."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

This PR adds a runnable notebook example demonstrating Dynamic Feed as a real-world remote Streamable-HTTP MCP server. All existing examples in `llama-index-tools-mcp/examples/` use `localhost`; this adds the first publicly-hosted, keyless endpoint that readers can run without standing up a server themselves.

**What is Dynamic Feed?**
Dynamic Feed (https://dynamicfeed.ai) is a live-data MCP server exposing 87 tools across 19 verticals (weather, earthquakes, hazards, CVE lookups, satellites, sanctions screening, macro data, shipping, …). Every JSON response carries a provenance envelope (source / licence / timestamp / age_seconds) and is Ed25519-signed for tamper-evidence — verifiable against the public key at `GET https://dynamicfeed.ai/.well-known/keys`. The signing is proof-of-existence and tamper-evidence; it is not a truth claim about the underlying data.

**Why does this belong here?**
- The MCP endpoint (`https://dynamicfeed.ai/mcp`) is Streamable HTTP — exactly the transport `BasicMCPClient` supports natively.
- No API key, no server setup: `BasicMCPClient("https://dynamicfeed.ai/mcp")` works in a fresh notebook immediately.
- The 87 tools are discoverable via `list_tools()` without credentials, so the example exercises the full `McpToolSpec` → `FunctionAgent` loop end-to-end.

**Files changed**

| File | Change |
|---|---|
| `llama-index-integrations/tools/llama-index-tools-mcp/examples/dynamicfeed_mcp.ipynb` | New notebook (added) |

**Notebook outline**

```python
# Cell 1 — install
# pip install llama-index-tools-mcp llama-index-llms-openai

# Cell 2 — connect and list tools
from llama_index.tools.mcp import BasicMCPClient, McpToolSpec

mcp_client = BasicMCPClient("https://dynamicfeed.ai/mcp")   # keyless, Streamable HTTP
mcp_tool_spec = McpToolSpec(client=mcp_client)
tools = await mcp_tool_spec.to_tool_list_async()
print(f"Tools available: {len(tools)}")
# → 87 tools (keyless surface)

# Cell 3 — run an agent
from llama_index.core.agent.workflow import FunctionAgent
from llama_index.llms.openai import OpenAI

agent = FunctionAgent(
    tools=tools,
    llm=OpenAI(model="gpt-4o-mini"),
    system_prompt="Ground every factual claim in live, verifiable data.",
)
response = await agent.run("Any significant earthquakes in the last 24 hours?")
print(response)

# Cell 4 — verify a signed response (optional, illustrates the provenance model)
# Each tool response includes a `provenance` envelope and an Ed25519 `signature`.
# Verify with: pip install dynamicfeed-verify
# from dynamicfeed_verify import verify_response
# verify_response(response_dict)   # raises if tampered
```

**Testing**
- Notebook executes end-to-end with a valid OpenAI key; the Dynamic Feed MCP surface is keyless and publicly reachable.
- The tool count (87) and the MCP URL are stable; the endpoint is production-deployed on Railway with a monitored uptime history.
- No new dependencies are added to the package itself; the notebook uses only the already-declared `llama-index-tools-mcp` and the optional `dynamicfeed-verify` for the verification cell.

**References**
- Dynamic Feed MCP endpoint: https://dynamicfeed.ai/mcp
- Public key / JWKS: https://dynamicfeed.ai/.well-known/keys
- PyPI (REST adapter, LlamaIndex extra): https://pypi.org/project/dynamicfeed-tools/
- Source catalog (all 70 sources + licences): https://dynamicfeed.ai/sources
- Signing spec: https://dynamicfeed.ai/standard