### PR TITLE
Add llama-index-llms-tokenmix integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/.gitignore
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/.gitignore
@@ -1,0 +1,48 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+# C extensions
+*.so
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+__pypackages__/
+.installed.cfg
+*.egg-info/
+.installed.cfg
+*.egg
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+# pytest
+.pytest_cache/
+.ruff_cache

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/LICENSE
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/Makefile
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/README.md
@@ -1,0 +1,89 @@
+# LlamaIndex Llms Integration: TokenMix
+
+[TokenMix](https://tokenmix.ai) is an OpenAI-compatible API gateway that exposes
+DeepSeek, Qwen, Kimi, GLM, MiniMax and other models through a single endpoint
+(`https://api.tokenmix.ai/v1`) and one API key.
+
+### Installation
+
+```bash
+%pip install llama-index-llms-tokenmix
+```
+
+### Select Model
+
+Browse the full model catalog at https://tokenmix.ai/models and use the full model
+name (for example `deepseek/deepseek-v4-pro`).
+
+### Basic usage
+
+```py
+from llama_index.llms.tokenmix import TokenMix
+
+# Set your API key (or export TOKENMIX_API_KEY)
+api_key = "Your API KEY"
+
+# Call complete function
+response = TokenMix(
+    model="deepseek/deepseek-v4-pro", api_key=api_key
+).complete("who are you")
+print(response)
+
+# Call chat with a list of messages
+from llama_index.core.llms import ChatMessage
+
+messages = [
+    ChatMessage(role="user", content="who are you"),
+]
+
+response = TokenMix(
+    model="deepseek/deepseek-v4-pro", api_key=api_key
+).chat(messages)
+print(response)
+```
+
+### Streaming
+
+```py
+from llama_index.llms.tokenmix import TokenMix
+from llama_index.core.llms import ChatMessage
+
+llm = TokenMix(model="deepseek/deepseek-v4-pro", api_key="Your API KEY")
+
+# Using stream_complete endpoint
+response = llm.stream_complete("who are you")
+for r in response:
+    print(r.delta, end="")
+
+# Using stream_chat endpoint
+messages = [
+    ChatMessage(role="user", content="who are you"),
+]
+
+response = llm.stream_chat(messages)
+for r in response:
+    print(r.delta, end="")
+```
+
+### Function Calling
+
+```py
+from datetime import datetime
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.tokenmix import TokenMix
+
+
+def get_current_time() -> dict:
+    """Get the current time"""
+    return {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+
+llm = TokenMix(model="deepseek/deepseek-v4-pro", api_key="Your API KEY")
+tool = FunctionTool.from_defaults(fn=get_current_time)
+response = llm.predict_and_call([tool], "What is the current time?")
+print(response)
+```
+
+### TokenMix Documentation
+
+API Documentation: https://tokenmix.ai/docs

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/llama_index/llms/tokenmix/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/llama_index/llms/tokenmix/__init__.py
@@ -1,0 +1,4 @@
+from llama_index.llms.tokenmix.base import TokenMix
+
+
+__all__ = ["TokenMix"]

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/llama_index/llms/tokenmix/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/llama_index/llms/tokenmix/base.py
@@ -1,0 +1,86 @@
+from typing import Any, Dict, Optional
+
+from llama_index.core.base.llms.generic_utils import (
+    get_from_param_or_env,
+)
+from llama_index.llms.openai_like import OpenAILike
+
+DEFAULT_API_BASE = "https://api.tokenmix.ai/v1"
+DEFAULT_MODEL = "deepseek/deepseek-v4-pro"
+
+
+def is_function_calling_model(model: str) -> bool:
+    """Return True for TokenMix model families that support tool / function calling."""
+    function_calling_families = {
+        "deepseek",
+        "qwen",
+        "kimi",
+        "moonshot",
+        "glm",
+        "minimax",
+    }
+    return any(family in model for family in function_calling_families)
+
+
+class TokenMix(OpenAILike):
+    """
+    TokenMix LLM.
+
+    TokenMix is an OpenAI-compatible API gateway that exposes DeepSeek, Qwen, Kimi,
+    GLM, MiniMax and other models through a single endpoint
+    (``https://api.tokenmix.ai/v1``) and one API key.
+
+    Because the gateway is OpenAI-compatible, this integration is a thin wrapper over
+    :class:`~llama_index.llms.openai_like.OpenAILike`. Set ``model`` to the full
+    TokenMix model name (for example ``deepseek/deepseek-v4-pro``) and provide your
+    API key via the ``api_key`` argument or the ``TOKENMIX_API_KEY`` environment
+    variable.
+
+    Examples:
+        ``pip install llama-index-llms-tokenmix``
+
+        ```python
+        from llama_index.llms.tokenmix import TokenMix
+
+        llm = TokenMix(model="deepseek/deepseek-v4-pro", api_key="YOUR_KEY")
+        response = llm.complete("Hello")
+        print(response)
+        ```
+
+    Get an API key and browse the model catalog at https://tokenmix.ai/models.
+
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        is_chat_model: bool = True,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        additional_kwargs = additional_kwargs or {}
+        api_base = get_from_param_or_env(
+            "api_base", api_base, "TOKENMIX_API_BASE", DEFAULT_API_BASE
+        )
+        api_key = get_from_param_or_env("api_key", api_key, "TOKENMIX_API_KEY")
+
+        super().__init__(
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            is_chat_model=is_chat_model,
+            is_function_calling_model=is_function_calling_model(model),
+            additional_kwargs=additional_kwargs,
+            **kwargs,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get class name."""
+        return "TokenMix"

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/pyproject.toml
@@ -1,0 +1,69 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-llms-tokenmix"
+version = "0.1.0"
+description = "llama-index llms tokenmix integration"
+authors = [{name = "TokenMix", email = "support@tokenmix.ai"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "openai>=1.0.0",
+    "llama-index-core>=0.13.0,<0.15",
+    "llama-index-llms-openai-like>=0.3.4",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.llms.tokenmix"
+
+[tool.llamahub.class_authors]
+TokenMix = "TokenMixAi"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/tests/conftest.py
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/tests/conftest.py
@@ -1,0 +1,2 @@
+# pants requires this import to recognize the dep
+import pytest_asyncio  # noqa: F401

--- a/llama-index-integrations/llms/llama-index-llms-tokenmix/tests/test_llms_tokenmix.py
+++ b/llama-index-integrations/llms/llama-index-llms-tokenmix/tests/test_llms_tokenmix.py
@@ -1,0 +1,75 @@
+import os
+from datetime import datetime
+
+import pytest
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.tokenmix import TokenMix
+
+model = "deepseek/deepseek-v4-pro"
+non_function_calling_model = "some-vendor/plain-text-model"
+api_key = os.environ.get("TOKENMIX_API_KEY", "")
+
+
+def test_llm_class():
+    names_of_base_classes = [b.__name__ for b in TokenMix.__mro__]
+    assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_tokenmix_llm_model_alias():
+    llm = TokenMix(model=model, api_key="dummy")
+    assert llm.model == model
+
+
+def test_tokenmix_llm_metadata():
+    llm = TokenMix(model=model, api_key="dummy")
+    assert llm.metadata.is_function_calling_model is True
+    llm = TokenMix(model=non_function_calling_model, api_key="dummy")
+    assert llm.metadata.is_function_calling_model is False
+
+
+def test_tokenmix_default_api_base():
+    llm = TokenMix(model=model, api_key="dummy")
+    assert llm.api_base == "https://api.tokenmix.ai/v1"
+
+
+@pytest.mark.skipif(not api_key, reason="No TokenMix API key set")
+def test_completion():
+    llm = TokenMix(model=model, api_key=api_key)
+    response = llm.complete("who are you")
+    print(response)
+    assert response
+
+
+@pytest.mark.skipif(not api_key, reason="No TokenMix API key set")
+@pytest.mark.asyncio
+async def test_async_completion():
+    llm = TokenMix(model=model, api_key=api_key)
+    response = await llm.acomplete("who are you")
+    print(response)
+    assert response
+
+
+@pytest.mark.skipif(not api_key, reason="No TokenMix API key set")
+def test_stream_complete():
+    llm = TokenMix(model=model, api_key=api_key)
+    response = llm.stream_complete("who are you")
+    responses = []
+    for r in response:
+        responses.append(r)
+        print(r.delta, end="")
+    assert responses
+    assert len(responses) > 0
+
+
+@pytest.mark.skipif(not api_key, reason="No TokenMix API key set")
+def test_function_calling():
+    def get_current_time() -> dict:
+        """Get the current time."""
+        return {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+    llm = TokenMix(model=model, api_key=api_key)
+    tool = FunctionTool.from_defaults(fn=get_current_time)
+    response = llm.predict_and_call([tool], "What is the current time?")
+    print(response)
+    assert response


### PR DESCRIPTION
# Description

Adds a new LLM integration package: **`llama-index-llms-tokenmix`**.

[TokenMix](https://tokenmix.ai) is an OpenAI-compatible API gateway that exposes DeepSeek, Qwen, Kimi, GLM, MiniMax and other models through a single endpoint (`https://api.tokenmix.ai/v1`) and one API key. Because the gateway is OpenAI-compatible, the integration is a thin wrapper over `OpenAILike` (same pattern as the existing Novita, SiliconFlow and OpenRouter integrations).

Usage:

```python
from llama_index.llms.tokenmix import TokenMix

llm = TokenMix(model="deepseek/deepseek-v4-pro", api_key="YOUR_KEY")
print(llm.complete("Hello"))
```

The API key can also be supplied via the `TOKENMIX_API_KEY` environment variable.

## New Package?

- [x] Yes
- [ ] No

# Version Bump?

- [ ] Yes
- [x] No

# Type of Change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Added new unit/integration tests
- [x] I ran `pytest tests` and `ruff check` / `ruff format --check` locally.

```
$ pytest tests -q
....ssss
4 passed, 4 skipped

$ ruff check .
All checks passed!

$ ruff format --check .
5 files already formatted
```

Network-dependent tests are guarded by `@pytest.mark.skipif(not api_key, ...)`. The non-network tests verify class hierarchy, model alias, default `api_base`, and `is_function_calling_model` behavior.

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
