### PR TITLE
Add local FunASRReader integration for audio ingestion

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-funasr/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/README.md
@@ -1,0 +1,8 @@
+# LlamaIndex FunASR Reader
+
+This package provides a local FunASR speech-to-text reader for LlamaIndex.
+
+## Installation
+
+```bash
+pip install llama-index-readers-funasr

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.funasr.base import FunASRReader
+
+__all__ = ["FunASRReader"]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
@@ -1,0 +1,110 @@
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fsspec import AbstractFileSystem
+
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+
+class FunASRReader(BaseReader):
+    """Reader for local FunASR speech-to-text transcription."""
+
+    def __init__(
+        self,
+        model: str = "iic/SenseVoiceSmall",
+        device: str = "cpu",
+        recognizer: Optional[Any] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        generate_kwargs: Optional[Dict[str, Any]] = None,
+        remove_tags: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.model = model
+        self.device = device
+        self.model_kwargs = model_kwargs or {}
+        self.generate_kwargs = generate_kwargs or {}
+        self.remove_tags = remove_tags
+
+        if recognizer is not None:
+            self.recognizer = recognizer
+        else:
+            try:
+                from funasr import AutoModel
+            except ImportError as exc:
+                raise ImportError(
+                    "Please install FunASR with `pip install funasr` "
+                    "to use FunASRReader."
+                ) from exc
+
+            self.recognizer = AutoModel(
+                model=self.model,
+                device=self.device,
+                **self.model_kwargs,
+            )
+
+    def _clean_text(self, text: str) -> str:
+        """Clean SenseVoice-style tags from transcript text."""
+        if self.remove_tags:
+            text = re.sub(r"<\|.*?\|>", "", text)
+
+        return text.strip()
+
+    def _extract_text(self, result: Any) -> str:
+        """Extract transcript text from common FunASR result formats."""
+        if isinstance(result, list) and result:
+            result = result[0]
+
+        if isinstance(result, dict):
+            text = (
+                result.get("text")
+                or result.get("transcript")
+                or result.get("transcription")
+            )
+            if text:
+                return self._clean_text(text)
+
+            segments = result.get("segments")
+            if isinstance(segments, list):
+                segment_text = " ".join(
+                    segment.get("text", "")
+                    for segment in segments
+                    if isinstance(segment, dict)
+                )
+                return self._clean_text(segment_text)
+
+        return self._clean_text(str(result)) if result else ""
+
+    def load_data(
+        self,
+        file: Path,
+        extra_info: Optional[Dict] = None,
+        fs: Optional[AbstractFileSystem] = None,
+    ) -> List[Document]:
+        """Transcribe an audio file using local FunASR."""
+        if fs is not None:
+            raise NotImplementedError(
+                "FunASRReader currently supports local file paths only."
+            )
+
+        file_path = Path(file)
+
+        result = self.recognizer.generate(
+            input=str(file_path),
+            **self.generate_kwargs,
+        )
+
+        transcript = self._extract_text(result)
+
+        metadata = extra_info.copy() if extra_info else {}
+        metadata.update(
+            {
+                "source_path": str(file_path),
+                "model": self.model,
+                "device": self.device,
+            }
+        )
+
+        return [Document(text=transcript, metadata=metadata)]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest==9.0.3",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+]
+
+[project]
+name = "llama-index-readers-funasr"
+version = "0.1.0"
+description = "llama-index FunASR reader integration"
+authors = [{ name = "sriharan0804", email = "sriharan08042005@gmail.com" }]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "funasr>=1.3.0",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.funasr"
+
+[tool.llamahub.class_authors]
+FunASRReader = "sriharan0804"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"

--- a/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_funasr.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_funasr.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+from llama_index.readers.funasr import FunASRReader
+
+
+def test_funasr_reader_extracts_text(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    recognizer = Mock()
+    recognizer.generate.return_value = [
+        {
+            "key": "en",
+            "text": "<|en|><|NEUTRAL|><|Speech|>hello from funasr",
+        }
+    ]
+
+    reader = FunASRReader(
+        model="iic/SenseVoiceSmall",
+        device="cpu",
+        recognizer=recognizer,
+    )
+
+    docs = reader.load_data(audio_file)
+
+    assert len(docs) == 1
+    assert docs[0].text == "hello from funasr"
+    assert docs[0].metadata["source_path"] == str(audio_file)
+    assert docs[0].metadata["model"] == "iic/SenseVoiceSmall"
+    assert docs[0].metadata["device"] == "cpu"
+
+    recognizer.generate.assert_called_once_with(input=str(audio_file))
+
+
+def test_funasr_reader_keeps_tags_when_configured(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    recognizer = Mock()
+    recognizer.generate.return_value = [
+        {
+            "text": "<|en|><|NEUTRAL|><|Speech|>hello from funasr",
+        }
+    ]
+
+    reader = FunASRReader(
+        recognizer=recognizer,
+        remove_tags=False,
+    )
+
+    docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "<|en|><|NEUTRAL|><|Speech|>hello from funasr"
+
+
+def test_funasr_reader_extracts_segment_text(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    recognizer = Mock()
+    recognizer.generate.return_value = [
+        {
+            "segments": [
+                {"text": "hello"},
+                {"text": "from"},
+                {"text": "segments"},
+            ]
+        }
+    ]
+
+    reader = FunASRReader(recognizer=recognizer)
+
+    docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "hello from segments"
+
+
+def test_funasr_reader_passes_generate_kwargs(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    recognizer = Mock()
+    recognizer.generate.return_value = [{"text": "hello"}]
+
+    reader = FunASRReader(
+        recognizer=recognizer,
+        generate_kwargs={"batch_size_s": 60},
+    )
+
+    reader.load_data(audio_file)
+
+    recognizer.generate.assert_called_once_with(
+        input=str(audio_file),
+        batch_size_s=60,
+    )

--- a/llama-index-integrations/readers/llama-index-readers-funasr/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/uv.lock
@@ -1,0 +1,84 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[manifest]
+
+[manifest.dependency-groups]
+dev = [
+    { name = "pytest", specifier = ">=9.1.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]


### PR DESCRIPTION
## Summary

Related to #21923.

This PR introduces a local `FunASRReader` integration for audio speech-to-text transcription using the FunASR Python package.

The reader accepts local audio files, performs transcription through FunASR, and returns LlamaIndex `Document` objects with transcription text and metadata.

## Features

* Local audio transcription using FunASR
* Configurable model and device selection
* Support for passing an existing FunASR recognizer instance
* Automatic transcript extraction from common FunASR response formats
* Optional cleaning of SenseVoice metadata tags
* Returns `Document` objects with source path, model, and device metadata

## Example

```python
from llama_index.readers.funasr import FunASRReader

reader = FunASRReader(
    model="iic/SenseVoiceSmall",
    device="cpu",
)

documents = reader.load_data("meeting.wav")
```

## Testing

* Added unit tests using mocked recognizers
* Verified transcript extraction
* Verified metadata generation
* Verified segment handling
* Verified generate kwargs forwarding

### Test Result

```bash
tests/test_funasr.py::test_funasr_reader_extracts_text PASSED
tests/test_funasr.py::test_funasr_reader_keeps_tags_when_configured PASSED
tests/test_funasr.py::test_funasr_reader_extracts_segment_text PASSED
tests/test_funasr.py::test_funasr_reader_passes_generate_kwargs PASSED
```

## Future Work

This initial implementation focuses on local audio transcription. Additional capabilities such as timestamps, speaker diarization, emotion labels, and video ingestion can be added in follow-up contributions.
