### PR TITLE
fix: declare Neptune graph vector capability

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
@@ -13,6 +13,8 @@ class NeptuneBaseGraphStore(GraphStore):
     and NeptuneAnalyticsGraphStore classes.
     """
 
+    supports_vector_queries: bool = False
+
     def __init__() -> None:
         pass
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/llama_index/graph_stores/neptune/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 from llama_index.core.graph_stores.types import GraphStore
 from .neptune import refresh_schema
 
@@ -13,9 +13,9 @@ class NeptuneBaseGraphStore(GraphStore):
     and NeptuneAnalyticsGraphStore classes.
     """
 
-    supports_vector_queries: bool = False
+    supports_vector_queries: ClassVar[bool] = False
 
-    def __init__() -> None:
+    def __init__(self) -> None:
         pass
 
     @property

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-graph-stores-neptune"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index graph stores amazon neptune integration"
 authors = [{name = "Dave Bechberger", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/tests/test_graph_stores_neptune.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/tests/test_graph_stores_neptune.py
@@ -19,3 +19,9 @@ def test_neptune_database_graph_store():
 def test_neptune_base_graph_store():
     names_of_bases = [b.__name__ for b in NeptuneBaseGraphStore.__bases__]
     assert GraphStore.__name__ in names_of_bases
+
+
+def test_neptune_graph_stores_do_not_advertise_vector_queries():
+    assert NeptuneBaseGraphStore.supports_vector_queries is False
+    assert NeptuneAnalyticsGraphStore.supports_vector_queries is False
+    assert NeptuneDatabaseGraphStore.supports_vector_queries is False

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/tests/test_graph_stores_neptune.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/tests/test_graph_stores_neptune.py
@@ -1,3 +1,5 @@
+import pytest
+
 from llama_index.core.graph_stores.types import GraphStore
 from llama_index.graph_stores.neptune import (
     NeptuneAnalyticsGraphStore,
@@ -21,7 +23,13 @@ def test_neptune_base_graph_store():
     assert GraphStore.__name__ in names_of_bases
 
 
-def test_neptune_graph_stores_do_not_advertise_vector_queries():
-    assert NeptuneBaseGraphStore.supports_vector_queries is False
-    assert NeptuneAnalyticsGraphStore.supports_vector_queries is False
-    assert NeptuneDatabaseGraphStore.supports_vector_queries is False
+@pytest.mark.parametrize(
+    "graph_store_cls",
+    [
+        NeptuneBaseGraphStore,
+        NeptuneAnalyticsGraphStore,
+        NeptuneDatabaseGraphStore,
+    ],
+)
+def test_neptune_graph_stores_do_not_advertise_vector_queries(graph_store_cls):
+    assert graph_store_cls.supports_vector_queries is False

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/uv.lock
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neptune/uv.lock
@@ -1848,7 +1848,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-graph-stores-neptune"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# Description

Adds the missing `supports_vector_queries = False` capability flag to the shared Neptune graph-store base class, so both legacy Neptune graph-store classes expose the capability expected by callers.

This matches the current behaviour: `NeptuneAnalyticsGraphStore` and `NeptuneDatabaseGraphStore` do not provide vector-query support.

While touching the base class, this also fixes the existing missing `self` parameter on `NeptuneBaseGraphStore.__init__`, which would otherwise make the base-class initializer unusable.

## Why this shape

Callers already use graph-store capability flags to decide whether vector queries are available. Setting the flag once on `NeptuneBaseGraphStore` keeps the two Neptune implementations consistent without adding vector-query behaviour they do not support.

Fixes #18372

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Checks run:

```bash
UV_CACHE_DIR=.uv-cache uv run -- pytest tests/test_graph_stores_neptune.py -q
UV_CACHE_DIR=.uv-cache uv run ruff check llama_index/graph_stores/neptune/base.py tests/test_graph_stores_neptune.py
UV_CACHE_DIR=.uv-cache uv run ruff format --check llama_index/graph_stores/neptune/base.py tests/test_graph_stores_neptune.py
git diff --check
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

I ran the package test and targeted Ruff checks for the touched Python files rather than the full repository make targets.