### PR TITLE
feat(tools): add llama-index-tools-buywhere integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-buywhere/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) BuyWhere
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-buywhere/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/README.md
@@ -1,0 +1,73 @@
+# LlamaIndex Tools: BuyWhere
+
+This tool connects a LlamaIndex agent to the [BuyWhere](https://buywhere.ai) product catalog
+API. BuyWhere indexes 1.5M+ products across Shopee, Lazada, Amazon, Walmart, and 20+
+retailers in Southeast Asia and the US, with live price comparison and affiliate deep-links.
+
+## Why BuyWhere
+
+- **Cross-border, cross-merchant search.** One query, one ranked result set across every
+  supported retailer — no per-merchant integration work.
+- **Honest price comparison.** Side-by-side offers with shipping, currency, and stock state.
+- **Affiliate-ready.** Generate tracked deep-links for any merchant in one call.
+
+## Installation
+
+```bash
+pip install llama-index-tools-buywhere
+```
+
+## Usage
+
+You will need a BuyWhere API key. Sign up at <https://buywhere.ai/developers> to get one
+(free tier includes 1,000 requests/day).
+
+```python
+from llama_index.tools.buywhere import BuyWhereToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+tool_spec = BuyWhereToolSpec(
+    api_key="your-buywhere-api-key",
+    country="US",
+)
+
+agent = FunctionAgent(
+    tools=tool_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4.1"),
+    system_prompt=(
+        "You are a shopping concierge. Use the buywhere tools to search the catalog, "
+        "compare prices, and return a shortlist with the best deal highlighted."
+    ),
+)
+
+print(await agent.run("What's the best gaming laptop under $1500 right now?"))
+print(await agent.run("Compare iPhone 17 Pro prices across Amazon and Shopee."))
+```
+
+## Available tools
+
+`search_products(query, limit=5)` — Search the catalog. Returns ranked results with title, price, merchant, and URL.
+
+`get_product(product_id)` — Fetch full product details by id.
+
+`compare_prices(product_id)` — Return every live offer for a product across all supported merchants.
+
+`get_affiliate_link(product_id, merchant=None)` — Generate a tracked deep-link (defaults to the lowest-priced merchant).
+
+`get_catalog(category, limit=10)` — Browse a category without a specific query.
+
+## Configuration
+
+| Field         | Default | Description                                                                 |
+|---------------|---------|-----------------------------------------------------------------------------|
+| `api_key`     | —       | BuyWhere API key (required).                                                |
+| `marketplace` | `None`  | Restrict searches to one marketplace (e.g. `amazon`, `shopee`). `None` = all.|
+| `country`     | `US`    | Country for pricing/currency (ISO 3166-1 alpha-2).                          |
+
+## Links
+
+- BuyWhere: <https://buywhere.ai>
+- API docs: <https://api.buywhere.ai/docs>
+- MCP server: <https://github.com/BuyWhere/buywhere-mcp>
+- npm SDK: <https://www.npmjs.com/package/@buywhere/sdk>

--- a/llama-index-integrations/tools/llama-index-tools-buywhere/llama_index/tools/buywhere/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/llama_index/tools/buywhere/__init__.py
@@ -1,0 +1,7 @@
+## init
+from llama_index.tools.buywhere.base import (
+    ENDPOINT_BASE_URL,
+    BuyWhereToolSpec,
+)
+
+__all__ = ["BuyWhereToolSpec", "ENDPOINT_BASE_URL"]

--- a/llama-index-integrations/tools/llama-index-tools-buywhere/llama_index/tools/buywhere/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/llama_index/tools/buywhere/base.py
@@ -1,0 +1,140 @@
+"""BuyWhere product catalog tool spec."""
+
+from typing import Dict, List, Optional
+
+import requests
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+
+ENDPOINT_BASE_URL = "https://api.buywhere.ai/v1"
+
+
+class BuyWhereToolSpec(BaseToolSpec):
+    """BuyWhere product catalog tool spec.
+
+    Search products, compare prices, and generate affiliate links across
+    1.5M+ products from Shopee, Lazada, Amazon, Walmart, and 20+ retailers
+    in Southeast Asia and the US.
+    """
+
+    spec_functions = [
+        "search_products",
+        "get_product",
+        "compare_prices",
+        "get_affiliate_link",
+        "get_catalog",
+    ]
+
+    def __init__(
+        self,
+        api_key: str,
+        marketplace: Optional[str] = None,
+        country: Optional[str] = "US",
+    ) -> None:
+        """Initialize with BuyWhere API key.
+
+        Args:
+            api_key: BuyWhere API key (sign up at https://buywhere.ai).
+            marketplace: Optional marketplace filter (e.g. ``"amazon"``,
+                ``"shopee"``). ``None`` searches all marketplaces.
+            country: Default country for results (ISO 3166-1 alpha-2).
+                Defaults to ``"US"``.
+        """
+        self.api_key = api_key
+        self.marketplace = marketplace
+        self.country = country
+
+    def _request(
+        self,
+        endpoint: str,
+        params: Optional[Dict] = None,
+    ) -> Dict:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "User-Agent": "llama-index-tools-buywhere/0.1.0",
+        }
+        response = requests.get(
+            f"{ENDPOINT_BASE_URL}{endpoint}",
+            headers=headers,
+            params=params or {},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def search_products(self, query: str, limit: Optional[int] = 5) -> List[Dict]:
+        """Search the BuyWhere product catalog for a query.
+
+        Use this for any product discovery task. Returns the top results
+        ranked by relevance, with title, price, merchant, and URL.
+
+        Args:
+            query: Natural-language search query (e.g. ``"best gaming laptop under $1500"``).
+            limit: Maximum number of products to return (1-50, default 5).
+
+        """
+        params: Dict = {"q": query, "limit": min(max(limit or 5, 1), 50), "country": self.country}
+        if self.marketplace:
+            params["marketplace"] = self.marketplace
+        data = self._request("/products/search", params=params)
+        return data.get("results", [])
+
+    def get_product(self, product_id: str) -> Dict:
+        """Fetch a single product's full details by BuyWhere product id.
+
+        Args:
+            product_id: The BuyWhere product id (e.g. ``"prod_abc123"``).
+
+        """
+        return self._request(f"/products/{product_id}")
+
+    def compare_prices(self, product_id: str) -> List[Dict]:
+        """Compare live prices for a product across every supported merchant.
+
+        Args:
+            product_id: The BuyWhere product id.
+
+        """
+        data = self._request(f"/products/{product_id}/prices")
+        return data.get("offers", [])
+
+    def get_affiliate_link(
+        self,
+        product_id: str,
+        merchant: Optional[str] = None,
+    ) -> Dict:
+        """Generate an affiliate-tagged deep link to a product.
+
+        Args:
+            product_id: The BuyWhere product id.
+            merchant: Optional merchant slug to deep-link to (defaults to the
+                merchant with the lowest current price).
+
+        """
+        params: Dict = {}
+        if merchant:
+            params["merchant"] = merchant
+        return self._request(
+            f"/products/{product_id}/affiliate",
+            params=params,
+        )
+
+    def get_catalog(self, category: str, limit: Optional[int] = 10) -> List[Dict]:
+        """Browse the BuyWhere catalog for a category.
+
+        Use this when the user wants to explore a category rather than search
+        a specific query (e.g. "show me budget laptops").
+
+        Args:
+            category: Category slug or display name (e.g. ``"laptops"``,
+                ``"smartphones"``, ``"running-shoes"``).
+            limit: Maximum number of products to return (1-50, default 10).
+
+        """
+        params = {
+            "category": category,
+            "limit": min(max(limit or 10, 1), 50),
+            "country": self.country,
+        }
+        data = self._request("/catalog", params=params)
+        return data.get("results", [])

--- a/llama-index-integrations/tools/llama-index-tools-buywhere/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests>=2.28.11.8",
+    "types-setuptools>=67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-tools-buywhere"
+version = "0.1.0"
+description = "llama-index tools buywhere integration"
+authors = [{name = "BuyWhere", email = "dev@buywhere.ai"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "BuyWhere", email = "dev@buywhere.ai"}]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "requests>=2.31.0,<3",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.ipynb"
+
+[tool.hatch.build.targets.wheel]
+packages = ["llama_index"]

--- a/llama-index-integrations/tools/llama-index-tools-buywhere/tests/test_tools_buywhere.py
+++ b/llama-index-integrations/tools/llama-index-tools-buywhere/tests/test_tools_buywhere.py
@@ -1,0 +1,18 @@
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.buywhere import BuyWhereToolSpec
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in BuyWhereToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions():
+    expected = {
+        "search_products",
+        "get_product",
+        "compare_prices",
+        "get_affiliate_link",
+        "get_catalog",
+    }
+    assert set(BuyWhereToolSpec.spec_functions) == expected


### PR DESCRIPTION
## Summary

Adds a new tool integration that exposes the **BuyWhere** product catalog API to LlamaIndex agents. BuyWhere indexes 1.5M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Southeast Asia and the US, with live price comparison and affiliate deep-links.

This PR mirrors the structure of existing tool integrations (e.g. `llama-index-tools-bing-search`) and is already published on PyPI as `llama-index-tools-buywhere` (companion package `buywhere-llamaindex`).

## Tools exposed

| Method | Purpose |
| --- | --- |
| `search_products(query, limit=5)` | Search the catalog, return ranked results with title, price, merchant, URL. |
| `get_product(product_id)` | Fetch full product details by id. |
| `compare_prices(product_id)` | Live offers for a product across all supported merchants. |
| `get_affiliate_link(product_id, merchant=None)` | Tracked deep-link, defaults to lowest-priced merchant. |
| `get_catalog(category, limit=10)` | Browse a category without a specific query. |

## Quick start

```python
from llama_index.tools.buywhere import BuyWhereToolSpec
from llama_index.core.agent.workflow import FunctionAgent
from llama_index.llms.openai import OpenAI

tool_spec = BuyWhereToolSpec(api_key="your-buywhere-api-key", country="US")

agent = FunctionAgent(
    tools=tool_spec.to_tool_list(),
    llm=OpenAI(model="gpt-4.1"),
    system_prompt="You are a shopping concierge...",
)

print(await agent.run("What is the best gaming laptop under $1500 right now?"))
```

## Links

- BuyWhere: https://buywhere.ai
- PyPI: https://pypi.org/project/llama-index-tools-buywhere/
- API docs: https://api.buywhere.ai/docs

Fixes none — first-party contribution from BuyWhere.
