### PR TITLE
fix(core): handle empty dirname in concat_dirs

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -389,7 +389,7 @@ def concat_dirs(dirname: str, basename: str) -> str:
     os.path.join(dirname, basename) will add a backslash before dirname if
     basename does not end with a slash, so we make sure it does.
     """
-    dirname += "/" if dirname[-1] != "/" else ""
+    dirname += "/" if dirname and dirname[-1] != "/" else ""
     return os.path.join(dirname, basename)
 
 

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -13,6 +13,7 @@ from llama_index.core.utils import (
     _LLAMA_INDEX_COLORS,
     ErrorToRetry,
     aretry_on_exceptions_with_backoff,
+    concat_dirs,
     _get_colored_text,
     get_cache_dir,
     get_color_mapping,
@@ -219,6 +220,14 @@ def test_iter_batch() -> None:
     assert list(iter_batch(gen, 3)) == [[0, 1, 2], [3, 4]]
 
     assert list(iter_batch([], 3)) == []
+
+
+def test_concat_dirs() -> None:
+    """Test concat_dirs joins paths and tolerates an empty dirname."""
+    assert concat_dirs("dir", "file.json") == os.path.join("dir/", "file.json")
+    assert concat_dirs("dir/", "file.json") == os.path.join("dir/", "file.json")
+    # An empty dirname should resolve to the current directory, not crash.
+    assert concat_dirs("", "file.json") == "file.json"
 
 
 def test_get_color_mapping() -> None:


### PR DESCRIPTION
### Summary

`concat_dirs()` indexes `dirname[-1]` without first checking for an empty string, so `concat_dirs("", basename)` raises `IndexError: string index out of range`. This is reachable through the storage layer — `concat_dirs(persist_dir, ...)` is used in `storage_context.py`, `storage/docstore/simple_docstore.py`, `storage/index_store/simple_index_store.py`, `vector_stores/simple.py`, `ingestion/pipeline.py`, and `objects/base_node_mapping.py` — so persisting/loading with an empty `persist_dir` (i.e. the current directory) crashes instead of working.

Fix: guard the trailing-slash check with a truthiness test. `os.path.join("", basename)` already returns `basename`, so the empty-dirname case resolves to the current directory. Behavior for non-empty dirnames is unchanged.

### Verification

- `uv run -- pytest tests/test_utils.py::test_concat_dirs` — added; covers normal, trailing-slash, and empty-dirname inputs (fails before this change with `IndexError`, passes after)
- `uv run -- pytest tests/test_utils.py` — 17 passed, no regressions
- `ruff check` clean on both changed files

> AI assistance: the one-line fix and the unit test were drafted with AI help. I reviewed the full diff, reproduced the original `IndexError`, and confirmed the new test is red before / green after the change.
