### PR TITLE
fix(core): avoid IndexError in truncate_text for whitespace-only text

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -20,7 +20,8 @@ def truncate_text(text: str, text_splitter: TextSplitter) -> str:
 
     """
     chunks = text_splitter.split_text(text)
-    return chunks[0]
+    # Whitespace-only text can split into no chunks; fall back to the input.
+    return chunks[0] if chunks else text
 
 
 def split_text_keep_separator(text: str, separator: str) -> List[str]:

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -41,6 +41,13 @@ def test_truncate_token() -> None:
     assert text == "foo"
 
 
+def test_truncate_text_no_chunks() -> None:
+    """Whitespace-only text yields no chunks; truncate_text must not raise."""
+    text_splitter = TokenTextSplitter(chunk_size=1, chunk_overlap=0)
+    assert text_splitter.split_text("   ") == []
+    assert truncate_text("   ", text_splitter) == "   "
+
+
 def test_split_long_token() -> None:
     """Test split a really long token."""
     token = "a" * 100


### PR DESCRIPTION
### Summary

The `node_parser` helper `truncate_text(text, text_splitter)` returns `chunks[0]` unconditionally, but `TokenTextSplitter` and `SentenceSplitter` return `[]` for whitespace-only input (e.g. `"   "`, `"\n\n"`). So `truncate_text("   ", splitter)` raises `IndexError: list index out of range` instead of returning the text. This helper is used in node/document display/`__repr__` paths, where whitespace-only content is plausible.

Fix: fall back to the original `text` when the splitter yields no chunks. (This is `node_parser/text/utils.py::truncate_text`, distinct from the unrelated `core/utils.py::truncate_text(text, max_length)`.)

### Verification

- `uv run -- pytest tests/text_splitter/test_token_splitter.py::test_truncate_text_no_chunks` — added; red before (IndexError), green after
- `uv run -- pytest tests/text_splitter/ tests/indices/test_prompt_helper.py` — 185 passed, 15 skipped, no regressions
- `ruff check` clean on both changed files

> AI assistance: the fix and the test were drafted with AI help. I reproduced the `IndexError`, confirmed the test is red before / green after, and verified the surrounding splitter tests still pass.
