### PR TITLE
fix(llms-anthropic): cap cache_control breakpoints across messages for cache_idx=-1

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -329,6 +329,54 @@ def blocks_to_anthropic_blocks(
     return anthropic_blocks
 
 
+# Anthropic enforces a hard limit of 4 blocks with cache_control per request.
+# See: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+ANTHROPIC_MAX_CACHE_CONTROL_BLOCKS = 4
+
+
+def _cacheable_message_indices(
+    messages: Sequence[ChatMessage], cache_idx: Optional[int]
+) -> set:
+    """
+    Return the set of message indices that should receive a ``cache_control``
+    breakpoint, capped at Anthropic's hard limit of 4 breakpoints per request.
+
+    Each stamped (non-system) message produces a breakpoint on its last block,
+    so stamping every message up to ``cache_idx`` can easily exceed the limit.
+    Because cache_control caches the whole prefix up to and including the
+    stamped block, the breakpoint closest to the end of the prefix already
+    caches everything before it. We therefore keep only the *last* breakpoints
+    at the prefix boundary, dropping redundant earlier ones.
+
+    ``cache_idx == -1`` means "cache all messages" (the documented
+    recommendation); it resolves to the last cacheable message so a single
+    breakpoint caches the entire conversation prefix.
+    """
+    if cache_idx is None:
+        return set()
+
+    upper = len(messages) - 1 if cache_idx == -1 else cache_idx
+    # System messages are folded into the system prompt and do not emit a
+    # message-level breakpoint, so they don't count against the limit.
+    candidate_indices = [
+        idx
+        for idx, message in enumerate(messages)
+        if idx <= upper and message.role != MessageRole.SYSTEM
+    ]
+    if not candidate_indices:
+        return set()
+
+    if cache_idx == -1:
+        # "Cache all messages": a single breakpoint on the last message caches
+        # the entire conversation prefix, so we don't need (and must not emit)
+        # one breakpoint per message.
+        return {candidate_indices[-1]}
+
+    # For an explicit positive cache_idx, keep the last <=4 breakpoints
+    # (closest to the prefix boundary) so we never exceed the API limit.
+    return set(candidate_indices[-ANTHROPIC_MAX_CACHE_CONTROL_BLOCKS:])
+
+
 def messages_to_anthropic_messages(
     messages: Sequence[ChatMessage],
     cache_idx: Optional[int] = None,
@@ -350,9 +398,11 @@ def messages_to_anthropic_messages(
     """
     anthropic_messages = []
     system_prompt = []
+    cacheable_indices = _cacheable_message_indices(messages, cache_idx)
     for idx, message in enumerate(messages):
-        # inject cache_control for all messages up to and including the cache_idx
-        if cache_idx is not None and (idx <= cache_idx or cache_idx == -1):
+        # inject cache_control for the messages selected by cache_idx, capped at
+        # Anthropic's limit of 4 cache_control breakpoints per request
+        if idx in cacheable_indices:
             if model is None or is_anthropic_prompt_caching_supported_model(model):
                 message.additional_kwargs["cache_control"] = {"type": "ephemeral"}
 
@@ -523,9 +573,11 @@ def messages_to_anthropic_beta_messages(
 ) -> Tuple[Sequence[BetaMessageParam], str]:
     anthropic_messages = []
     system_prompt: list[str] = []
+    cacheable_indices = _cacheable_message_indices(messages, cache_idx)
     for idx, message in enumerate(messages):
-        # inject cache_control for all messages up to and including the cache_idx
-        if cache_idx is not None and (idx <= cache_idx or cache_idx == -1):
+        # inject cache_control for the messages selected by cache_idx, capped at
+        # Anthropic's limit of 4 cache_control breakpoints per request
+        if idx in cacheable_indices:
             if model is None or is_anthropic_prompt_caching_supported_model(model):
                 message.additional_kwargs["cache_control"] = {"type": "ephemeral"}
 

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_anthropic_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_anthropic_utils.py
@@ -418,3 +418,80 @@ class TestCacheControlOnlyLastBlock:
         )
         # Verify it's on the last block
         assert "cache_control" in result[-1]
+
+
+def _count_cache_control_breakpoints(ant_messages) -> int:
+    """Count total cache_control breakpoints across all message blocks."""
+    count = 0
+    for message in ant_messages:
+        content = message["content"]
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and "cache_control" in block:
+                    count += 1
+    return count
+
+
+class TestCacheIdxBreakpointCap:
+    """
+    Regression tests for cache_idx stamping cache_control across messages.
+
+    Anthropic enforces a hard limit of 4 cache_control breakpoints per
+    request. Stamping every message up to cache_idx (especially cache_idx=-1,
+    the documented "cache all messages" recommendation) put one breakpoint per
+    message and produced a 400 once there were more than 4 messages. This is a
+    distinct bug from the intra-message capping in #20854/#20875: those capped
+    breakpoints within a single message; here we cap across messages.
+    """
+
+    def _make_messages(self, n: int):
+        return [
+            ChatMessage(role="user", blocks=[TextBlock(text=f"message {i}")])
+            for i in range(n)
+        ]
+
+    def test_cache_idx_minus_one_many_messages_stays_under_limit(self):
+        """cache_idx=-1 with >4 messages must not exceed 4 breakpoints."""
+        messages = self._make_messages(6)
+        ant_messages, _ = messages_to_anthropic_messages(messages, cache_idx=-1)
+
+        breakpoints = _count_cache_control_breakpoints(ant_messages)
+        assert breakpoints <= 4, (
+            f"cache_idx=-1 produced {breakpoints} breakpoints, exceeding the "
+            "Anthropic limit of 4"
+        )
+        # A single breakpoint on the last message caches the whole prefix.
+        assert breakpoints == 1
+        assert "cache_control" in ant_messages[-1]["content"][-1]
+
+    def test_cache_idx_minus_one_beta_many_messages_stays_under_limit(self):
+        """Beta path: cache_idx=-1 with >4 messages must stay <=4 breakpoints."""
+        messages = self._make_messages(6)
+        ant_messages, _ = messages_to_anthropic_beta_messages(
+            messages, cache_idx=-1
+        )
+
+        breakpoints = _count_cache_control_breakpoints(ant_messages)
+        assert breakpoints <= 4, (
+            f"cache_idx=-1 (beta) produced {breakpoints} breakpoints, exceeding "
+            "the Anthropic limit of 4"
+        )
+        assert breakpoints == 1
+
+    def test_positive_cache_idx_beyond_limit_stays_under_limit(self):
+        """A large positive cache_idx must also be capped at 4 breakpoints."""
+        messages = self._make_messages(10)
+        ant_messages, _ = messages_to_anthropic_messages(messages, cache_idx=8)
+
+        breakpoints = _count_cache_control_breakpoints(ant_messages)
+        assert breakpoints <= 4, (
+            f"cache_idx=8 produced {breakpoints} breakpoints, exceeding the "
+            "Anthropic limit of 4"
+        )
+
+    def test_cache_idx_none_no_breakpoints(self):
+        """cache_idx=None disables caching: no breakpoints at all."""
+        messages = self._make_messages(6)
+        ant_messages, _ = messages_to_anthropic_messages(messages, cache_idx=None)
+
+        assert _count_cache_control_breakpoints(ant_messages) == 0


### PR DESCRIPTION
> Note: This is a separate PR from the AP1 model-table change
> (`fix(llms-anthropic): add newer Claude models to prompt-caching support table`,
> branch `fix/anthropic-caching-support-table-newer-models`). The two changes are
> unrelated and should be reviewed independently.

## Summary

`messages_to_anthropic_messages` and `messages_to_anthropic_beta_messages` stamp
`cache_control` on **every** message where `idx <= cache_idx or cache_idx == -1`.
`blocks_to_anthropic_blocks` then places a cache breakpoint on the **last block of
each such message**. Anthropic enforces a **hard limit of 4 `cache_control`
breakpoints per request**, so as soon as there are more than 4 cacheable messages
the request is rejected with a 400.

This is especially easy to hit because `cache_idx = -1` is the **documented
recommendation**. The field docstring in `base.py` literally says:

```python
cache_idx: Optional[int] = Field(
    default=None,
    description=(
        "Set the cache_control for every message up to and including this index. "
        "Set to -1 to cache all messages. "
        "Set to None to disable caching."
    ),
)
```

So a user who follows the docs (`cache_idx=-1`) and has a conversation longer than
4 messages gets a 400. That is a real footgun, not an edge case.

## Why this is NOT a duplicate of #20854 / #20875

Those changes fixed the **intra-message** case: a single message with many blocks
used to put `cache_control` on every block; #20875 capped it to the **last block
within one message** (see `blocks_to_anthropic_blocks` / `blocks_to_anthropic_beta_blocks`,
"Apply cache_control only to the last block").

That fix does nothing for the **cross-message** case addressed here: with N > 4
messages, each message still contributes one breakpoint (on its last block), so the
total across the request is N > 4 and still exceeds the limit. The existing
regression test `test_many_blocks_stay_under_api_limit` only exercises a single
message's blocks, so the cross-message overflow is uncovered. This PR caps the
breakpoint count **across messages**, which #20854/#20875 do not touch.

## The fix

A small helper, `_cacheable_message_indices`, decides which message indices receive
a `cache_control` breakpoint, capped at Anthropic's limit of 4:

- `cache_idx is None` → no breakpoints (caching disabled), unchanged.
- `cache_idx == -1` ("cache all messages") → a **single** breakpoint on the **last
  cacheable message**. Because `cache_control` caches the whole prefix up to and
  including the stamped block, one breakpoint at the end of the prefix already
  caches the entire conversation — there is no need to stamp every message, and
  doing so is exactly what blows the limit.
- positive `cache_idx` → keep the **last ≤4** breakpoints at the prefix boundary
  (the ones closest to the end already subsume the earlier ones), so an explicit
  `cache_idx >= 4` can no longer overflow either.

System messages are folded into the system prompt and don't emit a message-level
breakpoint, so they're excluded from the count.

Behavior for the previously-working small cases is preserved (e.g. `cache_idx=0`
with a single message still stamps that message's last block).

## Tests

Added `TestCacheIdxBreakpointCap` in `tests/test_anthropic_utils.py`:

- `test_cache_idx_minus_one_many_messages_stays_under_limit` — 6 messages,
  `cache_idx=-1`, asserts total breakpoints ≤ 4 (and exactly 1 on the last message).
- `test_cache_idx_minus_one_beta_many_messages_stays_under_limit` — same for the
  beta path.
- `test_positive_cache_idx_beyond_limit_stays_under_limit` — 10 messages,
  `cache_idx=8`, asserts ≤ 4.
- `test_cache_idx_none_no_breakpoints` — `cache_idx=None` produces 0 breakpoints.

### Test / verification status in this environment

The local dev environment does not have `llama_index.core` installed, so pytest
cannot import the integration module
(`ModuleNotFoundError: No module named 'llama_index.core'`) — this is a
pre-existing environment limitation, not a problem with the change. Verified
instead by:

- `ast.parse` on both edited files → both parse cleanly.
- A standalone simulation of the capping logic confirming: `cache_idx=-1` over 6
  msgs → `{5}` (1 breakpoint); `cache_idx=8` over 10 msgs → `{5,6,7,8}` (4);
  `cache_idx=None` → `∅`; system-message exclusion; and `cache_idx=0`/1 msg → `{0}`.

The added pytest cases should pass in CI where `llama-index-core` is installed.

## Files changed

- `llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py`
- `llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_anthropic_utils.py`
