### PR TITLE
fix(core): honor retriever_weights in QueryFusionRetriever reciprocal_rerank mode

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -123,8 +123,11 @@ class QueryFusionRetriever(BaseRetriever):
         fused_scores = {}
         hash_to_node = {}
 
-        # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        # compute reciprocal rank scores, weighting each retriever's
+        # contribution by its configured `retriever_weights` entry. The
+        # retriever index is stored as the second element of each result key.
+        for (_, retriever_idx), nodes_with_scores in results.items():
+            retriever_weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +135,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += retriever_weight * (1.0 / (rank + k))
 
         # sort results
         reranked_results = dict(

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -4,12 +4,61 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.retrievers.fusion_retriever import FUSION_MODES
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
 
 class MockRetriever(BaseRetriever):
     def _retrieve(self, query_bundle: QueryBundle):
         return [NodeWithScore(node=TextNode(text="result"), score=1.0)]
+
+
+class FixedNodesRetriever(BaseRetriever):
+    """Retriever that always returns a fixed list of nodes."""
+
+    def __init__(self, nodes: list[NodeWithScore]) -> None:
+        self._nodes = nodes
+        super().__init__()
+
+    def _retrieve(self, query_bundle: QueryBundle):
+        return self._nodes
+
+
+def test_reciprocal_rerank_respects_retriever_weights():
+    """`retriever_weights` must influence reciprocal_rerank fusion (issue #21444)."""
+    retriever_0 = FixedNodesRetriever(
+        [
+            NodeWithScore(node=TextNode(text="node_A"), score=0.9),
+            NodeWithScore(node=TextNode(text="node_B"), score=0.8),
+        ]
+    )
+    retriever_1 = FixedNodesRetriever(
+        [
+            NodeWithScore(node=TextNode(text="node_C"), score=0.9),
+            NodeWithScore(node=TextNode(text="node_D"), score=0.8),
+        ]
+    )
+
+    retriever = QueryFusionRetriever(
+        retrievers=[retriever_0, retriever_1],
+        mode=FUSION_MODES.RECIPROCAL_RANK,
+        retriever_weights=[1.0, 0.0],
+        num_queries=1,
+        similarity_top_k=4,
+        use_async=False,
+    )
+
+    results = retriever.retrieve("test query")
+    contents = [n.node.get_content() for n in results]
+
+    # retriever_1 has weight 0, so its nodes must not outrank retriever_0's.
+    assert contents[:2] == ["node_A", "node_B"]
+
+    # Nodes from the zero-weight retriever contribute nothing to the fused score.
+    scores_by_content = {n.node.get_content(): n.score for n in results}
+    assert scores_by_content["node_C"] == 0.0
+    assert scores_by_content["node_D"] == 0.0
+    assert scores_by_content["node_A"] > scores_by_content["node_B"] > 0.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

`QueryFusionRetriever` accepts a `retriever_weights` argument, but in
`reciprocal_rerank` mode it was silently ignored — every retriever
contributed equally regardless of its weight.

`_reciprocal_rerank_fusion()` iterated over `results.values()`, discarding
the `retriever_idx` stored in each `(query_str, retriever_idx)` key, and
added `1.0 / (rank + k)` with no weight. `_relative_score_fusion()` already
uses that index to apply weights; this change makes RRF consistent by
weighting each retriever's reciprocal-rank contribution by
`self._retriever_weights[retriever_idx]`. With the default (uniform) weights
the resulting ranking is unchanged.

Fixes #21444

## Version Bump?
- [ ] Yes
- [x] No (core package)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

`test_reciprocal_rerank_respects_retriever_weights` reproduces the issue
(weights `[1.0, 0.0]`) and asserts the zero-weight retriever's nodes no
longer surface and receive a fused score of `0`. `pytest
tests/retrievers/test_fusion_retriever.py` passes.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Ran `ruff check` and `ruff format` on the changed files

> [!NOTE]
> Developed with AI assistance (Claude Code). The root cause was verified
> against the source, the fix mirrors the existing `_relative_score_fusion`
> weighting, and a new unit test fails without the change and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
