### PR TITLE
fix(core): count tool-call and thinking tokens in Memory token estimate

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -358,11 +358,12 @@ class Memory(BaseMemory):
                     CitableBlock,
                     CitationBlock,
                     ThinkingBlock,
+                    ToolCallBlock,
                 ]
             ] = []
 
             for block in message_or_blocks.blocks:
-                if not isinstance(block, (CachePoint, ToolCallBlock)):
+                if not isinstance(block, CachePoint):
                     blocks.append(block)
 
             # Estimate the token count for the additional kwargs
@@ -380,7 +381,7 @@ class Memory(BaseMemory):
                 blocks = []
                 for msg in messages:
                     for block in msg.blocks:
-                        if not isinstance(block, (CachePoint, ToolCallBlock)):
+                        if not isinstance(block, CachePoint):
                             blocks.append(block)
 
                 # Estimate the token count for the additional kwargs
@@ -437,6 +438,21 @@ class Memory(BaseMemory):
                 token_count += self.audio_token_size_estimate
             elif isinstance(block, DocumentBlock):
                 token_count += self.document_token_size_estimate
+            elif isinstance(block, ToolCallBlock):
+                # Tool calls add their name and serialized arguments to the
+                # prompt, so they must be counted. Mirrors
+                # ToolCallBlock.aestimate_tokens.
+                token_count += len(self.tokenizer_fn(block.model_dump_json()))
+            elif isinstance(block, ThinkingBlock):
+                # Mirrors ThinkingBlock.aestimate_tokens: prefer the provider
+                # reported token count, otherwise estimate from the content.
+                token_count += block.num_tokens or len(
+                    self.tokenizer_fn(block.content or "")
+                )
+            elif isinstance(block, CitableBlock):
+                token_count += self._estimate_token_count(block.content)
+            elif isinstance(block, CitationBlock):
+                token_count += self._estimate_token_count([block.cited_content])
 
         return token_count
 

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -2,9 +2,13 @@ import pytest
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    CitableBlock,
     DocumentBlock,
     ImageBlock,
     AudioBlock,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
     VideoBlock,
 )
 from llama_index.core.memory.memory import Memory
@@ -74,6 +78,65 @@ async def test_estimate_token_count_document(memory):
     message = ChatMessage(role="user", blocks=[block])
     count = memory._estimate_token_count(message)
     assert count == memory.document_token_size_estimate
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_tool_call(memory):
+    """Tool-call blocks must be counted from their serialized form (#21950)."""
+    block = ToolCallBlock(
+        tool_name="search",
+        tool_kwargs={"query": "what is the capital of France?"},
+    )
+    message = ChatMessage(role="assistant", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == len(memory.tokenizer_fn(block.model_dump_json()))
+    assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_includes_tool_calls_in_total(memory):
+    """A message mixing text and a tool call counts both (regression for #21950)."""
+    tool_call = ToolCallBlock(
+        tool_name="search", tool_kwargs={"query": "long query " * 20}
+    )
+    message = ChatMessage(
+        role="assistant", blocks=[TextBlock(text="Calling tool"), tool_call]
+    )
+    count = memory._estimate_token_count(message)
+    expected = len(memory.tokenizer_fn("Calling tool")) + len(
+        memory.tokenizer_fn(tool_call.model_dump_json())
+    )
+    assert count == expected
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_thinking(memory):
+    """Thinking blocks must be counted from their content."""
+    block = ThinkingBlock(content="Let me reason about this step by step.")
+    message = ChatMessage(role="assistant", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == len(memory.tokenizer_fn(block.content))
+    assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_thinking_uses_reported_tokens(memory):
+    """A provider-reported `num_tokens` is used directly when available."""
+    block = ThinkingBlock(content="some reasoning", num_tokens=123)
+    message = ChatMessage(role="assistant", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == 123
+
+
+@pytest.mark.asyncio
+async def test_estimate_token_count_citable(memory):
+    """Citable blocks must count their nested text content."""
+    block = CitableBlock(
+        title="title", source="source", content=[TextBlock(text="cited text here")]
+    )
+    message = ChatMessage(role="assistant", blocks=[block])
+    count = memory._estimate_token_count(message)
+    assert count == len(memory.tokenizer_fn("cited text here"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

`Memory._estimate_token_count` undercounts conversations that contain tool
calls. `ToolCallBlock` was filtered out of the counted blocks, and there was
no counting branch for `ThinkingBlock`, `CitableBlock`, or `CitationBlock`,
so all of these contributed **zero** tokens.

Tool calls in particular carry their name and serialized JSON arguments into
the prompt. Undercounting them means `Memory` does not flush in time, so the
conversation silently exceeds the model's context window and the provider
returns `prompt is too long` (HTTP 400) — commonly seen with `AgentWorkflow`
once tool calls accumulate.

This stops excluding `ToolCallBlock` and adds counting branches that mirror
each block's own `aestimate_tokens` implementation, using the configured
`tokenizer_fn`: tool calls from their serialized JSON, thinking blocks from
`num_tokens` (or their content), and citable/citation blocks from their
nested content.

Fixes #21950

## Version Bump?
- [ ] Yes
- [x] No (core package)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

Added tests in `tests/memory/test_memory_base.py` covering tool-call,
thinking (content and `num_tokens`), and citable blocks, plus a regression
test asserting a mixed text + tool-call message counts both. The full
`tests/memory/` suite passes (83 tests).

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Ran `ruff check` and `ruff format` on the changed files

> [!NOTE]
> Developed with AI assistance (Claude Code). Each new counting branch was
> matched to the corresponding block type's existing `aestimate_tokens`
> semantics, and the change is covered by new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
