### PR TITLE
fix(core): handle multi-block messages when writing streamed chat to history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -40,6 +41,32 @@ def is_function(message: ChatMessage) -> bool:
         "tool_calls" in message.additional_kwargs
         and len(message.additional_kwargs["tool_calls"]) > 0
     )
+
+
+def set_streamed_message_text(message: ChatMessage, text: str) -> None:
+    """
+    Set the final text of a streamed message before writing it to history.
+
+    Assigning to ``ChatMessage.content`` raises ``ValueError`` when the
+    message holds more than one block, or a single non-text block (e.g. a
+    ``ThinkingBlock`` produced by a reasoning model). Consolidate the text
+    blocks into a single ``TextBlock`` at the position of the first one while
+    preserving any non-text blocks and their order.
+    """
+    new_text_block = TextBlock(text=text)
+    new_blocks: List[Any] = []
+    inserted = False
+    for block in message.blocks:
+        if isinstance(block, TextBlock):
+            if not inserted:
+                new_blocks.append(new_text_block)
+                inserted = True
+            # Drop any additional text blocks; they are consolidated above.
+        else:
+            new_blocks.append(block)
+    if not inserted:
+        new_blocks.append(new_text_block)
+    message.blocks = new_blocks
 
 
 class ChatResponseMode(str, Enum):
@@ -191,7 +218,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                set_streamed_message_text(chat.message, final_text.strip())
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +276,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                set_streamed_message_text(chat.message, final_text.strip())
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_streaming_history.py
+++ b/llama-index-core/tests/chat_engine/test_streaming_history.py
@@ -1,0 +1,98 @@
+import pytest
+
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    TextBlock,
+    ThinkingBlock,
+)
+from llama_index.core.chat_engine.types import (
+    StreamingAgentChatResponse,
+    set_streamed_message_text,
+)
+from llama_index.core.memory import ChatMemoryBuffer
+
+
+def test_set_streamed_message_text_single_text_block():
+    message = ChatMessage(role="assistant", blocks=[TextBlock(text="old")])
+    set_streamed_message_text(message, "new")
+    assert message.content == "new"
+    assert len(message.blocks) == 1
+
+
+def test_set_streamed_message_text_no_blocks():
+    message = ChatMessage(role="assistant", blocks=[])
+    set_streamed_message_text(message, "new")
+    assert message.content == "new"
+
+
+def test_set_streamed_message_text_preserves_non_text_blocks():
+    """A thinking block alongside text must survive and keep its position."""
+    message = ChatMessage(
+        role="assistant",
+        blocks=[ThinkingBlock(content="reasoning"), TextBlock(text="old")],
+    )
+    set_streamed_message_text(message, "new")
+    assert message.content == "new"
+    assert [type(b) for b in message.blocks] == [ThinkingBlock, TextBlock]
+    assert message.blocks[0].content == "reasoning"
+
+
+def test_set_streamed_message_text_consolidates_multiple_text_blocks():
+    message = ChatMessage(
+        role="assistant",
+        blocks=[TextBlock(text="a"), TextBlock(text="b")],
+    )
+    set_streamed_message_text(message, "final")
+    assert message.content == "final"
+    assert sum(isinstance(b, TextBlock) for b in message.blocks) == 1
+
+
+def test_set_streamed_message_text_appends_when_no_text_block():
+    message = ChatMessage(role="assistant", blocks=[ThinkingBlock(content="r")])
+    set_streamed_message_text(message, "answer")
+    assert message.content == "answer"
+    assert [type(b) for b in message.blocks] == [ThinkingBlock, TextBlock]
+
+
+def test_write_response_to_history_handles_multi_block_message():
+    """Regression for #21679: writing a multi-block message must not raise."""
+    final_message = ChatMessage(
+        role="assistant",
+        blocks=[ThinkingBlock(content="reasoning"), TextBlock(text="hello")],
+    )
+
+    def gen():
+        yield ChatResponse(message=final_message, delta="hello")
+
+    response = StreamingAgentChatResponse(chat_stream=gen())
+    memory = ChatMemoryBuffer.from_defaults()
+
+    response.write_response_to_history(memory)
+
+    history = memory.get_all()
+    assert len(history) == 1
+    assert history[0].content == "hello"
+    assert any(isinstance(b, ThinkingBlock) for b in history[0].blocks)
+
+
+@pytest.mark.asyncio
+async def test_awrite_response_to_history_handles_multi_block_message():
+    """Regression for #21679 on the async path used by astream_chat."""
+    final_message = ChatMessage(
+        role="assistant",
+        blocks=[ThinkingBlock(content="reasoning"), TextBlock(text="hello there")],
+    )
+
+    async def agen():
+        yield ChatResponse(message=final_message, delta="hello there")
+
+    response = StreamingAgentChatResponse(achat_stream=agen())
+    memory = ChatMemoryBuffer.from_defaults()
+
+    await response.awrite_response_to_history(memory)
+
+    history = memory.get_all()
+    assert len(history) == 1
+    assert history[0].content == "hello there"
+    assert any(isinstance(b, ThinkingBlock) for b in history[0].blocks)


### PR DESCRIPTION
# Description

`StreamingAgentChatResponse.write_response_to_history` and its async
counterpart write the accumulated streamed text back to memory via
`chat.message.content = final_text`. The `ChatMessage.content` setter raises
`ValueError` when the message contains more than one block (or a single
non-text block), so a streamed assistant message that includes, for example,
a `ThinkingBlock` alongside its text crashes when written to history:

```
ValueError: ChatMessage contains multiple blocks, use 'ChatMessage.blocks' instead.
```

This adds `set_streamed_message_text`, which consolidates the text blocks
into a single `TextBlock` (in place) while preserving any non-text blocks and
their order, and uses it at both the sync and async write sites. For the
common single-text-block case the behaviour is unchanged.

Fixes #21679

## Version Bump?
- [ ] Yes
- [x] No (core package)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

Added `tests/chat_engine/test_streaming_history.py`: unit tests for the
helper across block configurations, plus sync and async regression tests that
drive a multi-block streamed message through `write_response_to_history` /
`awrite_response_to_history` and assert no crash and correct memory content.
The `tests/chat_engine/` suite passes (48 tests).

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Ran `ruff check` and `ruff format` on the changed files

> [!NOTE]
> Developed with AI assistance (Claude Code). The fix preserves non-text
> blocks (e.g. reasoning blocks) and is covered by new sync and async tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
