### PR TITLE
fix(redis): return exact node ids from add/async_add using removeprefix

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/llama_index/vector_stores/redis/base.py
@@ -355,10 +355,8 @@ class RedisVectorStore(BasePydanticVectorStore):
             data, id_field=NODE_ID_FIELD_NAME, **add_kwargs
         )
         logger.info(f"Added {len(keys)} documents to index {self._async_index.name}")
-        return [
-            key.strip(self._async_index.prefix + self._async_index.key_separator)
-            for key in keys
-        ]
+        prefix = self._async_index.prefix + self._async_index.key_separator
+        return [key.removeprefix(prefix) for key in keys]
 
     def add(self, nodes: List[BaseNode], **add_kwargs: Any) -> List[str]:
         """
@@ -407,9 +405,8 @@ class RedisVectorStore(BasePydanticVectorStore):
         # Load nodes to Redis
         keys = self._index.load(data, id_field=NODE_ID_FIELD_NAME, **add_kwargs)
         logger.info(f"Added {len(keys)} documents to index {self._index.name}")
-        return [
-            key.strip(self._index.prefix + self._index.key_separator) for key in keys
-        ]
+        prefix = self._index.prefix + self._index.key_separator
+        return [key.removeprefix(prefix) for key in keys]
 
     def _build_node_id_filter_expression(self, node_ids: list[str]) -> FilterExpression:
         """Build a Redis filter expression for one or more node IDs."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-redis"
-version = "0.8.0"
+version = "0.8.1"
 description = "llama-index vector_stores redis integration"
 authors = [{name = "Tyler Hutcherson", email = "tyler.hutcherson@redis.com"}]
 requires-python = ">=3.10,<3.14"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_node_id_prefix.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-redis/tests/test_node_id_prefix.py
@@ -1,0 +1,63 @@
+"""Regression tests for node-id prefix handling in add/async_add (#21483)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from redis.asyncio import Redis as RedisAsync
+
+from llama_index.core.schema import TextNode
+from llama_index.vector_stores.redis import RedisVectorStore
+from llama_index.vector_stores.redis.base import VECTOR_FIELD_NAME
+
+PREFIX = "semantic_cache_doc"
+SEPARATOR = ":"
+# The node id begins with 'e', a character that also appears in PREFIX. The old
+# ``key.strip(PREFIX + SEPARATOR)`` implementation removed every leading/trailing
+# character contained in the prefix, so it would mangle this id into
+# "7b95ae7-..."; ``removeprefix`` strips the exact substring instead.
+NODE_ID = "e7b95ae7-6369-404d-8287-1f4504121563"
+
+
+def _make_store() -> RedisVectorStore:
+    # Passing only an async client avoids create_index()/any connection in __init__.
+    return RedisVectorStore(
+        redis_client_async=RedisAsync.from_url("redis://localhost:6379")
+    )
+
+
+def _fake_index(load_return, is_async: bool) -> MagicMock:
+    index = MagicMock()
+    index.name = "test_index"
+    index.prefix = PREFIX
+    index.key_separator = SEPARATOR
+    index.schema.fields = {
+        VECTOR_FIELD_NAME: SimpleNamespace(attrs=SimpleNamespace(dims=4))
+    }
+    loader = AsyncMock if is_async else MagicMock
+    index.load = loader(return_value=load_return)
+    return index
+
+
+def _node() -> TextNode:
+    node = TextNode(text="x", id_=NODE_ID)
+    node.embedding = [0.1, 0.2, 0.3, 0.4]
+    return node
+
+
+def test_add_returns_exact_node_id():
+    """add() must return the original node id, not a strip()-mangled one."""
+    store = _make_store()
+    store._index = _fake_index([f"{PREFIX}{SEPARATOR}{NODE_ID}"], is_async=False)
+    assert store.add([_node()]) == [NODE_ID]
+
+
+@pytest.mark.asyncio
+async def test_async_add_returns_exact_node_id():
+    """async_add() must return the original node id."""
+    with patch.object(RedisVectorStore, "async_index_exists", new_callable=AsyncMock):
+        store = _make_store()
+        store._async_index = _fake_index(
+            [f"{PREFIX}{SEPARATOR}{NODE_ID}"], is_async=True
+        )
+        assert await store.async_add([_node()]) == [NODE_ID]


### PR DESCRIPTION
# Description

`RedisVectorStore.add` and `async_add` strip the index prefix from each
returned key with `key.strip(prefix + key_separator)`. `str.strip(chars)`
removes any leading/trailing characters contained in the argument set — not
the exact substring — so node ids that begin or end with a character present
in the prefix are corrupted.

For example, with prefix `semantic_cache_doc` the id
`e7b95ae7-6369-404d-8287-1f4504121563` is returned as
`7b95ae7-6369-404d-8287-1f4504121563` (leading `e` removed), because `e` is
in the prefix. Callers then receive ids that don't match what was stored.

This uses `str.removeprefix` to strip exactly the `prefix + key_separator`
substring.

Fixes #21483

## Version Bump?
- [x] Yes (`0.8.0` -> `0.8.1`)
- [ ] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

Added `tests/test_node_id_prefix.py` covering both `add` and `async_add`,
using a node id that begins with a character present in the prefix (the
reported failure mode) and asserting the original id is returned unchanged.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Ran `ruff check` and `ruff format` on the changed files

> [!NOTE]
> Developed with AI assistance (Claude Code). The fix and tests were verified
> against the package's source; the new tests fail on the old `.strip()`
> implementation and pass with `removeprefix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
