### PR TITLE
fix(azureaisearch): store falsy metadata values instead of dropping them

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,10 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            # Use an explicit ``is not None`` check so that falsy-but-valid
+            # values (0, "", [], False) are written to the index instead of
+            # being silently dropped (and read back as None).
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-azureaisearch"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index vector_stores azureaisearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -503,3 +503,52 @@ def test_close_does_not_call_external_client_close() -> None:
 
     # Verify close was NOT called on the external search client
     search_client.close.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
+def test_default_index_mapping_preserves_falsy_metadata() -> None:
+    """Falsy metadata values must be written to the index, not dropped (#21385)."""
+    search_client = mock_client_with_user_agent("search")
+    vector_store = AzureAISearchVectorStore(
+        search_or_index_client=search_client,
+        id_field_key="id",
+        chunk_field_key="content",
+        embedding_field_key="embedding",
+        metadata_string_field_key="metadata",
+        doc_id_field_key="doc_id",
+        filterable_metadata_field_keys=[
+            "zero",
+            "empty_str",
+            "empty_list",
+            "flag",
+            "none_val",
+        ],
+        index_management=IndexManagement.NO_VALIDATION,
+        embedding_dimensionality=2,
+    )
+
+    enriched_doc = {
+        "id": "1",
+        "chunk": "some text",
+        "embedding": [0.1, 0.2],
+        "metadata": "{}",
+        "doc_id": "doc-1",
+    }
+    metadata = {
+        "zero": 0,
+        "empty_str": "",
+        "empty_list": [],
+        "flag": False,
+        "none_val": None,
+    }
+
+    index_doc = vector_store._default_index_mapping(enriched_doc, metadata)
+
+    assert index_doc["zero"] == 0
+    assert index_doc["empty_str"] == ""
+    assert index_doc["empty_list"] == []
+    assert index_doc["flag"] is False
+    # None values should still be skipped.
+    assert "none_val" not in index_doc


### PR DESCRIPTION
# Description

`_default_index_mapping` guarded each metadata field with `if metadata_value:`,
which skips falsy-but-valid values such as `0`, `""`, `[]`, and `False`. Those
fields were never written to the Azure AI Search index and were read back as
`None`, silently losing data (e.g. an integer metadata value of `0`).

This guards with `if metadata_value is not None:` so that only genuinely
missing (`None`) values are skipped.

Fixes #21385

## Version Bump?
- [x] Yes (`0.5.0` -> `0.5.1`)
- [ ] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

Added `test_default_index_mapping_preserves_falsy_metadata` in
`tests/test_azureaisearch.py`, which asserts that `0`, `""`, `[]`, and `False`
are written to the index document while `None` is still skipped. Verified the
test fails on the old `if metadata_value:` code and passes with the fix.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Ran `ruff check` and `ruff format` on the changed files

> [!NOTE]
> Developed with AI assistance (Claude Code). The one-line fix matches the
> resolution suggested in the issue and is covered by a new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
