### PR TITLE
Add FunASR reader integration (llama-index-readers-funasr)

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-funasr/BUILD
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/BUILD
@@ -1,0 +1,3 @@
+poetry_requirements(
+    name="poetry",
+)

--- a/llama-index-integrations/readers/llama-index-readers-funasr/LICENSE
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) FunASR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/readers/llama-index-readers-funasr/Makefile
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/Makefile
@@ -1,0 +1,14 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests

--- a/llama-index-integrations/readers/llama-index-readers-funasr/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/README.md
@@ -1,0 +1,21 @@
+# LlamaIndex Readers Integration: FunASR
+
+Transcribe audio into LlamaIndex `Document`s with [FunASR](https://github.com/modelscope/FunASR) — self-hosted speech-to-text powered by [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) / Paraformer / Fun-ASR-Nano. Runs locally, no cloud API; strong on Chinese and 50+ languages.
+
+## Installation
+
+```bash
+pip install llama-index-readers-funasr
+```
+
+## Usage
+
+```python
+from llama_index.readers.funasr import FunASRReader
+
+reader = FunASRReader(model="iic/SenseVoiceSmall", device="cuda")
+documents = reader.load_data("meeting.wav")
+print(documents[0].text)
+```
+
+Pass `hub="hf"` with `model="FunAudioLLM/SenseVoiceSmall"` to load from HuggingFace. The built-in VAD handles audio of any length.

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.funasr.base import FunASRReader
+
+__all__ = ["FunASRReader"]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
@@ -1,0 +1,118 @@
+"""FunASR audio reader."""
+
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+_TARGET_SR = 16000
+_SENSE_VOICE_LANGUAGES = {"auto", "zh", "en", "yue", "ja", "ko"}
+
+
+class FunASRReader(BaseReader):
+    """
+    FunASR reader.
+
+    Reads audio files and transcribes them locally with FunASR
+    (SenseVoice / Paraformer / Fun-ASR-Nano) - no cloud API. Strong on Chinese
+    and 50+ languages.
+
+    Args:
+        model (str): FunASR model id. Defaults to "iic/SenseVoiceSmall".
+        device (str): Inference device, e.g. "cpu" or "cuda:0".
+        hub (str): Model hub, "ms" (ModelScope) or "hf" (HuggingFace).
+        language (str): SenseVoice decoding language ("auto"/"zh"/"en"/...).
+        use_itn (bool): Apply inverse text normalization.
+        vad_model (Optional[str]): VAD model; enables arbitrary-length audio.
+        batch_size_s (int): Dynamic batch size (seconds) for VAD segments.
+
+    """
+
+    def __init__(
+        self,
+        model: str = "iic/SenseVoiceSmall",
+        *,
+        device: str = "cpu",
+        hub: str = "ms",
+        language: str = "auto",
+        use_itn: bool = True,
+        vad_model: Optional[str] = "fsmn-vad",
+        batch_size_s: int = 300,
+    ) -> None:
+        """Initialize with arguments."""
+        super().__init__()
+        self.model_name = model
+        self.device = device
+        self.hub = hub
+        self.language = language
+        self.use_itn = use_itn
+        self.vad_model = vad_model
+        self.batch_size_s = batch_size_s
+        self._model = None
+        self._postprocess = None
+
+    def _ensure_model(self):
+        if self._model is None:
+            try:
+                from funasr import AutoModel
+                from funasr.utils.postprocess_utils import (
+                    rich_transcription_postprocess,
+                )
+            except ImportError as e:
+                raise ImportError(
+                    "llama-index-readers-funasr requires funasr. "
+                    "Install with `pip install funasr`."
+                ) from e
+            self._postprocess = rich_transcription_postprocess
+            kwargs = {
+                "model": self.model_name,
+                "hub": self.hub,
+                "device": self.device,
+                "disable_update": True,
+            }
+            if self.vad_model:
+                kwargs["vad_model"] = self.vad_model
+                kwargs["vad_kwargs"] = {"max_single_segment_time": 30000}
+            self._model = AutoModel(**kwargs)
+        return self._model
+
+    def _transcribe(self, input_file: Union[str, Path, bytes]) -> str:
+        try:
+            import librosa
+        except ImportError as e:
+            raise ImportError(
+                "llama-index-readers-funasr requires librosa for audio decoding. "
+                "Install with `pip install librosa`."
+            ) from e
+
+        model = self._ensure_model()
+        source: Union[str, BytesIO]
+        source = BytesIO(input_file) if isinstance(input_file, bytes) else str(input_file)
+        audio, _ = librosa.load(source, sr=_TARGET_SR, mono=True)
+
+        gen_kwargs = {
+            "input": audio,
+            "cache": {},
+            "use_itn": self.use_itn,
+            "batch_size_s": self.batch_size_s,
+        }
+        if "SenseVoice" in self.model_name:
+            lang = self.language if self.language in _SENSE_VOICE_LANGUAGES else "auto"
+            gen_kwargs["language"] = lang
+
+        result = model.generate(**gen_kwargs)
+        text = result[0]["text"] if result else ""
+        return self._postprocess(text).strip()
+
+    def load_data(
+        self,
+        input_file: Union[str, Path, bytes],
+        extra_info: Optional[Dict] = None,
+        **transcribe_kwargs: dict,
+    ) -> List[Document]:
+        """Transcribe an audio file into a list with a single Document."""
+        text = self._transcribe(input_file)
+        metadata = extra_info or {}
+        return [Document(text=text, metadata=metadata)]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-readers-funasr"
+version = "0.1.0"
+description = "llama-index readers FunASR (SenseVoice / Paraformer / Fun-ASR-Nano) integration"
+authors = [{name = "FunASR"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["funasr", "sensevoice", "paraformer", "speech-to-text", "asr", "audio", "transcription"]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "funasr>=1.1.0",
+    "librosa",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_readers_funasr.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_readers_funasr.py
@@ -1,0 +1,13 @@
+from llama_index.core.readers.base import BaseReader
+from llama_index.readers.funasr import FunASRReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in FunASRReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_init():
+    reader = FunASRReader(model="iic/SenseVoiceSmall", device="cpu")
+    assert reader.model_name == "iic/SenseVoiceSmall"
+    assert reader.hub == "ms"


### PR DESCRIPTION
## Description

Adds **`llama-index-readers-funasr`** — a **self-hosted** audio transcription reader backed by [FunASR](https://github.com/modelscope/FunASR) (SenseVoice / Paraformer / Fun-ASR-Nano). Runs **locally, no cloud API**; strong on Chinese and 50+ languages. Mirrors the structure of `llama-index-readers-whisper`.

```python
from llama_index.readers.funasr import FunASRReader

reader = FunASRReader(model="iic/SenseVoiceSmall", device="cuda")
documents = reader.load_data("meeting.wav")
```

`FunASRReader.load_data` accepts a file path or raw bytes and returns a `Document` with the transcript. The built-in VAD handles audio of any length; `hub="hf"` loads from HuggingFace.

## Tested
On an H100: `load_data` (path and bytes inputs) returns `Document`s with correct transcripts; the canonical `test_class` + `test_init` pass.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I added new unit tests to cover this change (`tests/test_readers_funasr.py`)
- [x] I believe this change is covered by existing unit tests