### PR TITLE
fix: resource leaks in HuggingFace FS, AlibabaCloud, Stripe Docs, SEC Filings readers and Galaxia retriever

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
@@ -123,8 +123,10 @@ class AlibabaCloudAISearchDocumentReader(BasePydanticReader):
             file_name = os.path.basename(file_path)
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
+            with open(file_path, "rb") as f:
+                file_content = base64.b64encode(f.read()).decode()
             document = CreateDocumentAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=file_content,
                 file_name=file_name,
                 file_type=file_type,
             )
@@ -261,8 +263,10 @@ class AlibabaCloudAISearchImageReader(AlibabaCloudAISearchDocumentReader):
             file_name = os.path.basename(file_path)
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
+            with open(file_path, "rb") as f:
+                file_content = base64.b64encode(f.read()).decode()
             document = CreateImageAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=file_content,
                 file_name=file_name,
                 file_type=file_type,
             )

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
@@ -40,9 +40,9 @@ class HuggingFaceFSReader(BaseReader):
                 with open(tmp / "tmp.jsonl.gz", "wb") as fp:
                     fp.write(test_data)
 
-                f = gzip.open(tmp / "tmp.jsonl.gz", "rb")
-                raw = f.read()
-                data = raw.decode()
+                with gzip.open(tmp / "tmp.jsonl.gz", "rb") as f:
+                    raw = f.read()
+                    data = raw.decode()
         else:
             data = test_data.decode()
 

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
@@ -305,7 +305,8 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
     if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    gzip_file = gzip.open(file.file).read()
+    with gzip.open(file.file) as gz:
+        gzip_file = gz.read()
     return UploadFile(
         file=io.BytesIO(gzip_file),
         size=len(gzip_file),

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
@@ -30,7 +30,8 @@ class StripeDocsReader(BaseReader):
         self._limit = limit
 
     def _load_url(self, url: str) -> str:
-        return urllib.request.urlopen(url).read()
+        with urllib.request.urlopen(url) as response:
+            return response.read()
 
     def _load_sitemap(self) -> str:
         return self._load_url(STRIPE_SITEMAP_URL)

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
@@ -65,36 +65,39 @@ class GalaxiaClient:
     ) -> Union[dict, None]:
         conn = http.client.HTTPSConnection(self.api_url)
 
-        flag_init = False
-        for i in range(self.n_retries):
-            init_res = self.initialize(conn, query)
+        try:
+            flag_init = False
+            for i in range(self.n_retries):
+                init_res = self.initialize(conn, query)
 
-            if "operationId" in init_res:
-                flag_init = True
-                break
+                if "operationId" in init_res:
+                    flag_init = True
+                    break
 
-            time.sleep(self.wait_time * i)
+                time.sleep(self.wait_time * i)
 
-        if not flag_init:
-            # failed to init
-            return None
+            if not flag_init:
+                # failed to init
+                return None
 
-        flag_proc = False
-        for i in range(1, self.n_retries + 1):
-            time.sleep(self.wait_time * i)
-            status = self.check_status(conn, init_res)
+            flag_proc = False
+            for i in range(1, self.n_retries + 1):
+                time.sleep(self.wait_time * i)
+                status = self.check_status(conn, init_res)
 
-            if status["status"] == "processed":
-                flag_proc = True
-                break
+                if status["status"] == "processed":
+                    flag_proc = True
+                    break
 
-        if flag_proc:
-            res = self.get_result(conn, init_res)
-            return res["result"]["resultItems"]
+            if flag_proc:
+                res = self.get_result(conn, init_res)
+                return res["result"]["resultItems"]
 
-        else:
-            # failed to process
-            return None
+            else:
+                # failed to process
+                return None
+        finally:
+            conn.close()
 
 
 class GalaxiaRetriever(BaseRetriever):


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Description</h1>
<p>Fix resource leaks across 5 integration packages where file handles and HTTP connections were not properly closed, preventing file descriptor exhaustion in long-running processes.</p>

Fixes #22026

Package | File | Issue | Fix
-- | -- | -- | --
llama-index-readers-huggingface-fs | base.py | gzip.open() without close | Wrapped in with context manager
llama-index-readers-alibabacloud-aisearch | base.py | open(file_path, "rb").read() without close (2 locations) | Wrapped in with context manager
llama-index-readers-stripe-docs | base.py | urllib.request.urlopen() without close | Wrapped in with context manager
llama-index-readers-sec-filings | section.py | gzip.open() without close | Wrapped in with context manager
llama-index-retrievers-galaxia | base.py | HTTPSConnection never closed | Added try/finally with conn.close()


<h2>New Package?</h2>
<ul>
<li>[x] No</li>
</ul>
<h2>Version Bump?</h2>
<ul>
<li>[x] No</li>
</ul>
<h2>Type of Change</h2>
<ul>
<li>[x] Bug fix (non-breaking change which fixes an issue)</li>
</ul>
<h2>How Has This Been Tested?</h2>
<ul>
<li>[x] I believe this change is already covered by existing unit tests</li>
</ul>
<h2>Suggested Checklist:</h2>
<ul>
<li>[x] I have performed a self-review of my own code</li>
<li>[x] My changes generate no new warnings</li>
<li>[x] New and existing unit tests pass locally with my changes</li>
</ul></body></html><!--EndFragment-->
</body>
</html>