### PR TITLE
fix: add missing timeout to HTTP requests across 9 integration packages

### DIFF
--- a/issue_description.md
+++ b/issue_description.md
@@ -1,0 +1,23 @@
+# Resource leaks in HuggingFace FS, AlibabaCloud, Stripe Docs, SEC Filings readers and Galaxia retriever
+
+## Bug Description
+
+Several integration packages have resource leaks where file handles and HTTP connections are opened but never properly closed. This can lead to file descriptor exhaustion in long-running processes.
+
+## Affected Packages
+
+| Package | File | Issue |
+|---------|------|-------|
+| `llama-index-readers-huggingface-fs` | `base.py:43` | `gzip.open()` called without context manager or `.close()` |
+| `llama-index-readers-alibabacloud-aisearch` | `base.py:127,267` | `open(file_path, "rb").read()` without context manager (2 locations) |
+| `llama-index-readers-stripe-docs` | `base.py:33` | `urllib.request.urlopen(url).read()` without context manager |
+| `llama-index-readers-sec-filings` | `section.py:308` | `gzip.open(file.file).read()` without context manager |
+| `llama-index-retrievers-galaxia` | `base.py:66` | `HTTPSConnection` created but never closed |
+
+## Expected Behavior
+
+All file handles and HTTP connections should be properly closed after use, either via `with` context managers or `try/finally` blocks.
+
+## Fix
+
+PR: #(PR number)

--- a/issue_timeouts.md
+++ b/issue_timeouts.md
@@ -1,0 +1,31 @@
+# Title
+Missing timeout on HTTP requests across 9 integration packages
+
+# Bug Description
+Several integration packages make HTTP requests using `requests.get()` or `requests.post()` without specifying a `timeout` parameter. This means requests can hang indefinitely if the remote server is unresponsive, causing the calling process to freeze.
+
+# Affected Packages
+
+| Package | File | Line(s) | Call |
+|---------|------|---------|------|
+| `llama-index-embeddings-huggingface` | `utils.py` | 85 | `requests.get(pooling_config_url)` |
+| `llama-index-llms-you` | `base.py` | 25, 35 | `requests.post(base_url, ...)` (2 locations) |
+| `llama-index-tools-wolfram-alpha` | `base.py` | 81 | `requests.get(url, headers=headers)` |
+| `llama-index-tools-text-to-image` | `base.py` | 55, 74 | `requests.get(url)` (2 locations) |
+| `llama-index-tools-openapi` | `base.py` | 35 | `requests.get(url)` |
+| `llama-index-readers-kaltura` | `base.py` | 177 | `requests.get(cap_json_url)` |
+| `llama-index-readers-zendesk` | `base.py` | 86 | `requests.get(url)` |
+| `llama-index-readers-intercom` | `base.py` | 90 | `requests.get(url, headers=headers)` |
+| `llama-index-indices-managed-dashscope` | `utils.py` | 6, 16, 37 | `requests.post/get()` (3 locations) |
+
+# Expected Behavior
+All HTTP requests should include a reasonable `timeout` parameter to prevent indefinite hangs.
+
+# Steps to Reproduce
+1. Use any of the affected packages in a production environment
+2. If the remote API server becomes unresponsive or has network issues
+3. The `requests.get()`/`requests.post()` call hangs indefinitely with no timeout
+4. The calling thread/process freezes and cannot recover
+
+# Version
+v0.14.22

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
@@ -76,13 +76,13 @@ def format_text(
     return f"{instruction} {text}".strip()
 
 
-def get_pooling_mode(model_name: Optional[str]) -> str:
+def get_pooling_mode(model_name: Optional[str], timeout: float = 30.0) -> str:
     pooling_config_url = (
         f"https://huggingface.co/{model_name}/raw/main/1_Pooling/config.json"
     )
 
     try:
-        response = requests.get(pooling_config_url)
+        response = requests.get(pooling_config_url, timeout=timeout)
         config_data = response.json()
 
         cls_token = config_data.get("pooling_mode_cls_token", False)

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
@@ -2,8 +2,8 @@ import requests
 import time
 
 
-def post(base_url: str, headers: dict, params: dict):
-    response = requests.post(base_url, headers=headers, json=params)
+def post(base_url: str, headers: dict, params: dict, timeout: float = 60.0):
+    response = requests.post(base_url, headers=headers, json=params, timeout=timeout)
     if response.status_code != 200:
         raise RuntimeError(response.text)
     response_dict = response.json()
@@ -12,8 +12,8 @@ def post(base_url: str, headers: dict, params: dict):
     return response_dict
 
 
-def get(base_url: str, headers: dict, params: dict):
-    response = requests.get(base_url, headers=headers, params=params)
+def get(base_url: str, headers: dict, params: dict, timeout: float = 60.0):
+    response = requests.get(base_url, headers=headers, params=params, timeout=timeout)
     if response.status_code != 200:
         raise RuntimeError(response.text)
 
@@ -23,12 +23,14 @@ def get(base_url: str, headers: dict, params: dict):
     return response_dict
 
 
-def get_pipeline_id(base_url: str, headers: dict, params: dict):
-    response_dict = get(base_url, headers, params)
+def get_pipeline_id(base_url: str, headers: dict, params: dict, timeout: float = 60.0):
+    response_dict = get(base_url, headers, params, timeout=timeout)
     return response_dict.get("id", "")
 
 
-def run_ingestion(request_url: str, headers: dict, verbose: bool = False):
+def run_ingestion(
+    request_url: str, headers: dict, verbose: bool = False, timeout: float = 60.0
+):
     ingestion_status = ""
     failed_docs = []
 
@@ -36,6 +38,7 @@ def run_ingestion(request_url: str, headers: dict, verbose: bool = False):
         response = requests.get(
             request_url,
             headers=headers,
+            timeout=timeout,
         )
         try:
             response_text = response.json()

--- a/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
@@ -16,23 +16,27 @@ SMART_ENDPOINT = "https://chat-api.you.com/smart"
 RESEARCH_ENDPOINT = "https://chat-api.you.com/research"
 
 
-def _request(base_url: str, api_key: str, **kwargs) -> Dict[str, Any]:
+def _request(
+    base_url: str, api_key: str, timeout: float = 60.0, **kwargs
+) -> Dict[str, Any]:
     """
     NOTE: This function can be replaced by a OpenAPI-generated Python SDK in the future,
     for better input/output typing support.
     """
     headers = {"x-api-key": api_key}
-    response = requests.post(base_url, headers=headers, json=kwargs)
+    response = requests.post(base_url, headers=headers, json=kwargs, timeout=timeout)
     response.raise_for_status()
     return response.json()
 
 
 def _request_stream(
-    base_url: str, api_key: str, **kwargs
+    base_url: str, api_key: str, timeout: float = 60.0, **kwargs
 ) -> Generator[str, None, None]:
     headers = {"x-api-key": api_key}
     params = dict(**kwargs, stream=True)
-    response = requests.post(base_url, headers=headers, stream=True, json=params)
+    response = requests.post(
+        base_url, headers=headers, stream=True, json=params, timeout=timeout
+    )
     response.raise_for_status()
 
     client = sseclient.SSEClient(response)
@@ -83,6 +87,11 @@ class You(CustomLLM):
         None,
         description="You.com API key, if `YDC_API_KEY` is not set in the environment",
     )
+    timeout: float = Field(
+        default=60.0,
+        description="Timeout in seconds for API requests.",
+        ge=0,
+    )
 
     @property
     def metadata(self) -> LLMMetadata:
@@ -97,6 +106,7 @@ class You(CustomLLM):
         response = _request(
             self.endpoint,
             api_key=self._api_key,
+            timeout=self.timeout,
             query=prompt,
         )
         return CompletionResponse(text=response["answer"], raw=response)
@@ -106,6 +116,7 @@ class You(CustomLLM):
         response = _request_stream(
             self.endpoint,
             api_key=self._api_key,
+            timeout=self.timeout,
             query=prompt,
         )
 

--- a/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
@@ -16,9 +16,12 @@ class IntercomReader(BaseReader):
 
     """
 
-    def __init__(self, intercom_access_token: str) -> None:
+    def __init__(
+        self, intercom_access_token: str, timeout: float = 30.0
+    ) -> None:
         """Initialize Intercom reader."""
         self.intercom_access_token = intercom_access_token
+        self.timeout = timeout
 
     def load_data(self) -> List[Document]:
         """
@@ -87,7 +90,7 @@ class IntercomReader(BaseReader):
             "authorization": f"Bearer {self.intercom_access_token}",
         }
 
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.timeout)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
@@ -174,7 +174,7 @@ class KalturaESearchReader(BaseReader):
             cap_json_url = self.client.caption.captionAsset.serveAsJson(
                 caption_asset_id
             )
-            return requests.get(cap_json_url).json()
+            return requests.get(cap_json_url, timeout=self.request_timeout).json()
         except Exception as e:
             logger.error(f"An error occurred while getting captions: {e}")
             return {}

--- a/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
@@ -17,10 +17,16 @@ class ZendeskReader(BaseReader):
 
     """
 
-    def __init__(self, zendesk_subdomain: str, locale: str = "en-us") -> None:
+    def __init__(
+        self,
+        zendesk_subdomain: str,
+        locale: str = "en-us",
+        timeout: float = 30.0,
+    ) -> None:
         """Initialize Zendesk reader."""
         self.zendesk_subdomain = zendesk_subdomain
         self.locale = locale
+        self.timeout = timeout
 
     def load_data(self) -> List[Document]:
         """
@@ -83,7 +89,7 @@ class ZendeskReader(BaseReader):
         else:
             url = next_page
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=self.timeout)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
@@ -24,15 +24,17 @@ class OpenAPIToolSpec(BaseToolSpec):
         spec: Optional[dict] = None,
         url: Optional[str] = None,
         operation_id_filter: Callable[[str], bool] = None,
+        timeout: float = 30.0,
     ):
         import yaml
 
+        self.timeout = timeout
         if spec and url:
             raise ValueError("Only provide one of OpenAPI dict or url")
         elif spec:
             pass
         elif url:
-            response = requests.get(url).text
+            response = requests.get(url, timeout=self.timeout).text
             spec = yaml.safe_load(response)
         else:
             raise ValueError("You must provide a url or OpenAPI spec as a dict")

--- a/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
@@ -13,9 +13,12 @@ class TextToImageToolSpec(BaseToolSpec):
 
     spec_functions = ["generate_images", "show_images", "generate_image_variation"]
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
+    def __init__(
+        self, api_key: Optional[str] = None, timeout: float = 30.0
+    ) -> None:
         if api_key:
             openai.api_key = api_key
+        self.timeout = timeout
 
     def generate_images(
         self, prompt: str, n: Optional[int] = 1, size: Optional[str] = "256x256"
@@ -52,7 +55,7 @@ class TextToImageToolSpec(BaseToolSpec):
         """
         try:
             response = openai.Image.create_variation(
-                image=BytesIO(requests.get(url).content).getvalue(), n=n, size=size
+                image=BytesIO(requests.get(url, timeout=self.timeout).content).getvalue(), n=n, size=size
             )
             return [image["url"] for image in response["data"]]
         except openai.error.OpenAIError as e:
@@ -71,5 +74,5 @@ class TextToImageToolSpec(BaseToolSpec):
 
         for url in urls:
             plt.figure()
-            plt.imshow(Image.open(BytesIO(requests.get(url).content)))
+            plt.imshow(Image.open(BytesIO(requests.get(url, timeout=self.timeout).content)))
         return "images rendered successfully"

--- a/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
@@ -18,10 +18,12 @@ class WolframAlphaToolSpec(BaseToolSpec):
         self,
         app_id: Optional[str] = None,
         api_params: Optional[dict] = None,
+        timeout: float = 30.0,
     ) -> None:
         """Initialize with parameters."""
         self.token = app_id
         self._api_params = api_params or {}
+        self.timeout = timeout
 
     def wolfram_alpha_query(self, query: str) -> str:
         r"""
@@ -78,6 +80,6 @@ class WolframAlphaToolSpec(BaseToolSpec):
         params = {"input": query, **self._api_params}
         url = f"{QUERY_URL_TMPL}?{urllib.parse.urlencode(params)}"
         headers = {"Authorization": f"Bearer {self.token}"}
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.timeout)
         response.raise_for_status()
         return response.text

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,30 @@
+# Description
+
+Fix resource leaks across 5 integration packages where file handles and HTTP connections were not properly closed, preventing file descriptor exhaustion in long-running processes.
+
+Fixes #22026
+
+| Package | File | Issue | Fix |
+|---------|------|-------|-----|
+| `llama-index-readers-huggingface-fs` | `base.py` | `gzip.open()` without close | Wrapped in `with` context manager |
+| `llama-index-readers-alibabacloud-aisearch` | `base.py` | `open(file_path, "rb").read()` without close (2 locations) | Wrapped in `with` context manager |
+| `llama-index-readers-stripe-docs` | `base.py` | `urllib.request.urlopen()` without close | Wrapped in `with` context manager |
+| `llama-index-readers-sec-filings` | `section.py` | `gzip.open()` without close | Wrapped in `with` context manager |
+| `llama-index-retrievers-galaxia` | `base.py` | `HTTPSConnection` never closed | Added `try/finally` with `conn.close()` |
+
+## New Package?
+- [x] No
+
+## Version Bump?
+- [x] No
+
+## Type of Change
+- [x] Bug fix (non-breaking change which fixes an issue)
+
+## How Has This Been Tested?
+- [x] I believe this change is already covered by existing unit tests
+
+## Suggested Checklist:
+- [x] I have performed a self-review of my own code
+- [x] My changes generate no new warnings
+- [x] New and existing unit tests pass locally with my changes

--- a/pr_timeouts.md
+++ b/pr_timeouts.md
@@ -1,0 +1,34 @@
+# Description
+
+Add missing `timeout` parameter to HTTP requests across 9 integration packages to prevent indefinite hangs when remote servers are unresponsive.
+
+Fixes #22028
+
+| Package | File | Fix |
+|---------|------|-----|
+| `llama-index-embeddings-huggingface` | `utils.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-llms-you` | `base.py` | Add `timeout=60` to `requests.post()` (2 locations) |
+| `llama-index-tools-wolfram-alpha` | `base.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-tools-text-to-image` | `base.py` | Add `timeout=30` to `requests.get()` (2 locations) |
+| `llama-index-tools-openapi` | `base.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-readers-kaltura` | `base.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-readers-zendesk` | `base.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-readers-intercom` | `base.py` | Add `timeout=30` to `requests.get()` |
+| `llama-index-indices-managed-dashscope` | `utils.py` | Add `timeout=60` to `requests.post/get()` (3 locations) |
+
+## New Package?
+- [x] No
+
+## Version Bump?
+- [x] No
+
+## Type of Change
+- [x] Bug fix (non-breaking change which fixes an issue)
+
+## How Has This Been Tested?
+- [x] I believe this change is already covered by existing unit tests
+
+## Suggested Checklist:
+- [x] I have performed a self-review of my own code
+- [x] My changes generate no new warnings
+- [x] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Description</h1>
<p>Add missing <code>timeout</code> parameter to HTTP requests across 9 integration packages to prevent indefinite hangs when remote servers are unresponsive.</p>
<p>Fixes #22028</p>

Package | File | Fix
-- | -- | --
llama-index-embeddings-huggingface | utils.py | Add timeout=30 to requests.get()
llama-index-llms-you | base.py | Add timeout=60 to requests.post() (2 locations)
llama-index-tools-wolfram-alpha | base.py | Add timeout=30 to requests.get()
llama-index-tools-text-to-image | base.py | Add timeout=30 to requests.get() (2 locations)
llama-index-tools-openapi | base.py | Add timeout=30 to requests.get()
llama-index-readers-kaltura | base.py | Add timeout=30 to requests.get()
llama-index-readers-zendesk | base.py | Add timeout=30 to requests.get()
llama-index-readers-intercom | base.py | Add timeout=30 to requests.get()
llama-index-indices-managed-dashscope | utils.py | Add timeout=60 to requests.post/get() (3 locations)


<h2>New Package?</h2>
<ul>
<li>[x] No</li>
</ul>
<h2>Version Bump?</h2>
<ul>
<li>[x] No</li>
</ul>
<h2>Type of Change</h2>
<ul>
<li>[x] Bug fix (non-breaking change which fixes an issue)</li>
</ul>
<h2>How Has This Been Tested?</h2>
<ul>
<li>[x] I believe this change is already covered by existing unit tests</li>
</ul>
<h2>Suggested Checklist:</h2>
<ul>
<li>[x] I have performed a self-review of my own code</li>
<li>[x] My changes generate no new warnings</li>
<li>[x] New and existing unit tests pass locally with my changes</li>
</ul></body></html><!--EndFragment-->
</body>
</html>