### PR TITLE
fix: close leaked file handle in AzureCodeInterpreter upload_file

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
@@ -226,31 +226,38 @@ class AzureCodeInterpreterToolSpec(BaseToolSpec):
         if data and local_file_path:
             raise ValueError("data and local_file_path cannot be provided together")
 
+        opened_file = None
         if local_file_path:
             remote_file_path = f"/mnt/data/{os.path.basename(local_file_path)}"
-            data = open(local_file_path, "rb")
+            data = opened_file = open(local_file_path, "rb")
 
-        access_token = self.access_token_provider()
-        if not remote_file_path.startswith("/mnt/data"):
-            remote_file_path = f"/mnt/data/{remote_file_path}"
-        api_url = self._build_url("files/upload")
-        headers = {
-            "Authorization": f"Bearer {access_token}",
-        }
+        try:
+            access_token = self.access_token_provider()
+            if not remote_file_path.startswith("/mnt/data"):
+                remote_file_path = f"/mnt/data/{remote_file_path}"
+            api_url = self._build_url("files/upload")
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+            }
 
-        files = [("file", (remote_file_path, data, "application/octet-stream"))]
+            files = [("file", (remote_file_path, data, "application/octet-stream"))]
 
-        response = requests.request("POST", api_url, headers=headers, files=files)
-        response.raise_for_status()
+            response = requests.request("POST", api_url, headers=headers, files=files)
+            response.raise_for_status()
 
-        response_json = response.json()
-        remote_files_metadatas = []
-        for entry in response_json["value"]:
-            if "properties" in entry:
-                remote_files_metadatas.append(
-                    RemoteFileMetadata.from_dict(entry["properties"])
-                )
-        return remote_files_metadatas
+            response_json = response.json()
+            remote_files_metadatas = []
+            for entry in response_json["value"]:
+                if "properties" in entry:
+                    remote_files_metadatas.append(
+                        RemoteFileMetadata.from_dict(entry["properties"])
+                    )
+            return remote_files_metadatas
+        finally:
+            # Close the handle we opened here (only when we opened it), so the
+            # file descriptor isn't leaked on success or error paths.
+            if opened_file is not None:
+                opened_file.close()
 
     def download_file_to_local(
         self, remote_file_path: str, local_file_path: Optional[str] = None

--- a/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-azure-code-interpreter/llama_index/tools/azure_code_interpreter/base.py
@@ -229,7 +229,8 @@ class AzureCodeInterpreterToolSpec(BaseToolSpec):
         opened_file = None
         if local_file_path:
             remote_file_path = f"/mnt/data/{os.path.basename(local_file_path)}"
-            data = opened_file = open(local_file_path, "rb")
+            opened_file = open(local_file_path, "rb")
+            data = opened_file
 
         try:
             access_token = self.access_token_provider()


### PR DESCRIPTION
## Description

`AzureCodeInterpreterToolSpec.upload_file()` opens the local file but never closes it:

```python
if local_file_path:
    remote_file_path = f"/mnt/data/{os.path.basename(local_file_path)}"
    data = open(local_file_path, "rb")   # never closed
```

The handle is passed to `requests.request(..., files=...)` and the function then returns without closing it, leaking a file descriptor on every `upload_file(local_file_path=...)` call — and on the error path too. Repeated uploads (common in agent loops) can exhaust `RLIMIT_NOFILE` ("too many open files").

## Fix

Track the handle we open and close it in a `try/finally`, so it's released on success and error paths. Only the handle we open here is closed (a caller-supplied `data` object is left untouched).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

`python -m py_compile` clean; the change is minimal and scoped to the leak.
