### PR TITLE
feat(bedrock-converse): add Claude Fable 5 to model allowlists

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -69,6 +69,7 @@ BEDROCK_MODELS = {
     "anthropic.claude-opus-4-6-v1": 1000000,
     "anthropic.claude-opus-4-7": 1000000,
     "anthropic.claude-opus-4-8": 1000000,
+    "anthropic.claude-fable-5": 1000000,
     "anthropic.claude-sonnet-4-20250514-v1:0": 200000,
     "anthropic.claude-sonnet-4-5-20250929-v1:0": 200000,
     "anthropic.claude-sonnet-4-6": 1000000,
@@ -129,6 +130,7 @@ BEDROCK_FUNCTION_CALLING_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -170,6 +172,7 @@ BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -195,6 +198,7 @@ BEDROCK_PROMPT_CACHING_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -215,6 +219,7 @@ BEDROCK_REASONING_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
     "anthropic.claude-sonnet-4-20250514-v1:0",
     "anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic.claude-sonnet-4-6",
@@ -228,12 +233,14 @@ BEDROCK_ADAPTIVE_THINKING_SUPPORTED_MODELS = (
     "anthropic.claude-opus-4-6-v1",
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
     "anthropic.claude-sonnet-4-6",
 )
 
 BEDROCK_NO_TEMP_MODELS = (
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-fable-5",
 )
 
 

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.13"
+version = "0.14.14"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
## Summary

Add `anthropic.claude-fable-5` to all relevant Bedrock Converse model allowlists:

- `BEDROCK_MODELS` (1M context window)
- `BEDROCK_FUNCTION_CALLING_MODELS`
- `BEDROCK_INFERENCE_PROFILE_SUPPORTED_MODELS`
- `BEDROCK_PROMPT_CACHING_SUPPORTED_MODELS`
- `BEDROCK_REASONING_MODELS`
- `BEDROCK_ADAPTIVE_THINKING_SUPPORTED_MODELS`
- `BEDROCK_NO_TEMP_MODELS` (temperature is rejected by this model)

Fable 5 is Anthropic's newest model tier — 1M context, adaptive thinking only (no `budget_tokens`), and sampling parameters (`temperature`, `top_p`, `top_k`) are not accepted. This follows the same pattern as the recent Opus 4.8 addition (#21802).

Bumps package version to 0.14.14.

## Test plan

- [ ] Verified the model ID `anthropic.claude-fable-5` matches the convention used in `llama-index-llms-anthropic` (PR #21919)
- [ ] Confirmed the model is added to all the same allowlists as Opus 4.8
- [ ] All pre-commit hooks pass