### PR TITLE
docs: add SynapCores vector store + property graph store to community integrations

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/graph_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/graph_stores.md
@@ -44,3 +44,18 @@ We support a `TiDBGraphStore` integration, for persisting graphs directly in [Ti
 See the associated guides below:
 
 - [TiDB Graph Store](/python/examples/index_structs/knowledge_graph/tidbkgindexdemo)
+
+## `SynapCoresPropertyGraphStore`
+
+We support a `SynapCoresPropertyGraphStore` integration that implements the full `PropertyGraphStore` ABC against [SynapCores](https://synapcores.com), a self-hosted AI-native SQL engine that combines vector search, graph traversal, SQL, and AI inference in a single binary. The integration declares both `supports_structured_queries=True` (Cypher pass-through with named-param binding) and `supports_vector_queries=True` (cosine over `ChunkNode` embeddings), implements the depth-bounded `get_rel_map` primitive used by `PropertyGraphIndex.as_retriever()`, and persists entities, relations, and chunks as native Cypher nodes.
+
+To start the engine locally:
+
+```sh
+docker run -p 8080:8080 -e AIDB_ACCEPT_LICENSE=1 synapcores/community:latest
+```
+
+See the associated guides below:
+
+- [SynapCores Property Graph Store](https://github.com/SynapCores/synapcores-llamaindex/blob/master/notebooks/property_graph_synapcores.ipynb)
+- [`llama-index-graph-stores-synapcores` on PyPI](https://pypi.org/project/llama-index-graph-stores-synapcores/)

--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -48,6 +48,7 @@ as the storage backend for `VectorStoreIndex`.
 - Redis (`RedisVectorStore`). [Installation](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/).
 - Relyt (`RelytVectorStore`). [Quickstart](https://docs.relyt.cn/docs/vector-engine/).
 - Supabase (`SupabaseVectorStore`). [Quickstart](https://supabase.github.io/vecs/api/).
+- SynapCores (`SynapCoresVectorStore`). [Quickstart](https://github.com/SynapCores/synapcores-llamaindex). [Docker Image](https://hub.docker.com/r/synapcores/community).
 - Tablestore (`Tablestore`). [Tablestore Overview](https://www.aliyun.com/product/ots). [Quickstart](/python/examples/vector_stores/tablestoredemo). [Python Client](https://github.com/aliyun/aliyun-tablestore-python-sdk).
 - TiDB (`TiDBVectorStore`). [Quickstart](/python/examples/vector_stores/tidbvector). [Installation](https://tidb.cloud/ai). [Python Client](https://github.com/pingcap/tidb-vector-python).
 - TimeScale (`TimescaleVectorStore`). [Installation](https://github.com/timescale/python-vector).


### PR DESCRIPTION
## Summary

Adds [SynapCores](https://synapcores.com) to the community integrations listings — one bullet to `vector_stores.md`, one new section to `graph_stores.md`. Both packages are already on PyPI:

- [`llama-index-vector-stores-synapcores`](https://pypi.org/project/llama-index-vector-stores-synapcores/) — `SynapCoresVectorStore(BasePydanticVectorStore)` for RAG
- [`llama-index-graph-stores-synapcores`](https://pypi.org/project/llama-index-graph-stores-synapcores/) — `SynapCoresPropertyGraphStore(PropertyGraphStore)` for GraphRAG

SynapCores is an open-core, self-hosted AI-native SQL engine that combines vector search, graph traversal, SQL, and AI inference in a single binary. The two integration packages let LlamaIndex users back both `VectorStoreIndex` and `PropertyGraphIndex` with one container instead of stitching together separate vector and graph databases.

## What works

**Vector store.** Full `BasePydanticVectorStore` ABC: `add`, `delete`, `query`, `delete_nodes`, `clear`, and the async surface via `asyncio.to_thread`. Full `MetadataFilters` grammar — all 12 operators (`EQ`, `NE`, `GT`/`GTE`/`LT`/`LTE`, `IN`, `NIN`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, `CONTAINS`, `IS_EMPTY`) with `AND` / `OR` / `NOT` and nested groups. Upsert on the primary key. `VectorStoreIndex.from_vector_store(vs)` for picking up existing data.

**Property graph store.** Full `PropertyGraphStore` ABC with both `supports_structured_queries=True` and `supports_vector_queries=True`. All 8 required abstract methods including `get_rel_map(depth=N)` — the depth-bounded BFS primitive that backs `PropertyGraphIndex.as_retriever()` — `structured_query()` Cypher pass-through with named-param binding, and `vector_query` over `ChunkNode` embeddings.

## Test coverage

48 tests against a live engine via docker-compose (23 vector + 25 graph). 9-cell and 10-cell notebooks execute end-to-end with real HuggingFace MiniLM embeddings (384 dims, includes negative values).

- Source + tests: https://github.com/SynapCores/synapcores-llamaindex
- Notebooks: https://github.com/SynapCores/synapcores-llamaindex/tree/master/notebooks

## Try it locally

```sh
docker run -p 8080:8080 -e AIDB_ACCEPT_LICENSE=1 synapcores/community:latest
pip install llama-index llama-index-vector-stores-synapcores llama-index-graph-stores-synapcores
```

```python
from llama_index.vector_stores.synapcores import SynapCoresVectorStore
from llama_index.graph_stores.synapcores import SynapCoresPropertyGraphStore

vector_store = SynapCoresVectorStore(uri="http://localhost:8080", embedding_dim=1536)
graph_store = SynapCoresPropertyGraphStore(uri="http://localhost:8080")
```

Happy to address anything reviewers want to see changed.