### PR TITLE
LLama Index Core IngestionCache: add async protocol

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/cache.py
+++ b/llama-index-core/llama_index/core/ingestion/cache.py
@@ -10,6 +10,7 @@ from llama_index.core.storage.kvstore import (
 from llama_index.core.storage.kvstore.types import (
     BaseKVStore as BaseCache,
 )
+from llama_index.core.async_utils import run_async_tasks
 
 DEFAULT_CACHE_NAME = "llama_cache"
 
@@ -23,7 +24,6 @@ class IngestionCache(BaseModel):
     )
     cache: BaseCache = Field(default_factory=SimpleCache, description="Cache to use.")
 
-    # TODO: add async get/put methods?
     def put(
         self, key: str, nodes: Sequence[BaseNode], collection: Optional[str] = None
     ) -> None:
@@ -52,6 +52,36 @@ class IngestionCache(BaseModel):
         for key in data:
             self.cache.delete(key, collection=collection)
 
+    async def aput(
+        self, key: str, nodes: Sequence[BaseNode], collection: Optional[str] = None
+    ) -> None:
+        """Async put a value into the cache."""
+        collection = collection or self.collection
+
+        val = {self.nodes_key: [doc_to_json(node) for node in nodes]}
+        await self.cache.aput(key, val, collection=collection)
+
+    async def aget(
+        self, key: str, collection: Optional[str] = None
+    ) -> Optional[Sequence[BaseNode]]:
+        """Async get a value from the cache."""
+        collection = collection or self.collection
+        node_dicts = await self.cache.aget(key, collection=collection)
+
+        if node_dicts is None:
+            return None
+
+        return [json_to_doc(node_dict) for node_dict in node_dicts[self.nodes_key]]
+
+    async def aclear(self, collection: Optional[str] = None) -> None:
+        """Async clear the cache."""
+        collection = collection or self.collection
+        data = await self.cache.aget_all(collection=collection)
+
+        tasks = [self.cache.adelete(key, collection=collection) for key in data]
+        run_async_tasks(tasks)
+
+    # TODO: add async persist?
     def persist(
         self, persist_path: str, fs: Optional[fsspec.AbstractFileSystem] = None
     ) -> None:

--- a/llama-index-core/tests/ingestion/test_cache.py
+++ b/llama-index-core/tests/ingestion/test_cache.py
@@ -1,5 +1,7 @@
 from typing import Any, List
 
+import pytest
+
 from llama_index.core.ingestion import IngestionCache
 from llama_index.core.ingestion.pipeline import get_transformation_hash
 from llama_index.core.schema import BaseNode, TextNode, TransformComponent
@@ -45,3 +47,43 @@ def test_cache_clear() -> None:
 
     cache.clear()
     assert cache.get(hash) is None
+
+
+@pytest.mark.asyncio
+async def test_async_cache() -> None:
+    cache = IngestionCache()
+    transformation = DummyTransform()
+
+    node = TextNode(text="dummy")
+    hash = get_transformation_hash([node], transformation)
+
+    new_nodes = transformation([node])
+    await cache.aput(hash, new_nodes)
+
+    cache_hit = await cache.aget(hash)
+    assert cache_hit is not None
+    assert cache_hit[0].get_content() == new_nodes[0].get_content()
+
+    new_hash = get_transformation_hash(new_nodes, transformation)
+    new_hash_cache_hit = await cache.aget(new_hash)
+    assert new_hash_cache_hit is None
+
+
+@pytest.mark.asyncio
+async def test__async_cache_clear() -> None:
+    cache = IngestionCache()
+    transformation = DummyTransform()
+
+    node1 = TextNode(text="dummy1")
+    node2 = TextNode(text="dummy2")
+    hash = get_transformation_hash([node1, node2], transformation)
+
+    new_nodes = transformation([node1, node2])
+    cache.put(hash, new_nodes)
+
+    cache_hit = await cache.aget(hash)
+    assert cache_hit is not None
+
+    await cache.aclear()
+    new_cache_hit = await cache.aget(hash)
+    assert new_cache_hit is None


### PR DESCRIPTION
# Description

Add llama_index core IngestionCache async protocol implementation to support non block functionality

Further consideration: to add async persist, will need non blocking file I/O package, since fsspec support only non blocking HTTPFileSystem

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
