### PR TITLE
fix(onedrive-reader): sanitize remote filename to prevent path traversal

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -267,7 +267,13 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         """
         # Extract download URL and filename from the provided item.
         file_download_url = item["@microsoft.graph.downloadUrl"]
-        file_name = item["name"]
+        # os.path.basename strips any directory components from the remote
+        # filename so a value like "../evil.txt" cannot escape local_dir.
+        file_name = os.path.basename(item["name"])
+        if not file_name:
+            raise ValueError(
+                f"OneDrive item has an invalid or empty filename: {item.get('name')!r}"
+            )
 
         # Download the file.
         file_data = requests.get(file_download_url)


### PR DESCRIPTION
## Summary

Fixes #21867

The `_download_file_by_url` method in `llama-index-readers-microsoft-onedrive` used the remote-controlled `item["name"]` field directly to construct a local file path:

```python
file_name = item["name"]                        # ← unsanitized remote value
file_path = os.path.join(local_dir, file_name)  # ← path escape possible
```

When a Microsoft Graph API response contains a filename with path traversal sequences (e.g. `../secrets.txt`), `os.path.join` resolves the path outside the intended `local_dir`, writing the file to an arbitrary location on the host filesystem. This is the same pattern as CVE-2025-1060 (internetarchive).

**Fix:** apply `os.path.basename()` to strip any directory components from the remote filename before building the local path. Also raise `ValueError` when `basename` returns an empty string (e.g. for a name that is entirely path separators), so callers get a clear error instead of silently writing to the directory root.

## Changes

- `llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py`
  - `_download_file_by_url`: wrap `item["name"]` in `os.path.basename()` and guard against an empty result

## Test plan

- [ ] Unit test: `_download_file_by_url` with `item["name"] = "../evil.txt"` should now produce a path inside `local_dir`, not above it
- [ ] Unit test: `item["name"] = "/absolute/path.txt"` (POSIX) and `"C:\..\path.txt"` (Windows basename) → basename returns only `path.txt`
- [ ] Existing `load_data()` integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)