### PR TITLE
fix: add timeout to HTTP requests across integration packages

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
@@ -82,7 +82,7 @@ def get_pooling_mode(model_name: Optional[str]) -> str:
     )
 
     try:
-        response = requests.get(pooling_config_url)
+        response = requests.get(pooling_config_url, timeout=60)
         config_data = response.json()
 
         cls_token = config_data.get("pooling_mode_cls_token", False)

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/base.py
@@ -141,6 +141,7 @@ class DashScopeCloudIndex(BaseManagedIndex):
         response = requests.post(
             base_url + START_PIPELINE_ENDPOINT.format(pipeline_id=pipeline_id),
             headers=headers,
+            timeout=60,
         )
         response_text = response.json()
         ingestion_id = response_text.get("ingestionId", None)
@@ -268,6 +269,7 @@ class DashScopeCloudIndex(BaseManagedIndex):
             self._base_url + DELETE_DOC_ENDPOINT.format(pipeline_id=pipeline_id),
             json=doc_delete,
             headers=self._headers,
+            timeout=60,
         )
         response_text = response.json()
         if response_text.get("code", "") != Status.SUCCESS.value:

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
@@ -3,7 +3,7 @@ import time
 
 
 def post(base_url: str, headers: dict, params: dict):
-    response = requests.post(base_url, headers=headers, json=params)
+    response = requests.post(base_url, headers=headers, json=params, timeout=60)
     if response.status_code != 200:
         raise RuntimeError(response.text)
     response_dict = response.json()
@@ -13,7 +13,7 @@ def post(base_url: str, headers: dict, params: dict):
 
 
 def get(base_url: str, headers: dict, params: dict):
-    response = requests.get(base_url, headers=headers, params=params)
+    response = requests.get(base_url, headers=headers, params=params, timeout=60)
     if response.status_code != 200:
         raise RuntimeError(response.text)
 
@@ -36,6 +36,7 @@ def run_ingestion(request_url: str, headers: dict, verbose: bool = False):
         response = requests.get(
             request_url,
             headers=headers,
+            timeout=60,
         )
         try:
             response_text = response.json()

--- a/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
@@ -22,7 +22,7 @@ def _request(base_url: str, api_key: str, **kwargs) -> Dict[str, Any]:
     for better input/output typing support.
     """
     headers = {"x-api-key": api_key}
-    response = requests.post(base_url, headers=headers, json=kwargs)
+    response = requests.post(base_url, headers=headers, json=kwargs, timeout=60)
     response.raise_for_status()
     return response.json()
 
@@ -32,7 +32,7 @@ def _request_stream(
 ) -> Generator[str, None, None]:
     headers = {"x-api-key": api_key}
     params = dict(**kwargs, stream=True)
-    response = requests.post(base_url, headers=headers, stream=True, json=params)
+    response = requests.post(base_url, headers=headers, stream=True, json=params, timeout=60)
     response.raise_for_status()
 
     client = sseclient.SSEClient(response)

--- a/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
@@ -87,7 +87,7 @@ class IntercomReader(BaseReader):
             "authorization": f"Bearer {self.intercom_access_token}",
         }
 
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=60)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
@@ -174,7 +174,7 @@ class KalturaESearchReader(BaseReader):
             cap_json_url = self.client.caption.captionAsset.serveAsJson(
                 caption_asset_id
             )
-            return requests.get(cap_json_url).json()
+            return requests.get(cap_json_url, timeout=60).json()
         except Exception as e:
             logger.error(f"An error occurred while getting captions: {e}")
             return {}

--- a/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
@@ -83,7 +83,7 @@ class ZendeskReader(BaseReader):
         else:
             url = next_page
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=60)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
@@ -32,7 +32,7 @@ class OpenAPIToolSpec(BaseToolSpec):
         elif spec:
             pass
         elif url:
-            response = requests.get(url).text
+            response = requests.get(url, timeout=60).text
             spec = yaml.safe_load(response)
         else:
             raise ValueError("You must provide a url or OpenAPI spec as a dict")

--- a/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
@@ -52,7 +52,7 @@ class TextToImageToolSpec(BaseToolSpec):
         """
         try:
             response = openai.Image.create_variation(
-                image=BytesIO(requests.get(url).content).getvalue(), n=n, size=size
+                image=BytesIO(requests.get(url, timeout=60).content).getvalue(), n=n, size=size
             )
             return [image["url"] for image in response["data"]]
         except openai.error.OpenAIError as e:
@@ -71,5 +71,5 @@ class TextToImageToolSpec(BaseToolSpec):
 
         for url in urls:
             plt.figure()
-            plt.imshow(Image.open(BytesIO(requests.get(url).content)))
+            plt.imshow(Image.open(BytesIO(requests.get(url, timeout=60).content)))
         return "images rendered successfully"

--- a/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
@@ -78,6 +78,6 @@ class WolframAlphaToolSpec(BaseToolSpec):
         params = {"input": query, **self._api_params}
         url = f"{QUERY_URL_TMPL}?{urllib.parse.urlencode(params)}"
         headers = {"Authorization": f"Bearer {self.token}"}
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=60)
         response.raise_for_status()
         return response.text


### PR DESCRIPTION
## Description

Several integration packages make HTTP requests with `requests.get()` / `requests.post()` **without a `timeout`**, so a call can hang indefinitely if the remote server is unresponsive — freezing the calling thread with no way to recover (per #22028).

This adds `timeout=60` to every such call. `60s` is generous enough not to break slow LLM/search APIs while guaranteeing a hung connection eventually fails instead of blocking forever. No behavioral change on the success path.

### Packages fixed
- `llama-index-embeddings-huggingface` — `utils.py` (pooling-config fetch)
- `llama-index-llms-you` — `base.py` (2 calls)
- `llama-index-tools-wolfram-alpha` — `base.py`
- `llama-index-tools-text-to-image` — `base.py` (2 calls)
- `llama-index-tools-openapi` — `base.py`
- `llama-index-readers-kaltura` — `base.py`
- `llama-index-readers-zendesk` — `base.py`
- `llama-index-readers-intercom` — `base.py`
- `llama-index-indices-managed-dashscope` — `utils.py` + `base.py` (also covered the remaining HTTP calls in this package for completeness)

10 files, +15/−12, logic-only. All files compile clean.

Fixes #22028

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
