### PR TITLE
fix(readers): preserve remote PDF URIs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
@@ -39,15 +39,21 @@ class PDFReader(BaseReader):
     )
     def load_data(
         self,
-        file: Union[Path, PurePosixPath],
+        file: Union[Path, PurePosixPath, str],
         extra_info: Optional[Dict] = None,
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
         """Parse file."""
         fs = fs or get_default_fs()
-        _Path = Path if is_default_fs(fs) else PurePosixPath
+        default_fs = is_default_fs(fs)
+        _Path = Path if default_fs else PurePosixPath
         if not isinstance(file, (Path, PurePosixPath)):
-            file = _Path(file)
+            file = _Path(file) if default_fs else file
+        file_name = (
+            file.name
+            if isinstance(file, (Path, PurePosixPath))
+            else PurePosixPath(file).name
+        )
 
         try:
             import pypdf
@@ -59,7 +65,7 @@ class PDFReader(BaseReader):
         with fs.open(str(file), "rb") as fp:
             # Load the file in memory if the filesystem is not the default one to avoid
             # issues with pypdf
-            stream = fp if is_default_fs(fs) else io.BytesIO(fp.read())
+            stream = fp if default_fs else io.BytesIO(fp.read())
 
             # Create a PDF object
             pdf = pypdf.PdfReader(stream)
@@ -71,7 +77,7 @@ class PDFReader(BaseReader):
 
             # This block returns a whole PDF as a single Document
             if self.return_full_document:
-                metadata = {"file_name": file.name}
+                metadata = {"file_name": file_name}
                 if extra_info is not None:
                     metadata.update(extra_info)
 
@@ -91,7 +97,7 @@ class PDFReader(BaseReader):
                     page_text = pdf.pages[page].extract_text()
                     page_label = pdf.page_labels[page]
 
-                    metadata = {"page_label": page_label, "file_name": file.name}
+                    metadata = {"page_label": page_label, "file_name": file_name}
                     if extra_info is not None:
                         metadata.update(extra_info)
 

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_docs.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_docs.py
@@ -1,8 +1,10 @@
+import io
 import os
 import pypdf
 import pytest
 import tempfile
 from fpdf import FPDF
+from fsspec import AbstractFileSystem
 from llama_index.readers.file import PDFReader
 from pathlib import Path
 from typing import Dict
@@ -103,3 +105,30 @@ def test_pdfreader_loads_metadata_into_multiple_documents(
         assert docs[page].metadata == expected_metadata
 
     os.remove(temp_file.name)
+
+
+def test_pdfreader_preserves_remote_uri_for_non_default_filesystem(
+    multi_page_pdf: FPDF,
+) -> None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+        multi_page_pdf.output(temp_file.name)
+        temp_file_path = Path(temp_file.name)
+    pdf_bytes = temp_file_path.read_bytes()
+    os.remove(temp_file.name)
+
+    remote_uri = "s3://bucket/path/to/test.pdf"
+
+    class RemoteFileSystem(AbstractFileSystem):
+        opened_path = ""
+
+        def open(self, path: str, mode: str) -> io.BytesIO:
+            self.opened_path = path
+            return io.BytesIO(pdf_bytes)
+
+    fs = RemoteFileSystem()
+    reader = PDFReader(return_full_document=True)
+
+    docs = reader.load_data(remote_uri, fs=fs)
+
+    assert fs.opened_path == remote_uri
+    assert docs[0].metadata["file_name"] == "test.pdf"


### PR DESCRIPTION
# Description

Fixes #15406.

`PDFReader.load_data(..., fs=<non-default fsspec fs>)` currently routes string inputs through `PurePosixPath`. That is safe for plain bucket/key paths, but it corrupts URI-style remote paths such as `s3://bucket/path/to/file.pdf` into `s3:/bucket/path/to/file.pdf` before calling `fs.open(...)`.

This keeps local/default filesystem behavior unchanged, while preserving string paths exactly for non-default filesystems. Metadata filename extraction still works for both `Path`-like and string inputs.

Related prior attempt: #21353 addressed the same issue shape but is closed and did not include a regression test. This PR keeps the diff narrow and adds direct coverage for URI preservation.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Local verification:

- `uv run -- pytest tests/test_docs.py::test_pdfreader_preserves_remote_uri_for_non_default_filesystem -q` (red before fix, green after)
- `uv run ruff check llama_index/readers/file/docs/base.py tests/test_docs.py`
- `uv run ruff format --check llama_index/readers/file/docs/base.py tests/test_docs.py`
- `uv run -- pytest tests/test_file.py tests/test_docs.py -q` (32 passed)

Second-agent review:

- Preferred reviewer `claude -p` was unavailable due auth 401.
- Fallback fresh-context Hermes subagent reviewed `/tmp/oss-pr-second-agent-review.diff`.
- Initial finding: remove accidental `uv.lock` change from local `uv run`; fixed by reverting `uv.lock`.
- Rerun result: CLEAN, no blocking correctness/security/test/maintainer-fit issues.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run ruff check ...` and `uv run ruff format --check ...`

AI assistance disclosure: drafted with Hermes Agent. I inspected the issue thread, existing path-handling code, related closed PRs, and verified the change with a failing-first regression test plus focused local checks.
