### PR TITLE
fix(llms/perplexity): keep aiohttp session open while streaming response

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-perplexity/llama_index/llms/perplexity/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-perplexity/llama_index/llms/perplexity/base.py
@@ -372,35 +372,39 @@ class Perplexity(LLM):
         }
 
         @retry(stop=stop_after_attempt(self.max_retries), wait=wait_fixed(1))
-        async def make_request():
-            async with aiohttp.ClientSession() as session:
-                response = await session.post(
-                    url, json=payload, headers=self.headers, timeout=self.timeout
-                )
-                response.raise_for_status()
-                return response
+        async def make_request(session: aiohttp.ClientSession):
+            response = await session.post(
+                url, json=payload, headers=self.headers, timeout=self.timeout
+            )
+            response.raise_for_status()
+            return response
 
         async def gen() -> CompletionResponseAsyncGen:
-            response = await make_request()
             text = ""
 
-            async for line in response.content:
-                line_text = line.decode("utf-8").strip()
-                if line_text.startswith("data:"):
-                    line_text = line_text[5:]
-                    if line_text.strip() == "[DONE]":
-                        break
-                    try:
-                        data = json.loads(line_text)
-                        if "choices" in data and data["choices"]:
-                            delta = data["choices"][0]["delta"].get("content", "")
-                            if delta:
-                                text += delta
-                                yield CompletionResponse(
-                                    delta=delta, text=text, raw=data
-                                )
-                    except json.JSONDecodeError:
-                        continue  # Skip malformed JSON
+            # Keep the session open while the streamed body is consumed. Returning
+            # the response out of the ``async with`` closed the session before
+            # ``response.content`` was read, which raised at read time. Mirrors
+            # ``_acomplete``, which reads the body inside the client block.
+            async with aiohttp.ClientSession() as session:
+                response = await make_request(session)
+                async for line in response.content:
+                    line_text = line.decode("utf-8").strip()
+                    if line_text.startswith("data:"):
+                        line_text = line_text[5:]
+                        if line_text.strip() == "[DONE]":
+                            break
+                        try:
+                            data = json.loads(line_text)
+                            if "choices" in data and data["choices"]:
+                                delta = data["choices"][0]["delta"].get("content", "")
+                                if delta:
+                                    text += delta
+                                    yield CompletionResponse(
+                                        delta=delta, text=text, raw=data
+                                    )
+                        except json.JSONDecodeError:
+                            continue  # Skip malformed JSON
 
         return gen()
 
@@ -478,37 +482,43 @@ class Perplexity(LLM):
         }
 
         @retry(stop=stop_after_attempt(self.max_retries), wait=wait_fixed(1))
-        async def make_request():
-            async with aiohttp.ClientSession() as session:
-                response = await session.post(
-                    url, json=payload, headers=self.headers, timeout=self.timeout
-                )
-                response.raise_for_status()
-                return response
+        async def make_request(session: aiohttp.ClientSession):
+            response = await session.post(
+                url, json=payload, headers=self.headers, timeout=self.timeout
+            )
+            response.raise_for_status()
+            return response
 
         async def gen():
-            response = await make_request()
             text = ""
 
-            async for line in response.content:
-                line_text = line.decode("utf-8").strip()
-                if line_text.startswith("data:"):
-                    line_text = line_text[5:]
-                    if line_text.strip() == "[DONE]":
-                        break
-                    try:
-                        data = json.loads(line_text)
-                        if "choices" in data and data["choices"]:
-                            delta = data["choices"][0]["delta"].get("content", "")
-                            if delta:
-                                text += delta
-                                yield ChatResponse(
-                                    message=ChatMessage(role="assistant", content=text),
-                                    delta=delta,
-                                    raw=data,
-                                )
-                    except json.JSONDecodeError:
-                        continue  # Skip malformed JSON
+            # Keep the session open while the streamed body is consumed. Returning
+            # the response out of the ``async with`` closed the session before
+            # ``response.content`` was read, which raised at read time. Mirrors
+            # ``_achat``, which reads the body inside the client block.
+            async with aiohttp.ClientSession() as session:
+                response = await make_request(session)
+                async for line in response.content:
+                    line_text = line.decode("utf-8").strip()
+                    if line_text.startswith("data:"):
+                        line_text = line_text[5:]
+                        if line_text.strip() == "[DONE]":
+                            break
+                        try:
+                            data = json.loads(line_text)
+                            if "choices" in data and data["choices"]:
+                                delta = data["choices"][0]["delta"].get("content", "")
+                                if delta:
+                                    text += delta
+                                    yield ChatResponse(
+                                        message=ChatMessage(
+                                            role="assistant", content=text
+                                        ),
+                                        delta=delta,
+                                        raw=data,
+                                    )
+                        except json.JSONDecodeError:
+                            continue  # Skip malformed JSON
 
         return gen()
 

--- a/llama-index-integrations/llms/llama-index-llms-perplexity/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-perplexity/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-perplexity"
-version = "0.5.1"
+version = "0.5.2"
 description = "llama-index llms perplexity integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-perplexity/tests/test_perplexity_streaming.py
+++ b/llama-index-integrations/llms/llama-index-llms-perplexity/tests/test_perplexity_streaming.py
@@ -1,0 +1,85 @@
+"""Regression tests for the async streaming session lifecycle.
+
+`_astream_complete` / `_astream_chat` must read the streamed response body while
+the ``aiohttp.ClientSession`` is still open. Previously they returned the
+response out of the ``async with aiohttp.ClientSession()`` block, so the session
+was closed before ``response.content`` was iterated, raising at read time.
+"""
+
+import aiohttp
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.llms.perplexity import Perplexity
+
+
+class _FakeContent:
+    """Async line iterator that fails once its session has been closed,
+    mirroring aiohttp's behaviour when the connection is released."""
+
+    def __init__(self, lines, session):
+        self._lines = list(lines)
+        self._session = session
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._session.closed:
+            raise RuntimeError("Cannot read from a closed aiohttp session")
+        if not self._lines:
+            raise StopAsyncIteration
+        return self._lines.pop(0)
+
+
+class _FakeResponse:
+    def __init__(self, lines, session):
+        self.content = _FakeContent(lines, session)
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeSession:
+    def __init__(self, lines):
+        self._lines = lines
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+    async def post(self, *args, **kwargs):
+        return _FakeResponse(self._lines, self)
+
+
+_SSE_LINES = [
+    b'data: {"choices": [{"delta": {"content": "Hello"}}]}',
+    b'data: {"choices": [{"delta": {"content": " world"}}]}',
+    b"data: [DONE]",
+]
+
+
+@pytest.mark.asyncio
+async def test_astream_complete_reads_body_before_session_closes(monkeypatch):
+    monkeypatch.setattr(
+        aiohttp, "ClientSession", lambda *a, **k: _FakeSession(list(_SSE_LINES))
+    )
+    llm = Perplexity(api_key="test", model="sonar")
+    gen = await llm.astream_complete("hi")
+    deltas = [chunk.delta async for chunk in gen]
+    assert "".join(deltas) == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_reads_body_before_session_closes(monkeypatch):
+    monkeypatch.setattr(
+        aiohttp, "ClientSession", lambda *a, **k: _FakeSession(list(_SSE_LINES))
+    )
+    llm = Perplexity(api_key="test", model="sonar")
+    gen = await llm.astream_chat([ChatMessage(role="user", content="hi")])
+    deltas = [chunk.delta async for chunk in gen]
+    assert "".join(deltas) == "Hello world"


### PR DESCRIPTION
# Description

`Perplexity._astream_complete` and `_astream_chat` build the streamed response inside an inner `make_request()` that wraps the POST in `async with aiohttp.ClientSession() as session:` and **returns the response out of that block**. The `async with` closes the session (and its connector) on exit, so by the time `gen()` iterates `response.content` the session is already closed and aiohttp raises while reading the body — every `astream_complete` / `astream_chat` call fails on a real Perplexity endpoint.

The non-streaming siblings `_acomplete` / `_achat` do it correctly: they read the body **inside** the `async with httpx.AsyncClient()` block. This PR aligns the streaming paths with that contract — the `aiohttp.ClientSession` is now created in `gen()` and kept open for the full duration of the streamed iteration (the `@retry`-wrapped POST still runs, now against the passed-in session). No API or happy-path behaviour change.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-llms-perplexity` 0.5.1 → 0.5.2
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `tests/test_perplexity_streaming.py` with two tests that patch `aiohttp.ClientSession` with a fake whose stream reader raises once the session is closed (mirroring aiohttp's real behaviour). On `main` both fail with `RuntimeError: Cannot read from a closed aiohttp session`, raised from `base.py` at `async for line in response.content`; after the fix both pass. Full package suite: **17 passed, 8 skipped** (skips are live-API key-gated). `uv run ruff check` / `ruff format` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
