### PR TITLE
docs(serpex-example): default to gpt-4o-mini for cost savings

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-serpex/examples/serpex_example.py
+++ b/llama-index-integrations/tools/llama-index-tools-serpex/examples/serpex_example.py
@@ -80,7 +80,9 @@ def agent_example():
         serpex_tool = SerpexToolSpec()
 
         # Create agent
-        llm = OpenAI(model="gpt-4")
+        # Use gpt-4o-mini for examples: ~20x cheaper than gpt-4 and sufficient
+        # for tool-routing tasks. Users can swap for a larger model if needed.
+        llm = OpenAI(model="gpt-4o-mini")
         agent = OpenAIAgent.from_tools(serpex_tool.to_tool_list(), llm=llm, verbose=True)
 
         # Ask question that requires web search


### PR DESCRIPTION
The SERPEX tool example used model="gpt-4" for the agent demo, which costs ~20x more than gpt-4o-mini per token ($30/1M vs $0.15/1M input) without adding quality for a tool-routing demo. Swap to gpt-4o-mini and add a short comment so users understand the choice and can opt up if needed.

Docstring/example only — no library code or public API changes.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
