### PR TITLE
fix(readers-minio): default TLS verification to True in BotoMinioReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
@@ -36,6 +36,7 @@ class BotoMinioReader(BaseReader):
         aws_access_secret: Optional[str] = None,
         aws_session_token: Optional[str] = None,
         s3_endpoint_url: Optional[str] = "https://s3.amazonaws.com",
+        verify: bool = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -62,6 +63,8 @@ class BotoMinioReader(BaseReader):
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.
         s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
+        verify (bool): Whether to verify TLS certificates. Defaults to True.
+            Set to False only for self-signed certs in controlled environments.
 
         """
         super().__init__(*args, **kwargs)
@@ -80,6 +83,7 @@ class BotoMinioReader(BaseReader):
         self.aws_access_secret = aws_access_secret
         self.aws_session_token = aws_session_token
         self.s3_endpoint_url = s3_endpoint_url
+        self.verify = verify
 
     def load_data(self) -> List[Document]:
         """Load file(s) from S3."""
@@ -92,7 +96,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify,
         )
         s3 = boto3.resource(
             "s3",
@@ -101,7 +105,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify,
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Problem

`BotoMinioReader.load_data()` hardcodes `verify=False` for both `boto3.client()` and `boto3.resource()` calls. This unconditionally disables TLS certificate verification for all S3 connections, making every user of this reader vulnerable to man-in-the-middle attacks.

An attacker on the same network can intercept all traffic including AWS credentials (access key, secret key, session token) and file contents.

This matches SECURITY.md example #4: "Disabled TLS Verification in Outbound Requests."

Fixes #21978

## Solution

Add a `verify` parameter to `BotoMinioReader.__init__()` with a default of `True` (secure by default). The parameter is passed through to both boto3 calls instead of the hardcoded `False`.

Users with self-signed certificates in controlled environments can pass `verify=False` explicitly.

## Changes

- `llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py`: Add `verify: bool = True` parameter, store as instance attribute, use in boto3 calls

## Verification

```bash
cd llama-index-integrations/readers/llama-index-readers-minio
uv run pytest tests/ -v
```

Existing tests pass. The change is backward-incompatible for users who relied on TLS being disabled by default — they now need to pass `verify=False` explicitly, which is the correct security posture.