### PR TITLE
fix: close file descriptor leaks in Vectara, Replicate, SemanticScholar, and BGE-M3 integrations

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-bge-m3/llama_index/indices/managed/bge_m3/base.py
@@ -154,9 +154,8 @@ class BGEM3Index(BaseIndex[IndexDict]):
             int(k): v for k, v in index.index_struct.nodes_dict.items()
         }
         index._docs_pos_to_node_id = docs_pos_to_node_id
-        index._multi_embed_store = pickle.load(
-            open(Path(persist_dir) / "multi_embed_store.pkl", "rb")
-        )
+        with open(Path(persist_dir) / "multi_embed_store.pkl", "rb") as f:
+            index._multi_embed_store = pickle.load(f)
         return index
 
     def query(self, query_str: str, top_k: int = 10) -> List[NodeWithScore]:

--- a/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-vectara/llama_index/indices/managed/vectara/base.py
@@ -359,36 +359,37 @@ class VectaraIndex(BaseManagedIndex):
         if filename is None:
             filename = file_path.split("/")[-1]
 
-        files = {"file": (filename, open(file_path, "rb"))}
+        with open(file_path, "rb") as fp:
+            files = {"file": (filename, fp)}
 
-        if metadata:
-            metadata["framework"] = "llama_index"
-            files["metadata"] = (None, json.dumps(metadata), "application/json")
+            if metadata:
+                metadata["framework"] = "llama_index"
+                files["metadata"] = (None, json.dumps(metadata), "application/json")
 
-        if chunking_strategy:
-            files["chunking_strategy"] = (
-                None,
-                json.dumps(chunking_strategy),
-                "application/json",
+            if chunking_strategy:
+                files["chunking_strategy"] = (
+                    None,
+                    json.dumps(chunking_strategy),
+                    "application/json",
+                )
+
+            if enable_table_extraction:
+                files["table_extraction_config"] = (
+                    None,
+                    json.dumps({"extract_tables": enable_table_extraction}),
+                    "application/json",
+                )
+
+            headers = self._get_post_headers()
+            headers.pop("Content-Type")
+            valid_corpus_key = self._get_corpus_key(corpus_key)
+            response = self._session.post(
+                f"{self._base_url}/v2/corpora/{valid_corpus_key}/upload_file",
+                files=files,
+                verify=True,
+                headers=headers,
+                timeout=self.vectara_api_timeout,
             )
-
-        if enable_table_extraction:
-            files["table_extraction_config"] = (
-                None,
-                json.dumps({"extract_tables": enable_table_extraction}),
-                "application/json",
-            )
-
-        headers = self._get_post_headers()
-        headers.pop("Content-Type")
-        valid_corpus_key = self._get_corpus_key(corpus_key)
-        response = self._session.post(
-            f"{self._base_url}/v2/corpora/{valid_corpus_key}/upload_file",
-            files=files,
-            verify=True,
-            headers=headers,
-            timeout=self.vectara_api_timeout,
-        )
 
         res = response.json()
         if response.status_code == 201:

--- a/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-replicate/llama_index/llms/replicate/base.py
@@ -94,7 +94,8 @@ class Replicate(CustomLLM):
         }
         if self.image != "":
             try:
-                base_kwargs["image"] = open(self.image, "rb")
+                with open(self.image, "rb") as f:
+                    base_kwargs["image"] = f.read()
             except FileNotFoundError:
                 raise FileNotFoundError(
                     "Could not load image file. Please check whether the file exists"

--- a/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
@@ -125,16 +125,15 @@ class SemanticScholarReader(BaseReader):
                 try:
                     with open(file_path, "rb") as f:
                         pdf = PdfReader(f)
+                        text = ""
+                        for page in pdf.pages:
+                            text += page.extract_text()
+                        full_text_docs.append(Document(text=text, extra_info=metadata))
                 except Exception as e:
                     logging.error(
                         f"Failed to read pdf with exception: {e}. Skipping document..."
                     )
                     continue
-
-                text = ""
-                for page in pdf.pages:
-                    text += page.extract_text()
-                full_text_docs.append(Document(text=text, extra_info=metadata))
 
         return full_text_docs
 

--- a/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-semanticscholar/llama_index/readers/semanticscholar/base.py
@@ -123,7 +123,8 @@ class SemanticScholarReader(BaseReader):
             # Then, check if it's a valid PDF. If it's not, skip to the next document.
             if file_path:
                 try:
-                    pdf = PdfReader(open(file_path, "rb"))
+                    with open(file_path, "rb") as f:
+                        pdf = PdfReader(f)
                 except Exception as e:
                     logging.error(
                         f"Failed to read pdf with exception: {e}. Skipping document..."


### PR DESCRIPTION
Fixes #21973

## Summary

Four integrations used bare `open()` calls without context managers, leaking file descriptors on every invocation.

## Changes

**BGE-M3** (`bge_m3/base.py`)
```python
# Before
index._multi_embed_store = pickle.load(open(Path(persist_dir) / "multi_embed_store.pkl", "rb"))

# After
with open(Path(persist_dir) / "multi_embed_store.pkl", "rb") as f:
    index._multi_embed_store = pickle.load(f)
```

**SemanticScholar** (`semanticscholar/base.py`)
```python
# Before
pdf = PdfReader(open(file_path, "rb"))  # leaked per paper in loop

# After
with open(file_path, "rb") as f:
    pdf = PdfReader(f)
```

**Replicate LLM** (`replicate/base.py`)
```python
# Before
base_kwargs["image"] = open(self.image, "rb")  # leaked on every inference call

# After
with open(self.image, "rb") as f:
    base_kwargs["image"] = f.read()
```

**Vectara** (`vectara/base.py`)
```python
# Before
files = {"file": (filename, open(file_path, "rb"))}  # open handle passed into requests.post
# ...request made outside any context manager

# After
with open(file_path, "rb") as fp:
    files = {"file": (filename, fp)}
    # ...request made while file is still open
```