### PR TITLE
fix(core): accurately count tool_call tokens in memory buffers

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_memory_buffer.py
@@ -164,5 +164,10 @@ class ChatMemoryBuffer(BaseChatStoreMemory):
         if len(messages) <= 0:
             return 0
 
-        msg_str = " ".join(str(m.content) for m in messages)
-        return len(self.tokenizer_fn(msg_str))
+        token_count = 0
+        for m in messages:
+            msg_str = str(m.content) if m.content is not None else ""
+            token_count += len(self.tokenizer_fn(msg_str))
+            if m.additional_kwargs:
+                token_count += len(self.tokenizer_fn(str(m.additional_kwargs)))
+        return token_count

--- a/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
@@ -228,8 +228,13 @@ class ChatSummaryMemoryBuffer(BaseMemory):
         if len(messages) <= 0:
             return 0
 
-        msg_str = " ".join(str(m.content) for m in messages)
-        return len(self.tokenizer_fn(msg_str))
+        token_count = 0
+        for m in messages:
+            msg_str = str(m.content) if m.content is not None else ""
+            token_count += len(self.tokenizer_fn(msg_str))
+            if m.additional_kwargs:
+                token_count += len(self.tokenizer_fn(str(m.additional_kwargs)))
+        return token_count
 
     def _split_messages_summary_or_full_text(
         self, chat_history: List[ChatMessage]


### PR DESCRIPTION
### Description

Resolves #21950.

Currently, `ChatMemoryBuffer` and `ChatSummaryMemoryBuffer` calculate token counts for messages by only tokenizing `str(m.content)`. This ignores `m.additional_kwargs`, which is where `tool_calls` are often stored. When `AgentWorkflow` uses `ChatMemoryBuffer` (which it does by default), large tool-call payloads are silently excluded from the token calculation. This causes the buffer to wildly underestimate its token usage, passing massive arrays to the LLM and resulting in 400 "prompt is too long" errors.

This PR updates `_token_count_for_messages` in both buffers to correctly calculate tokens from `m.additional_kwargs` if it exists, ensuring the memory buffer ejects old messages properly before overflowing the LLM context window.
