### PR TITLE
[codex] Redact API keys from callback payloads

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -152,7 +152,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -199,7 +199,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -387,7 +387,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -435,7 +435,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             )
         )
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
@@ -500,7 +500,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 )
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 ) as event:
                     if self.rate_limiter is not None:
                         self.rate_limiter.acquire()
@@ -554,7 +554,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 )
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 )
                 callback_payloads.append((event_id, cur_batch))
 

--- a/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
+++ b/llama-index-core/llama_index/core/embeddings/multi_modal_base.py
@@ -38,8 +38,10 @@ class MultiModalEmbedding(BaseEmbedding):
         """
         Embed the input image.
         """
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             image_embedding = self._get_image_embedding(img_file_path)
 
@@ -53,8 +55,10 @@ class MultiModalEmbedding(BaseEmbedding):
 
     async def aget_image_embedding(self, img_file_path: ImageType) -> Embedding:
         """Get image embedding."""
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         with self.callback_manager.event(
-            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
+            CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: model_dict}
         ) as event:
             image_embedding = await self._aget_image_embedding(img_file_path)
 
@@ -104,6 +108,8 @@ class MultiModalEmbedding(BaseEmbedding):
                 img_file_paths, show_progress, "Generating image embeddings"
             )
         )
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
 
         for idx, img_file_path in queue_with_progress:
             cur_batch.append(img_file_path)
@@ -114,7 +120,7 @@ class MultiModalEmbedding(BaseEmbedding):
                 # flush
                 with self.callback_manager.event(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 ) as event:
                     embeddings = self._get_image_embeddings(cur_batch)
                     result_embeddings.extend(embeddings)
@@ -136,6 +142,8 @@ class MultiModalEmbedding(BaseEmbedding):
         callback_payloads: List[Tuple[str, List[ImageType]]] = []
         result_embeddings: List[Embedding] = []
         embeddings_coroutines: List[Coroutine] = []
+        model_dict = self.to_dict()
+        model_dict.pop("api_key", None)
         for idx, img_file_path in enumerate(img_file_paths):
             cur_batch.append(img_file_path)
             if (
@@ -145,7 +153,7 @@ class MultiModalEmbedding(BaseEmbedding):
                 # flush
                 event_id = self.callback_manager.on_event_start(
                     CBEventType.EMBEDDING,
-                    payload={EventPayload.SERIALIZED: self.to_dict()},
+                    payload={EventPayload.SERIALIZED: model_dict},
                 )
                 callback_payloads.append((event_id, cur_batch))
                 embeddings_coroutines.append(self._aget_image_embeddings(cur_batch))

--- a/llama-index-core/llama_index/core/llms/callbacks.py
+++ b/llama-index-core/llama_index/core/llms/callbacks.py
@@ -69,7 +69,7 @@ def llm_chat_callback() -> Callable:
                     payload={
                         EventPayload.MESSAGES: messages,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:
@@ -171,7 +171,7 @@ def llm_chat_callback() -> Callable:
                     payload={
                         EventPayload.MESSAGES: messages,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:
@@ -335,7 +335,7 @@ def llm_completion_callback() -> Callable:
                     payload={
                         EventPayload.PROMPT: prompt,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
 
@@ -437,7 +437,7 @@ def llm_completion_callback() -> Callable:
                     payload={
                         EventPayload.PROMPT: prompt,
                         EventPayload.ADDITIONAL_KWARGS: kwargs,
-                        EventPayload.SERIALIZED: _self.to_dict(),
+                        EventPayload.SERIALIZED: model_dict,
                     },
                 )
                 if _self.rate_limiter is not None:

--- a/llama-index-core/tests/embeddings/test_base.py
+++ b/llama-index-core/tests/embeddings/test_base.py
@@ -5,7 +5,18 @@ from unittest.mock import patch
 import pytest
 
 from llama_index.core.base.embeddings.base import SimilarityMode, mean_agg
+from llama_index.core.callbacks import CallbackManager, CBEventType, EventPayload
+from llama_index.core.callbacks.llama_debug import LlamaDebugHandler
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.embeddings.mock_embed_model import MockMultiModalEmbedding
+
+
+class ApiKeyMockEmbedding(MockEmbedding):
+    api_key: str = "test-secret-key"
+
+
+class ApiKeyMockMultiModalEmbedding(MockMultiModalEmbedding):
+    api_key: str = "test-secret-key"
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -100,3 +111,29 @@ def test_mean_agg_empty_list() -> None:
     """Test mean aggregation raises ValueError for empty list."""
     with pytest.raises(ValueError, match="No embeddings to aggregate"):
         mean_agg([])
+
+
+def test_embedding_callback_serialized_payload_redacts_api_key() -> None:
+    handler = LlamaDebugHandler(print_trace_on_end=False)
+    embed_model = ApiKeyMockEmbedding(
+        embed_dim=8, callback_manager=CallbackManager([handler])
+    )
+
+    embed_model.get_text_embedding("Hello world.")
+
+    start_event = handler.get_events(CBEventType.EMBEDDING)[0]
+    serialized = start_event.payload[EventPayload.SERIALIZED]  # type: ignore[index]
+    assert "api_key" not in serialized
+
+
+def test_multi_modal_embedding_callback_serialized_payload_redacts_api_key() -> None:
+    handler = LlamaDebugHandler(print_trace_on_end=False)
+    embed_model = ApiKeyMockMultiModalEmbedding(
+        embed_dim=8, callback_manager=CallbackManager([handler])
+    )
+
+    embed_model.get_image_embedding("image.png")
+
+    start_event = handler.get_events(CBEventType.EMBEDDING)[0]
+    serialized = start_event.payload[EventPayload.SERIALIZED]  # type: ignore[index]
+    assert "api_key" not in serialized

--- a/llama-index-core/tests/llms/test_callbacks.py
+++ b/llama-index-core/tests/llms/test_callbacks.py
@@ -1,8 +1,14 @@
 import pytest
 from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.callbacks import CallbackManager, CBEventType, EventPayload
+from llama_index.core.callbacks.llama_debug import LlamaDebugHandler
 from llama_index.core.llms.llm import LLM
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.llms.mock import MockLLMWithNonyieldingChatStream
+
+
+class ApiKeyMockLLM(MockLLM):
+    api_key: str = "test-secret-key"
 
 
 @pytest.fixture()
@@ -81,3 +87,14 @@ def test_llm_stream_complete_throws_if_duplicate_prompt(llm: LLM, prompt: str) -
 def test_llm_stream_complete_throws_if_no_prompt(llm: LLM) -> None:
     with pytest.raises(ValueError):
         llm.stream_complete()
+
+
+def test_llm_callback_serialized_payload_redacts_api_key() -> None:
+    handler = LlamaDebugHandler(print_trace_on_end=False)
+    llm = ApiKeyMockLLM(callback_manager=CallbackManager([handler]))
+
+    llm.complete("test prompt")
+
+    start_event = handler.get_events(CBEventType.LLM)[0]
+    serialized = start_event.payload[EventPayload.SERIALIZED]  # type: ignore[index]
+    assert "api_key" not in serialized


### PR DESCRIPTION
## Summary
- Reuse the sanitized LLM and embedding model metadata for callback `EventPayload.SERIALIZED` payloads.
- Add the same `api_key` redaction path for multi-modal image embedding callbacks.
- Add regression coverage for LLM, text embedding, and multi-modal embedding callback payloads.

## Why
The dispatcher events were already using a sanitized `model_dict`, but callback manager payloads still serialized the raw model metadata in several paths. This hardening keeps callback/debug handlers from receiving provider credentials through serialized metadata.

## Validation
- `.venv/bin/python -m pytest llama-index-core/tests/llms/test_callbacks.py llama-index-core/tests/embeddings/test_base.py`
- `git diff --check`