### PR TITLE
fix(integrations): Add missing timeouts to HTTP requests across 9 packages

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/utils.py
@@ -82,7 +82,7 @@ def get_pooling_mode(model_name: Optional[str]) -> str:
     )
 
     try:
-        response = requests.get(pooling_config_url)
+        response = requests.get(pooling_config_url, timeout=60.0)
         config_data = response.json()
 
         cls_token = config_data.get("pooling_mode_cls_token", False)

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/utils.py
@@ -3,7 +3,7 @@ import time
 
 
 def post(base_url: str, headers: dict, params: dict):
-    response = requests.post(base_url, headers=headers, json=params)
+    response = requests.post(base_url, headers=headers, json=params, timeout=60.0)
     if response.status_code != 200:
         raise RuntimeError(response.text)
     response_dict = response.json()
@@ -13,7 +13,7 @@ def post(base_url: str, headers: dict, params: dict):
 
 
 def get(base_url: str, headers: dict, params: dict):
-    response = requests.get(base_url, headers=headers, params=params)
+    response = requests.get(base_url, headers=headers, params=params, timeout=60.0)
     if response.status_code != 200:
         raise RuntimeError(response.text)
 
@@ -36,6 +36,7 @@ def run_ingestion(request_url: str, headers: dict, verbose: bool = False):
         response = requests.get(
             request_url,
             headers=headers,
+            timeout=60.0,
         )
         try:
             response_text = response.json()

--- a/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-you/llama_index/llms/you/base.py
@@ -16,23 +16,27 @@ SMART_ENDPOINT = "https://chat-api.you.com/smart"
 RESEARCH_ENDPOINT = "https://chat-api.you.com/research"
 
 
-def _request(base_url: str, api_key: str, **kwargs) -> Dict[str, Any]:
+def _request(
+    base_url: str, api_key: str, timeout: float = 60.0, **kwargs
+) -> Dict[str, Any]:
     """
     NOTE: This function can be replaced by a OpenAPI-generated Python SDK in the future,
     for better input/output typing support.
     """
     headers = {"x-api-key": api_key}
-    response = requests.post(base_url, headers=headers, json=kwargs)
+    response = requests.post(base_url, headers=headers, json=kwargs, timeout=timeout)
     response.raise_for_status()
     return response.json()
 
 
 def _request_stream(
-    base_url: str, api_key: str, **kwargs
+    base_url: str, api_key: str, timeout: float = 60.0, **kwargs
 ) -> Generator[str, None, None]:
     headers = {"x-api-key": api_key}
     params = dict(**kwargs, stream=True)
-    response = requests.post(base_url, headers=headers, stream=True, json=params)
+    response = requests.post(
+        base_url, headers=headers, stream=True, json=params, timeout=timeout
+    )
     response.raise_for_status()
 
     client = sseclient.SSEClient(response)
@@ -83,6 +87,11 @@ class You(CustomLLM):
         None,
         description="You.com API key, if `YDC_API_KEY` is not set in the environment",
     )
+    timeout: float = Field(
+        default=60.0,
+        description="Timeout for the API requests in seconds.",
+        ge=0,
+    )
 
     @property
     def metadata(self) -> LLMMetadata:
@@ -97,6 +106,7 @@ class You(CustomLLM):
         response = _request(
             self.endpoint,
             api_key=self._api_key,
+            timeout=self.timeout,
             query=prompt,
         )
         return CompletionResponse(text=response["answer"], raw=response)
@@ -106,6 +116,7 @@ class You(CustomLLM):
         response = _request_stream(
             self.endpoint,
             api_key=self._api_key,
+            timeout=self.timeout,
             query=prompt,
         )
 

--- a/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-intercom/llama_index/readers/intercom/base.py
@@ -87,7 +87,7 @@ class IntercomReader(BaseReader):
             "authorization": f"Bearer {self.intercom_access_token}",
         }
 
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=60.0)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-kaltura/llama_index/readers/kaltura_esearch/base.py
@@ -174,7 +174,7 @@ class KalturaESearchReader(BaseReader):
             cap_json_url = self.client.caption.captionAsset.serveAsJson(
                 caption_asset_id
             )
-            return requests.get(cap_json_url).json()
+            return requests.get(cap_json_url, timeout=self.request_timeout).json()
         except Exception as e:
             logger.error(f"An error occurred while getting captions: {e}")
             return {}

--- a/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-zendesk/llama_index/readers/zendesk/base.py
@@ -83,7 +83,7 @@ class ZendeskReader(BaseReader):
         else:
             url = next_page
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=60.0)
 
         response_json = json.loads(response.text)
 

--- a/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-openapi/llama_index/tools/openapi/base.py
@@ -24,6 +24,7 @@ class OpenAPIToolSpec(BaseToolSpec):
         spec: Optional[dict] = None,
         url: Optional[str] = None,
         operation_id_filter: Callable[[str], bool] = None,
+        timeout: float = 60.0,
     ):
         import yaml
 
@@ -32,7 +33,7 @@ class OpenAPIToolSpec(BaseToolSpec):
         elif spec:
             pass
         elif url:
-            response = requests.get(url).text
+            response = requests.get(url, timeout=timeout).text
             spec = yaml.safe_load(response)
         else:
             raise ValueError("You must provide a url or OpenAPI spec as a dict")

--- a/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-text-to-image/llama_index/tools/text_to_image/base.py
@@ -13,9 +13,10 @@ class TextToImageToolSpec(BaseToolSpec):
 
     spec_functions = ["generate_images", "show_images", "generate_image_variation"]
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
+    def __init__(self, api_key: Optional[str] = None, timeout: float = 60.0) -> None:
         if api_key:
             openai.api_key = api_key
+        self.timeout = timeout
 
     def generate_images(
         self, prompt: str, n: Optional[int] = 1, size: Optional[str] = "256x256"
@@ -52,7 +53,11 @@ class TextToImageToolSpec(BaseToolSpec):
         """
         try:
             response = openai.Image.create_variation(
-                image=BytesIO(requests.get(url).content).getvalue(), n=n, size=size
+                image=BytesIO(
+                    requests.get(url, timeout=self.timeout).content
+                ).getvalue(),
+                n=n,
+                size=size,
             )
             return [image["url"] for image in response["data"]]
         except openai.error.OpenAIError as e:
@@ -71,5 +76,7 @@ class TextToImageToolSpec(BaseToolSpec):
 
         for url in urls:
             plt.figure()
-            plt.imshow(Image.open(BytesIO(requests.get(url).content)))
+            plt.imshow(
+                Image.open(BytesIO(requests.get(url, timeout=self.timeout).content))
+            )
         return "images rendered successfully"

--- a/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/llama_index/tools/wolfram_alpha/base.py
@@ -18,10 +18,12 @@ class WolframAlphaToolSpec(BaseToolSpec):
         self,
         app_id: Optional[str] = None,
         api_params: Optional[dict] = None,
+        timeout: float = 60.0,
     ) -> None:
         """Initialize with parameters."""
         self.token = app_id
         self._api_params = api_params or {}
+        self.timeout = timeout
 
     def wolfram_alpha_query(self, query: str) -> str:
         r"""
@@ -78,6 +80,6 @@ class WolframAlphaToolSpec(BaseToolSpec):
         params = {"input": query, **self._api_params}
         url = f"{QUERY_URL_TMPL}?{urllib.parse.urlencode(params)}"
         headers = {"Authorization": f"Bearer {self.token}"}
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.timeout)
         response.raise_for_status()
         return response.text


### PR DESCRIPTION
Fixes #22028. This PR adds a missing `timeout` parameter (defaulting to 60.0s) to `requests.get()` and `requests.post()` across 9 integration packages to prevent indefinite hangs in production environments if the remote server is unresponsive.
