### PR TITLE
fix(core): align EmbeddingRecencyPostprocessor dedup with sorted node order

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/node_recency.py
+++ b/llama-index-core/llama_index/core/postprocessor/node_recency.py
@@ -128,8 +128,12 @@ class EmbeddingRecencyPostprocessor(BaseNodePostprocessor):
         sorted_node_idxs = np.flip(node_dates.argsort())
         sorted_nodes: List[NodeWithScore] = [nodes[idx] for idx in sorted_node_idxs]
 
-        # get embeddings for each node
-        texts = [node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes]
+        # get embeddings for each node, in the same (date-sorted) order used by
+        # the dedup loop below so ``text_embeddings[idx2]`` lines up with
+        # ``sorted_nodes[idx2]``.
+        texts = [
+            node.get_content(metadata_mode=MetadataMode.EMBED) for node in sorted_nodes
+        ]
         text_embeddings = self.embed_model.get_text_embedding_batch(texts=texts)
 
         node_ids_to_skip: Set[str] = set()

--- a/llama-index-core/tests/postprocessor/test_base.py
+++ b/llama-index-core/tests/postprocessor/test_base.py
@@ -2,9 +2,10 @@
 
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Dict, cast
+from typing import Dict, List, cast
 
 import pytest
+from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.postprocessor.node import (
     KeywordNodePostprocessor,
     PrevNextNodePostprocessor,
@@ -253,6 +254,102 @@ def test_embedding_recency_postprocessor() -> None:
     # assert cast(Dict, result_nodes[1].node.metadata)["date"] == "2020-01-03"
     # assert result_nodes[2].node.get_content() == "This is a test."
     # assert cast(Dict, result_nodes[2].node.metadata)["date"] == "2020-01-02"
+
+
+class _ContentEmbedding(BaseEmbedding):
+    """
+    Deterministic embedding keyed on text/query content (no network).
+
+    Unlike the shared ``MockEmbedding`` (whose query embedding is constant), the
+    query embedding here depends on the node content, so it exercises the
+    ``EmbeddingRecencyPostprocessor`` dedup loop the way a real embedder would.
+    """
+
+    _vectors: Dict[str, List[float]] = {
+        "old unique": [1.0, 0.0, 0.0, 0.0, 0.0],
+        "DUP_A": [0.0, 1.0, 0.0, 0.0, 0.0],
+        "middle unique": [0.0, 0.0, 1.0, 0.0, 0.0],
+        "DUP_B": [0.0, 1.0, 0.0, 0.0, 0.0],  # identical direction to DUP_A
+        "newest unique": [0.0, 0.0, 0.0, 0.0, 1.0],
+    }
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return self._vectors[query]
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._vectors[query]
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return self._vectors[text]
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return self._vectors[text]
+
+
+def test_embedding_recency_postprocessor_dedup_alignment() -> None:
+    """
+    Dedup must align embeddings with the date-sorted node order.
+
+    Regression test: ``_postprocess_nodes`` previously built ``text_embeddings``
+    from the original (un-sorted) ``nodes`` while the dedup loop indexed them by
+    position in the date-sorted ``sorted_nodes``. For any input not already
+    sorted by date this compared the query against the wrong node's embedding,
+    silently dropping genuinely-unique nodes. Here only the true duplicate
+    (``DUP_A``/``DUP_B``) should be removed and all unique nodes must survive.
+    """
+    nodes = [
+        TextNode(
+            text="old unique",
+            id_="1",
+            metadata={"date": "2020-01-01"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="DUP_A",
+            id_="2",
+            metadata={"date": "2020-01-02"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="middle unique",
+            id_="3",
+            metadata={"date": "2020-01-03"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="DUP_B",
+            id_="4",
+            metadata={"date": "2020-01-04"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="newest unique",
+            id_="5",
+            metadata={"date": "2020-01-05"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+    ]
+    nodes_with_scores = [NodeWithScore(node=node) for node in nodes]
+
+    postprocessor = EmbeddingRecencyPostprocessor(
+        embed_model=_ContentEmbedding(),
+        query_embedding_tmpl="{context_str}",
+        similarity_cutoff=0.5,
+    )
+    result = postprocessor.postprocess_nodes(
+        nodes_with_scores, query_bundle=QueryBundle(query_str="What is?")
+    )
+
+    ids = [n.node.node_id for n in result]
+    texts = [n.node.get_content() for n in result]
+    # every unique node survives
+    assert "old unique" in texts
+    assert "middle unique" in texts
+    assert "newest unique" in texts
+    # exactly one of the two identical nodes is dropped
+    assert texts.count("DUP_A") + texts.count("DUP_B") == 1
+    assert len(result) == 4
+    assert "1" in ids  # the oldest unique node is not wrongly skipped
 
 
 def test_time_weighted_postprocessor() -> None:


### PR DESCRIPTION
# Description

`EmbeddingRecencyPostprocessor._postprocess_nodes` builds the per-node embedding list from the **original** `nodes`, but the dedup loop indexes that list by position in the **date-sorted** `sorted_nodes`:

```python
texts = [node.get_content(...) for node in nodes]      # original order
text_embeddings = self.embed_model.get_text_embedding_batch(texts=texts)
...
for idx, node in enumerate(sorted_nodes):              # sorted order
    ...
    for idx2 in range(idx + 1, len(sorted_nodes)):
        node2 = sorted_nodes[idx2]                     # sorted order
        if np.dot(query_embedding, text_embeddings[idx2]) > self.similarity_cutoff:
            node_ids_to_skip.add(node2.node.node_id)   # ...but embedding is from `nodes[idx2]`
```

Unless the caller already passes nodes pre-sorted by date, `text_embeddings[idx2]` belongs to a **different** node than `sorted_nodes[idx2]`. The similarity check therefore compares the query against the wrong document embedding and adds the wrong node id to `node_ids_to_skip`, so on a normal (un-sorted) retriever output the postprocessor silently drops genuinely-unique nodes — and can keep true duplicates.

The fix builds `texts`/`text_embeddings` from `sorted_nodes` so `text_embeddings[idx2]` lines up with `sorted_nodes[idx2]`. `text_embeddings` is only consumed inside that sorted-order loop, so this is the only ordering consistent with the code's own indexing.

Fixes # (no existing issue filed)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (this is the `llama-index-core` package)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_embedding_recency_postprocessor_dedup_alignment` in `llama-index-core/tests/postprocessor/test_base.py`. It uses a small deterministic, content-keyed embedding (the shared `MockEmbedding` returns a **constant** query embedding and so cannot exercise this dedup path — which is also why the older dedup asserts in `test_embedding_recency_postprocessor` are commented out). The test feeds nodes in ascending-date order (the normal un-sorted case) with one true duplicate plus several unique nodes:

- **Before** the fix it fails — a unique node is wrongly dropped (`['5', '4', '3']`, missing the unique node `'1'`).
- **After** the fix it passes — only the true duplicate is removed and all unique nodes survive (`['5', '4', '3', '1']`).

`pytest tests/postprocessor/test_base.py` → `5 passed, 2 skipped`. `ruff check` / `ruff format --check` clean on both changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the formatter and linter on the changed files