### PR TITLE
Add llama-index-readers-funasr (local multilingual audio reader)

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-funasr/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/README.md
@@ -1,0 +1,25 @@
+# FunASR Reader
+
+## Overview
+
+FunASR Reader reads audio files and transcribes them to text locally with [FunASR](https://github.com/modelscope/FunASR) (SenseVoice / Paraformer / Fun-ASR-Nano). It is multilingual (Chinese, Cantonese, English, Japanese, Korean and more), runs on CPU or GPU, and needs **no API key**. SenseVoice (the default) auto-detects the spoken language, and a built-in FSMN-VAD handles long audio.
+
+### Installation
+
+```bash
+pip install llama-index-readers-funasr
+```
+
+## Usage
+
+```python
+from llama_index.readers.funasr import FunASRReader
+
+# Initialize FunASRReader (downloads the model on first use)
+reader = FunASRReader(model="iic/SenseVoiceSmall", device="cpu")
+
+# Load data from an audio file
+documents = reader.load_data("path/to/your/audio/file.wav")
+```
+
+This loader is designed to ingest audio (meetings, podcasts, voice notes) into a LlamaIndex pipeline for retrieval and question answering.

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.funasr.base import FunASRReader
+
+__all__ = ["FunASRReader"]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/llama_index/readers/funasr/base.py
@@ -1,0 +1,71 @@
+"""FunASR reader."""
+
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+
+class FunASRReader(BaseReader):
+    """
+    FunASR reader.
+
+    Reads audio files and transcribes them locally with
+    [FunASR](https://github.com/modelscope/FunASR) (SenseVoice / Paraformer /
+    Fun-ASR-Nano) — multilingual ASR (Chinese, Cantonese, English, Japanese,
+    Korean and more) that runs on CPU or GPU with no API key. SenseVoice (the
+    default) auto-detects the spoken language, and a built-in FSMN-VAD handles
+    long audio.
+
+    Args:
+        model (str): FunASR model id on ModelScope/Hugging Face.
+            Defaults to ``"iic/SenseVoiceSmall"``.
+        device (str): Inference device, ``"cpu"`` or ``"cuda"``. Defaults to ``"cpu"``.
+        language (str): Spoken language; ``"auto"`` auto-detects. Defaults to ``"auto"``.
+        use_itn (bool): Apply inverse text normalization. Defaults to ``True``.
+
+    """
+
+    def __init__(
+        self,
+        model: str = "iic/SenseVoiceSmall",
+        device: str = "cpu",
+        language: str = "auto",
+        use_itn: bool = True,
+    ) -> None:
+        """Initialize with arguments."""
+        super().__init__()
+        try:
+            from funasr import AutoModel
+        except ImportError:
+            raise ImportError(
+                "`funasr` package not found, please run `pip install funasr`"
+            )
+        self._language = language
+        self._use_itn = use_itn
+        self._model = AutoModel(
+            model=model,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=device,
+            disable_update=True,
+        )
+
+    def load_data(
+        self,
+        input_file: Union[str, Path],
+        extra_info: Optional[Dict] = None,
+    ) -> List[Document]:
+        """Transcribe ``input_file`` and return a single ``Document`` with the text."""
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        result = self._model.generate(
+            input=str(input_file),
+            cache={},
+            language=self._language,
+            use_itn=self._use_itn,
+        )
+        text = rich_transcription_postprocess(result[0]["text"]).strip() if result else ""
+        metadata = {"file_name": str(input_file), **(extra_info or {})}
+        return [Document(text=text, metadata=metadata)]

--- a/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-readers-funasr"
+version = "0.1.0"
+description = "llama-index readers FunASR (SenseVoice / Paraformer / Fun-ASR-Nano) integration"
+authors = [{name = "FunAudioLLM"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "funasr>=1.1.0",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.readers.funasr"
+
+[tool.llamahub.class_authors]
+FunASRReader = "funaudiollm"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_readers_funasr.py
+++ b/llama-index-integrations/readers/llama-index-readers-funasr/tests/test_readers_funasr.py
@@ -1,0 +1,7 @@
+from llama_index.core.readers.base import BaseReader
+from llama_index.readers.funasr import FunASRReader
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in FunASRReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes


### PR DESCRIPTION
Adds **`llama-index-readers-funasr`**, a local audio reader backed by [FunASR](https://github.com/modelscope/FunASR) (SenseVoice / Paraformer / Fun-ASR-Nano).

**Why:** lets you ingest audio (meetings, podcasts, voice notes) into a LlamaIndex pipeline with a **local, multilingual** ASR — strong on Chinese, Cantonese, Japanese, Korean — that runs on CPU or GPU with **no API key** (unlike the OpenAI Whisper reader). SenseVoice auto-detects the language; built-in FSMN-VAD handles long audio.

**What it does:** `FunASRReader(BaseReader).load_data(file)` runs the local model and returns a `Document` with the transcript. Mirrors the existing `llama-index-readers-whisper` package layout. `funasr` is a normal dependency (lazily imported with a clear error).

**Verified:** the FunASR transcription core (audio file -> SenseVoice + FSMN-VAD -> text) was verified standalone (produces the expected transcript with rich tags stripped). The class-inheritance test passes without the model.

Note: happy to regenerate `uv.lock` / add anything the integration checks expect.

```python
from llama_index.readers.funasr import FunASRReader
docs = FunASRReader(model="iic/SenseVoiceSmall").load_data("audio.wav")
```