### PR TITLE
fix(ag-ui): record ToolMessage for frontend tool_call_ids at suspend boundary

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -401,6 +401,32 @@ class AGUIChatWorkflow(Workflow):
                 )
             )
 
+        # Frontend tool calls are dispatched to the client and the workflow
+        # suspends with StopEvent. We still need to record a matching
+        # ChatMessage(role="tool", ...) for each frontend tool_call_id in the
+        # persisted chat_history so the LLM-provider pairing invariant
+        # ("every tool_call_id in an AIMessage must have a matching
+        # ToolMessage") holds at the suspend boundary. The frontend will
+        # typically replace this stub content with the real client-side
+        # result on the next run via a ToolMessage in the input messages,
+        # but writing a stub now keeps history valid in the meantime.
+        for tool_result in frontend_tool_calls:
+            frontend_content = tool_result.tool_output.content
+            if frontend_content is None:
+                frontend_content = (
+                    f"[frontend tool {tool_result.tool_name} dispatched; "
+                    f"result will be provided by the client]"
+                )
+            new_tool_messages.append(
+                ChatMessage(
+                    role="tool",
+                    content=frontend_content,
+                    additional_kwargs={
+                        "tool_call_id": tool_result.tool_call_id,
+                    },
+                )
+            )
+
         # emit a messages snapshot event if there are new messages
         chat_history = await ctx.store.get("chat_history")
         if new_tool_messages:

--- a/test_fix_22066.py
+++ b/test_fix_22066.py
@@ -1,0 +1,118 @@
+"""Reproduction + regression test for issue #22066.
+
+Bug: AGUIChatWorkflow.aggregate_tool_calls only appended ToolMessages for
+backend tool calls, orphaning frontend tool_call_ids. This broke the
+LLM-provider pairing invariant when backend + frontend tools fired in the
+same assistant turn.
+"""
+import asyncio
+import sys
+from uuid import uuid4
+
+from ag_ui.core import RunAgentInput, UserMessage
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.llms.mock import MockFunctionCallingLLM
+from llama_index.core.tools import FunctionTool
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow
+
+
+async def backend_calc(x: int, y: int) -> str:
+    return str(x + y)
+
+
+async def frontend_show(message: str) -> str:
+    return ""
+
+
+def make_workflow():
+    backend = FunctionTool.from_defaults(
+        async_fn=backend_calc,
+        name="backend_calc",
+        description="add x+y server-side",
+    )
+    frontend = FunctionTool.from_defaults(
+        async_fn=frontend_show,
+        name="frontend_show",
+        description="render in UI (frontend)",
+    )
+
+    B = f"call_backend_{uuid4().hex[:8]}"
+    F = f"call_frontend_{uuid4().hex[:8]}"
+
+    def gen(messages, **kw):
+        if any(m.role == MessageRole.TOOL for m in messages):
+            return ChatMessage(role="assistant", content="(done)")
+        return ChatMessage(
+            role="assistant",
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    ToolSelection(
+                        tool_id=B,
+                        tool_name="backend_calc",
+                        tool_kwargs={"x": 2, "y": 3},
+                    ),
+                    ToolSelection(
+                        tool_id=F,
+                        tool_name="frontend_show",
+                        tool_kwargs={"message": "5"},
+                    ),
+                ]
+            },
+        )
+
+    wf = AGUIChatWorkflow(
+        llm=MockFunctionCallingLLM(response_generator=gen, is_chat_model=True),
+        backend_tools=[backend],
+        frontend_tools=[frontend],
+        timeout=30,
+    )
+    return wf, B, F
+
+
+async def main() -> int:
+    wf, B, F = make_workflow()
+
+    handler = wf.run(
+        input_data=RunAgentInput(
+            threadId="t",
+            runId="r",
+            state={},
+            tools=[],
+            context=[],
+            forwardedProps={},
+            messages=[
+                UserMessage(id="u1", role="user", content="Compute 2+3 and show.")
+            ],
+        )
+    )
+    async for _ in handler.stream_events():
+        pass
+    await handler
+
+    history = await handler.ctx.store.get("chat_history")
+    claimed = {
+        tc.tool_id
+        for m in history
+        if m.role == MessageRole.ASSISTANT
+        for tc in (m.additional_kwargs or {}).get("tool_calls", [])
+    }
+    replied = {
+        (m.additional_kwargs or {}).get("tool_call_id")
+        for m in history
+        if m.role == MessageRole.TOOL
+    }
+
+    print(f"Claimed tool_call_ids: {claimed}")
+    print(f"Replied tool_call_ids: {replied}")
+    missing = claimed - replied
+    if missing:
+        print(f"FAIL: orphan tool_call_ids: {missing}")
+        return 1
+    print("PASS: every tool_call_id has a matching ToolMessage")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Fixes #22066.

## Problem

`AGUIChatWorkflow.aggregate_tool_calls` partitioned the parallel tool fan-out results into `frontend_tool_calls` and `backend_tool_calls`, then built `new_tool_messages` **only from `backend_tool_calls`**. The frontend `tool_call_id`s the LLM emitted in the prior assistant turn therefore never got a matching `ChatMessage(role="tool", ...)` in `chat_history`. The persisted state violated the LLM-provider invariant *"every tool_call_id in an `AIMessage` must have a matching `ToolMessage`"*, and any subsequent provider call against that history was rejected with HTTP 400 (`tool_use_id ... has no matching tool_result`).

The bug fired every time the LLM picked a backend tool and a frontend tool in the same assistant turn — the canonical AG-UI use case of server compute + UI rendering.

## Fix

Also append a `ChatMessage(role="tool", ...)` stub for each frontend `tool_call_id` before the `StopEvent` suspends the workflow. The stub content is filled from `tool_result.tool_output.content` when available, or falls back to a short marker string. The frontend typically replaces this stub with the real client-side result on the next run via a ToolMessage in the input messages, but writing the stub now keeps history valid in the meantime.

## Reproduction

Run `test_fix_22066.py` at the repo root:

- **Without the fix:** `FAIL: orphan tool_call_ids: {'call_frontend_...'}` (frontend id never gets a matching ToolMessage).
- **With the fix:** `PASS: every tool_call_id has a matching ToolMessage`.

## Files changed

- `llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py` — 26 lines added in `aggregate_tool_calls`.
- `test_fix_22066.py` — regression test using `MockFunctionCallingLLM` with one backend + one frontend tool, asserting the pairing invariant on the persisted `chat_history`.

## Testing

Verified with the reproduction script in this repo:
1. Without the fix the test fails with the exact orphan tool_call_id reported in the issue.
2. With the fix the test passes and every assistant tool_call_id has a matching ToolMessage in the persisted chat history.