### PR TITLE
fix(llms): default streaming role to ASSISTANT when delta.role is None (zhipuai, konko)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-konko/llama_index/llms/konko/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-konko/llama_index/llms/konko/base.py
@@ -566,15 +566,17 @@ class Konko(LLM):
                         delta = response.choices[0].delta
                     else:
                         delta = {}
-                    role = delta.role
-                    content_delta = delta.content
+                    role_value = delta.role
+                    content_delta = delta.content or ""
                 else:
                     if len(response["choices"]) > 0:
                         delta = response["choices"][0].delta
                     else:
                         delta = {}
-                    role = delta["role"]
-                    content_delta = delta["content"]
+                    role_value = delta.get("role")
+                    content_delta = delta.get("content") or ""
+
+                role = role_value if role_value is not None else "assistant"
                 content += content_delta
 
                 yield ChatResponse(

--- a/llama-index-integrations/llms/llama-index-llms-konko/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-konko/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-konko"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms konko integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-zhipuai/llama_index/llms/zhipuai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-zhipuai/llama_index/llms/zhipuai/base.py
@@ -323,7 +323,7 @@ class ZhipuAI(FunctionCallingLLM):
                 yield ChatResponse(
                     message=ChatMessage(
                         content=response_txt,
-                        role=chunk.choices[0].delta.role,
+                        role=chunk.choices[0].delta.role or MessageRole.ASSISTANT,
                         additional_kwargs={"tool_calls": tool_calls},
                     ),
                     delta=chunk.choices[0].delta.content,
@@ -363,7 +363,7 @@ class ZhipuAI(FunctionCallingLLM):
                 yield ChatResponse(
                     message=ChatMessage(
                         content=response_txt,
-                        role=chunk.choices[0].delta.role,
+                        role=chunk.choices[0].delta.role or MessageRole.ASSISTANT,
                         additional_kwargs={"tool_calls": tool_calls},
                     ),
                     delta=chunk.choices[0].delta.content,

--- a/llama-index-integrations/llms/llama-index-llms-zhipuai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-zhipuai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-zhipuai"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms zhipuai integration"
 authors = [{name = "nightosong"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-zhipuai/tests/test_llms_zhipuai.py
+++ b/llama-index-integrations/llms/llama-index-llms-zhipuai/tests/test_llms_zhipuai.py
@@ -7,9 +7,40 @@ from zhipuai.types.chat.chat_completion import (
     CompletionMessage,
     CompletionUsage,
 )
-from llama_index.core.base.llms.types import CompletionResponse
+from zhipuai.types.chat.chat_completion_chunk import (
+    ChatCompletionChunk,
+    Choice,
+    ChoiceDelta,
+)
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    CompletionResponse,
+    MessageRole,
+)
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.zhipuai import ZhipuAI
+
+
+def _stream_chunk(role, content, index=0):
+    """
+    Build a streaming chunk mirroring the OpenAI-compatible ZhipuAI stream.
+
+    The first chunk carries ``delta.role="assistant"`` while subsequent
+    content chunks have ``delta.role=None`` (the real-world behavior).
+    """
+    return ChatCompletionChunk(
+        id="chatcmpl-test",
+        created=1703487403,
+        model="glm-4",
+        choices=[
+            Choice(
+                index=index,
+                delta=ChoiceDelta(role=role, content=content, tool_calls=None),
+                finish_reason=None,
+            )
+        ],
+        extra_json={},
+    )
 
 
 def test_llm_class():
@@ -62,6 +93,60 @@ def test_zhipuai_completions_with_stop():
     ):
         actual_chat = llm.complete("__query__", stop=["stop_words"])
         assert actual_chat == predict_response
+
+
+def test_zhipuai_stream_chat_role_none_on_later_chunks():
+    """
+    Later stream chunks have delta.role=None and must not raise.
+
+    Regression test: ``ChatMessage.role`` is a non-Optional ``MessageRole``,
+    so passing ``role=None`` (as later chunks deliver) raised a pydantic
+    ValidationError before the ``or MessageRole.ASSISTANT`` fallback was added.
+    """
+    chunks = [
+        _stream_chunk(role="assistant", content="Hello"),
+        _stream_chunk(role=None, content=" there"),
+        _stream_chunk(role=None, content="!"),
+    ]
+
+    llm = ZhipuAI(model="glm-4", api_key="__fake_key__")
+    with mock.patch.object(
+        llm._client.chat.completions, "create", return_value=iter(chunks)
+    ):
+        responses = list(
+            llm.stream_chat([ChatMessage(role=MessageRole.USER, content="hi")])
+        )
+
+    assert len(responses) == len(chunks)
+    for response in responses:
+        assert response.message.role == MessageRole.ASSISTANT
+    assert responses[-1].message.content == "Hello there!"
+
+
+@pytest.mark.asyncio
+async def test_zhipuai_astream_chat_role_none_on_later_chunks():
+    """Async streaming must also tolerate delta.role=None on later chunks."""
+    chunks = [
+        _stream_chunk(role="assistant", content="Hello"),
+        _stream_chunk(role=None, content=" there"),
+        _stream_chunk(role=None, content="!"),
+    ]
+
+    llm = ZhipuAI(model="glm-4", api_key="__fake_key__")
+    with mock.patch.object(
+        llm._client.chat.completions, "create", return_value=iter(chunks)
+    ):
+        responses = [
+            response
+            async for response in await llm.astream_chat(
+                [ChatMessage(role=MessageRole.USER, content="hi")]
+            )
+        ]
+
+    assert len(responses) == len(chunks)
+    for response in responses:
+        assert response.message.role == MessageRole.ASSISTANT
+    assert responses[-1].message.content == "Hello there!"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# Description

In OpenAI-compatible streaming the assistant `role` is present **only on the first chunk**; every subsequent content chunk has `delta.role = None`. `ChatMessage.role` is a non-Optional `MessageRole` field (`llama-index-core/.../base/llms/types.py`), so constructing `ChatMessage(role=None)` raises a pydantic `ValidationError`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatMessage
role
  Input should be 'system', 'developer', 'user', 'assistant', ... [input_value=None]
```

Two adapters feed `delta.role` straight into `ChatMessage` without the `or MessageRole.ASSISTANT` fallback that the canonical `llama-index-llms-openai` adapter uses (`openai/base.py:568, 860`), so they **crash on the first content chunk of any normal multi-token stream**:

- **zhipuai** — both `stream_chat` and `astream_chat`.
- **konko** — the async `_astream_chat` path. (konko's own sync `_stream_chat` already coalesces the role to `"assistant"`; this just makes the async path consistent, and also reads the delta with `.get(...)` to avoid a `KeyError` when later chunks omit the key.)

Fixes # (no existing issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-llms-zhipuai` 0.5.0 → 0.5.1 and `llama-index-llms-konko` 0.5.0 → 0.5.1
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `tests/test_llms_zhipuai.py::test_zhipuai_stream_chat_role_none_on_later_chunks` (and the async variant). They mock the ZhipuAI client to yield a first chunk with `role="assistant"` followed by content chunks with `role=None`, and assert that streaming does not raise and every `ChatResponse.message.role == MessageRole.ASSISTANT`.

- **Before** the fix: `ValidationError` (`Input should be ... [input_value=None]`).
- **After** the fix: `2 passed`; full package suite `6 passed, 2 skipped` (skips need a live `ZHIPUAI_API_KEY`).

The konko async fix was verified by driving `_astream_chat` over the same role=None chunk sequence (red → ValidationError, green → all roles ASSISTANT); it mirrors konko's existing sync path so it is covered by the in-file sibling.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings