### PR TITLE
fix: support workflow factories for MCP apps

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -94,6 +94,17 @@ workflow = LoudWorkflow()
 mcp = workflow_as_mcp(workflow, start_event_model=RunEvent)
 ```
 
+If your workflow stores per-request state on `self`, pass a factory so every
+MCP tool call runs on a fresh workflow instance:
+
+```python
+mcp = workflow_as_mcp(
+    LoudWorkflow(),
+    start_event_model=RunEvent,
+    workflow_factory=lambda: LoudWorkflow(),
+)
+```
+
 Then, you can launch the MCP server (assuming you have the `mcp[cli]` extra installed):
 
 ```bash

--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -105,6 +105,21 @@ mcp = workflow_as_mcp(
 )
 ```
 
+The factory may also be async, which is useful when building the workflow needs
+to await setup work such as opening a connection:
+
+```python
+async def build_workflow() -> LoudWorkflow:
+    return LoudWorkflow()
+
+
+mcp = workflow_as_mcp(
+    LoudWorkflow(),
+    start_event_model=RunEvent,
+    workflow_factory=build_workflow,
+)
+```
+
 Then, you can launch the MCP server (assuming you have the `mcp[cli]` extra installed):
 
 ```bash

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional
+from inspect import isawaitable
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 from mcp.client.session import ClientSession
 from mcp.server.fastmcp import FastMCP, Context
@@ -8,6 +9,8 @@ from llama_index.core.tools import FunctionTool
 from llama_index.core.workflow import Event, StartEvent, StopEvent, Workflow
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
+
+WorkflowFactory = Callable[[], Union[Workflow, Awaitable[Workflow]]]
 
 
 def get_tools_from_mcp_url(
@@ -79,6 +82,7 @@ def workflow_as_mcp(
     workflow_name: Optional[str] = None,
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
+    workflow_factory: Optional[WorkflowFactory] = None,
     **fastmcp_init_kwargs: Any,
 ) -> FastMCP:
     """
@@ -97,6 +101,9 @@ def workflow_as_mcp(
         start_event_model (optional):
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
+        workflow_factory (optional):
+            Factory that returns a fresh workflow for each MCP tool call. Use this when
+            the workflow stores per-request mutable state on `self`.
         **fastmcp_init_kwargs:
             Additional keyword arguments to pass to the FastMCP constructor.
 
@@ -119,16 +126,27 @@ def workflow_as_mcp(
 
     @app.tool(name=workflow_name, description=workflow_description)
     async def _workflow_tool(run_args: StartEventCLS, context: Context) -> Any:
+        workflow_for_run: Workflow = workflow
+        if workflow_factory is not None:
+            factory_result = workflow_factory()
+            if isawaitable(factory_result):
+                workflow_for_run = await factory_result
+            else:
+                workflow_for_run = factory_result
+
         # Handle edge cases where the start event is an Event or a BaseModel
         # If the workflow does not have a custom StartEvent class, then we need to handle the event differently
 
-        if isinstance(run_args, Event) and workflow._start_event_class != StartEvent:
-            handler = workflow.run(start_event=run_args)
+        if (
+            isinstance(run_args, Event)
+            and workflow_for_run._start_event_class != StartEvent
+        ):
+            handler = workflow_for_run.run(start_event=run_args)
         elif isinstance(run_args, BaseModel):
-            handler = workflow.run(**run_args.model_dump())
+            handler = workflow_for_run.run(**run_args.model_dump())
         elif isinstance(run_args, dict):
             start_event = StartEventCLS.model_validate(run_args)
-            handler = workflow.run(start_event=start_event)
+            handler = workflow_for_run.run(start_event=start_event)
         else:
             raise ValueError(f"Invalid start event type: {type(run_args)}")
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
@@ -1,0 +1,61 @@
+import json
+from typing import Any
+
+import pytest
+
+from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
+from llama_index.tools.mcp import workflow_as_mcp
+
+
+class TenantStart(StartEvent):
+    tenant_id: str
+
+
+class CountingWorkflow(Workflow):
+    def __init__(self, label: str = "default", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.label = label
+        self.call_count = 0
+        self.history: list[str] = []
+
+    @step
+    async def echo(self, ctx: Context, ev: TenantStart) -> StopEvent:
+        self.call_count += 1
+        self.history.append(ev.tenant_id)
+        return StopEvent(
+            result={
+                "call_index": self.call_count,
+                "history_visible": list(self.history),
+                "label": self.label,
+            }
+        )
+
+
+def _tool_payload(result: list[Any]) -> dict[str, Any]:
+    return json.loads(result[0].text)
+
+
+@pytest.mark.asyncio
+async def test_workflow_as_mcp_accepts_explicit_workflow_factory() -> None:
+    factory_call_count = 0
+
+    def workflow_factory() -> CountingWorkflow:
+        nonlocal factory_call_count
+        factory_call_count += 1
+        return CountingWorkflow(label="factory", timeout=30)
+
+    app = workflow_as_mcp(
+        CountingWorkflow(label="metadata", timeout=30),
+        workflow_factory=workflow_factory,
+    )
+
+    first_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "alice"}}
+    )
+    second_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "bob"}}
+    )
+
+    assert _tool_payload(first_result)["label"] == "factory"
+    assert _tool_payload(second_result)["label"] == "factory"
+    assert factory_call_count == 2

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
@@ -32,8 +32,13 @@ class CountingWorkflow(Workflow):
         )
 
 
-def _tool_payload(result: list[Any]) -> dict[str, Any]:
-    return json.loads(result[0].text)
+def _tool_payload(result: Any) -> dict[str, Any]:
+    # `call_tool` returns the content list on its own, or `(content, structured)` when
+    # the tool has an output schema. The workflow tool is annotated `-> Any`, which
+    # FastMCP wraps into an output model on Python 3.10 but not on 3.11+ (where `Any`
+    # became a class), so both shapes are reachable and both carry the same payload.
+    content = result[0] if isinstance(result, tuple) else result
+    return json.loads(content[0].text)
 
 
 @pytest.mark.asyncio

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
@@ -2,6 +2,7 @@ import json
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
 from llama_index.tools.mcp import workflow_as_mcp
@@ -56,6 +57,106 @@ async def test_workflow_as_mcp_accepts_explicit_workflow_factory() -> None:
         "CountingWorkflow", {"run_args": {"tenant_id": "bob"}}
     )
 
-    assert _tool_payload(first_result)["label"] == "factory"
-    assert _tool_payload(second_result)["label"] == "factory"
+    first_payload = _tool_payload(first_result)
+    second_payload = _tool_payload(second_result)
+
+    # Each call runs on a fresh instance, so nothing accumulates on `self`.
+    assert first_payload["call_index"] == 1
+    assert second_payload["call_index"] == 1
+    assert first_payload["history_visible"] == ["alice"]
+    assert second_payload["history_visible"] == ["bob"]
+
+    assert first_payload["label"] == "factory"
+    assert second_payload["label"] == "factory"
+    assert factory_call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_workflow_as_mcp_shares_instance_without_factory() -> None:
+    app = workflow_as_mcp(CountingWorkflow(label="shared", timeout=30))
+
+    first_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "alice"}}
+    )
+    second_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "bob"}}
+    )
+
+    # Characterization test: documents the pre-existing shared-instance behavior
+    # that `workflow_factory` opts out of. This is not a guarantee; drop this
+    # test if the default ever becomes per-call isolation.
+    assert _tool_payload(first_result)["call_index"] == 1
+    assert _tool_payload(second_result)["call_index"] == 2
+    assert _tool_payload(second_result)["history_visible"] == ["alice", "bob"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_as_mcp_accepts_async_workflow_factory() -> None:
+    factory_call_count = 0
+
+    async def workflow_factory() -> CountingWorkflow:
+        nonlocal factory_call_count
+        factory_call_count += 1
+        return CountingWorkflow(label="async-factory", timeout=30)
+
+    app = workflow_as_mcp(
+        CountingWorkflow(label="metadata", timeout=30),
+        workflow_factory=workflow_factory,
+    )
+
+    first_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "alice"}}
+    )
+    second_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "bob"}}
+    )
+
+    first_payload = _tool_payload(first_result)
+    second_payload = _tool_payload(second_result)
+
+    # Awaited factories get the same per-call isolation as sync ones.
+    assert first_payload["call_index"] == 1
+    assert second_payload["call_index"] == 1
+    assert first_payload["history_visible"] == ["alice"]
+    assert second_payload["history_visible"] == ["bob"]
+
+    assert first_payload["label"] == "async-factory"
+    assert second_payload["label"] == "async-factory"
+    assert factory_call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_workflow_as_mcp_uses_factory_for_base_model_start_event() -> None:
+    """The factory must also be honored on the plain-BaseModel dispatch branch."""
+
+    class TenantArgs(BaseModel):
+        tenant_id: str
+
+    factory_call_count = 0
+
+    def workflow_factory() -> CountingWorkflow:
+        nonlocal factory_call_count
+        factory_call_count += 1
+        return CountingWorkflow(label="factory", timeout=30)
+
+    app = workflow_as_mcp(
+        CountingWorkflow(label="metadata", timeout=30),
+        start_event_model=TenantArgs,
+        workflow_factory=workflow_factory,
+    )
+
+    first_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "alice"}}
+    )
+    second_result = await app.call_tool(
+        "CountingWorkflow", {"run_args": {"tenant_id": "bob"}}
+    )
+
+    first_payload = _tool_payload(first_result)
+    second_payload = _tool_payload(second_result)
+
+    assert first_payload["call_index"] == 1
+    assert second_payload["call_index"] == 1
+    assert second_payload["history_visible"] == ["bob"]
+    assert second_payload["label"] == "factory"
     assert factory_call_count == 2

--- a/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
@@ -1856,7 +1856,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
Closes #22071

## What changed

`workflow_as_mcp` can now take an optional `workflow_factory`. When it is provided, the MCP tool calls the factory for each request and runs that fresh `Workflow` instance instead of reusing the metadata instance captured by the closure.

This keeps the existing `workflow_as_mcp(workflow, ...)` path working as before, while giving servers a direct isolation path for workflows that keep mutable per-request data on `self`.

## Verification

```bash
cd llama-index-integrations/tools/llama-index-tools-mcp
uv run pytest tests/test_workflow_as_mcp.py tests/test_tools_mcp.py tests/test_client.py -q
uv run ruff check llama_index/tools/mcp/utils.py tests/test_workflow_as_mcp.py
uv run ruff format --check llama_index/tools/mcp/utils.py tests/test_workflow_as_mcp.py
```

<!-- oss-radar:idempotency=auto-20260622-124452.w1.run-llama_llama_index.22071 -->
