### PR TITLE
fix(core): unescape "{{"/"}}" in SafeFormatter.format

### DIFF
--- a/llama-index-core/llama_index/core/prompts/utils.py
+++ b/llama-index-core/llama_index/core/prompts/utils.py
@@ -13,7 +13,10 @@ class SafeFormatter:
         self.format_dict = format_dict or {}
 
     def format(self, format_string: str) -> str:
-        return re.sub(r"\{([^{}]+)\}", self._replace_match, format_string)
+        # Handle "{{" and "}}" as escaped literal braces (like str.format) in the
+        # same pass as field substitution, so that escaped braces are not treated
+        # as field markers (e.g. "{{...}}" stays literal "{...}").
+        return re.sub(r"\{\{|\}\}|\{([^{}]+)\}", self._replace_match, format_string)
 
     def parse(self, format_string: str) -> List[str]:
         return re.findall(
@@ -21,8 +24,15 @@ class SafeFormatter:
         )
 
     def _replace_match(self, match: re.Match) -> str:
+        matched = match.group(0)
+        # Escaped literal braces: collapse "{{" -> "{" and "}}" -> "}".
+        if matched == "{{":
+            return "{"
+        if matched == "}}":
+            return "}"
+
         key = match.group(1)
-        value = self.format_dict.get(key, match.group(0))
+        value = self.format_dict.get(key, matched)
         if isinstance(value, bytes):
             return resolve_binary(value, as_base64=True).read().decode("utf-8")
 

--- a/llama-index-core/tests/prompts/test_utils.py
+++ b/llama-index-core/tests/prompts/test_utils.py
@@ -1,7 +1,27 @@
-from llama_index.core.prompts.utils import get_template_vars
+from llama_index.core.prompts.utils import SafeFormatter, get_template_vars
 
 
 def test_get_template_vars() -> None:
     template = "hello {text} {foo}"
     template_vars = get_template_vars(template)
     assert template_vars == ["text", "foo"]
+
+
+def test_safe_formatter_unescapes_braces() -> None:
+    """Escaped braces ("{{"/"}}") should collapse to literal braces, like str.format."""
+    formatter = SafeFormatter(format_dict={"x": "X"})
+
+    # "{{" -> "{" and "}}" -> "}", even when the escaped content is not a key
+    # (matching the behavior of Python's str.format).
+    template = "{{'head': '', 'props': {{...}}}} and {x}"
+    assert formatter.format(template) == template.format(x="X")
+    assert formatter.format(template) == "{'head': '', 'props': {...}} and X"
+
+    # Empty escaped braces.
+    assert formatter.format("{{}}") == "{}"
+
+    # Escaped braces must not be treated as a field even when they wrap a valid key.
+    assert formatter.format("{{x}}") == "{x}"
+
+    # Missing keys are still left untouched (safe formatting, no KeyError).
+    assert formatter.format("hi {missing}") == "hi {missing}"


### PR DESCRIPTION
# Description

`SafeFormatter.format` (in `llama-index-core/llama_index/core/prompts/utils.py`) is the formatter used by `PromptTemplate.format` (via `format_string`). Unlike Python's `str.format`, it never collapsed escaped braces: `{{` and `}}` were left **doubled** in the output.

This matters because the prompt templates rely on `str.format` escaping semantics. Several shipped default prompts escape literal JSON braces as `{{...}}` so they render as `{...}` after formatting. The most clear-cut example is `DEFAULT_DYNAMIC_EXTRACT_PROPS_PROMPT` / `DEFAULT_DYNAMIC_EXTRACT_PROMPT` (used by `DynamicLLMPathExtractor`), whose guideline/example lines are written as `[{{'head': '', ...}}]`.

**Root cause:** `format()` only substituted `{field}` patterns with the regex `r"\{([^{}]+)\}"` and did nothing with `{{`/`}}`. The previous behavior was also *inconsistent*: `{{key}}` happened to collapse to `{key}` only when `key` was a provided format variable (the inner `{key}` got substituted, leaving the outer braces), but `{{...}}` or `{{'head': ''}}` — where the inner content is not a key — stayed doubled.

**Observable effect:** the prompt actually sent to the LLM contained malformed JSON examples, e.g.

```
- Output in JSON format: [{{'head': '', 'head_type': '', 'head_props': {{...}}, ...}}]
```

instead of the intended

```
- Output in JSON format: [{'head': '', 'head_type': '', 'head_props': {...}, ...}]
```

**Fix:** handle `{{` and `}}` as escaped literal braces in the *same* regex pass as field substitution, so escaped braces are never treated as field markers. After the change, `SafeFormatter.format(...)` output is byte-for-byte identical to `str.format(...)` on these templates, while preserving the existing "safe" behavior (missing keys are left untouched instead of raising `KeyError`).

Fixes # (no tracking issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_safe_formatter_unescapes_braces` in `llama-index-core/tests/prompts/test_utils.py`. It asserts that escaped braces collapse to literal braces (matching `str.format`), including when the escaped content is not a key, for empty escaped braces `{{}}`, and for `{{key}}` wrapping a valid key — while still leaving missing keys untouched.

Red→green proof on the unmodified code:

```
template = "{{'head': '', 'props': {{...}}}} and {x}"
SafeFormatter({"x": "X"}).format(template)
# before:  "{{'head': '', 'props': {{...}}}} and X"   (assert fails)
# after:   "{'head': '', 'props': {...}} and X"        (== template.format(x="X"))
```

Existing `tests/prompts/` and `tests/agent/react/` suites continue to pass (no regressions). The existing `test_template` case `PromptTemplate("test {{message}} {{test}}")` still formats to `test {message} {test}`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the linters (`ruff check`, `ruff format`, `black`, `codespell`, `mypy`) on the changed files
