### PR TITLE
fix(protocols/ag-ui): deep-copy initial_state so workflows don't share state

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -136,7 +137,11 @@ class AGUIChatWorkflow(Workflow):
         self.backend_tools = {
             tool.metadata.name: tool for tool in validated_backend_tools
         }
-        self.initial_state = initial_state or {}
+        # Deep-copy so each workflow owns a private initial_state. The default
+        # factory hands the same operator dict to every workflow it produces;
+        # storing it by reference would alias that dict (and its nested values)
+        # across all workflows and back onto the operator's config.
+        self.initial_state = copy.deepcopy(initial_state) if initial_state else {}
         self.system_prompt = system_prompt
 
     def _snapshot_messages(self, ctx: Context, chat_history: List[ChatMessage]) -> None:
@@ -183,8 +188,10 @@ class AGUIChatWorkflow(Workflow):
                 state = json.loads(state)
                 state.pop("messages", None)
             else:
-                # initial state is not provided, use the default state
-                state = self.initial_state.copy()
+                # initial state is not provided, use the default state.
+                # Deep-copy so per-request mutations (including nested values)
+                # never bleed back into the workflow's template state.
+                state = copy.deepcopy(self.initial_state)
 
             # Save state to context for tools to use
             await ctx.store.set("state", state)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state_isolation.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state_isolation.py
@@ -1,0 +1,157 @@
+"""
+Regression tests for initial_state isolation across AGUIChatWorkflow instances.
+
+The default workflow factory is meant to give each request its own isolated
+workflow, but it used to hand the operator's ``initial_state`` dict to every
+workflow it produced (stored by reference in ``__init__``), and the ``chat``
+step derived per-request state with a shallow ``dict.copy()``. Both let state
+leak across requests. These tests pin down the isolation contract.
+"""
+
+import asyncio
+from typing import Any, AsyncGenerator
+
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse, LLMMetadata
+from llama_index.core.llms.function_calling import FunctionCallingLLM
+from llama_index.protocols.ag_ui.router import get_default_workflow_factory
+
+
+class _FakeLLM(FunctionCallingLLM):
+    """
+    Minimal function-calling LLM that streams one assistant message.
+
+    Only the methods the ``chat`` step actually calls are implemented; the
+    remaining abstract methods are never invoked in these tests.
+    """
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=True, model_name="fake")
+
+    async def astream_chat_with_tools(
+        self, *args: Any, **kwargs: Any
+    ) -> AsyncGenerator[ChatResponse, None]:
+        async def _gen() -> AsyncGenerator[ChatResponse, None]:
+            yield ChatResponse(
+                message=ChatMessage(role="assistant", content="ok"), delta="ok"
+            )
+
+        return _gen()
+
+    def get_tool_calls_from_response(self, *args: Any, **kwargs: Any) -> list:
+        return []
+
+    def chat(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def achat(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def stream_chat(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def astream_chat(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def complete(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def acomplete(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def stream_complete(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    async def astream_complete(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _prepare_chat_with_tools(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def test_factory_isolates_initial_state_across_workflows() -> None:
+    """Each workflow the factory produces must own a private initial_state."""
+    operator_state = {"counter": 0, "items": [], "user": {"roles": []}}
+    factory = get_default_workflow_factory(
+        llm=_FakeLLM(), initial_state=operator_state, timeout=30
+    )
+
+    first = asyncio.run(factory())
+    second = asyncio.run(factory())
+
+    # Top-level dict must be a distinct object on each workflow and distinct
+    # from the operator's config object.
+    assert first.initial_state is not second.initial_state
+    assert first.initial_state is not operator_state
+    assert second.initial_state is not operator_state
+
+    # A mutation on one workflow must not leak to the other or to the operator.
+    first.initial_state["secret"] = "API-KEY-ALICE"
+    assert "secret" not in second.initial_state
+    assert "secret" not in operator_state
+
+
+def test_factory_deep_copies_nested_state() -> None:
+    """Nested mutable values must not be aliased across produced workflows."""
+    operator_state = {"items": [], "user": {"roles": []}}
+    factory = get_default_workflow_factory(
+        llm=_FakeLLM(), initial_state=operator_state, timeout=30
+    )
+
+    first = asyncio.run(factory())
+    second = asyncio.run(factory())
+
+    assert first.initial_state["items"] is not second.initial_state["items"]
+    assert first.initial_state["items"] is not operator_state["items"]
+    assert first.initial_state["user"] is not operator_state["user"]
+
+    first.initial_state["items"].append({"order_id": "ALICE-77"})
+    first.initial_state["user"]["roles"].append("admin")
+    assert second.initial_state["items"] == []
+    assert second.initial_state["user"]["roles"] == []
+    assert operator_state["items"] == []
+    assert operator_state["user"]["roles"] == []
+
+
+def test_chat_step_state_does_not_alias_initial_state() -> None:
+    """
+    When no request state is supplied, the per-request state derived in the
+    ``chat`` step must be a deep copy of ``initial_state`` so that tool
+    mutations during a run cannot bleed back into the template state.
+    """
+    from ag_ui.core import RunAgentInput, UserMessage
+
+    async def _run() -> None:
+        operator_state = {"counter": 0, "items": [], "user": {"roles": []}}
+        factory = get_default_workflow_factory(
+            llm=_FakeLLM(), initial_state=operator_state, timeout=30
+        )
+        workflow = await factory()
+
+        run_input = RunAgentInput(
+            thread_id="t1",
+            run_id="r1",
+            messages=[UserMessage(id="m1", role="user", content="hi")],
+            tools=[],
+            context=[],
+            state=None,
+            forwarded_props={},
+        )
+
+        handler = workflow.run(input_data=run_input)
+        async for _ in handler.stream_events():
+            pass
+        await handler
+
+        derived_state = await handler.ctx.store.get("state")
+        assert derived_state["items"] is not workflow.initial_state["items"]
+        assert derived_state["user"] is not workflow.initial_state["user"]
+
+        # A mutation on the per-request state (as a tool would do via the
+        # context store) must not bleed back into the template state.
+        derived_state["items"].append({"order_id": "ALICE-77"})
+        derived_state["user"]["roles"].append("admin")
+        assert workflow.initial_state["items"] == []
+        assert workflow.initial_state["user"]["roles"] == []
+
+    asyncio.run(_run())

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
# Description

`get_default_workflow_factory` defines an inner `workflow_factory()` that closes over the operator's `initial_state` dict and passes it into every `AGUIChatWorkflow` it produces. `AGUIChatWorkflow.__init__` stored it by reference (`self.initial_state = initial_state or {}`), so all workflows the factory yields alias the same dict — defeating the per-request isolation the factory exists to provide.

Two leak surfaces, both reported in #22069:

1. Any mutation through `self.initial_state[...]` on one workflow is visible on every other workflow the factory produced, and on the operator's original config object.
2. The `chat` step derived per-request state with a shallow `state = self.initial_state.copy()`, so nested mutable values (`items: []`, `user: {"roles": []}`) stayed aliased across requests.

Fix:
- Deep-copy `initial_state` in `AGUIChatWorkflow.__init__` so each workflow owns a private copy. This protects all callers, not just the default factory.
- Replace the `chat` step's shallow `.copy()` with `copy.deepcopy(...)` so per-request state never bleeds back into the template state.

`initial_state or {}` falsy semantics are unchanged (an empty/None state still yields `{}`).

Fixes #22069

## Version Bump?

- [x] Yes (`0.3.1` -> `0.3.2`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `tests/test_initial_state_isolation.py` covering both leak surfaces: factory-produced workflows hold independent (deeply copied) `initial_state`, and the `chat` step's default-state branch derives a deep copy that doesn't bleed mutations back into the template. All pass; `ruff` and `black` are clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

<!-- oss-radar:idempotency=auto-20260622-124452.w2.run-llama_llama_index.22069 -->
