### PR TITLE
[codex] Use CreateSchema for chat store schemas

### DIFF
--- a/llama-index-core/llama_index/core/storage/chat_store/sql.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/sql.py
@@ -13,8 +13,8 @@ from sqlalchemy import (
     select,
     insert,
     update,
-    text,
 )
+from sqlalchemy.schema import CreateSchema
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -143,7 +143,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
             # Create schema if it doesn't exist (PostgreSQL, SQL Server, etc.)
             async with async_engine.begin() as conn:
                 await conn.execute(
-                    text(f'CREATE SCHEMA IF NOT EXISTS "{self.db_schema}"')
+                    CreateSchema(self.db_schema, if_not_exists=True)
                 )
 
         # Create messages table with status column

--- a/llama-index-core/tests/storage/chat_store/test_sql_schema.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql_schema.py
@@ -1,10 +1,21 @@
 """Tests for SQLAlchemyChatStore schema functionality."""
 
 import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateSchema
 from unittest.mock import AsyncMock, MagicMock
 
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.storage.chat_store.sql import SQLAlchemyChatStore
+
+
+def _compile_schema_creation(schema_name: str) -> str:
+    """Compile CREATE SCHEMA with the PostgreSQL dialect for assertion stability."""
+    return str(
+        CreateSchema(schema_name, if_not_exists=True).compile(
+            dialect=postgresql.dialect()
+        )
+    )
 
 
 class TestSQLAlchemyChatStoreSchema:
@@ -72,10 +83,42 @@ class TestSQLAlchemyChatStoreSchema:
         # Verify schema creation was called
         mock_conn.execute.assert_called()
         call_args = mock_conn.execute.call_args_list[0][0][0]
-        assert 'CREATE SCHEMA IF NOT EXISTS "test_schema"' in str(call_args)
+        assert isinstance(call_args, CreateSchema)
+        assert str(call_args.compile(dialect=postgresql.dialect())) == (
+            _compile_schema_creation("test_schema")
+        )
 
         # Verify MetaData has schema
         assert store._metadata.schema == "test_schema"
+
+    @pytest.mark.asyncio
+    async def test_postgresql_schema_creation_escapes_schema_name(self):
+        """Test that schema creation safely quotes attacker-controlled schema names."""
+        store = SQLAlchemyChatStore(
+            table_name="test_messages",
+            async_database_uri="postgresql+asyncpg://user:pass@host/db",
+            db_schema='x"; DROP TABLE messages; --',
+        )
+
+        async_engine = MagicMock()
+        async_engine.begin.return_value.__aenter__ = AsyncMock()
+        async_engine.begin.return_value.__aexit__ = AsyncMock()
+
+        mock_conn = MagicMock()
+        mock_conn.execute = AsyncMock()
+        mock_conn.run_sync = AsyncMock()
+
+        async_engine.begin.return_value.__aenter__.return_value = mock_conn
+        store._async_engine = async_engine
+
+        await store._setup_tables(async_engine)
+
+        call_args = mock_conn.execute.call_args_list[0][0][0]
+        assert isinstance(call_args, CreateSchema)
+
+        assert str(call_args.compile(dialect=postgresql.dialect())) == (
+            _compile_schema_creation('x"; DROP TABLE messages; --')
+        )
 
     @pytest.mark.asyncio
     async def test_sqlite_schema_behavior(self):
@@ -179,7 +222,10 @@ class TestSQLAlchemyChatStoreSchema:
         # Verify schema creation SQL was called
         mock_conn.execute.assert_called()
         call_args = mock_conn.execute.call_args_list[0][0][0]
-        assert 'CREATE SCHEMA IF NOT EXISTS "my_schema"' in str(call_args)
+        assert isinstance(call_args, CreateSchema)
+        assert str(call_args.compile(dialect=postgresql.dialect())) == (
+            _compile_schema_creation("my_schema")
+        )
         assert store._metadata.schema == "my_schema"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace raw `CREATE SCHEMA` string interpolation in `SQLAlchemyChatStore` with SQLAlchemy's `CreateSchema`
- add regression coverage that compiles schema creation through the PostgreSQL dialect, including an attacker-controlled schema name
- keep existing schema behavior intact for valid identifiers while preventing SQL injection through `db_schema`

## Root Cause
`db_schema` was interpolated directly into a SQL string during schema creation. If an application passed an untrusted schema name, initialization could execute injected SQL.

## Validation
- `/private/tmp/llama_index_core_test_env/bin/pytest /Users/chenjianliang/Documents/github安全審計獎金/llama_index/llama-index-core/tests/storage/chat_store/test_sql_schema.py`
