### PR TITLE
fix: refresh shared docstore vector indexes

### DIFF
--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -19,6 +19,7 @@ from llama_index.core.indices.base import BaseIndex
 from llama_index.core.indices.utils import async_embed_nodes, embed_nodes
 from llama_index.core.schema import (
     BaseNode,
+    Document,
     ImageNode,
     IndexNode,
     MetadataMode,
@@ -28,7 +29,12 @@ from llama_index.core.settings import Settings
 from llama_index.core.storage.docstore.types import RefDocInfo
 from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core.utils import iter_batch
-from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    FilterCondition,
+    MetadataFilter,
+    MetadataFilters,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -410,10 +416,183 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
     def _delete_from_index_struct(self, ref_doc_id: str) -> None:
         # delete from index_struct only if needed
         if not self._vector_store.stores_text or self._store_nodes_override:
-            ref_doc_info = self._docstore.get_ref_doc_info(ref_doc_id)
-            if ref_doc_info is not None:
-                for node_id in ref_doc_info.node_ids:
-                    self._index_struct.delete(node_id)
+            for node_id in self._get_node_ids_in_index(ref_doc_id):
+                self._index_struct.delete(node_id)
+
+    def _get_node_ids_in_index(self, ref_doc_id: str) -> List[str]:
+        """Get node ids for a ref doc that are present in this index struct."""
+        node_ids: List[str] = []
+        for vector_id, node_id in list(self._index_struct.nodes_dict.items()):
+            node = self._docstore.get_node(node_id, raise_error=False)
+            if node is not None and node.ref_doc_id == ref_doc_id:
+                node_ids.append(vector_id)
+        return node_ids
+
+    def _get_docstore_node_ids_in_index(self, ref_doc_id: str) -> List[str]:
+        """Get docstore node ids for a ref doc in this index struct."""
+        node_ids: List[str] = []
+        for node_id in list(self._index_struct.nodes_dict.values()):
+            node = self._docstore.get_node(node_id, raise_error=False)
+            if node is not None and node.ref_doc_id == ref_doc_id:
+                node_ids.append(node_id)
+        return node_ids
+
+    async def _aget_node_ids_in_index(self, ref_doc_id: str) -> List[str]:
+        """Get node ids for a ref doc that are present in this index struct."""
+        node_ids: List[str] = []
+        for vector_id, node_id in list(self._index_struct.nodes_dict.items()):
+            node = await self._docstore.aget_node(node_id, raise_error=False)
+            if node is not None and node.ref_doc_id == ref_doc_id:
+                node_ids.append(vector_id)
+        return node_ids
+
+    async def _aget_docstore_node_ids_in_index(self, ref_doc_id: str) -> List[str]:
+        """Get docstore node ids for a ref doc in this index struct."""
+        node_ids: List[str] = []
+        for node_id in list(self._index_struct.nodes_dict.values()):
+            node = await self._docstore.aget_node(node_id, raise_error=False)
+            if node is not None and node.ref_doc_id == ref_doc_id:
+                node_ids.append(node_id)
+        return node_ids
+
+    def _has_index_node_changed(self, document: Document) -> bool:
+        """Check this index's stored nodes rather than only the shared docstore."""
+        nodes = self._get_nodes_for_ref_doc_id(document.id_)
+        if nodes is None:
+            return True
+
+        for node in nodes:
+            if node.source_node is not None:
+                return node.source_node.hash != document.hash
+        return False
+
+    async def _ahas_index_node_changed(self, document: Document) -> bool:
+        """Check this index's stored nodes rather than only the shared docstore."""
+        nodes = await self._aget_nodes_for_ref_doc_id(document.id_)
+        if nodes is None:
+            return True
+
+        for node in nodes:
+            if node.source_node is not None:
+                return node.source_node.hash != document.hash
+        return False
+
+    def _get_ref_doc_filter(self, ref_doc_id: str) -> MetadataFilters:
+        return MetadataFilters(
+            filters=[
+                MetadataFilter(key="doc_id", value=ref_doc_id),
+                MetadataFilter(key="document_id", value=ref_doc_id),
+                MetadataFilter(key="ref_doc_id", value=ref_doc_id),
+            ],
+            condition=FilterCondition.OR,
+        )
+
+    def _get_nodes_for_ref_doc_id(self, ref_doc_id: str) -> Optional[List[BaseNode]]:
+        if not self._vector_store.stores_text or self._store_nodes_override:
+            nodes: List[BaseNode] = []
+            for node_id in self._index_struct.nodes_dict.values():
+                node = self._docstore.get_node(node_id, raise_error=False)
+                if node is not None and node.ref_doc_id == ref_doc_id:
+                    nodes.append(node)
+            return nodes
+
+        try:
+            nodes = self._vector_store.get_nodes(
+                filters=self._get_ref_doc_filter(ref_doc_id)
+            )
+            return [node for node in nodes if node.ref_doc_id == ref_doc_id]
+        except NotImplementedError:
+            return None
+
+    async def _aget_nodes_for_ref_doc_id(
+        self, ref_doc_id: str
+    ) -> Optional[List[BaseNode]]:
+        if not self._vector_store.stores_text or self._store_nodes_override:
+            nodes: List[BaseNode] = []
+            for node_id in self._index_struct.nodes_dict.values():
+                node = await self._docstore.aget_node(node_id, raise_error=False)
+                if node is not None and node.ref_doc_id == ref_doc_id:
+                    nodes.append(node)
+            return nodes
+
+        try:
+            nodes = await self._vector_store.aget_nodes(
+                filters=self._get_ref_doc_filter(ref_doc_id)
+            )
+            return [node for node in nodes if node.ref_doc_id == ref_doc_id]
+        except NotImplementedError:
+            return None
+
+    def _refresh_ref_doc(self, document: Document, **update_kwargs: Any) -> None:
+        """Update this vector index without deleting shared docstore nodes."""
+        old_node_ids = self._get_docstore_node_ids_in_index(document.id_)
+        self.delete_ref_doc(
+            document.id_,
+            delete_from_docstore=False,
+            **update_kwargs.get("delete_kwargs", {}),
+        )
+        for node_id in old_node_ids:
+            self._docstore.delete_document(node_id, raise_error=False)
+        self.insert(document, **update_kwargs.get("insert_kwargs", {}))
+
+    async def _arefresh_ref_doc(self, document: Document, **update_kwargs: Any) -> None:
+        """Update this vector index without deleting shared docstore nodes."""
+        old_node_ids = await self._aget_docstore_node_ids_in_index(document.id_)
+        await self.adelete_ref_doc(
+            document.id_,
+            delete_from_docstore=False,
+            **update_kwargs.get("delete_kwargs", {}),
+        )
+        for node_id in old_node_ids:
+            await self._docstore.adelete_document(node_id, raise_error=False)
+        await self.ainsert(document, **update_kwargs.get("insert_kwargs", {}))
+
+    def refresh_ref_docs(
+        self, documents: Sequence[Document], **update_kwargs: Any
+    ) -> List[bool]:
+        """Refresh documents in this vector index."""
+        with self._callback_manager.as_trace("refresh_ref_docs"):
+            refreshed_documents = [False] * len(documents)
+            for i, document in enumerate(documents):
+                existing_doc_hash = self._docstore.get_document_hash(document.id_)
+                if existing_doc_hash is None:
+                    self.insert(document, **update_kwargs.get("insert_kwargs", {}))
+                    refreshed_documents[i] = True
+                elif existing_doc_hash != document.hash or self._has_index_node_changed(
+                    document
+                ):
+                    self._refresh_ref_doc(
+                        document, **update_kwargs.get("update_kwargs", {})
+                    )
+                    refreshed_documents[i] = True
+
+            return refreshed_documents
+
+    async def arefresh_ref_docs(
+        self, documents: Sequence[Document], **update_kwargs: Any
+    ) -> List[bool]:
+        """Asynchronously refresh documents in this vector index."""
+        with self._callback_manager.as_trace("arefresh_ref_docs"):
+            refreshed_documents = [False] * len(documents)
+            for i, document in enumerate(documents):
+                existing_doc_hash = await self._docstore.aget_document_hash(
+                    document.id_
+                )
+                if existing_doc_hash is None:
+                    await self.ainsert(
+                        document, **update_kwargs.get("insert_kwargs", {})
+                    )
+                    refreshed_documents[i] = True
+                elif (
+                    existing_doc_hash != document.hash
+                    or await self._ahas_index_node_changed(document)
+                ):
+                    await self._arefresh_ref_doc(
+                        document, **update_kwargs.get("update_kwargs", {})
+                    )
+                    refreshed_documents[i] = True
+
+            return refreshed_documents
 
     def _delete_from_docstore(self, ref_doc_id: str) -> None:
         # delete from docstore only if needed
@@ -433,10 +612,8 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
     async def _adelete_from_index_struct(self, ref_doc_id: str) -> None:
         """Delete from index_struct only if needed."""
         if not self._vector_store.stores_text or self._store_nodes_override:
-            ref_doc_info = await self._docstore.aget_ref_doc_info(ref_doc_id)
-            if ref_doc_info is not None:
-                for node_id in ref_doc_info.node_ids:
-                    self._index_struct.delete(node_id)
+            for node_id in await self._aget_node_ids_in_index(ref_doc_id):
+                self._index_struct.delete(node_id)
 
     async def _adelete_from_docstore(self, ref_doc_id: str) -> None:
         """Delete from docstore only if needed."""

--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -511,11 +511,12 @@ class KVDocumentStore(BaseDocumentStore):
         Helper function to remove node doc_id from ref_doc_collection.
         If ref_doc has no more doc_ids, delete it from the collection.
         """
-        ref_doc_id, ref_doc_info = await asyncio.gather(
-            self._aget_ref_doc_id(doc_id),
-            self.aget_ref_doc_info(doc_id),
-        )
-        if ref_doc_id is None or ref_doc_info is None:
+        ref_doc_id = await self._aget_ref_doc_id(doc_id)
+        if ref_doc_id is None:
+            return
+
+        ref_doc_info = await self.aget_ref_doc_info(ref_doc_id)
+        if ref_doc_info is None:
             return
 
         if doc_id in ref_doc_info.node_ids:  # sanity check
@@ -545,8 +546,8 @@ class KVDocumentStore(BaseDocumentStore):
 
     async def adelete_document(self, doc_id: str, raise_error: bool = True) -> None:
         """Delete a document from the store."""
-        _, delete_success, _ = await asyncio.gather(
-            self._aremove_from_ref_doc_node(doc_id),
+        await self._aremove_from_ref_doc_node(doc_id)
+        delete_success, _ = await asyncio.gather(
             self._kvstore.adelete(doc_id, collection=self._node_collection),
             self._kvstore.adelete(doc_id, collection=self._metadata_collection),
         )

--- a/llama-index-core/tests/indices/vector_store/test_simple.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple.py
@@ -1,14 +1,17 @@
 """Test vector store indexes."""
 
 import pickle
-from typing import Any, List, cast
+from typing import Any, Dict, List, Optional, Sequence, cast
 
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.indices.loading import load_index_from_storage
 from llama_index.core.indices.vector_store.base import VectorStoreIndex
 from llama_index.core.indices.keyword_table.simple_base import SimpleKeywordTableIndex
-from llama_index.core.schema import Document
+from llama_index.core.schema import BaseNode, Document
+from llama_index.core.storage.docstore.simple_docstore import SimpleDocumentStore
 from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core.vector_stores.simple import SimpleVectorStore
+from llama_index.core.vector_stores.types import MetadataFilters
 
 
 def test_build_simple(
@@ -150,6 +153,172 @@ def test_simple_delete_ref_node_from_docstore(
     docstore = index.docstore.get_ref_doc_info("test_id_1")
 
     assert docstore is None
+
+
+def test_refresh_shared_docstore_updates_each_vector_index(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    """Refresh each vector index even when another index updated the docstore."""
+    docstore = SimpleDocumentStore()
+    vector_store_1 = SimpleVectorStore()
+    vector_store_2 = SimpleVectorStore()
+    document = Document(text="Hello world.", id_="doc_id")
+
+    index_1 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_1
+        ),
+        embed_model=mock_embed_model,
+    )
+    index_2 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_2
+        ),
+        embed_model=mock_embed_model,
+    )
+
+    refreshed_document = Document(text="This is a test.", id_="doc_id")
+
+    assert index_1.refresh_ref_docs([refreshed_document]) == [True]
+    assert index_2.refresh_ref_docs([refreshed_document]) == [True]
+
+    assert list(vector_store_1.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
+    assert list(vector_store_2.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
+    assert len(index_1.index_struct.nodes_dict) == 1
+    assert len(index_2.index_struct.nodes_dict) == 1
+
+
+def test_delete_shared_docstore_removes_only_nodes_for_current_vector_index(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    """Deleting one vector index should not remove another index's nodes."""
+    docstore = SimpleDocumentStore()
+    vector_store_1 = SimpleVectorStore()
+    vector_store_2 = SimpleVectorStore()
+    document = Document(text="Hello world.", id_="doc_id")
+
+    index_1 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_1
+        ),
+        embed_model=mock_embed_model,
+    )
+    index_2 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_2
+        ),
+        embed_model=mock_embed_model,
+    )
+
+    index_1.delete_ref_doc("doc_id")
+
+    assert len(index_1.index_struct.nodes_dict) == 0
+    assert len(vector_store_1.data.embedding_dict) == 0
+    assert len(index_2.index_struct.nodes_dict) == 1
+    assert len(vector_store_2.data.embedding_dict) == 1
+
+
+class TextStoringVectorStore(SimpleVectorStore):
+    stores_text: bool = True
+    _nodes: Dict[str, BaseNode] = PrivateAttr(default_factory=dict)
+
+    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> List[str]:
+        for node in nodes:
+            self._nodes[node.node_id] = node
+        return super().add(nodes, **add_kwargs)
+
+    def get_nodes(
+        self,
+        node_ids: Optional[List[str]] = None,
+        filters: Optional[MetadataFilters] = None,
+    ) -> List[BaseNode]:
+        del filters
+        nodes = list(self._nodes.values())
+        if node_ids is not None:
+            node_id_set = set(node_ids)
+            nodes = [node for node in nodes if node.node_id in node_id_set]
+        return nodes
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        super().delete(ref_doc_id, **delete_kwargs)
+        self._nodes = {
+            node_id: node
+            for node_id, node in self._nodes.items()
+            if node.ref_doc_id != ref_doc_id
+        }
+
+
+def test_refresh_shared_docstore_updates_each_text_storing_vector_index(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    docstore = SimpleDocumentStore()
+    vector_store_1 = TextStoringVectorStore()
+    vector_store_2 = TextStoringVectorStore()
+    document = Document(text="Hello world.", id_="doc_id")
+
+    index_1 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_1
+        ),
+        embed_model=mock_embed_model,
+    )
+    index_2 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_2
+        ),
+        embed_model=mock_embed_model,
+    )
+
+    refreshed_document = Document(text="This is a test.", id_="doc_id")
+
+    assert index_1.refresh_ref_docs([refreshed_document]) == [True]
+    assert index_2.refresh_ref_docs([refreshed_document]) == [True]
+
+    assert list(vector_store_1.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
+    assert list(vector_store_2.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
+    assert len(index_1.index_struct.nodes_dict) == 0
+    assert len(index_2.index_struct.nodes_dict) == 0
+
+
+def test_refresh_shared_docstore_updates_text_storing_index_without_get_nodes(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    class TextStoreWithoutGetNodes(SimpleVectorStore):
+        stores_text: bool = True
+
+    docstore = SimpleDocumentStore()
+    vector_store_1 = TextStoreWithoutGetNodes()
+    vector_store_2 = TextStoreWithoutGetNodes()
+    document = Document(text="Hello world.", id_="doc_id")
+
+    index_1 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_1
+        ),
+        embed_model=mock_embed_model,
+    )
+    index_2 = VectorStoreIndex.from_documents(
+        [document],
+        storage_context=StorageContext.from_defaults(
+            docstore=docstore, vector_store=vector_store_2
+        ),
+        embed_model=mock_embed_model,
+    )
+
+    refreshed_document = Document(text="This is a test.", id_="doc_id")
+
+    assert index_1.refresh_ref_docs([refreshed_document]) == [True]
+    assert index_2.refresh_ref_docs([refreshed_document]) == [True]
+
+    assert list(vector_store_1.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
+    assert list(vector_store_2.data.embedding_dict.values()) == [[0, 1, 0, 0, 0]]
 
 
 def test_delete_ref_doc_nodes_removed_from_docstore(

--- a/llama-index-core/tests/storage/docstore/test_simple_docstore.py
+++ b/llama-index-core/tests/storage/docstore/test_simple_docstore.py
@@ -125,6 +125,24 @@ def test_docstore_delete_ref_doc_not_in_docstore() -> None:
     assert docstore._kvstore.get("d3", docstore._ref_doc_collection) is None
 
 
+@pytest.mark.asyncio
+async def test_docstore_adelete_document_updates_ref_doc_info() -> None:
+    ref_doc = Document(text="hello world", id_="d1", metadata={"foo": "bar"})
+    doc = Document(text="hello world", id_="d2", metadata={"foo": "bar"})
+    doc.relationships[NodeRelationship.SOURCE] = ref_doc.as_related_node_info()
+    node = TextNode(text="my node", id_="d3", metadata={"node": "info"})
+    node.relationships[NodeRelationship.SOURCE] = ref_doc.as_related_node_info()
+
+    docstore = SimpleDocumentStore()
+    docstore.add_documents([ref_doc, doc, node])
+
+    await docstore.adelete_document("d2")
+
+    ref_doc_info = docstore.get_ref_doc_info("d1")
+    assert ref_doc_info is not None
+    assert ref_doc_info.node_ids == ["d3"]
+
+
 def test_docstore_delete_all_ref_doc_nodes() -> None:
     ref_doc = Document(text="hello world", id_="d1", metadata={"foo": "bar"})
     doc = Document(text="hello world", id_="d2", metadata={"foo": "bar"})


### PR DESCRIPTION
## Summary
- Refresh vector indexes against their own stored nodes when a shared docstore was already updated by another index
- Delete only nodes that belong to the current vector index when indexes share a docstore
- Fix async docstore deletion so ref doc metadata is updated before node metadata is removed

## Test plan
- uv run pytest llama-index-core/tests/indices/vector_store/test_simple.py llama-index-core/tests/storage/docstore/test_simple_docstore.py -q
- uv run ruff check llama-index-core/llama_index/core/indices/vector_store/base.py llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py llama-index-core/tests/indices/vector_store/test_simple.py llama-index-core/tests/storage/docstore/test_simple_docstore.py
- cd llama-index-core && uv run mypy llama_index/core/indices/vector_store/base.py llama_index/core/storage/docstore/keyval_docstore.py --ignore-missing-imports

Fixes #14943