### PR TITLE
fix(protocols/ag-ui): require tool_call_id on tool messages

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -60,13 +60,16 @@ def llama_index_message_to_ag_ui_message(
             tool_calls=tool_calls,
         )
     elif message.role.value == "tool" or "tool_call_id" in message.additional_kwargs:
+        if "tool_call_id" not in message.additional_kwargs:
+            raise ValueError(
+                "Tool messages must include additional_kwargs['tool_call_id'] "
+                "to preserve the assistant tool-call pairing."
+            )
         return ToolMessage(
             id=msg_id,
             content=message.content or "",
             role="tool",
-            tool_call_id=message.additional_kwargs.get(
-                "tool_call_id", str(uuid.uuid4())
-            ),
+            tool_call_id=message.additional_kwargs["tool_call_id"],
         )
     else:
         raise ValueError(f"Unknown message role: {message.role}")

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
@@ -1,0 +1,32 @@
+import pytest
+from ag_ui.core import ToolMessage
+
+from llama_index.core.llms import ChatMessage
+from llama_index.protocols.ag_ui.utils import llama_index_message_to_ag_ui_message
+
+
+def test_tool_message_requires_tool_call_id() -> None:
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1"},
+    )
+
+    with pytest.raises(ValueError, match="tool_call_id"):
+        llama_index_message_to_ag_ui_message(message)
+
+
+def test_tool_message_preserves_tool_call_id() -> None:
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={
+            "id": "tool_msg_1",
+            "tool_call_id": "call_get_weather_001",
+        },
+    )
+
+    ag_ui_message = llama_index_message_to_ag_ui_message(message)
+
+    assert isinstance(ag_ui_message, ToolMessage)
+    assert ag_ui_message.tool_call_id == "call_get_weather_001"

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary

- stop fabricating a random `tool_call_id` when converting LlamaIndex tool-role messages to AG-UI `ToolMessage`s
- raise a clear `ValueError` instead, so broken histories fail before an orphan tool result is serialized and round-tripped
- add regression tests for the missing-id failure path and the valid preservation path
- sync the integration lock entry with the current `0.3.2` package version

Fixes #22068.

## Root cause

`llama_index_message_to_ag_ui_message()` routed `role="tool"` messages into the AG-UI `ToolMessage` branch even when `additional_kwargs["tool_call_id"]` was missing. The branch then used `str(uuid.uuid4())` as a fallback. That silently produced a tool result id that did not match any prior assistant tool call, violating the provider message-history pairing invariant.

## Current-main verification

Refreshed onto `main@67514f63410c6d4c2344e7ca14b3ea7214d0bb84`; current head is `740a24ed5`. Current upstream still uses the random UUID fallback and issue #22068 remains open.

- `uv run --python 3.12 --frozen pytest tests/test_utils.py -q` -> 2 passed
- `uv run --python 3.12 --frozen ruff check llama_index/protocols/ag_ui/utils.py tests/test_utils.py` -> passed
- `uv run --python 3.12 --frozen ruff format --check llama_index/protocols/ag_ui/utils.py tests/test_utils.py pyproject.toml` -> passed
- `git diff --check origin/main...HEAD` -> passed

The first local test attempt selected Python 3.13 and stopped before collection because locked `tree-sitter-languages==1.10.2` only provides wheels through cp312. Re-running in the compatible Python 3.12 frozen environment passed without changing dependencies.