### PR TITLE
fix(protocols/ag-ui): use real tool_call_id instead of fabricating a uuid4

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -60,13 +60,16 @@ def llama_index_message_to_ag_ui_message(
             tool_calls=tool_calls,
         )
     elif message.role.value == "tool" or "tool_call_id" in message.additional_kwargs:
+        # Prefer the real tool_call_id the message already carries so the
+        # ToolMessage stays paired with the AssistantMessage.tool_calls[*].id
+        # that produced it. Only when it is genuinely absent do we fall back to
+        # the message's own stable id (msg_id) instead of fabricating a fresh,
+        # unrelated uuid4 that would pair with nothing.
         return ToolMessage(
             id=msg_id,
             content=message.content or "",
             role="tool",
-            tool_call_id=message.additional_kwargs.get(
-                "tool_call_id", str(uuid.uuid4())
-            ),
+            tool_call_id=message.additional_kwargs.get("tool_call_id") or msg_id,
         )
     else:
         raise ValueError(f"Unknown message role: {message.role}")

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
@@ -1,0 +1,63 @@
+import re
+
+from ag_ui.core import ToolMessage
+from llama_index.core.llms import ChatMessage
+from llama_index.protocols.ag_ui.utils import (
+    llama_index_message_to_ag_ui_message,
+)
+
+UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def test_tool_message_uses_real_tool_call_id_from_additional_kwargs():
+    """A tool ChatMessage carrying the real id must reuse it, not mint a uuid."""
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1", "tool_call_id": "call_get_weather_001"},
+    )
+
+    ag_ui_message = llama_index_message_to_ag_ui_message(message)
+
+    assert isinstance(ag_ui_message, ToolMessage)
+    assert ag_ui_message.tool_call_id == "call_get_weather_001"
+
+
+def test_user_role_message_with_tool_call_id_uses_real_id():
+    """A role="user" message that carries tool_call_id routes to ToolMessage and keeps the id."""
+    message = ChatMessage(
+        role="user",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1", "tool_call_id": "call_get_weather_001"},
+    )
+
+    ag_ui_message = llama_index_message_to_ag_ui_message(message)
+
+    assert isinstance(ag_ui_message, ToolMessage)
+    assert ag_ui_message.tool_call_id == "call_get_weather_001"
+
+
+def test_tool_message_without_tool_call_id_does_not_fabricate_random_uuid():
+    """
+    When the id is genuinely absent the fallback must be deterministic.
+
+    The old behaviour minted a fresh ``uuid.uuid4()`` each call, producing a
+    different orphan id every time and silently breaking the
+    AssistantMessage.tool_calls[*].id <-> ToolMessage.tool_call_id pairing.
+    The fallback must instead be stable and derived from the message itself.
+    """
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1"},  # no tool_call_id
+    )
+
+    first = llama_index_message_to_ag_ui_message(message)
+    second = llama_index_message_to_ag_ui_message(message)
+
+    assert isinstance(first, ToolMessage)
+    # Deterministic: converting the same message twice yields the same id.
+    assert first.tool_call_id == second.tool_call_id
+    # The fallback is the message's own id, not a freshly fabricated uuid4.
+    assert first.tool_call_id == "tool_msg_1"
+    assert not UUID4_RE.match(first.tool_call_id or "")


### PR DESCRIPTION
## Description

`llama_index_message_to_ag_ui_message` minted a fresh `uuid4()` for a tool message's `tool_call_id` whenever the top-level key was absent — even though the real id is in `additional_kwargs["tool_call_id"]`. That fabricated a new, unrelated id on every call, orphaning the `AssistantMessage.tool_calls[*].id` pairing (#22068).

It now reads `additional_kwargs["tool_call_id"]` first and, on genuine absence, falls back to the message's own stable `id` (`msg_id`) instead of a random uuid — deterministic and tied to the message.

Fixes #22068

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests

`tests/test_utils.py` (3 tests): preserves a present `tool_call_id`, routes a `role="user"` + `tool_call_id` message to a ToolMessage, and asserts the no-id case uses a deterministic fallback (same across calls, not a uuid4). Red→green; `uv run pytest` → 3 passed; `ruff check` / `ruff format` clean.

## Checklist

- [x] I ran `uv run make format; uv run make lint`
- [x] Version bumped (0.3.1 → 0.3.2)
