### PR TITLE
fix: initialize multimodal retriever base state

### DIFF
--- a/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
@@ -61,6 +61,8 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         doc_ids: Optional[List[str]] = None,
         sparse_top_k: Optional[int] = None,
         callback_manager: Optional[CallbackManager] = None,
+        object_map: Optional[dict] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -84,7 +86,11 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         self._sparse_top_k = sparse_top_k
 
         self._kwargs: Dict[str, Any] = kwargs.get("vector_store_kwargs", {})
-        self.callback_manager = callback_manager or Settings.callback_manager
+        super().__init__(
+            callback_manager=callback_manager or Settings.callback_manager,
+            object_map=object_map,
+            verbose=verbose,
+        )
 
     @property
     def similarity_top_k(self) -> int:

--- a/llama-index-core/tests/indices/multi_modal/test_retriever.py
+++ b/llama-index-core/tests/indices/multi_modal/test_retriever.py
@@ -1,0 +1,21 @@
+from llama_index.core import MockEmbedding
+from llama_index.core.embeddings import MockMultiModalEmbedding
+from llama_index.core.indices import MultiModalVectorStoreIndex
+from llama_index.core.schema import IndexNode
+
+
+def test_retrieve_index_node_initializes_base_retriever_state() -> None:
+    index = MultiModalVectorStoreIndex(
+        nodes=[IndexNode(text="nested", index_id="nested")],
+        embed_model=MockEmbedding(embed_dim=3),
+        image_embed_model=MockMultiModalEmbedding(embed_dim=3),
+        is_image_vector_store_empty=True,
+    )
+    retriever = index.as_retriever()
+
+    assert retriever.object_map == {}
+    nodes = retriever.retrieve("nested")
+
+    assert len(nodes) == 1
+    assert isinstance(nodes[0].node, IndexNode)
+    assert nodes[0].node.index_id == "nested"


### PR DESCRIPTION
## Summary
- initialize `BaseRetriever` state from `MultiModalVectorIndexRetriever`
- preserve the existing Settings callback manager default
- add a regression test for retrieving an `IndexNode` through a multimodal vector retriever

## Root cause
`MultiModalVectorIndexRetriever` inherits from `BaseRetriever` through `MultiModalRetriever`, but its constructor assigned `callback_manager` directly instead of calling `BaseRetriever.__init__()`. That left base retriever fields such as `object_map` and `_verbose` unset.

When a multimodal vector retrieval result contains an `IndexNode`, `BaseRetriever._handle_recursive_retrieval()` evaluates `self.object_map`, raising `AttributeError: MultiModalVectorIndexRetriever object has no attribute object_map`.

Fixes #22080.

## Current-main verification
Refreshed onto `main@67514f63410c6d4c2344e7ca14b3ea7214d0bb84`; current head is `acc95d12d`. The current upstream constructor still assigns `callback_manager` directly and the issue remains open.

- `uv run --project llama-index-core pytest llama-index-core/tests/indices/multi_modal/test_retriever.py llama-index-core/tests/chat_engine/test_multi_modal_context.py -q` -> 7 passed
- `uv run --project llama-index-core ruff check llama-index-core/llama_index/core/indices/multi_modal/retriever.py llama-index-core/tests/indices/multi_modal/test_retriever.py` -> passed
- `uv run --project llama-index-core ruff format --check llama-index-core/llama_index/core/indices/multi_modal/retriever.py llama-index-core/tests/indices/multi_modal/test_retriever.py` -> passed
- `git diff --check origin/main...HEAD` -> passed