### PR TITLE
fix: preserve falsy Azure AI Search metadata

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/llama_index/vector_stores/azureaisearch/base.py
@@ -896,7 +896,7 @@ class AzureAISearchVectorStore(BasePydanticVectorStore):
             _,
         ) in self._metadata_to_index_field_map.items():
             metadata_value = metadata.get(metadata_field_name)
-            if metadata_value:
+            if metadata_value is not None:
                 index_doc[index_field_name] = metadata_value
 
         return index_doc

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch/tests/test_azureaisearch.py
@@ -80,6 +80,51 @@ def create_sample_documents(n: int) -> List[TextNode]:
 @pytest.mark.skipif(
     not azureaisearch_installed, reason="azure-search-documents package not installed"
 )
+def test_azureaisearch_add_preserves_falsy_metadata_values() -> None:
+    search_client = mock_client_with_user_agent("search")
+    with patch("azure.search.documents.IndexDocumentsBatch") as MockIndexDocumentsBatch:
+        index_documents_batch_instance = MockIndexDocumentsBatch.return_value
+        vector_store = AzureAISearchVectorStore(
+            search_or_index_client=search_client,
+            id_field_key="id",
+            chunk_field_key="content",
+            embedding_field_key="embedding",
+            metadata_string_field_key="metadata",
+            doc_id_field_key="doc_id",
+            filterable_metadata_field_keys={
+                "zero": 0,
+                "empty_string": "",
+                "empty_collection": [],
+                "none_value": "none_value",
+            },
+            hidden_field_keys=["embedding"],
+            index_management=IndexManagement.NO_VALIDATION,
+            embedding_dimensionality=2,
+        )
+        node = TextNode(
+            text="node text",
+            embedding=[0.5, 0.5],
+            metadata={
+                "zero": 0,
+                "empty_string": "",
+                "empty_collection": [],
+                "none_value": None,
+            },
+        )
+
+        vector_store.add([node])
+
+    index_doc = index_documents_batch_instance.add_upload_actions.call_args.args[0]
+    assert index_doc["zero"] == 0
+    assert index_doc["empty_string"] == ""
+    assert index_doc["empty_collection"] == []
+    assert "none_value" not in index_doc
+    search_client.index_documents.assert_called_once()
+
+
+@pytest.mark.skipif(
+    not azureaisearch_installed, reason="azure-search-documents package not installed"
+)
 def test_user_agent_configuration() -> None:
     """Test that user agent is properly configured."""
     # Test with SearchClient


### PR DESCRIPTION
## Summary
- Fixes #21385
- Preserve valid falsy metadata values such as `0`, `""`, and `[]` when mapping Azure AI Search filterable metadata fields
- Continue omitting metadata fields whose value is actually `None`

## Root cause
`AzureAISearchVectorStore._default_index_mapping()` used a truthiness check before copying mapped metadata values into the Azure index document. That skipped valid falsy values and made them disappear from the indexed document.

## Validation
From `llama-index-integrations/vector_stores/llama-index-vector-stores-azureaisearch`:

```bash
uv run -- pytest tests/test_azureaisearch.py::test_azureaisearch_add_preserves_falsy_metadata_values tests/test_azureaisearch.py tests/test_vector_stores_cogsearch.py
uv run -- ruff check llama_index/vector_stores/azureaisearch/base.py tests/test_azureaisearch.py
uv run -- ruff format --check llama_index/vector_stores/azureaisearch/base.py tests/test_azureaisearch.py
```

## AI assistance
I used Codex to inspect the issue, check for duplicate open PRs, make the focused patch, and run local validation. I reviewed the final diff and test evidence before opening this PR.