### PR TITLE
fix: isolate AG-UI initial state

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from ag_ui.core import RunAgentInput, Tool as AGUITool
@@ -136,7 +137,9 @@ class AGUIChatWorkflow(Workflow):
         self.backend_tools = {
             tool.metadata.name: tool for tool in validated_backend_tools
         }
-        self.initial_state = initial_state or {}
+        self.initial_state = (
+            deepcopy(initial_state) if initial_state is not None else {}
+        )
         self.system_prompt = system_prompt
 
     def _snapshot_messages(self, ctx: Context, chat_history: List[ChatMessage]) -> None:
@@ -184,7 +187,7 @@ class AGUIChatWorkflow(Workflow):
                 state.pop("messages", None)
             else:
                 # initial state is not provided, use the default state
-                state = self.initial_state.copy()
+                state = deepcopy(self.initial_state)
 
             # Save state to context for tools to use
             await ctx.store.set("state", state)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from llama_index.core.llms import MockFunctionCallingLLM
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow
+from llama_index.protocols.ag_ui.router import get_default_workflow_factory
+
+
+def test_agui_chat_workflow_copies_initial_state_from_caller() -> None:
+    initial_state = {"filters": {"tenant_ids": []}}
+
+    workflow = AGUIChatWorkflow(
+        llm=MockFunctionCallingLLM(),
+        initial_state=initial_state,
+    )
+    workflow.initial_state["filters"]["tenant_ids"].append("alice")
+
+    assert initial_state == {"filters": {"tenant_ids": []}}
+
+
+def test_default_workflow_factory_copies_initial_state_per_workflow() -> None:
+    initial_state = {"filters": {"tenant_ids": []}}
+    workflow_factory = get_default_workflow_factory(
+        llm=MockFunctionCallingLLM(),
+        initial_state=initial_state,
+    )
+
+    async def create_workflows() -> tuple[AGUIChatWorkflow, AGUIChatWorkflow]:
+        first = await workflow_factory()
+        second = await workflow_factory()
+        assert isinstance(first, AGUIChatWorkflow)
+        assert isinstance(second, AGUIChatWorkflow)
+        return first, second
+
+    first, second = asyncio.run(create_workflows())
+    first.initial_state["filters"]["tenant_ids"].append("alice")
+
+    assert second.initial_state == {"filters": {"tenant_ids": []}}
+    assert initial_state == {"filters": {"tenant_ids": []}}


### PR DESCRIPTION
# Description

Fixes #22069.

`AGUIChatWorkflow` kept the caller-provided `initial_state` by reference, and the chat step derived per-request state with a shallow `.copy()`. That means nested mutable values can leak between workflows produced by the default workflow factory, between requests, and back into the operator-provided config object.

This PR deep-copies the initial state at workflow construction time and when deriving the per-request state used by the chat step. It also adds regression coverage for both surfaces:

- constructing a workflow does not mutate or alias the caller's initial state;
- two workflows produced by `get_default_workflow_factory()` do not share nested initial-state containers.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Validated from `llama-index-integrations/protocols/llama-index-protocols-ag-ui`:

- `uv run --with pytest pytest tests/test_initial_state.py -q` -> `2 passed`
- `uv run --with ruff ruff check llama_index/protocols/ag_ui/agent.py tests/test_initial_state.py` -> `All checks passed!`
- `uv run --with ruff ruff format --check llama_index/protocols/ag_ui/agent.py tests/test_initial_state.py pyproject.toml` -> `2 files already formatted`
- `git diff --check` -> passed

Note: local `uv run` rewrote root/package `uv.lock` registry URLs as validation noise; I restored those files, so this PR only changes the AG-UI source, tests, and package version.

AI assistance was used to inspect the issue/code path and draft the focused test and patch; I reviewed the diff and validated it locally with the commands above.