### PR TITLE
fix: scope HITL waiters per agent tool call

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -76,6 +76,35 @@ WORKFLOW_KWARGS = (
 )
 
 
+class _ToolCallContext:
+    """Delegate Context calls while scoping default HITL waiter ids per tool."""
+
+    def __init__(self, ctx: Context, tool_id: str) -> None:
+        self._ctx = ctx
+        self._tool_id = tool_id
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._ctx, name)
+
+    async def wait_for_event(
+        self,
+        event_type: Type[Any],
+        waiter_event: Any = None,
+        waiter_id: Optional[str] = None,
+        requirements: Optional[dict[str, Any]] = None,
+        timeout: Optional[float] = 2000,
+    ) -> Any:
+        if waiter_id is None:
+            waiter_id = f"agent_tool_call:{self._tool_id}"
+        return await self._ctx.wait_for_event(
+            event_type,
+            waiter_event=waiter_event,
+            waiter_id=waiter_id,
+            requirements=requirements,
+            timeout=timeout,
+        )
+
+
 def get_default_llm() -> LLM:
     return Settings.llm
 
@@ -349,8 +378,10 @@ class BaseWorkflowAgent(
         ctx: Context,
         tool: AsyncBaseTool,
         tool_input: dict,
+        tool_id: Optional[str] = None,
     ) -> ToolOutput:
         """Call the given tool with the given input."""
+        tool_id = tool_id or tool.metadata.get_name()
         try:
             if (
                 isinstance(tool, FunctionTool)
@@ -358,7 +389,7 @@ class BaseWorkflowAgent(
                 and tool.ctx_param_name is not None
             ):
                 new_tool_input = {**tool_input}
-                new_tool_input[tool.ctx_param_name] = ctx
+                new_tool_input[tool.ctx_param_name] = _ToolCallContext(ctx, tool_id)
                 tool_output = await tool.acall(**new_tool_input)
             else:
                 tool_output = await tool.acall(**tool_input)
@@ -645,7 +676,7 @@ class BaseWorkflowAgent(
             )
         else:
             tool = tools_by_name[ev.tool_name]
-            result = await self._call_tool(ctx, tool, ev.tool_kwargs)
+            result = await self._call_tool(ctx, tool, ev.tool_kwargs, ev.tool_id)
 
         result_ev = ToolCallResult(
             tool_name=ev.tool_name,

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -24,6 +24,7 @@ from llama_index.core.agent.workflow.base_agent import (
     DEFAULT_AGENT_NAME,
     DEFAULT_AGENT_DESCRIPTION,
     DEFAULT_MAX_ITERATIONS,
+    _ToolCallContext,
     _get_waiting_for_event_exception,
 )
 from llama_index.core.agent.workflow.prompts import DEFAULT_EARLY_STOPPING_PROMPT
@@ -350,8 +351,10 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         ctx: Context,
         tool: AsyncBaseTool,
         tool_input: dict,
+        tool_id: Optional[str] = None,
     ) -> ToolOutput:
         """Call the given tool with the given input."""
+        tool_id = tool_id or tool.metadata.get_name()
         try:
             if (
                 isinstance(tool, FunctionTool)
@@ -359,7 +362,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 and tool.ctx_param_name is not None
             ):
                 new_tool_input = {**tool_input}
-                new_tool_input[tool.ctx_param_name] = ctx
+                new_tool_input[tool.ctx_param_name] = _ToolCallContext(ctx, tool_id)
                 tool_output = await tool.acall(**new_tool_input)
             else:
                 tool_output = await tool.acall(**tool_input)
@@ -654,7 +657,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             )
         else:
             tool = tools_by_name[ev.tool_name]
-            result = await self._call_tool(ctx, tool, ev.tool_kwargs)
+            result = await self._call_tool(ctx, tool, ev.tool_kwargs, ev.tool_id)
 
         result_ev = ToolCallResult(
             tool_name=ev.tool_name,

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List
 
 import pytest
@@ -422,6 +423,69 @@ async def test_agent_with_hitl():
 
     assert response is not None
     assert "HITL successful" in str(response)
+
+
+@pytest.mark.asyncio
+async def test_parallel_hitl_tool_calls_have_scoped_waiters():
+    """Parallel tools that wait for HITL should not overwrite each other."""
+
+    async def hitl(ctx: Context, label: str):
+        resp = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix=f"approve {label}?"),
+            timeout=5,
+        )
+        return f"{label}: {resp.response}"
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[hitl],
+        llm=MockFunctionCallingLLM(
+            response_generator=_response_generator_from_list(
+                [
+                    ChatMessage(
+                        role=MessageRole.ASSISTANT,
+                        content="need approval",
+                        additional_kwargs={
+                            "tool_calls": [
+                                ToolSelection(
+                                    tool_id="call_one",
+                                    tool_name="hitl",
+                                    tool_kwargs={"label": "one"},
+                                ),
+                                ToolSelection(
+                                    tool_id="call_two",
+                                    tool_name="hitl",
+                                    tool_kwargs={"label": "two"},
+                                ),
+                            ]
+                        },
+                    ),
+                    ChatMessage(role=MessageRole.ASSISTANT, content="done"),
+                ]
+            )
+        ),
+    )
+
+    workflow = AgentWorkflow(agents=[agent], root_agent="agent", timeout=10)
+    handler = workflow.run(user_msg="test")
+
+    input_required_events = []
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            input_required_events.append(ev)
+            handler.ctx.send_event(
+                HumanResponseEvent(response=f"ok {len(input_required_events)}")
+            )
+            if len(input_required_events) == 2:
+                break
+
+    response = await asyncio.wait_for(handler, timeout=10)
+
+    assert len(input_required_events) == 2
+    assert response is not None
+    assert "done" in str(response)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #22070.

## Summary

Parallel `FunctionAgent` tool calls can each enter the documented HITL pattern via `ctx.wait_for_event(...)`. When those tool functions do not pass an explicit `waiter_id`, the workflow runtime derives the same waiter key for every parallel branch, so the later waiter overwrites the earlier one and only one `InputRequiredEvent` is emitted.

This PR scopes the default waiter id used by agent tool contexts to the current tool call id. Explicit `waiter_id` values are preserved, so callers that intentionally coordinate multiple waits under a shared id can still do so.

## Changes

- Add a small delegated tool-call context that forwards all `Context` behavior but fills a missing `waiter_id` with `agent_tool_call:<tool_id>`.
- Pass that scoped context into context-aware `FunctionTool` calls from both `BaseWorkflowAgent` and `AgentWorkflow`.
- Add a regression test with two parallel HITL tool calls; both now emit `InputRequiredEvent`s and the workflow completes after both responses.

## Validation

- Reproduced the issue on current `main` with the issue PoC: only `1` of `3` `InputRequiredEvent`s was emitted and the workflow timed out.
- `uv run --python 3.12 --frozen pytest tests/agent/workflow/test_multi_agent_workflow.py::test_parallel_hitl_tool_calls_have_scoped_waiters tests/agent/workflow/test_multi_agent_workflow.py::test_agent_with_hitl tests/agent/workflow/test_multi_agent_workflow.py::test_workflow_pickle_serialize_and_resume -q`
- `uv run --python 3.12 --frozen pytest tests/agent/workflow/test_function_call.py::test_call_tool_with_exception tests/agent/workflow/test_function_call.py -q`
- `uv run --python 3.12 --frozen ruff check llama_index/core/agent/workflow/base_agent.py llama_index/core/agent/workflow/multi_agent_workflow.py tests/agent/workflow/test_multi_agent_workflow.py`
- `uv run --python 3.12 --frozen ruff format llama_index/core/agent/workflow/base_agent.py llama_index/core/agent/workflow/multi_agent_workflow.py tests/agent/workflow/test_multi_agent_workflow.py --check`

AI assistance was used to inspect the code path and draft the patch; I manually reviewed the diff and validated it with the checks above.