### PR TITLE
fix(tools-brave-search): add configurable timeout to HTTP request

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-brave-search/llama_index/tools/brave_search/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-brave-search/llama_index/tools/brave_search/base.py
@@ -6,6 +6,8 @@ from llama_index.core.tools.tool_spec.base import BaseToolSpec
 
 SEARCH_URL_TMPL = "https://api.search.brave.com/res/v1/web/search?{params}"
 
+DEFAULT_TIMEOUT = 10.0
+
 
 class BraveSearchToolSpec(BaseToolSpec):
     """
@@ -14,11 +16,17 @@ class BraveSearchToolSpec(BaseToolSpec):
 
     spec_functions = ["brave_search"]
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, timeout: float = DEFAULT_TIMEOUT) -> None:
         """
         Initialize with parameters.
+
+        Args:
+            api_key (str): The Brave Search API subscription token.
+            timeout (float): Timeout in seconds for the HTTP request, default is 10.0.
+
         """
         self.api_key = api_key
+        self.timeout = timeout
 
     def _make_request(self, params: Dict) -> requests.Response:
         """
@@ -38,7 +46,7 @@ class BraveSearchToolSpec(BaseToolSpec):
         }
         url = SEARCH_URL_TMPL.format(params=urllib.parse.urlencode(params))
 
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=self.timeout)
         response.raise_for_status()
         return response
 

--- a/llama-index-integrations/tools/llama-index-tools-brave-search/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-brave-search/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-brave-search"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index tools brave_search integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-brave-search/tests/test_tools_brave_search.py
+++ b/llama-index-integrations/tools/llama-index-tools-brave-search/tests/test_tools_brave_search.py
@@ -1,7 +1,37 @@
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.schema import Document
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.brave_search import BraveSearchToolSpec
+from llama_index.tools.brave_search.base import DEFAULT_TIMEOUT
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in BraveSearchToolSpec.__mro__]
     assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+@patch("llama_index.tools.brave_search.base.requests.get")
+def test_brave_search_passes_default_timeout(mock_get):
+    mock_response = MagicMock()
+    mock_response.text = "{}"
+    mock_get.return_value = mock_response
+
+    tool = BraveSearchToolSpec(api_key="test-key")
+    results = tool.brave_search("hello world")
+
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs["timeout"] == DEFAULT_TIMEOUT
+    assert all(isinstance(doc, Document) for doc in results)
+
+
+@patch("llama_index.tools.brave_search.base.requests.get")
+def test_brave_search_passes_custom_timeout(mock_get):
+    mock_response = MagicMock()
+    mock_response.text = "{}"
+    mock_get.return_value = mock_response
+
+    tool = BraveSearchToolSpec(api_key="test-key", timeout=2.5)
+    tool.brave_search("hello world")
+
+    assert mock_get.call_args.kwargs["timeout"] == 2.5


### PR DESCRIPTION
## Summary

`BraveSearchToolSpec._make_request` calls `requests.get(...)` **without a `timeout`**. Python's `requests` has no default timeout, so a stalled or unresponsive connection to the Brave Search API makes the call block **indefinitely**, hanging any agent/tool that uses this integration with no way to recover.

This PR adds a bounded, configurable timeout.

## Root cause

```python
# llama_index/tools/brave_search/base.py
response = requests.get(url, headers=headers)   # no timeout -> can hang forever
```

## What changed

- Added a `timeout` parameter to `BraveSearchToolSpec.__init__` (default `10.0` seconds), stored on the instance.
- Passed it through to `requests.get(..., timeout=self.timeout)`.
- The change is **backward compatible** — existing callers keep working and simply gain a sane default timeout; callers that need a different bound can pass `BraveSearchToolSpec(api_key=..., timeout=...)`.
- Bumped the package version `0.5.0` -> `0.5.1`.

## Testing

Added unit tests (external HTTP mocked, no network) asserting the timeout is forwarded to `requests.get`:

- `test_brave_search_passes_default_timeout` — default `10.0s` is passed and results are returned as `Document`s.
- `test_brave_search_passes_custom_timeout` — a custom `timeout=2.5` is forwarded.

```
$ uv run -- pytest -q
3 passed
```

`uv run pre-commit run` passes (ruff, ruff-format, mypy, codespell, etc.).

## Notes

This is the same defect class already being addressed for other integrations (e.g. #22028); this package was not covered by any existing PR.

---

*AI-assisted: this change was drafted with AI assistance and reviewed by me; I understand and stand behind it, per the project's AI-contribution policy.*