### PR TITLE
fix: isolate AG-UI initial state

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -136,7 +137,9 @@ class AGUIChatWorkflow(Workflow):
         self.backend_tools = {
             tool.metadata.name: tool for tool in validated_backend_tools
         }
-        self.initial_state = initial_state or {}
+        self.initial_state = (
+            copy.deepcopy(initial_state) if initial_state is not None else {}
+        )
         self.system_prompt = system_prompt
 
     def _snapshot_messages(self, ctx: Context, chat_history: List[ChatMessage]) -> None:
@@ -184,7 +187,7 @@ class AGUIChatWorkflow(Workflow):
                 state.pop("messages", None)
             else:
                 # initial state is not provided, use the default state
-                state = self.initial_state.copy()
+                state = copy.deepcopy(self.initial_state)
 
             # Save state to context for tools to use
             await ctx.store.set("state", state)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from ag_ui.core import RunAgentInput, UserMessage
+
+from llama_index.core.llms.mock import MockFunctionCallingLLM
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow
+from llama_index.protocols.ag_ui.router import get_default_workflow_factory
+
+
+def _llm() -> MockFunctionCallingLLM:
+    return MockFunctionCallingLLM(is_chat_model=True)
+
+
+async def _run_workflow_and_get_state(workflow: AGUIChatWorkflow) -> dict:
+    handler = workflow.run(
+        input_data=RunAgentInput(
+            threadId="thread",
+            runId="run",
+            state=None,
+            messages=[UserMessage(id="user-message", content="hello")],
+            tools=[],
+            context=[],
+            forwardedProps={},
+        )
+    )
+    async for _ in handler.stream_events():
+        pass
+    await handler
+    return await handler.ctx.store.get("state")
+
+
+def test_default_workflow_factory_copies_initial_state_per_workflow() -> None:
+    initial_state = {"items": [], "user": {"roles": []}}
+
+    factory = get_default_workflow_factory(llm=_llm(), initial_state=initial_state)
+    first = asyncio.run(factory())
+    second = asyncio.run(factory())
+
+    first.initial_state["items"].append("first")
+    first.initial_state["user"]["roles"].append("admin")
+    first.initial_state["secret"] = "from-first"
+
+    assert second.initial_state == {"items": [], "user": {"roles": []}}
+    assert initial_state == {"items": [], "user": {"roles": []}}
+
+
+def test_default_state_is_copied_for_each_run() -> None:
+    workflow = AGUIChatWorkflow(
+        llm=_llm(),
+        initial_state={"items": [], "user": {"roles": []}},
+    )
+
+    first_state = asyncio.run(_run_workflow_and_get_state(workflow))
+    first_state["items"].append("first-run")
+    first_state["user"]["roles"].append("admin")
+
+    second_state = asyncio.run(_run_workflow_and_get_state(workflow))
+
+    assert second_state == {"items": [], "user": {"roles": []}}


### PR DESCRIPTION
## Summary

Fixes #22069.

This prevents AG-UI workflows from sharing mutable `initial_state` containers across factory-created workflow instances or across runs that fall back to the workflow default state.

- Deep-copy `initial_state` when constructing `AGUIChatWorkflow` so the caller-owned dict is not retained by reference.
- Deep-copy the workflow default state for each run when the AG-UI input does not provide a state payload.
- Add regression coverage for both factory-created workflow isolation and per-run default state isolation.

## Tests

- `python -m pytest tests\test_initial_state.py -q`
- `python -m ruff check llama_index\protocols\ag_ui\agent.py tests\test_initial_state.py`
- `python -m ruff format --check llama_index\protocols\ag_ui\agent.py tests\test_initial_state.py`
- `git diff --check`