### PR TITLE
fix: isolate MCP workflow calls with factory

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -94,6 +94,18 @@ workflow = LoudWorkflow()
 mcp = workflow_as_mcp(workflow, start_event_model=RunEvent)
 ```
 
+To isolate mutable workflow instance state between MCP tool calls, pass a
+`workflow_factory`. The `workflow` argument is still used as the prototype for the
+tool name, description, and start event model.
+
+```python
+mcp = workflow_as_mcp(
+    LoudWorkflow(),
+    start_event_model=RunEvent,
+    workflow_factory=lambda: LoudWorkflow(),
+)
+```
+
 Then, you can launch the MCP server (assuming you have the `mcp[cli]` extra installed):
 
 ```bash

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional
+import inspect
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 from mcp.client.session import ClientSession
 from mcp.server.fastmcp import FastMCP, Context
@@ -8,6 +9,8 @@ from llama_index.core.tools import FunctionTool
 from llama_index.core.workflow import Event, StartEvent, StopEvent, Workflow
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
+
+WorkflowFactory = Callable[[], Union[Workflow, Awaitable[Workflow]]]
 
 
 def get_tools_from_mcp_url(
@@ -79,6 +82,7 @@ def workflow_as_mcp(
     workflow_name: Optional[str] = None,
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
+    workflow_factory: Optional[WorkflowFactory] = None,
     **fastmcp_init_kwargs: Any,
 ) -> FastMCP:
     """
@@ -97,6 +101,10 @@ def workflow_as_mcp(
         start_event_model (optional):
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
+        workflow_factory (optional):
+            A callable that returns a fresh workflow instance for each MCP tool call.
+            The returned workflow must be compatible with the provided workflow's
+            start event model. Defaults to reusing the provided workflow instance.
         **fastmcp_init_kwargs:
             Additional keyword arguments to pass to the FastMCP constructor.
 
@@ -117,18 +125,29 @@ def workflow_as_mcp(
     workflow_name = workflow_name or workflow.__class__.__name__
     workflow_description = workflow_description or workflow.__doc__
 
+    async def _get_workflow() -> Workflow:
+        if workflow_factory is None:
+            return workflow
+
+        new_workflow = workflow_factory()
+        if inspect.isawaitable(new_workflow):
+            new_workflow = await new_workflow
+
+        return new_workflow
+
     @app.tool(name=workflow_name, description=workflow_description)
     async def _workflow_tool(run_args: StartEventCLS, context: Context) -> Any:
         # Handle edge cases where the start event is an Event or a BaseModel
         # If the workflow does not have a custom StartEvent class, then we need to handle the event differently
 
-        if isinstance(run_args, Event) and workflow._start_event_class != StartEvent:
-            handler = workflow.run(start_event=run_args)
+        workflow_instance = await _get_workflow()
+        if isinstance(run_args, Event) and StartEventCLS != StartEvent:
+            handler = workflow_instance.run(start_event=run_args)
         elif isinstance(run_args, BaseModel):
-            handler = workflow.run(**run_args.model_dump())
+            handler = workflow_instance.run(**run_args.model_dump())
         elif isinstance(run_args, dict):
             start_event = StartEventCLS.model_validate(run_args)
-            handler = workflow.run(start_event=start_event)
+            handler = workflow_instance.run(start_event=start_event)
         else:
             raise ValueError(f"Invalid start event type: {type(run_args)}")
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -4,9 +4,11 @@ from typing import Literal, get_args
 import pytest
 
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.core.workflow import Context, StartEvent, StopEvent, Workflow, step
 from llama_index.tools.mcp import (
     BasicMCPClient,
     McpToolSpec,
+    workflow_as_mcp,
     get_tools_from_mcp_url,
     aget_tools_from_mcp_url,
 )
@@ -693,6 +695,44 @@ def test_get_tools_from_mcp_url_propagates_combined_params(client: BasicMCPClien
     update_schema = update_user_tool.metadata.fn_schema.model_json_schema()
     assert "user_id" not in update_schema["properties"]
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+class TenantStartEvent(StartEvent):
+    tenant_id: str
+
+
+class CountingWorkflow(Workflow):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.history = []
+
+    @step
+    async def echo(self, ctx: Context, ev: TenantStartEvent) -> StopEvent:
+        self.history.append(ev.tenant_id)
+        return StopEvent(result={"history_visible": list(self.history)})
+
+
+@pytest.mark.asyncio
+async def test_workflow_as_mcp_uses_workflow_factory_per_call():
+    created_workflows = []
+
+    def workflow_factory():
+        workflow = CountingWorkflow(timeout=30)
+        created_workflows.append(workflow)
+        return workflow
+
+    app = workflow_as_mcp(
+        CountingWorkflow(timeout=30),
+        workflow_factory=workflow_factory,
+    )
+
+    await app.call_tool("CountingWorkflow", {"run_args": {"tenant_id": "alice"}})
+    await app.call_tool("CountingWorkflow", {"run_args": {"tenant_id": "bob"}})
+
+    assert [workflow.history for workflow in created_workflows] == [
+        ["alice"],
+        ["bob"],
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #22071.

`workflow_as_mcp()` currently closes over a single workflow instance, so mutable `self.*` state on that workflow can be shared across every MCP tool call. This keeps the existing default behavior for backwards compatibility, and adds an opt-in `workflow_factory` parameter for users who need fresh workflow instances per MCP request.

- Add optional `workflow_factory` support to `workflow_as_mcp()`.
- Use the provided workflow as the metadata/start-event prototype while using the factory-created workflow for each call.
- Document the factory usage in the MCP tools README.
- Add regression coverage that calls the generated MCP tool twice and verifies each request uses an isolated `CountingWorkflow` instance.

## Tests

- `python -m pytest tests\test_tools_mcp.py::test_workflow_as_mcp_uses_workflow_factory_per_call -q`
- `python -m pytest tests\test_tools_mcp.py::test_class tests\test_tools_mcp.py::test_workflow_as_mcp_uses_workflow_factory_per_call -q`
- `python -m ruff check llama_index\tools\mcp\utils.py tests\test_tools_mcp.py`
- `python -m ruff format --check llama_index\tools\mcp\utils.py tests\test_tools_mcp.py`
- `git diff --check`

Note: running the entire `tests\test_tools_mcp.py` file in my local Windows checkout fails before exercising this change because the existing stdio test server is launched as `python tests\server.py`, and that direct execution path cannot import `tests.schemas` in the subprocess. The new regression test does not depend on that server path and passes.