### PR TITLE
feat(tools): add BGPT tool spec for structured evidence retrieval

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+
+from llama_index.memory.mem0.base import Mem0Memory, Mem0Context
+from llama_index.core.memory import Memory as LlamaIndexMemory
+from llama_index.core.base.llms.types import MessageRole
+
+
+def test_mem0_search_merges_user_and_agent_results():
+    """
+    When both user_id and agent_id are provided in context, Mem0Memory
+    should perform separate searches and merge the results.
+    """
+
+    # Mock primary memory (no chat history)
+    primary_memory = LlamaIndexMemory.from_defaults()
+    primary_memory.get = MagicMock(return_value=[])
+
+    # Mock Mem0 client
+    mock_client = MagicMock()
+
+    # Two separate search results:
+    # first call -> user_id search
+    # second call -> agent_id search
+    mock_client.search.side_effect = [
+        [{"content": "Anne likes biking"}],
+        [{"content": "Peter hates stew"}],
+    ]
+
+    context = Mem0Context(user_id="user123", agent_id="agent123")
+
+    memory = Mem0Memory(
+        primary_memory=primary_memory,
+        context=context,
+        client=mock_client,
+    )
+
+    messages = memory.get("What do we know about Anne and Peter?")
+
+    # One system message should be added at the top
+    assert messages[0].role == MessageRole.SYSTEM
+    assert messages[0].content is not None
+
+    # Both memories should be present in merged system message
+    assert "Anne likes biking" in messages[0].content
+    assert "Peter hates stew" in messages[0].content
+
+    # Ensure Mem0 search was called twice (user + agent)
+    assert mock_client.search.call_count == 2

--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from llama_index.memory.mem0.base import Mem0Memory, Mem0Context
 from llama_index.core.memory import Memory as LlamaIndexMemory
@@ -11,38 +11,40 @@ def test_mem0_search_merges_user_and_agent_results():
     should perform separate searches and merge the results.
     """
 
-    # Mock primary memory (no chat history)
-    primary_memory = LlamaIndexMemory.from_defaults()
-    primary_memory.get = MagicMock(return_value=[])
+    # Patch the MemoryClient where it is used
+    with patch("llama_index.memory.mem0.base.MemoryClient") as MockClient:
+        mock_client = MockClient.return_value
 
-    # Mock Mem0 client
-    mock_client = MagicMock()
+        # Two separate search results:
+        # first call -> user_id search
+        # second call -> agent_id search
+        mock_client.search.side_effect = [
+            [{"content": "Anne likes biking"}],
+            [{"content": "Peter hates stew"}],
+        ]
 
-    # Two separate search results:
-    # first call -> user_id search
-    # second call -> agent_id search
-    mock_client.search.side_effect = [
-        [{"content": "Anne likes biking"}],
-        [{"content": "Peter hates stew"}],
-    ]
+        # Mock primary memory (no chat history)
+        primary_memory = LlamaIndexMemory.from_defaults()
+        primary_memory.get = MagicMock(return_value=[])
+        primary_memory.get_all = MagicMock(return_value=[])
 
-    context = Mem0Context(user_id="user123", agent_id="agent123")
+        context = Mem0Context(user_id="user123", agent_id="agent123")
 
-    memory = Mem0Memory(
-        primary_memory=primary_memory,
-        context=context,
-        client=mock_client,
-    )
+        memory = Mem0Memory(
+            primary_memory=primary_memory,
+            context=context,
+            client=mock_client,
+        )
 
-    messages = memory.get("What do we know about Anne and Peter?")
+        messages = memory.get("What do we know about Anne and Peter?")
 
-    # One system message should be added at the top
-    assert messages[0].role == MessageRole.SYSTEM
-    assert messages[0].content is not None
+        # One system message should be added at the top
+        assert messages[0].role == MessageRole.SYSTEM
+        assert messages[0].content is not None
 
-    # Both memories should be present in merged system message
-    assert "Anne likes biking" in messages[0].content
-    assert "Peter hates stew" in messages[0].content
+        # Both memories should be present in merged system message
+        assert "Anne likes biking" in messages[0].content
+        assert "Peter hates stew" in messages[0].content
 
-    # Ensure Mem0 search was called twice (user + agent)
-    assert mock_client.search.call_count == 2
+        # Ensure Mem0 search was called twice (user + agent)
+        assert mock_client.search.call_count == 2

--- a/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
+++ b/llama-index-integrations/memory/llama-index-memory-mem0/llama_index/memory/mem0/tests/test_base.py
@@ -1,29 +1,23 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from llama_index.memory.mem0.base import Mem0Memory, Mem0Context
 from llama_index.core.memory import Memory as LlamaIndexMemory
 from llama_index.core.base.llms.types import MessageRole
 
 
 def test_mem0_search_merges_user_and_agent_results():
-    """
-    When both user_id and agent_id are provided in context, Mem0Memory
-    should perform separate searches and merge the results.
-    """
+    """When both user_id and agent_id are provided, results should be merged."""
 
-    # Patch the MemoryClient where it is used
     with patch("llama_index.memory.mem0.base.MemoryClient") as MockClient:
         mock_client = MockClient.return_value
 
-        # Two separate search results:
-        # first call -> user_id search
-        # second call -> agent_id search
         mock_client.search.side_effect = [
             [{"content": "Anne likes biking"}],
             [{"content": "Peter hates stew"}],
         ]
 
-        # Mock primary memory (no chat history)
         primary_memory = LlamaIndexMemory.from_defaults()
         primary_memory.get = MagicMock(return_value=[])
         primary_memory.get_all = MagicMock(return_value=[])
@@ -38,13 +32,8 @@ def test_mem0_search_merges_user_and_agent_results():
 
         messages = memory.get("What do we know about Anne and Peter?")
 
-        # One system message should be added at the top
+        assert messages
         assert messages[0].role == MessageRole.SYSTEM
-        assert messages[0].content is not None
-
-        # Both memories should be present in merged system message
         assert "Anne likes biking" in messages[0].content
         assert "Peter hates stew" in messages[0].content
-
-        # Ensure Mem0 search was called twice (user + agent)
         assert mock_client.search.call_count == 2

--- a/llama-index-integrations/tools/llama-index-tools-bgpt/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-bgpt/README.md
@@ -1,0 +1,96 @@
+# LlamaIndex Tool Integration: BGPT Evidence Retrieval
+
+This tool allows LlamaIndex agents to search for structured scientific literature using the [BGPT API](https://bgpt.pro/mcp/). 
+
+Unlike standard search tools that only return titles or abstracts, BGPT provides deep, study-level evidence. It extracts and formats specific scientific fields from papers, making it highly effective for AI agents conducting rigorous academic or medical research.
+
+## Features
+The tool returns structured dictionaries containing:
+* **Methods & Experimental Techniques**
+* **Sample Size & Population Characteristics**
+* **Paper Limitations & Biases**
+* **Quality Scores** (Scientific quality, reproducibility, novelty)
+* **Conflict of Interest Statements**
+* **How to Falsify**
+
+## Installation
+
+```bash
+pip install llama-index-tools-bgpt
+```
+
+## Usage
+
+You can use the BGPT tool either as a standalone function or plug it into any LlamaIndex agent.
+
+### 1. Standalone Usage
+
+```python
+from llama_index.tools.bgpt import BGPTToolSpec
+
+# Initialize the tool
+# Note: BGPT provides the first 50 results for free. 
+# An API key is only required if you need higher limits.
+tool_spec = BGPTToolSpec(api_key="your-optional-api-key")
+
+# Call the search function directly
+results = tool_spec.search_literature(
+    query="effects of sleep deprivation on memory",
+    num_results=2,
+    days_back=365
+)
+
+for paper in results:
+    print(f"Title: {paper.get('title')}")
+    print(f"Limitations: {paper.get('paper_limitations_and_biases')}\n")
+```
+
+### 2. Usage with an Agent
+
+```python
+import os
+from llama_index.tools.bgpt import BGPTToolSpec
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+
+os.environ["OPENAI_API_KEY"] = "sk-..."
+
+# Initialize tool and convert to LlamaIndex format
+tool_spec = BGPTToolSpec()
+tools = tool_spec.to_tool_list()
+
+# Create the agent
+agent = ReActAgent.from_tools(
+    tools, 
+    llm=OpenAI(model="gpt-4o"), 
+    verbose=True
+)
+
+# Query the agent
+response = agent.chat(
+    "Find a recent study on the effects of intermittent fasting on blood pressure "
+    "using the BGPT tool. Summarize the sample size and the study's limitations."
+)
+
+print(response)
+```
+
+## Tool Arguments
+
+The `search_literature` function accepts the following parameters:
+
+* `query` (str): The specific research question or topic to search for.
+* `num_results` (int, optional): The number of top results to return. Defaults to 5.
+* `days_back` (int, optional): Filter results to only include papers published within the last N days.
+
+## Testing
+
+To run the tests for this tool locally, ensure you have `pytest` installed, and then run the following commands from the package root:
+
+```bash
+# Install the package in editable mode
+pip install -e .
+
+# Run the test suite
+pytest tests/
+```

--- a/llama-index-integrations/tools/llama-index-tools-bgpt/llama_index/tools/bgpt/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-bgpt/llama_index/tools/bgpt/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.bgpt.base import BGPTToolSpec
+
+__all__ = ["BGPTToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-bgpt/llama_index/tools/bgpt/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-bgpt/llama_index/tools/bgpt/base.py
@@ -1,0 +1,77 @@
+"""BGPT Tool Spec for LlamaIndex."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import requests
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+logger = logging.getLogger(__name__)
+
+class BGPTToolSpec(BaseToolSpec):
+    """BGPT Tool Spec for retrieving structured scientific literature evidence.
+    
+    This tool interacts with the BGPT API to fetch comprehensive, study-level 
+    evidence including methods, limitations, quality scores, and falsifiability.
+    """
+
+    spec_functions = ["search_literature"]
+    DEFAULT_BASE_URL = "https://bgpt.pro/api/mcp-search"
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        """Initialize the BGPT Tool Spec.
+
+        Args:
+            api_key (Optional[str]): The BGPT API key. Only required when 
+                                     requesting more than 50 results.
+        """
+        self.api_key = api_key
+        self.base_url = self.DEFAULT_BASE_URL
+
+    def search_literature(
+        self,
+        query: str,
+        num_results: int = 5,
+        days_back: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search for scientific literature and structured evidence using BGPT.
+        
+        Use this tool when you need deep, study-level evidence such as methods, 
+        limitations, sample sizes, and quality scores, rather than just abstracts.
+
+        Args:
+            query (str): The specific research question or topic to search for 
+                         (e.g., 'effects of sleep deprivation on memory').
+            num_results (int): The number of top results to return. Defaults to 5.
+            days_back (Optional[int]): Filter results to only include papers published 
+                                       within the last N days.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing structured 
+                                  fields of a scientific paper, or an error dictionary.
+        """
+        payload: Dict[str, Any] = {
+            "query": query,
+            "num_results": num_results,
+        }
+
+        if days_back is not None:
+            payload["days_back"] = days_back
+            
+        if self.api_key is not None:
+            payload["api_key"] = self.api_key
+
+        try:
+            response = requests.post(self.base_url, json=payload, timeout=30)
+            response.raise_for_status()
+            
+            data = response.json()
+            return data.get("results", [])
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Network or HTTP error fetching data from BGPT API: {e}")
+            return [{"error": f"API request failed: {str(e)}"}]
+        except ValueError as e:
+            logger.error(f"Failed to parse JSON response from BGPT API: {e}")
+            return [{"error": "Invalid JSON response received from API."}]

--- a/llama-index-integrations/tools/llama-index-tools-bgpt/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-bgpt/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-tools-bgpt"
+version = "0.1.0"
+description = "llama-index tools bgpt integration"
+authors = [{name = "Gopesh Pandey", email = "gopeshpandey0807@gmail.com"}]
+requires-python = ">=3.9,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "Gopesh111"}]
+dependencies = [
+    "requests>=2.31.0",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.bgpt"
+
+[tool.llamahub.class_authors]
+BGPTToolSpec = "Gopesh111"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-bgpt/tests/test_tool_bgpt.py
+++ b/llama-index-integrations/tools/llama-index-tools-bgpt/tests/test_tool_bgpt.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+from llama_index.tools.bgpt import BGPTToolSpec
+
+
+def test_class_initialization() -> None:
+    """Test that the BGPTToolSpec initializes correctly."""
+    # Without API key
+    tool = BGPTToolSpec()
+    assert tool.api_key is None
+    assert tool.base_url == "https://bgpt.pro/api/mcp-search"
+
+    # With API key
+    tool_with_key = BGPTToolSpec(api_key="test_key")
+    assert tool_with_key.api_key == "test_key"
+
+
+def test_tool_functions_list() -> None:
+    """Test that the correct functions are exposed to the agent."""
+    tool = BGPTToolSpec()
+    assert "search_literature" in tool.spec_functions
+
+
+@patch("requests.post")
+def test_search_literature_success(mock_post: MagicMock) -> None:
+    """Test successful API call with mocked response."""
+    # Setup the fake response
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [{"title": "Fake Sleep Study", "paper_limitations_and_biases": "None"}]
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    # Run the tool
+    tool = BGPTToolSpec()
+    results = tool.search_literature("sleep and memory", num_results=1)
+
+    # Assertions
+    assert len(results) == 1
+    assert results[0]["title"] == "Fake Sleep Study"
+    mock_post.assert_called_once()
+
+
+@patch("requests.post")
+def test_search_literature_network_error(mock_post: MagicMock) -> None:
+    """Test handling of network/HTTP errors."""
+    # Setup the mock to throw an error
+    mock_post.side_effect = requests.exceptions.HTTPError("404 Client Error")
+
+    tool = BGPTToolSpec()
+    results = tool.search_literature("sleep and memory")
+
+    # Assertions
+    assert len(results) == 1
+    assert "error" in results[0]
+    assert "404 Client Error" in results[0]["error"]


### PR DESCRIPTION
# Description

This PR adds the `BGPTToolSpec` integration to allow LlamaIndex agents to retrieve structured scientific literature evidence using the BGPT API. Unlike standard abstract searches, this tool returns study-level fields like limitations, sample sizes, and falsifiability. 

Fixes #21964

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_tool_bgpt.py` which uses `unittest.mock` to mock API responses and test tool initialization, function exposure, and network error handling.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods