### PR TITLE
fix: shut down default executor before closing event loop in asyncio_run

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -6,9 +6,31 @@ import concurrent.futures
 from itertools import zip_longest
 from typing import Any, Coroutine, Iterable, List, Optional, TypeVar
 
+import logging
+
 import llama_index.core.instrumentation as instrument
 
+logger = logging.getLogger(__name__)
+
 dispatcher = instrument.get_dispatcher(__name__)
+
+
+def _shutdown_default_executor(loop: asyncio.AbstractEventLoop) -> None:
+    """
+    Best-effort shutdown of the loop's default executor.
+
+    Mirrors the cleanup that ``asyncio.run()`` performs (bpo-34037) so that
+    worker threads created by ``loop.run_in_executor(None, ...)`` are joined
+    before the loop is closed.
+    """
+    if loop.is_closed():
+        return
+    if getattr(loop, "_default_executor", None) is None:
+        return
+    try:
+        loop.run_until_complete(loop.shutdown_default_executor())
+    except Exception:
+        logger.debug("Failed to shut down default executor for %r", loop, exc_info=True)
 
 
 def get_asyncio_module(show_progress: bool = False) -> Any:
@@ -57,6 +79,11 @@ def asyncio_run(coro: Coroutine) -> Any:
                 try:
                     return ctx.run(new_loop.run_until_complete, coro)
                 finally:
+                    # Shut down the default executor before closing, matching
+                    # asyncio.run() behavior (bpo-34037).  Without this, any
+                    # ThreadPoolExecutor lazily created by
+                    # loop.run_in_executor(None, ...) leaks its worker threads.
+                    _shutdown_default_executor(new_loop)
                     new_loop.close()
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import threading
 import pytest
 from llama_index.core.async_utils import batch_gather, asyncio_run
 
@@ -16,6 +17,36 @@ def test_batch_gather_indivisible_task_list() -> None:
     coroutines = [async_method(n) for n in range(5)]
     results = asyncio.run(batch_gather(coroutines, batch_size=2))
     assert results == list(range(len(coroutines)))
+
+
+@pytest.mark.asyncio
+async def test_asyncio_run_shuts_down_default_executor() -> None:
+    """
+    Verify that asyncio_run shuts down the event loop's default executor.
+
+    When a coroutine calls loop.run_in_executor(None, ...), the loop lazily
+    creates a default ThreadPoolExecutor.  asyncio_run must shut it down
+    before closing the loop so that its worker threads are joined and do not
+    leak.
+    """
+    executor_threads_before = {
+        t for t in threading.enumerate() if "ThreadPoolExecutor" in t.name
+    }
+
+    async def use_default_executor() -> str:
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: "done")
+
+    # Calling from inside a running loop triggers the loop.is_running() path,
+    # which creates a new loop in a worker thread.
+    result = asyncio_run(use_default_executor())
+    assert result == "done"
+
+    executor_threads_after = {
+        t for t in threading.enumerate() if "ThreadPoolExecutor" in t.name
+    }
+    leaked = executor_threads_after - executor_threads_before
+    assert not leaked, f"Default executor threads were not shut down: {leaked}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

`asyncio_run` creates a fresh event loop when the caller is already
inside a running loop (the `loop.is_running()` branch). After running the
coroutine it calls `new_loop.close()` but never shuts down the loop's
default `ThreadPoolExecutor`.

If the coroutine (or anything it awaits) triggers
`loop.run_in_executor(None, ...)`, the loop lazily creates a default
`ThreadPoolExecutor` whose worker threads then block on
`work_queue.get(block=True)` indefinitely after the loop is closed.

CPython's own `asyncio.run()` fixed this exact pattern via bpo-34037 /
bpo-78218 by calling `loop.shutdown_default_executor()` before
`loop.close()`. Since `asyncio_run` reimplements the same
create-loop / run / close sequence, it should include the same cleanup
step.

The fix adds `loop.shutdown_default_executor()` before `loop.close()`,
matching `asyncio.run()` behavior.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

(Change is in `llama-index-core`, which does not require a version bump.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

A new test (`test_asyncio_run_shuts_down_default_executor`) verifies that
after `asyncio_run` returns, the event loop's default executor (if one was
created during execution) has been shut down and its worker threads have
joined. The test forces executor creation by calling
`loop.run_in_executor(None, ...)` inside the coroutine, then asserts that
no executor threads remain alive.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods