### PR TITLE
feat: surface provider-reported token counts in EmbeddingEndEvent

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -4,7 +4,17 @@ import asyncio
 import uuid
 from abc import abstractmethod
 from enum import Enum
-from typing import Any, Callable, Coroutine, List, Optional, Sequence, Tuple, cast
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 from typing_extensions import Self
 
 import numpy as np
@@ -25,6 +35,71 @@ from llama_index.core.async_utils import run_jobs
 
 # TODO: change to numpy array
 Embedding = List[float]
+
+
+class EmbeddingResponse:
+    """
+    Response from an embedding call, carrying the vector and optional metadata.
+
+    Mirrors ``CompletionResponse`` / ``ChatResponse`` for LLMs: integrations
+    that can report provider-side token usage return an ``EmbeddingResponse``
+    instead of a plain ``List[float]``.  Integrations that return a plain list
+    continue to work unchanged.
+
+    Args:
+        embedding: The embedding vector.
+        token_count: Provider-reported token count for this call, if available.
+        raw: The raw API response object, for caller inspection.
+
+    """
+
+    __slots__ = ("embedding", "token_count", "raw")
+
+    def __init__(
+        self,
+        embedding: Embedding,
+        token_count: Optional[int] = None,
+        raw: Optional[Any] = None,
+    ) -> None:
+        self.embedding = embedding
+        self.token_count = token_count
+        self.raw = raw
+
+
+EmbeddingResultType = Union[Embedding, EmbeddingResponse]
+BatchEmbeddingResultType = List[EmbeddingResultType]
+
+
+def _unpack_embedding(result: EmbeddingResultType) -> Tuple[Embedding, Optional[int]]:
+    """
+    Unpack an embedding result into (vector, token_count).
+
+    Accepts both plain ``List[float]`` (backwards-compatible) and the new
+    ``EmbeddingResponse``.
+    """
+    if isinstance(result, EmbeddingResponse):
+        return result.embedding, result.token_count
+    return result, None
+
+
+def _unpack_embeddings(
+    results: BatchEmbeddingResultType,
+) -> Tuple[List[Embedding], Optional[int]]:
+    """
+    Unpack a batch of embedding results.
+
+    Returns (embeddings, total_token_count).  Token counts are summed across
+    all items that report them; the total is ``None`` only when *no* item
+    carried a count.
+    """
+    embeddings: List[Embedding] = []
+    total: Optional[int] = None
+    for r in results:
+        emb, tc = _unpack_embedding(r)
+        embeddings.append(emb)
+        if tc is not None:
+            total = (total or 0) + tc
+    return embeddings, total
 
 
 from llama_index.core.instrumentation.events.embedding import (
@@ -116,21 +191,23 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         return self
 
     @abstractmethod
-    def _get_query_embedding(self, query: str) -> Embedding:
+    def _get_query_embedding(self, query: str) -> EmbeddingResultType:
         """
         Embed the input query synchronously.
 
-        Subclasses should implement this method. Reference get_query_embedding's
-        docstring for more information.
+        Subclasses should implement this method.  May return a plain
+        ``List[float]`` (backwards-compatible) or an ``EmbeddingResponse``
+        carrying the vector together with provider-reported token usage.
         """
 
     @abstractmethod
-    async def _aget_query_embedding(self, query: str) -> Embedding:
+    async def _aget_query_embedding(self, query: str) -> EmbeddingResultType:
         """
         Embed the input query asynchronously.
 
-        Subclasses should implement this method. Reference get_query_embedding's
-        docstring for more information.
+        Subclasses should implement this method.  May return a plain
+        ``List[float]`` (backwards-compatible) or an ``EmbeddingResponse``
+        carrying the vector together with provider-reported token usage.
         """
 
     @dispatcher.span
@@ -151,13 +228,16 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 model_dict=model_dict,
             )
         )
+        token_count: Optional[int] = None
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
                     self.rate_limiter.acquire()
-                query_embedding = self._get_query_embedding(query)
+                query_embedding, token_count = _unpack_embedding(
+                    self._get_query_embedding(query)
+                )
             elif self.embeddings_cache is not None:
                 cached_emb = self.embeddings_cache.get(
                     key=query, collection="embeddings"
@@ -168,7 +248,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 else:
                     if self.rate_limiter is not None:
                         self.rate_limiter.acquire()
-                    query_embedding = self._get_query_embedding(query)
+                    query_embedding, token_count = _unpack_embedding(
+                        self._get_query_embedding(query)
+                    )
                     self.embeddings_cache.put(
                         key=query,
                         val={str(uuid.uuid4()): query_embedding},
@@ -184,6 +266,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             EmbeddingEndEvent(
                 chunks=[query],
                 embeddings=[query_embedding],
+                token_count=token_count,
             )
         )
         return query_embedding
@@ -198,13 +281,16 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 model_dict=model_dict,
             )
         )
+        token_count: Optional[int] = None
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
                     await self.rate_limiter.async_acquire()
-                query_embedding = await self._aget_query_embedding(query)
+                query_embedding, token_count = _unpack_embedding(
+                    await self._aget_query_embedding(query)
+                )
             elif self.embeddings_cache is not None:
                 cached_emb = await self.embeddings_cache.aget(
                     key=query, collection="embeddings"
@@ -215,7 +301,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 else:
                     if self.rate_limiter is not None:
                         await self.rate_limiter.async_acquire()
-                    query_embedding = await self._aget_query_embedding(query)
+                    query_embedding, token_count = _unpack_embedding(
+                        await self._aget_query_embedding(query)
+                    )
                     await self.embeddings_cache.aput(
                         key=query,
                         val={str(uuid.uuid4()): query_embedding},
@@ -232,6 +320,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             EmbeddingEndEvent(
                 chunks=[query],
                 embeddings=[query_embedding],
+                token_count=token_count,
             )
         )
         return query_embedding
@@ -257,26 +346,26 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         return agg_fn(query_embeddings)
 
     @abstractmethod
-    def _get_text_embedding(self, text: str) -> Embedding:
+    def _get_text_embedding(self, text: str) -> EmbeddingResultType:
         """
         Embed the input text synchronously.
 
-        Subclasses should implement this method. Reference get_text_embedding's
-        docstring for more information.
+        Subclasses should implement this method.  May return a plain
+        ``List[float]`` (backwards-compatible) or an ``EmbeddingResponse``
+        carrying the vector together with provider-reported token usage.
         """
 
-    async def _aget_text_embedding(self, text: str) -> Embedding:
+    async def _aget_text_embedding(self, text: str) -> EmbeddingResultType:
         """
         Embed the input text asynchronously.
 
         Subclasses can implement this method if there is a true async
-        implementation. Reference get_text_embedding's docstring for more
-        information.
+        implementation.
         """
         # Default implementation just falls back on _get_text_embedding
         return self._get_text_embedding(text)
 
-    def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+    def _get_text_embeddings(self, texts: List[str]) -> BatchEmbeddingResultType:
         """
         Embed the input sequence of text synchronously.
 
@@ -285,7 +374,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         # Default implementation just loops over _get_text_embedding
         return [self._get_text_embedding(text) for text in texts]
 
-    async def _aget_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+    async def _aget_text_embeddings(self, texts: List[str]) -> BatchEmbeddingResultType:
         """
         Embed the input sequence of text asynchronously.
 
@@ -297,7 +386,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
 
     async def _aget_text_embeddings_rate_limited(
         self, texts: List[str]
-    ) -> List[Embedding]:
+    ) -> BatchEmbeddingResultType:
         """Acquire rate limiter before delegating to _aget_text_embeddings."""
         if self.rate_limiter is not None:
             await self.rate_limiter.async_acquire()
@@ -321,10 +410,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             else:
                 non_cached_texts.append((i, txt))
         if len(non_cached_texts) > 0:
-            text_embeddings = self._get_text_embeddings(
-                [x[1] for x in non_cached_texts]
-            )
-            for j, text_embedding in enumerate(text_embeddings):
+            raw_results = self._get_text_embeddings([x[1] for x in non_cached_texts])
+            unpacked, _ = _unpack_embeddings(raw_results)
+            for j, text_embedding in enumerate(unpacked):
                 orig_i = non_cached_texts[j][0]
                 embeddings[orig_i] = text_embedding
 
@@ -356,10 +444,11 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 non_cached_texts.append((i, txt))
 
         if len(non_cached_texts) > 0:
-            text_embeddings = await self._aget_text_embeddings(
+            raw_results = await self._aget_text_embeddings(
                 [x[1] for x in non_cached_texts]
             )
-            for j, text_embedding in enumerate(text_embeddings):
+            unpacked, _ = _unpack_embeddings(raw_results)
+            for j, text_embedding in enumerate(unpacked):
                 orig_i = non_cached_texts[j][0]
                 embeddings[orig_i] = text_embedding
                 await self.embeddings_cache.aput(
@@ -386,13 +475,16 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 model_dict=model_dict,
             )
         )
+        token_count: Optional[int] = None
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
                     self.rate_limiter.acquire()
-                text_embedding = self._get_text_embedding(text)
+                text_embedding, token_count = _unpack_embedding(
+                    self._get_text_embedding(text)
+                )
             elif self.embeddings_cache is not None:
                 cached_emb = self.embeddings_cache.get(
                     key=text, collection="embeddings"
@@ -403,7 +495,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 else:
                     if self.rate_limiter is not None:
                         self.rate_limiter.acquire()
-                    text_embedding = self._get_text_embedding(text)
+                    text_embedding, token_count = _unpack_embedding(
+                        self._get_text_embedding(text)
+                    )
                     self.embeddings_cache.put(
                         key=text,
                         val={str(uuid.uuid4()): text_embedding},
@@ -420,6 +514,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             EmbeddingEndEvent(
                 chunks=[text],
                 embeddings=[text_embedding],
+                token_count=token_count,
             )
         )
         return text_embedding
@@ -434,13 +529,16 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 model_dict=model_dict,
             )
         )
+        token_count: Optional[int] = None
         with self.callback_manager.event(
             CBEventType.EMBEDDING, payload={EventPayload.SERIALIZED: self.to_dict()}
         ) as event:
             if not self.embeddings_cache:
                 if self.rate_limiter is not None:
                     await self.rate_limiter.async_acquire()
-                text_embedding = await self._aget_text_embedding(text)
+                text_embedding, token_count = _unpack_embedding(
+                    await self._aget_text_embedding(text)
+                )
             elif self.embeddings_cache is not None:
                 cached_emb = await self.embeddings_cache.aget(
                     key=text, collection="embeddings"
@@ -451,7 +549,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 else:
                     if self.rate_limiter is not None:
                         await self.rate_limiter.async_acquire()
-                    text_embedding = await self._aget_text_embedding(text)
+                    text_embedding, token_count = _unpack_embedding(
+                        await self._aget_text_embedding(text)
+                    )
                     await self.embeddings_cache.aput(
                         key=text,
                         val={str(uuid.uuid4()): text_embedding},
@@ -468,6 +568,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             EmbeddingEndEvent(
                 chunks=[text],
                 embeddings=[text_embedding],
+                token_count=token_count,
             )
         )
         return text_embedding
@@ -505,9 +606,12 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                     if self.rate_limiter is not None:
                         self.rate_limiter.acquire()
                     if not self.embeddings_cache:
-                        embeddings = self._get_text_embeddings(cur_batch)
+                        embeddings, token_count = _unpack_embeddings(
+                            self._get_text_embeddings(cur_batch)
+                        )
                     elif self.embeddings_cache is not None:
                         embeddings = self._get_text_embeddings_cached(cur_batch)
+                        token_count = None
                     result_embeddings.extend(embeddings)
                     event.on_end(
                         payload={
@@ -519,6 +623,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                     EmbeddingEndEvent(
                         chunks=cur_batch,
                         embeddings=embeddings,
+                        token_count=token_count,
                     )
                 )
                 cur_batch = []
@@ -594,17 +699,21 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
         else:
             nested_embeddings = []
 
-        result_embeddings = [
-            embedding for embeddings in nested_embeddings for embedding in embeddings
-        ]
+        result_embeddings: List[Embedding] = []
+        unpacked_batches: List[Tuple[List[Embedding], Optional[int]]] = []
+        for batch_results in nested_embeddings:
+            embeddings, token_count = _unpack_embeddings(batch_results)
+            result_embeddings.extend(embeddings)
+            unpacked_batches.append((embeddings, token_count))
 
-        for (event_id, text_batch), embeddings in zip(
-            callback_payloads, nested_embeddings
+        for (event_id, text_batch), (embeddings, token_count) in zip(
+            callback_payloads, unpacked_batches
         ):
             dispatcher.event(
                 EmbeddingEndEvent(
                     chunks=text_batch,
                     embeddings=embeddings,
+                    token_count=token_count,
                 )
             )
             self.callback_manager.on_event_end(

--- a/llama-index-core/llama_index/core/embeddings/__init__.py
+++ b/llama-index-core/llama_index/core/embeddings/__init__.py
@@ -1,4 +1,4 @@
-from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.base.embeddings.base import BaseEmbedding, EmbeddingResponse
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.embeddings.mock_embed_model import MockMultiModalEmbedding
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
@@ -7,6 +7,7 @@ from llama_index.core.embeddings.utils import resolve_embed_model
 
 __all__ = [
     "BaseEmbedding",
+    "EmbeddingResponse",
     "MockEmbedding",
     "MultiModalEmbedding",
     "MockMultiModalEmbedding",

--- a/llama-index-core/llama_index/core/instrumentation/events/embedding.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/embedding.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from llama_index.core.instrumentation.events.base import BaseEvent
 from llama_index.core.bridge.pydantic import ConfigDict
@@ -29,11 +29,15 @@ class EmbeddingEndEvent(BaseEvent):
     Args:
         chunks (List[str]): List of chunks.
         embeddings (List[List[float]]): List of embeddings.
+        token_count (Optional[int]): Provider-reported token count for this
+            embedding call.  ``None`` when the integration does not report
+            token usage.
 
     """
 
     chunks: List[str]
     embeddings: List[List[float]]
+    token_count: Optional[int] = None
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -116,7 +116,11 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                     )
                 )
 
-            text_embeddings = self._embed_model._get_text_embeddings(split_text)
+            from llama_index.core.base.embeddings.base import _unpack_embeddings
+
+            text_embeddings, _ = _unpack_embeddings(
+                self._embed_model._get_text_embeddings(split_text)
+            )
 
             num_top_k = None
             threshold = None

--- a/llama-index-core/tests/embeddings/test_base.py
+++ b/llama-index-core/tests/embeddings/test_base.py
@@ -4,8 +4,15 @@ from typing import Any, List
 from unittest.mock import patch
 import pytest
 
-from llama_index.core.base.embeddings.base import SimilarityMode, mean_agg
+from llama_index.core.base.embeddings.base import (
+    EmbeddingResponse,
+    SimilarityMode,
+    _unpack_embedding,
+    _unpack_embeddings,
+    mean_agg,
+)
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.instrumentation.events.embedding import EmbeddingEndEvent
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -100,3 +107,130 @@ def test_mean_agg_empty_list() -> None:
     """Test mean aggregation raises ValueError for empty list."""
     with pytest.raises(ValueError, match="No embeddings to aggregate"):
         mean_agg([])
+
+
+# --- EmbeddingResponse / unpack helpers ---
+
+
+def test_unpack_embedding_plain_list() -> None:
+    """Plain List[float] unpacks to (embedding, None)."""
+    emb, tc = _unpack_embedding([0.1, 0.2])
+    assert emb == [0.1, 0.2]
+    assert tc is None
+
+
+def test_unpack_embedding_response() -> None:
+    """EmbeddingResponse unpacks to (embedding, token_count)."""
+    resp = EmbeddingResponse(embedding=[0.1, 0.2], token_count=42)
+    emb, tc = _unpack_embedding(resp)
+    assert emb == [0.1, 0.2]
+    assert tc == 42
+
+
+def test_unpack_embeddings_plain_list() -> None:
+    """Batch of plain lists produces (embeddings, None)."""
+    embs, tc = _unpack_embeddings([[0.1], [0.2]])
+    assert embs == [[0.1], [0.2]]
+    assert tc is None
+
+
+def test_unpack_embeddings_with_token_counts() -> None:
+    """Batch of EmbeddingResponse sums token counts."""
+    batch = [
+        EmbeddingResponse(embedding=[0.1], token_count=10),
+        EmbeddingResponse(embedding=[0.2], token_count=None),
+        EmbeddingResponse(embedding=[0.3], token_count=5),
+    ]
+    embs, tc = _unpack_embeddings(batch)
+    assert embs == [[0.1], [0.2], [0.3]]
+    assert tc == 15
+
+
+def test_embedding_end_event_token_count_default() -> None:
+    """EmbeddingEndEvent.token_count defaults to None."""
+    event = EmbeddingEndEvent(chunks=["hello"], embeddings=[[0.1]])
+    assert event.token_count is None
+
+
+def test_embedding_end_event_token_count_set() -> None:
+    """EmbeddingEndEvent accepts a token_count value."""
+    event = EmbeddingEndEvent(chunks=["hello"], embeddings=[[0.1]], token_count=42)
+    assert event.token_count == 42
+
+
+def test_embedding_response_surfaces_token_count_in_event() -> None:
+    """
+    When a subclass returns EmbeddingResponse, the dispatched
+    EmbeddingEndEvent carries the token_count.
+    """
+    import llama_index.core.instrumentation as instrument
+    from llama_index.core.instrumentation.event_handlers import BaseEventHandler
+
+    captured: List[EmbeddingEndEvent] = []
+
+    class Capture(BaseEventHandler):
+        @classmethod
+        def class_name(cls) -> str:
+            return "Capture"
+
+        def handle(self, event: Any, **kwargs: Any) -> None:
+            if isinstance(event, EmbeddingEndEvent):
+                captured.append(event)
+
+    handler = Capture()
+    root = instrument.get_dispatcher()
+    root.add_event_handler(handler)
+
+    try:
+
+        class TokenReportingEmbedding(MockEmbedding):
+            def _get_text_embedding(self, text: str) -> EmbeddingResponse:
+                vec = [0.0] * self.embed_dim
+                return EmbeddingResponse(embedding=vec, token_count=99)
+
+            async def _aget_query_embedding(self, query: str) -> EmbeddingResponse:
+                return self._get_text_embedding(query)
+
+            def _get_query_embedding(self, query: str) -> EmbeddingResponse:
+                return self._get_text_embedding(query)
+
+        model = TokenReportingEmbedding(embed_dim=5)
+        result = model.get_text_embedding("test")
+        assert result == [0.0] * 5
+        assert len(captured) == 1
+        assert captured[0].token_count == 99
+    finally:
+        root.event_handlers.remove(handler)
+
+
+def test_plain_embedding_still_works() -> None:
+    """
+    Existing integrations returning plain List[float] continue to work
+    and produce token_count=None in the event.
+    """
+    import llama_index.core.instrumentation as instrument
+    from llama_index.core.instrumentation.event_handlers import BaseEventHandler
+
+    captured: List[EmbeddingEndEvent] = []
+
+    class Capture(BaseEventHandler):
+        @classmethod
+        def class_name(cls) -> str:
+            return "Capture"
+
+        def handle(self, event: Any, **kwargs: Any) -> None:
+            if isinstance(event, EmbeddingEndEvent):
+                captured.append(event)
+
+    handler = Capture()
+    root = instrument.get_dispatcher()
+    root.add_event_handler(handler)
+
+    try:
+        model = MockEmbedding(embed_dim=5)
+        result = model.get_text_embedding("test")
+        assert isinstance(result, list)
+        assert len(captured) == 1
+        assert captured[0].token_count is None
+    finally:
+        root.event_handlers.remove(handler)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -5,7 +5,11 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 
 from deprecated import deprecated
-from llama_index.core.base.embeddings.base import BaseEmbedding, Embedding
+from llama_index.core.base.embeddings.base import (
+    BaseEmbedding,
+    EmbeddingResponse,
+    EmbeddingResultType,
+)
 from llama_index.core.base.llms.types import ChatMessage
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks.base import CallbackManager
@@ -64,6 +68,37 @@ def _parse_cohere_response(
         return embeddings if is_batch else embeddings[0]
 
     raise ValueError(f"Unexpected Cohere embedding response format: {type(embeddings)}")
+
+
+def _extract_bedrock_token_count(
+    response: Dict[str, Any], resp_body: Dict[str, Any]
+) -> Optional[int]:
+    """
+    Extract input token count from a Bedrock invoke_model response.
+
+    Checks two sources in order:
+    1. HTTP header ``x-amzn-bedrock-input-token-count`` (available for all
+       Bedrock models).
+    2. Response body ``inputTextTokenCount`` (Amazon Titan only).
+
+    Returns ``None`` if neither source is available.
+    """
+    try:
+        headers = response.get("ResponseMetadata", {}).get("HTTPHeaders", {})
+        header_count = headers.get("x-amzn-bedrock-input-token-count")
+        if header_count is not None:
+            return int(header_count)
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        body_count = resp_body.get("inputTextTokenCount")
+        if body_count is not None:
+            return int(body_count)
+    except (TypeError, ValueError):
+        pass
+
+    return None
 
 
 PROVIDER_SPECIFIC_IDENTIFIERS = {
@@ -410,16 +445,16 @@ class BedrockEmbedding(BaseEmbedding):
 
     def _get_embedding(
         self, payload: Union[str, List[str]], type: Literal["text", "query"]
-    ) -> Union[Embedding, List[Embedding]]:
+    ) -> Union[EmbeddingResponse, List[EmbeddingResponse]]:
         """
         Get the embedding for the given payload.
 
         Args:
             payload (Union[str, List[str]]): The text or list of texts for which the embeddings are to be obtained.
-            type (Literal[&quot;text&quot;, &quot;query&quot;]): The type of the payload. It can be either "text" or "query".
+            type (Literal["text", "query"]): The type of the payload.
 
         Returns:
-            Union[Embedding, List[Embedding]]: The embedding or list of embeddings for the given payload. If the payload is a list of strings, then the response will be a list of embeddings.
+            Union[EmbeddingResponse, List[EmbeddingResponse]]: The embedding(s) with provider-reported token count.
 
         """
         if self._client is None:
@@ -442,15 +477,32 @@ class BedrockEmbedding(BaseEmbedding):
         identifiers = PROVIDER_SPECIFIC_IDENTIFIERS.get(provider)
         if identifiers is None:
             raise ValueError("Provider not supported")
-        return identifiers["get_embeddings_func"](resp, isinstance(payload, list))
 
-    def _get_query_embedding(self, query: str) -> Embedding:
+        raw_result = identifiers["get_embeddings_func"](resp, isinstance(payload, list))
+        token_count = _extract_bedrock_token_count(response, resp)
+
+        if (
+            isinstance(raw_result, list)
+            and raw_result
+            and isinstance(raw_result[0], list)
+        ):
+            return [
+                EmbeddingResponse(
+                    embedding=v, token_count=token_count if i == 0 else None, raw=resp
+                )
+                for i, v in enumerate(raw_result)
+            ]
+        return EmbeddingResponse(
+            embedding=raw_result, token_count=token_count, raw=resp
+        )
+
+    def _get_query_embedding(self, query: str) -> EmbeddingResultType:
         return self._get_embedding(query, "query")
 
-    def _get_text_embedding(self, text: str) -> Embedding:
+    def _get_text_embedding(self, text: str) -> EmbeddingResultType:
         return self._get_embedding(text, "text")
 
-    def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
+    def _get_text_embeddings(self, texts: List[str]) -> List[EmbeddingResponse]:
         provider = self._get_provider()
         if provider == PROVIDERS.COHERE:
             return self._get_embedding(texts, "text")
@@ -525,16 +577,16 @@ class BedrockEmbedding(BaseEmbedding):
 
     async def _aget_embedding(
         self, payload: Union[str, List[str]], type: Literal["text", "query"]
-    ) -> Union[Embedding, List[Embedding]]:
+    ) -> Union[EmbeddingResponse, List[EmbeddingResponse]]:
         """
         Get the embedding asynchronously for the given payload.
 
         Args:
             payload (Union[str, List[str]]): The text or list of texts for which the embeddings are to be obtained.
-            type (Literal[&quot;text&quot;, &quot;query&quot;]): The type of the payload. It can be either "text" or "query".
+            type (Literal["text", "query"]): The type of the payload.
 
         Returns:
-            Union[Embedding, List[Embedding]]: The embedding or list of embeddings for the given payload. If the payload is a list of strings, then the response will be a list of embeddings.
+            Union[EmbeddingResponse, List[EmbeddingResponse]]: The embedding(s) with provider-reported token count.
 
         """
         if self._asession is None:
@@ -558,10 +610,27 @@ class BedrockEmbedding(BaseEmbedding):
         identifiers = PROVIDER_SPECIFIC_IDENTIFIERS.get(provider)
         if identifiers is None:
             raise ValueError("Provider not supported")
-        return identifiers["get_embeddings_func"](resp, isinstance(payload, list))
 
-    async def _aget_query_embedding(self, query: str) -> Embedding:
+        raw_result = identifiers["get_embeddings_func"](resp, isinstance(payload, list))
+        token_count = _extract_bedrock_token_count(response, resp)
+
+        if (
+            isinstance(raw_result, list)
+            and raw_result
+            and isinstance(raw_result[0], list)
+        ):
+            return [
+                EmbeddingResponse(
+                    embedding=v, token_count=token_count if i == 0 else None, raw=resp
+                )
+                for i, v in enumerate(raw_result)
+            ]
+        return EmbeddingResponse(
+            embedding=raw_result, token_count=token_count, raw=resp
+        )
+
+    async def _aget_query_embedding(self, query: str) -> EmbeddingResultType:
         return await self._aget_embedding(query, "query")
 
-    async def _aget_text_embedding(self, text: str) -> Embedding:
+    async def _aget_text_embedding(self, text: str) -> EmbeddingResultType:
         return await self._aget_embedding(text, "text")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-bedrock"
-version = "0.8.0"
+version = "0.9.0"
 description = "llama-index embeddings bedrock integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_async.py
@@ -31,7 +31,11 @@ class AsyncMockClient:
         pass
 
     async def invoke_model(self, *args, **kwargs):
-        return {"contentType": "application/json", "body": AsyncMockStreamReader()}
+        return {
+            "contentType": "application/json",
+            "body": AsyncMockStreamReader(),
+            "ResponseMetadata": {"HTTPHeaders": {}},
+        }
 
 
 class AsyncMockSession:
@@ -58,7 +62,10 @@ def bedrock_embedding(mock_aioboto3_session):
 @pytest.mark.asyncio
 async def test_aget_text_embedding(bedrock_embedding):
     response = await bedrock_embedding._aget_text_embedding(EXP_REQUEST)
-    assert response == EXP_RESPONSE["embedding"]
+    from llama_index.core.base.embeddings.base import EmbeddingResponse
+
+    assert isinstance(response, EmbeddingResponse)
+    assert response.embedding == EXP_RESPONSE["embedding"]
 
 
 @pytest.mark.asyncio

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
@@ -1,6 +1,9 @@
+import json
+from unittest.mock import MagicMock, patch
+
 import boto3
 import pytest
-from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.base.embeddings.base import BaseEmbedding, EmbeddingResponse
 from llama_index.embeddings.bedrock import BedrockEmbedding
 
 
@@ -96,3 +99,62 @@ def test_get_provider(model_name, expected_provider):
         client=bedrock_client,
     )
     assert embedding._get_provider() == expected_provider
+
+
+def _make_invoke_model_response(body_dict: dict, input_token_count: int = 10) -> dict:
+    """Build a mock boto3 invoke_model response with headers and body."""
+    body_bytes = json.dumps(body_dict).encode("utf-8")
+    stream = MagicMock()
+    stream.read.return_value = body_bytes
+    return {
+        "body": stream,
+        "ResponseMetadata": {
+            "HTTPHeaders": {
+                "x-amzn-bedrock-input-token-count": str(input_token_count),
+            },
+        },
+    }
+
+
+def test_get_embedding_extracts_token_count_from_header() -> None:
+    """Token count is extracted from x-amzn-bedrock-input-token-count header."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    emb = BedrockEmbedding(
+        model_name="amazon.titan-embed-text-v1",
+        client=bedrock_client,
+    )
+
+    resp = _make_invoke_model_response(
+        {"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5},
+        input_token_count=5,
+    )
+    with patch.object(emb._client, "invoke_model", return_value=resp):
+        result = emb._get_embedding("hello", "text")
+
+    assert isinstance(result, EmbeddingResponse)
+    assert result.embedding == [0.1, 0.2, 0.3]
+    assert result.token_count == 5
+
+
+def test_get_embedding_falls_back_to_body_token_count() -> None:
+    """When header is missing, falls back to inputTextTokenCount in body."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    emb = BedrockEmbedding(
+        model_name="amazon.titan-embed-text-v1",
+        client=bedrock_client,
+    )
+
+    body_bytes = json.dumps({"embedding": [0.1, 0.2], "inputTextTokenCount": 7}).encode(
+        "utf-8"
+    )
+    stream = MagicMock()
+    stream.read.return_value = body_bytes
+    resp = {
+        "body": stream,
+        "ResponseMetadata": {"HTTPHeaders": {}},
+    }
+    with patch.object(emb._client, "invoke_model", return_value=resp):
+        result = emb._get_embedding("hello", "text")
+
+    assert isinstance(result, EmbeddingResponse)
+    assert result.token_count == 7

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/llama_index/embeddings/cohere/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/llama_index/embeddings/cohere/base.py
@@ -7,7 +7,11 @@ from typing import Any, Callable, List, Optional, Union
 
 import cohere
 import httpx
-from llama_index.core.base.embeddings.base import DEFAULT_EMBED_BATCH_SIZE, Embedding
+from llama_index.core.base.embeddings.base import (
+    DEFAULT_EMBED_BATCH_SIZE,
+    Embedding,
+    EmbeddingResponse,
+)
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.callbacks import CallbackManager
 from llama_index.core.embeddings import MultiModalEmbedding
@@ -132,6 +136,26 @@ MAX_EMBED_BATCH_SIZE = 96
 
 # Default max retries for API calls
 DEFAULT_MAX_RETRIES = 10
+
+
+def _extract_billed_input_tokens(response: Any) -> Optional[int]:
+    """
+    Extract billed input token count from a Cohere embed response.
+
+    Returns the provider-reported count from
+    ``response.meta.billed_units.input_tokens``, or ``None`` if unavailable.
+    """
+    try:
+        meta = getattr(response, "meta", None)
+        if meta is None:
+            return None
+        billed = getattr(meta, "billed_units", None)
+        if billed is None:
+            return None
+        count = getattr(billed, "input_tokens", None)
+        return int(count) if count is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _create_retry_decorator(max_retries: int) -> Callable[[Any], Any]:
@@ -320,7 +344,7 @@ class CohereEmbedding(MultiModalEmbedding):
         self,
         texts: Optional[List[str]] = None,
         input_type: str = "search_document",
-    ) -> List[List[float]]:
+    ) -> List[EmbeddingResponse]:
         """Embed sentences using Cohere."""
         client = self._get_client()
 
@@ -332,15 +356,24 @@ class CohereEmbedding(MultiModalEmbedding):
         retry_decorator = _create_retry_decorator(max_retries=self.max_retries)
 
         @retry_decorator
-        def _embed_with_retry() -> List[List[float]]:
-            result = client.embed(
+        def _embed_with_retry() -> List[EmbeddingResponse]:
+            response = client.embed(
                 texts=texts,
                 input_type=input_type,
                 embedding_types=[self.embedding_type],
                 model=self.model_name,
                 truncate=self.truncate,
-            ).embeddings
-            return getattr(result, self.embedding_type, None)
+            )
+            vectors = getattr(response.embeddings, self.embedding_type, None) or []
+            token_count = _extract_billed_input_tokens(response)
+            return [
+                EmbeddingResponse(
+                    embedding=v,
+                    token_count=token_count if i == 0 else None,
+                    raw=response,
+                )
+                for i, v in enumerate(vectors)
+            ]
 
         return _embed_with_retry()
 
@@ -348,7 +381,7 @@ class CohereEmbedding(MultiModalEmbedding):
         self,
         texts: Optional[List[str]] = None,
         input_type: str = "search_document",
-    ) -> List[List[float]]:
+    ) -> List[EmbeddingResponse]:
         """Embed sentences using Cohere."""
         async_client = self._get_async_client()
 
@@ -360,17 +393,24 @@ class CohereEmbedding(MultiModalEmbedding):
         retry_decorator = _create_retry_decorator(max_retries=self.max_retries)
 
         @retry_decorator
-        async def _aembed_with_retry() -> List[List[float]]:
-            result = (
-                await async_client.embed(
-                    texts=texts,
-                    input_type=input_type,
-                    embedding_types=[self.embedding_type],
-                    model=self.model_name,
-                    truncate=self.truncate,
+        async def _aembed_with_retry() -> List[EmbeddingResponse]:
+            response = await async_client.embed(
+                texts=texts,
+                input_type=input_type,
+                embedding_types=[self.embedding_type],
+                model=self.model_name,
+                truncate=self.truncate,
+            )
+            vectors = getattr(response.embeddings, self.embedding_type, None) or []
+            token_count = _extract_billed_input_tokens(response)
+            return [
+                EmbeddingResponse(
+                    embedding=v,
+                    token_count=token_count if i == 0 else None,
+                    raw=response,
                 )
-            ).embeddings
-            return getattr(result, self.embedding_type, None)
+                for i, v in enumerate(vectors)
+            ]
 
         return await _aembed_with_retry()
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-cohere"
-version = "0.8.0"
+version = "0.9.0"
 description = "llama-index embeddings cohere integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-cohere/tests/test_embeddings.py
@@ -240,15 +240,26 @@ def test_create_retry_decorator_retries_on_gateway_timeout():
     assert call_count == 2
 
 
-def test_embed_with_retry():
-    """Test that _embed uses retry logic."""
-    emb = CohereEmbedding(api_key="test_key", max_retries=3)
-
+def _make_mock_response(vectors: list, input_tokens: int = 10) -> MagicMock:
+    """Build a mock Cohere embed response with billed_units metadata."""
     mock_embeddings = MagicMock()
-    mock_embeddings.float = [[0.1, 0.2, 0.3]]
+    mock_embeddings.float = vectors
+
+    billed_units = MagicMock()
+    billed_units.input_tokens = input_tokens
+    meta = MagicMock()
+    meta.billed_units = billed_units
 
     mock_response = MagicMock()
     mock_response.embeddings = mock_embeddings
+    mock_response.meta = meta
+    return mock_response
+
+
+def test_embed_with_retry():
+    """Test that _embed uses retry logic."""
+    emb = CohereEmbedding(api_key="test_key", max_retries=3)
+    mock_response = _make_mock_response([[0.1, 0.2, 0.3]])
 
     mock_client = MagicMock()
     mock_client.embed.return_value = mock_response
@@ -256,7 +267,7 @@ def test_embed_with_retry():
     with patch.object(emb, "_get_client", return_value=mock_client):
         result = emb._embed(texts=["test text"])
 
-    assert result == [[0.1, 0.2, 0.3]]
+    assert result[0].embedding == [0.1, 0.2, 0.3]
     mock_client.embed.assert_called_once()
 
 
@@ -264,12 +275,7 @@ def test_embed_with_retry():
 async def test_aembed_with_retry():
     """Test that _aembed uses retry logic."""
     emb = CohereEmbedding(api_key="test_key", max_retries=3)
-
-    mock_embeddings = MagicMock()
-    mock_embeddings.float = [[0.1, 0.2, 0.3]]
-
-    mock_response = MagicMock()
-    mock_response.embeddings = mock_embeddings
+    mock_response = _make_mock_response([[0.1, 0.2, 0.3]])
 
     mock_client = MagicMock()
     mock_client.embed = AsyncMock(return_value=mock_response)
@@ -277,8 +283,55 @@ async def test_aembed_with_retry():
     with patch.object(emb, "_get_async_client", return_value=mock_client):
         result = await emb._aembed(texts=["test text"])
 
-    assert result == [[0.1, 0.2, 0.3]]
+    assert result[0].embedding == [0.1, 0.2, 0.3]
     mock_client.embed.assert_called_once()
+
+
+def test_embed_extracts_billed_token_count():
+    """Test that _embed extracts billed_units.input_tokens from the response."""
+    emb = CohereEmbedding(api_key="test_key", max_retries=3)
+    mock_response = _make_mock_response([[0.1, 0.2]], input_tokens=42)
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = mock_response
+
+    with patch.object(emb, "_get_client", return_value=mock_client):
+        result = emb._embed(texts=["hello"])
+
+    assert len(result) == 1
+    assert result[0].token_count == 42
+
+
+@pytest.mark.asyncio
+async def test_aembed_extracts_billed_token_count():
+    """Test that _aembed extracts billed_units.input_tokens from the response."""
+    emb = CohereEmbedding(api_key="test_key", max_retries=3)
+    mock_response = _make_mock_response([[0.1, 0.2]], input_tokens=42)
+
+    mock_client = MagicMock()
+    mock_client.embed = AsyncMock(return_value=mock_response)
+
+    with patch.object(emb, "_get_async_client", return_value=mock_client):
+        result = await emb._aembed(texts=["hello"])
+
+    assert len(result) == 1
+    assert result[0].token_count == 42
+
+
+def test_embed_batch_token_count_on_first_only():
+    """In a batch, token_count appears only on the first EmbeddingResponse."""
+    emb = CohereEmbedding(api_key="test_key", max_retries=3)
+    mock_response = _make_mock_response([[0.1], [0.2], [0.3]], input_tokens=30)
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = mock_response
+
+    with patch.object(emb, "_get_client", return_value=mock_client):
+        result = emb._embed(texts=["a", "b", "c"])
+
+    assert result[0].token_count == 30
+    assert result[1].token_count is None
+    assert result[2].token_count is None
 
 
 def test_embed_image_with_retry():


### PR DESCRIPTION
# Description

LLM integrations already carry provider-reported token usage through
`CompletionResponse.additional_kwargs`, making it available in
`LLMChatEndEvent`. The embedding path has no equivalent: all token
counting relies on local tokenizer estimates via `TokenCountingHandler`,
which can diverge from what the provider actually bills (e.g., Cohere's
`billed_units.input_tokens` uses a different tokenizer than tiktoken).

This PR introduces `EmbeddingResponse`, a lightweight return type that
embedding integrations can use to report provider-side token usage
alongside the embedding vector, and surfaces it through
`EmbeddingEndEvent.token_count`.

**Core changes (`llama-index-core`):**
- New `EmbeddingResponse` class (plain Python, not Pydantic) with
  `embedding`, `token_count`, and `raw` fields. Mirrors
  `CompletionResponse` / `ChatResponse` for LLMs.
- `EmbeddingResultType = Union[Embedding, EmbeddingResponse]` type alias.
- `_unpack_embedding` / `_unpack_embeddings` helpers that transparently
  handle both plain `List[float]` and `EmbeddingResponse`.
- `EmbeddingEndEvent` gains `token_count: Optional[int] = None`.
- `BaseEmbedding` public methods unpack results and forward `token_count`
  into the dispatched event.
- Abstract method signatures updated to `-> EmbeddingResultType`.
  Existing integrations returning `List[float]` remain fully compatible.

**Cohere integration (`llama-index-embeddings-cohere`):**
- `_embed` / `_aembed` now read `response.meta.billed_units.input_tokens`
  and return `List[EmbeddingResponse]`.

**Bedrock integration (`llama-index-embeddings-bedrock`):**
- `_get_embedding` / `_aget_embedding` now read the
  `x-amzn-bedrock-input-token-count` HTTP header (with fallback to
  `inputTextTokenCount` in the response body for Titan) and return
  `EmbeddingResponse`.

### Design: `EmbeddingResponse` vs. instance attribute

The LLM path uses `CompletionResponse` to carry token usage through the
return value. For embeddings, the `_get_*` methods previously returned
plain `List[float]`. Rather than using a hidden instance attribute
(implicit, not thread-safe, no lifecycle management), this PR introduces
a proper return type that mirrors the LLM pattern.

Backwards compatibility is maintained via `Union[Embedding,
EmbeddingResponse]` and `isinstance` dispatch in the base class.
Integrations that return plain lists continue to work with
`token_count=None` in the event.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

`llama-index-embeddings-cohere` 0.8.0 -> 0.9.0
`llama-index-embeddings-bedrock` 0.8.0 -> 0.9.0

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

**Core (13 tests):**
- `_unpack_embedding` / `_unpack_embeddings` with plain lists and
  `EmbeddingResponse` inputs
- `EmbeddingEndEvent.token_count` default and explicit values
- End-to-end: subclass returning `EmbeddingResponse` surfaces
  `token_count` in the dispatched event
- End-to-end: existing `MockEmbedding` (plain list) produces
  `token_count=None`

**Cohere (new tests):**
- `_embed` / `_aembed` extract `billed_units.input_tokens` from
  mocked responses
- Batch: `token_count` on first item only (no double-counting)

**Bedrock (new tests):**
- Token count extracted from `x-amzn-bedrock-input-token-count` header
- Fallback to `inputTextTokenCount` in body when header is missing

**Integration tests (not in CI):**
- Real API calls to Cohere embed-english-v3.0: single, batch, query
- Real API calls to Bedrock: Titan v1, Titan v2, Cohere English v3,
  Cohere Multilingual v3

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods