### PR TITLE
fix(google-genai): do not raise on MALFORMED_FUNCTION_CALL / UNEXPECTED_TOOL_CALL finish reasons

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -120,9 +120,25 @@ def merge_neighboring_same_role_messages(
     return merged_messages
 
 
+_TOOL_CALL_FINISH_REASONS = frozenset(
+    {
+        types.FinishReason.MALFORMED_FUNCTION_CALL,
+        types.FinishReason.UNEXPECTED_TOOL_CALL,
+    }
+)
+
+
 def _error_if_finished_early(candidate: types.Candidate) -> None:
     if finish_reason := candidate.finish_reason:
         if finish_reason != types.FinishReason.STOP:
+            if finish_reason in _TOOL_CALL_FINISH_REASONS:
+                logger.warning(
+                    "Gemini returned %s finish reason; treating response as "
+                    "usable and letting the caller decide how to proceed.",
+                    finish_reason.name,
+                )
+                return
+
             reason = finish_reason.name
 
             # Safety reasons have more detail, so include that if we can.

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.5"
+version = "0.9.6"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -2048,3 +2048,45 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+class TestErrorIfFinishedEarly:
+    """Tests for _error_if_finished_early finish reason handling."""
+
+    def _make_candidate(self, finish_reason: types.FinishReason) -> types.Candidate:
+        candidate = MagicMock(spec=types.Candidate)
+        candidate.finish_reason = finish_reason
+        candidate.safety_ratings = None
+        return candidate
+
+    def test_stop_does_not_raise(self) -> None:
+        from llama_index.llms.google_genai.utils import _error_if_finished_early
+
+        candidate = self._make_candidate(types.FinishReason.STOP)
+        _error_if_finished_early(candidate)
+
+    def test_safety_raises(self) -> None:
+        from llama_index.llms.google_genai.utils import _error_if_finished_early
+
+        candidate = self._make_candidate(types.FinishReason.SAFETY)
+        with pytest.raises(RuntimeError, match="terminated early"):
+            _error_if_finished_early(candidate)
+
+    def test_malformed_function_call_does_not_raise(self) -> None:
+        from llama_index.llms.google_genai.utils import _error_if_finished_early
+
+        candidate = self._make_candidate(types.FinishReason.MALFORMED_FUNCTION_CALL)
+        _error_if_finished_early(candidate)
+
+    def test_unexpected_tool_call_does_not_raise(self) -> None:
+        from llama_index.llms.google_genai.utils import _error_if_finished_early
+
+        candidate = self._make_candidate(types.FinishReason.UNEXPECTED_TOOL_CALL)
+        _error_if_finished_early(candidate)
+
+    def test_recitation_raises(self) -> None:
+        from llama_index.llms.google_genai.utils import _error_if_finished_early
+
+        candidate = self._make_candidate(types.FinishReason.RECITATION)
+        with pytest.raises(RuntimeError, match="terminated early"):
+            _error_if_finished_early(candidate)


### PR DESCRIPTION
# Description

Gemini occasionally returns `MALFORMED_FUNCTION_CALL` or
`UNEXPECTED_TOOL_CALL` as the finish reason, even when the request
explicitly declares tools. This is a transient server-side model
behavior (not a client error). The current `_error_if_finished_early`
raises `RuntimeError` on any non-STOP finish reason, which crashes the
entire agent loop.

This patch logs a warning for these two tool-call finish reasons and
returns normally, letting the caller decide how to proceed. Other
finish reasons (SAFETY, RECITATION, etc.) keep the original raise
behavior.

This matches the approach taken by langchain-google-genai, which
records finish_reason as metadata without raising.

Related upstream issues (all unresolved):
- googleapis/python-genai#1818
- langchain-ai/langchainjs#8589
- langchain-ai/langchain-google#1268

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

\`llama-index-llms-google-genai\` 0.9.1 -> 0.9.2

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Five tests in \`TestErrorIfFinishedEarly\`:
- STOP: does not raise (existing behavior preserved)
- SAFETY: raises RuntimeError (existing behavior preserved)
- RECITATION: raises RuntimeError (existing behavior preserved)
- MALFORMED_FUNCTION_CALL: does not raise (new behavior)
- UNEXPECTED_TOOL_CALL: does not raise (new behavior)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran \`uv run make format; uv run make lint\` to appease the lint gods