### PR TITLE
Fix MCP tool schema handling for additionalProperties

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -12,12 +12,17 @@ from llama_index.core.tools.types import ToolMetadata
 from llama_index.tools.mcp.tool_spec_mixins import (
     TypeResolutionMixin,
     TypeCreationMixin,
+    ConfigDictExtractionMixin,
     FieldExtractionMixin,
 )
 
 
 class McpToolSpec(
-    BaseToolSpec, TypeResolutionMixin, TypeCreationMixin, FieldExtractionMixin
+    BaseToolSpec,
+    TypeResolutionMixin,
+    TypeCreationMixin,
+    ConfigDictExtractionMixin,
+    FieldExtractionMixin,
 ):
     """
     MCPToolSpec will get the tools from MCP Client (only need to implement ClientSession) and convert them to LlamaIndex's FunctionTool objects.
@@ -238,7 +243,8 @@ class McpToolSpec(
             return self.properties_cache[model_name]
 
         fields = self._extract_fields(schema, defs)
-        model = create_model(model_name, **fields)
+        config = self._extract_config(schema)
+        model = create_model(model_name, __config__=config, **fields)
         self.properties_cache[model_name] = model
         return model
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Union, Literal, Type, TYPE_CHECKING
-from pydantic import Field
+from pydantic import ConfigDict, Field, ValidationError
 
 if TYPE_CHECKING:
     from llama_index.tools.mcp.base import McpToolSpec
@@ -134,6 +134,26 @@ class TypeCreationMixin:
         return ref_path.split("#/$defs/")[-1]
 
 
+class ConfigDictExtractionMixin:
+    def _extract_config(self: "McpToolSpec", schema: dict) -> ConfigDict:
+        """Extract Pydantic config from schema."""
+        extra_properties_policy = self._extract_extra_properties_policy(schema)
+        return ConfigDict(extra=extra_properties_policy)
+
+    def _extract_extra_properties_policy(self, schema: dict) -> str:
+        if schema.get("additionalProperties") is True:
+            extra_properties_policy = "allow"
+        elif isinstance(schema.get("additionalProperties"), dict):
+            extra_properties_policy = "allow"
+        elif schema.get("additionalProperties") is False:
+            extra_properties_policy = "forbid"
+        elif schema.get("additionalProperties") is None:
+            extra_properties_policy = "ignore"
+        else:
+            raise ValidationError("Invalid additionalProperties value in schema")
+        return extra_properties_policy
+
+
 class FieldExtractionMixin:
     def _extract_fields(self: "McpToolSpec", schema: dict, defs: dict) -> dict:
         """Extract Pydantic fields from schema."""
@@ -156,7 +176,18 @@ class FieldExtractionMixin:
 
             fields[field_name] = (
                 final_type,
-                Field(default_value, description=field_schema.get("description", "")),
+                Field(default_value, description=field_schema.get("description", None)),
+            )
+
+        additional_properties = schema.get("additionalProperties")
+        # Configure Pydantic to track extra fields with typed validation
+        if isinstance(additional_properties, dict):
+            extra_value_type = self._resolve_field_type(additional_properties, defs)
+            # __pydantic_extra__ enables runtime type checking for dynamic properties
+            # init=False prevents this metadata field from appearing in __init__
+            fields["__pydantic_extra__"] = (
+                Dict[str, extra_value_type],
+                Field(init=False),
             )
 
         return fields

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -143,25 +143,6 @@ additional_properties_test_cases = [
     ),
     pytest.param(
         {
-            "additionalProperties": False,
-            "properties": {
-                "nested": {
-                    "additionalProperties": False,
-                    "properties": {
-                        "value": {"title": "Value", "type": "string"},
-                    },
-                    "required": ["value"],
-                    "title": "Inner",
-                    "type": "object",
-                },
-            },
-            "required": ["nested"],
-            "type": "object",
-        },
-        id="forbids-extra-properties-in-nested-model",
-    ),
-    pytest.param(
-        {
             "$defs": {
                 "Inner": {
                     "additionalProperties": False,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -97,6 +97,87 @@ async def test_pydantic_models_tool(client: BasicMCPClient):
     )
 
 
+@pytest.mark.parametrize(
+    "json_schema",
+    [
+        pytest.param(
+            {
+                "properties": {
+                    "known": {"title": "Known", "type": "string"},
+                },
+                "required": ["known"],
+                "type": "object",
+            },
+            id="ignore-extra-properties-by-default",
+        ),
+        pytest.param(
+            {
+                "additionalProperties": True,
+                "properties": {
+                    "known": {"title": "Known", "type": "string"},
+                },
+                "required": ["known"],
+                "type": "object",
+            },
+            id="allows-untyped-extra-properties",
+        ),
+        pytest.param(
+            {
+                "additionalProperties": False,
+                "properties": {
+                    "known": {"title": "Known", "type": "string"},
+                },
+                "required": ["known"],
+                "type": "object",
+            },
+            id="forbids-extra-properties",
+        ),
+        pytest.param(
+            {
+                "additionalProperties": {"type": "string"},
+                "properties": {
+                    "known": {"title": "Known", "type": "string"},
+                },
+                "required": ["known"],
+                "type": "object",
+            },
+            id="allows-string-extra-properties",
+        ),
+        pytest.param(
+            {
+                "$defs": {
+                    "Inner": {
+                        "additionalProperties": False,
+                        "properties": {
+                            "value": {"title": "Value", "type": "string"},
+                        },
+                        "required": ["value"],
+                        "title": "Inner",
+                        "type": "object",
+                    },
+                },
+                "additionalProperties": False,
+                "properties": {
+                    "nested": {"$ref": "#/$defs/Inner"},
+                },
+                "required": ["nested"],
+                "type": "object",
+            },
+            id="forbids-extra-properties-in-nested-model",
+        ),
+    ],
+)
+def test_create_model_from_json_schema(client: BasicMCPClient, json_schema: dict):
+    """Test the test_pydantic tool with Pydantic models that use custom type aliases and Literal types."""
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+    pydantic_model = tool_spec.create_model_from_json_schema(json_schema)
+    json_schema_from_pydantic_model = pydantic_model.model_json_schema()
+
+    del json_schema_from_pydantic_model["title"]
+
+    assert json_schema == json_schema_from_pydantic_model
+
+
 def test_pydantic_models_schema_structure(client: BasicMCPClient):
     """Test that the test_pydantic tool generates correct schema structure."""
     tool = McpToolSpec(client, allowed_tools=["test_pydantic"]).to_tool_list()[0]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -173,7 +173,7 @@ additional_properties_test_cases = [
     ],
 )
 def test_create_model_from_json_schema(client: BasicMCPClient, json_schema: dict):
-    """Test the test_pydantic tool with Pydantic models that use custom type aliases and Literal types."""
+    """Converting a JSON schema into a Pydantic model and back to a JSON schema should yield the original schema."""
     tool_spec = McpToolSpec(client, allowed_tools=[])
     pydantic_model = tool_spec.create_model_from_json_schema(json_schema)
     json_schema_from_pydantic_model = pydantic_model.model_json_schema()

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -97,74 +97,98 @@ async def test_pydantic_models_tool(client: BasicMCPClient):
     )
 
 
+additional_properties_test_cases = [
+    pytest.param(
+        {
+            "properties": {
+                "known": {"title": "Known", "type": "string"},
+            },
+            "required": ["known"],
+            "type": "object",
+        },
+        id="ignore-extra-properties-by-default",
+    ),
+    pytest.param(
+        {
+            "additionalProperties": True,
+            "properties": {
+                "known": {"title": "Known", "type": "string"},
+            },
+            "required": ["known"],
+            "type": "object",
+        },
+        id="allows-untyped-extra-properties",
+    ),
+    pytest.param(
+        {
+            "additionalProperties": False,
+            "properties": {
+                "known": {"title": "Known", "type": "string"},
+            },
+            "required": ["known"],
+            "type": "object",
+        },
+        id="forbids-extra-properties",
+    ),
+    pytest.param(
+        {
+            "additionalProperties": {"type": "string"},
+            "properties": {
+                "known": {"title": "Known", "type": "string"},
+            },
+            "required": ["known"],
+            "type": "object",
+        },
+        id="allows-string-extra-properties",
+    ),
+    pytest.param(
+        {
+            "additionalProperties": False,
+            "properties": {
+                "nested": {
+                    "additionalProperties": False,
+                    "properties": {
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                    "required": ["value"],
+                    "title": "Inner",
+                    "type": "object",
+                },
+            },
+            "required": ["nested"],
+            "type": "object",
+        },
+        id="forbids-extra-properties-in-nested-model",
+    ),
+    pytest.param(
+        {
+            "$defs": {
+                "Inner": {
+                    "additionalProperties": False,
+                    "properties": {
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                    "required": ["value"],
+                    "title": "Inner",
+                    "type": "object",
+                },
+            },
+            "additionalProperties": False,
+            "properties": {
+                "nested": {"$ref": "#/$defs/Inner"},
+            },
+            "required": ["nested"],
+            "type": "object",
+        },
+        id="forbids-extra-properties-in-nested-model-with-def",
+    ),
+]
+
+
 @pytest.mark.parametrize(
     "json_schema",
     [
-        pytest.param(
-            {
-                "properties": {
-                    "known": {"title": "Known", "type": "string"},
-                },
-                "required": ["known"],
-                "type": "object",
-            },
-            id="ignore-extra-properties-by-default",
-        ),
-        pytest.param(
-            {
-                "additionalProperties": True,
-                "properties": {
-                    "known": {"title": "Known", "type": "string"},
-                },
-                "required": ["known"],
-                "type": "object",
-            },
-            id="allows-untyped-extra-properties",
-        ),
-        pytest.param(
-            {
-                "additionalProperties": False,
-                "properties": {
-                    "known": {"title": "Known", "type": "string"},
-                },
-                "required": ["known"],
-                "type": "object",
-            },
-            id="forbids-extra-properties",
-        ),
-        pytest.param(
-            {
-                "additionalProperties": {"type": "string"},
-                "properties": {
-                    "known": {"title": "Known", "type": "string"},
-                },
-                "required": ["known"],
-                "type": "object",
-            },
-            id="allows-string-extra-properties",
-        ),
-        pytest.param(
-            {
-                "$defs": {
-                    "Inner": {
-                        "additionalProperties": False,
-                        "properties": {
-                            "value": {"title": "Value", "type": "string"},
-                        },
-                        "required": ["value"],
-                        "title": "Inner",
-                        "type": "object",
-                    },
-                },
-                "additionalProperties": False,
-                "properties": {
-                    "nested": {"$ref": "#/$defs/Inner"},
-                },
-                "required": ["nested"],
-                "type": "object",
-            },
-            id="forbids-extra-properties-in-nested-model",
-        ),
+        *additional_properties_test_cases,
     ],
 )
 def test_create_model_from_json_schema(client: BasicMCPClient, json_schema: dict):

--- a/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
@@ -1856,7 +1856,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

This change improves MCP tool JSON Schema parsing when converting schemas into Pydantic models for LlamaIndex tools.

Previously, MCP tool schemas that used `additionalProperties` could lose important schema semantics. This change maps JSON Schema `additionalProperties` behavior into Pydantic model configuration more explicitly:

* `additionalProperties: false` -> forbid extra fields
* `additionalProperties: true` -> allow extra fields
* `additionalProperties` as an object schema -> allow typed extra fields
* omitted `additionalProperties` -> ignore extra fields by default

The change also adds coverage for default, boolean, typed, and nested `additionalProperties` cases to ensure generated Pydantic JSON schemas match the input schema behavior.

Dependencies: None.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

* [x] Yes
* [ ] No

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

* [x] I added new unit tests to cover this change
* [ ] I believe this change is already covered by existing unit tests

Added/updated tests covering:

* default behavior when `additionalProperties` is omitted
* allowing untyped extra properties
* forbidding extra properties
* allowing typed extra properties
* forbidding extra properties in nested models

## Suggested Checklist:

* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Note: I ran `uv run ruff check --fix` and `uv run ruff format`; full format/lint command still needs confirmation.
