### PR TITLE
fix(ag-ui): deepcopy initial_state to prevent shared state across requests

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -184,7 +185,7 @@ class AGUIChatWorkflow(Workflow):
                 state.pop("messages", None)
             else:
                 # initial state is not provided, use the default state
-                state = self.initial_state.copy()
+                state = copy.deepcopy(self.initial_state)
 
             # Save state to context for tools to use
             await ctx.store.set("state", state)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/router.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Callable, Dict, Any, List, Optional, Awaitable
 
 from ag_ui.core import RunAgentInput
@@ -109,7 +110,7 @@ def get_default_workflow_factory(
             llm=llm,
             frontend_tools=frontend_tools,
             backend_tools=backend_tools,
-            initial_state=initial_state,
+            initial_state=copy.deepcopy(initial_state),
             system_prompt=system_prompt,
             timeout=timeout,
         )


### PR DESCRIPTION
**Problem:** `get_default_workflow_factory` closes over the `initial_state` dict and passes the same reference to every `AGUIChatWorkflow` it produces. Combined with the shallow `.copy()` in the `chat` step, mutations on nested mutable values (e.g. `items: []`, `user: {"roles": []}`) leak across concurrent requests and pollute the operator config object.

Two leak surfaces exist: any mutation through `self.initial_state[...]` on one workflow is visible on every other workflow the factory has produced; the shallow copy at the `chat` step means nested values are aliased across all in-flight requests.

**Fix:** Use `copy.deepcopy` in `workflow_factory` so each workflow gets its own isolated copy, and `copy.deepcopy` again in the `chat` fallback path to ensure nested mutable values are not aliased.

Fixes #22069