### PR TITLE
fix(multi-modal): call super().__init__() in MultiModalVectorIndexRetriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
@@ -85,6 +85,7 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
 
         self._kwargs: Dict[str, Any] = kwargs.get("vector_store_kwargs", {})
         self.callback_manager = callback_manager or Settings.callback_manager
+        super().__init__(callback_manager=self.callback_manager)
 
     @property
     def similarity_top_k(self) -> int:


### PR DESCRIPTION
**Problem:** `MultiModalVectorIndexRetriever.__init__` does not call `super().__init__()`, so `BaseRetriever.object_map` is never initialized. Any call path that reaches `BaseRetriever.retrieve` or `BaseRetriever.aretrieve` then raises `AttributeError: 'MultiModalVectorIndexRetriever' object has no attribute 'object_map'`.

**Fix:** Call `super().__init__(callback_manager=self.callback_manager)` at the end of `__init__` so `object_map` and other base-class attributes are properly set.

Fixes #22080