### PR TITLE
Fix multimodal retriever object map

### DIFF
--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -135,6 +135,8 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         return MultiModalVectorIndexRetriever(
             self,
             node_ids=list(self.index_struct.nodes_dict.values()),
+            callback_manager=self._callback_manager,
+            object_map=self._object_map,
             **kwargs,
         )
 

--- a/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
@@ -61,6 +61,8 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         doc_ids: Optional[List[str]] = None,
         sparse_top_k: Optional[int] = None,
         callback_manager: Optional[CallbackManager] = None,
+        object_map: Optional[dict] = None,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize params."""
@@ -84,7 +86,11 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         self._sparse_top_k = sparse_top_k
 
         self._kwargs: Dict[str, Any] = kwargs.get("vector_store_kwargs", {})
-        self.callback_manager = callback_manager or Settings.callback_manager
+        super().__init__(
+            callback_manager=callback_manager or Settings.callback_manager,
+            object_map=object_map,
+            verbose=verbose,
+        )
 
     @property
     def similarity_top_k(self) -> int:

--- a/llama-index-core/tests/indices/multi_modal/test_retriever.py
+++ b/llama-index-core/tests/indices/multi_modal/test_retriever.py
@@ -1,0 +1,37 @@
+from llama_index.core import MockEmbedding
+from llama_index.core.embeddings import MockMultiModalEmbedding
+from llama_index.core.indices import MultiModalVectorStoreIndex
+from llama_index.core.schema import Document, IndexNode, TextNode
+
+
+def test_retriever_initializes_base_state_from_documents() -> None:
+    index = MultiModalVectorStoreIndex.from_documents(
+        [Document.example()],
+        embed_model=MockEmbedding(embed_dim=3),
+        image_embed_model=MockMultiModalEmbedding(embed_dim=3),
+    )
+
+    retriever = index.as_retriever()
+
+    assert retriever.object_map == {}
+
+
+def test_retriever_uses_index_object_map_for_recursive_retrieval() -> None:
+    visible_node = TextNode(text="Visible node", id_="visible_node")
+    index_node = IndexNode(
+        text="Hidden node pointer",
+        id_="index_node",
+        index_id="hidden_node_index",
+        obj=TextNode(text="Hidden node", id_="hidden_node"),
+    )
+    index = MultiModalVectorStoreIndex(
+        nodes=[visible_node],
+        objects=[index_node],
+        embed_model=MockEmbedding(embed_dim=3),
+        image_embed_model=MockMultiModalEmbedding(embed_dim=3),
+        is_image_vector_store_empty=True,
+    )
+
+    nodes = index.as_retriever(similarity_top_k=2).retrieve("node")
+
+    assert {node.node.id_ for node in nodes} == {"visible_node", "hidden_node"}


### PR DESCRIPTION
# Description
Fixes #22080.

`MultiModalVectorIndexRetriever` was setting `callback_manager` directly instead of initializing `BaseRetriever`, so base retriever state such as `object_map` and `_verbose` was missing.

This also passes `MultiModalVectorStoreIndex._object_map` through `as_retriever()` so recursive retrieval can resolve object-backed `IndexNode` entries created through `objects=[...]`.

## New Package?
No.

## Version Bump?
No. This changes `llama-index-core`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

## Suggested Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

Local checks:
- `uv run pytest tests/indices/multi_modal/test_retriever.py -q`
- `uv run ruff check llama_index/core/indices/multi_modal/retriever.py llama_index/core/indices/multi_modal/base.py tests/indices/multi_modal/test_retriever.py`
- `uv run ruff format llama_index/core/indices/multi_modal/retriever.py llama_index/core/indices/multi_modal/base.py tests/indices/multi_modal/test_retriever.py --check`
- `git diff --check`
