### PR TITLE
fix: bound HWP section decompression

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/docs/base.py
@@ -138,6 +138,7 @@ class HWPReader(BaseReader):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.MAX_DECOMPRESSED_SECTION_SIZE = 100 * 1024 * 1024
         self.FILE_HEADER_SECTION = "FileHeader"
         self.HWP_SUMMARY_SECTION = "\x05HwpSummaryInformation"
         self.SECTION_NAME_LENGTH = len("Section")
@@ -224,7 +225,7 @@ class HWPReader(BaseReader):
         data = bodytext.read()
 
         unpacked_data = (
-            zlib.decompress(data, -15) if self.is_compressed(load_file) else data
+            self._decompress_section(data) if self.is_compressed(load_file) else data
         )
         size = len(unpacked_data)
 
@@ -245,3 +246,28 @@ class HWPReader(BaseReader):
             i += 4 + rec_len
 
         return text
+
+    def _decompress_section(self, data: bytes) -> bytes:
+        decompressor = zlib.decompressobj(-15)
+        max_size = self.MAX_DECOMPRESSED_SECTION_SIZE
+        unpacked_data = decompressor.decompress(data, max_size + 1)
+
+        if len(unpacked_data) > max_size or decompressor.unconsumed_tail:
+            raise ValueError(
+                "Decompressed HWP section exceeds maximum allowed size "
+                f"({max_size} bytes)."
+            )
+
+        remaining_size = max_size + 1 - len(unpacked_data)
+        unpacked_data += decompressor.flush(remaining_size)
+        if not decompressor.eof:
+            raise zlib.error(
+                "Compressed HWP section ended before the stream was complete."
+            )
+        if len(unpacked_data) > max_size:
+            raise ValueError(
+                "Decompressed HWP section exceeds maximum allowed size "
+                f"({max_size} bytes)."
+            )
+
+        return unpacked_data

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
@@ -1,3 +1,9 @@
+import io
+import struct
+import zlib
+
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.file import (
     DocxReader,
@@ -17,6 +23,29 @@ from llama_index.readers.file import (
     XMLReader,
     ImageTabularChartReader,
 )
+
+
+class FakeHWPFile:
+    def __init__(self, section_data: bytes) -> None:
+        self.section_data = section_data
+
+    def openstream(self, section: str) -> io.BytesIO:
+        if section == "FileHeader":
+            header = bytearray(37)
+            header[36] = 1
+            return io.BytesIO(header)
+        return io.BytesIO(self.section_data)
+
+
+def raw_deflate(data: bytes) -> bytes:
+    compressor = zlib.compressobj(wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+def hwp_text_record(text: str) -> bytes:
+    encoded_text = text.encode("utf-16")
+    header = 67 | (len(encoded_text) << 20)
+    return struct.pack("<I", header) + encoded_text
 
 
 def test_classes():
@@ -67,3 +96,27 @@ def test_classes():
 
     names_of_base_classes = [b.__name__ for b in ImageTabularChartReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_hwp_compressed_section_is_decompressed_with_limit():
+    reader = HWPReader()
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("hello")))
+
+    assert reader.get_text_from_section(load_file, "BodyText/Section0") == "hello\n"
+
+
+def test_hwp_compressed_section_rejects_decompression_bomb():
+    reader = HWPReader()
+    reader.MAX_DECOMPRESSED_SECTION_SIZE = 16
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("too large")))
+
+    with pytest.raises(ValueError, match="Decompressed HWP section exceeds"):
+        reader.get_text_from_section(load_file, "BodyText/Section0")
+
+
+def test_hwp_compressed_section_rejects_truncated_stream():
+    reader = HWPReader()
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("hello"))[:-1])
+
+    with pytest.raises(zlib.error, match="ended before the stream was complete"):
+        reader.get_text_from_section(load_file, "BodyText/Section0")

--- a/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
@@ -15,6 +15,7 @@ class HWPReader(BaseReader):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.MAX_DECOMPRESSED_SECTION_SIZE = 100 * 1024 * 1024
         self.FILE_HEADER_SECTION = "FileHeader"
         self.HWP_SUMMARY_SECTION = "\x05HwpSummaryInformation"
         self.SECTION_NAME_LENGTH = len("Section")
@@ -91,7 +92,7 @@ class HWPReader(BaseReader):
         data = bodytext.read()
 
         unpacked_data = (
-            zlib.decompress(data, -15) if self.is_compressed(load_file) else data
+            self._decompress_section(data) if self.is_compressed(load_file) else data
         )
         size = len(unpacked_data)
 
@@ -112,3 +113,28 @@ class HWPReader(BaseReader):
             i += 4 + rec_len
 
         return text
+
+    def _decompress_section(self, data: bytes) -> bytes:
+        decompressor = zlib.decompressobj(-15)
+        max_size = self.MAX_DECOMPRESSED_SECTION_SIZE
+        unpacked_data = decompressor.decompress(data, max_size + 1)
+
+        if len(unpacked_data) > max_size or decompressor.unconsumed_tail:
+            raise ValueError(
+                "Decompressed HWP section exceeds maximum allowed size "
+                f"({max_size} bytes)."
+            )
+
+        remaining_size = max_size + 1 - len(unpacked_data)
+        unpacked_data += decompressor.flush(remaining_size)
+        if not decompressor.eof:
+            raise zlib.error(
+                "Compressed HWP section ended before the stream was complete."
+            )
+        if len(unpacked_data) > max_size:
+            raise ValueError(
+                "Decompressed HWP section exceeds maximum allowed size "
+                f"({max_size} bytes)."
+            )
+
+        return unpacked_data

--- a/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
@@ -1,3 +1,9 @@
+import io
+import struct
+import zlib
+
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.hwp import HWPReader
 
@@ -5,3 +11,50 @@ from llama_index.readers.hwp import HWPReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HWPReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+class FakeHWPFile:
+    def __init__(self, section_data: bytes) -> None:
+        self.section_data = section_data
+
+    def openstream(self, section: str) -> io.BytesIO:
+        if section == "FileHeader":
+            header = bytearray(37)
+            header[36] = 1
+            return io.BytesIO(header)
+        return io.BytesIO(self.section_data)
+
+
+def raw_deflate(data: bytes) -> bytes:
+    compressor = zlib.compressobj(wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+def hwp_text_record(text: str) -> bytes:
+    encoded_text = text.encode("utf-16")
+    header = 67 | (len(encoded_text) << 20)
+    return struct.pack("<I", header) + encoded_text
+
+
+def test_compressed_section_is_decompressed_with_limit():
+    reader = HWPReader()
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("hello")))
+
+    assert reader.get_text_from_section(load_file, "BodyText/Section0") == "hello\n"
+
+
+def test_compressed_section_rejects_decompression_bomb():
+    reader = HWPReader()
+    reader.MAX_DECOMPRESSED_SECTION_SIZE = 16
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("too large")))
+
+    with pytest.raises(ValueError, match="Decompressed HWP section exceeds"):
+        reader.get_text_from_section(load_file, "BodyText/Section0")
+
+
+def test_compressed_section_rejects_truncated_stream():
+    reader = HWPReader()
+    load_file = FakeHWPFile(raw_deflate(hwp_text_record("hello"))[:-1])
+
+    with pytest.raises(zlib.error, match="ended before the stream was complete"):
+        reader.get_text_from_section(load_file, "BodyText/Section0")


### PR DESCRIPTION
## Summary

- replace unbounded HWP raw-deflate decompression with bounded incremental decompression
- apply the same safety boundary to both the standalone HWP reader and the duplicated HWP reader shipped by `llama-index-readers-file`
- reject output over 100 MiB and incomplete/truncated deflate streams
- cover normal compressed sections, oversized output, and truncated input in both packages

Fixes #22101.

## Root cause

Both production reader implementations call `zlib.decompress(data, -15)` directly. A small raw-deflate section can therefore allocate unbounded decompressed output before HWP record parsing begins.

The helper uses `zlib.decompressobj(-15)` with `max_length`, rejects `unconsumed_tail`, checks the final size, and requires `decompressor.eof`.

## Current-main and duplicate audit

Rechecked against `main@67514f634`: both unbounded call sites are still present. Three linked fixes remain open; this PR is the earliest and is the only one that updates and tests both shipped HWP reader implementations while also rejecting truncated streams.

## Validation

Rebased onto `main@67514f634` and validated with Python 3.13.12, loading each package from this worktree:

- standalone HWP reader: `pytest tests/test_readers_hwp.py -q` -> `4 passed`
- readers-file HWP implementation: `pytest tests/test_readers_file.py -q` -> `4 passed`
- targeted Ruff check for both production/test pairs -> passed
- targeted Ruff format check for both production/test pairs -> passed
- `git diff --check origin/main...HEAD` -> passed

The pytest deprecation warnings in the standalone package come from its existing pytest assertion-rewrite dependency under Python 3.13; no test or patch path emitted a new warning. AI assistance was used for source comparison, rebasing, and validation; I reviewed the final diff and evidence.