### PR TITLE
fix: preserve multiblock streaming chat history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -144,6 +145,15 @@ class StreamingAgentChatResponse:
             self.response = self.unformatted_response.strip()
         return self.response
 
+    @staticmethod
+    def _set_message_text(message: ChatMessage, text: str) -> None:
+        for block in message.blocks:
+            if isinstance(block, TextBlock):
+                block.text = text
+                return
+
+        message.blocks = [TextBlock(text=text)]
+
     def _ensure_async_setup(self) -> None:
         if self.aqueue is None:
             self.aqueue = asyncio.Queue()
@@ -191,7 +201,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                self._set_message_text(chat.message, final_text.strip())
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -249,7 +259,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                self._set_message_text(chat.message, final_text.strip())
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -3,8 +3,11 @@ import asyncio
 from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.base.llms.types import (
     ChatMessage,
+    ChatResponse,
     CompletionResponse,
     CompletionResponseGen,
+    ImageBlock,
+    TextBlock,
 )
 from typing import Any
 from llama_index.core.llms.callbacks import llm_completion_callback
@@ -12,6 +15,7 @@ from llama_index.core.llms.mock import MockLLM
 import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.chat_engine.simple import SimpleChatEngine
+from llama_index.core.chat_engine.types import StreamingAgentChatResponse
 
 
 def test_simple_chat_engine() -> None:
@@ -71,6 +75,57 @@ async def test_simple_chat_engine_astream():
     assert num_iters > 10
     assert "Hello World!" in response.unformatted_response
     assert "What is the capital of the moon?" in response.unformatted_response
+
+
+@pytest.mark.asyncio
+async def test_streaming_history_write_handles_multiblock_final_message():
+    memory = ChatMemoryBuffer.from_defaults()
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[TextBlock(text="draft"), ImageBlock()],
+    )
+
+    async def stream():
+        yield ChatResponse(message=message, delta="final ")
+        yield ChatResponse(message=message, delta="answer")
+
+    response = StreamingAgentChatResponse(achat_stream=stream())
+    response.awrite_response_to_history_task = asyncio.create_task(
+        response.awrite_response_to_history(memory)
+    )
+
+    chunks = [chunk async for chunk in response.async_response_gen()]
+
+    assert chunks == ["final ", "answer"]
+    assert response.response == "final answer"
+    history = memory.get_all()
+    assert len(history) == 1
+    assert history[0].role == MessageRole.ASSISTANT
+    assert isinstance(history[0].blocks[0], TextBlock)
+    assert history[0].blocks[0].text == "final answer"
+    assert isinstance(history[0].blocks[1], ImageBlock)
+
+
+def test_sync_streaming_history_write_handles_multiblock_final_message():
+    memory = ChatMemoryBuffer.from_defaults()
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[TextBlock(text="draft"), ImageBlock()],
+    )
+
+    def stream():
+        yield ChatResponse(message=message, delta="final ")
+        yield ChatResponse(message=message, delta="answer")
+
+    response = StreamingAgentChatResponse(chat_stream=stream())
+    response.write_response_to_history(memory)
+
+    history = memory.get_all()
+    assert len(history) == 1
+    assert history[0].role == MessageRole.ASSISTANT
+    assert isinstance(history[0].blocks[0], TextBlock)
+    assert history[0].blocks[0].text == "final answer"
+    assert isinstance(history[0].blocks[1], ImageBlock)
 
 
 def test_simple_chat_engine_astream_exception_handling():


### PR DESCRIPTION
## Description

Fixes #21679.

Streaming chat history writeback currently assigns the final streamed text through `ChatMessage.content`. That setter raises when the final assistant message already has multiple blocks, so async consumers can fail after the stream completes.

This updates the streaming writeback path to set the first existing `TextBlock` directly, or create one when the message has no text block. Non-text blocks are preserved. The same helper is used by both sync and async streaming history writeback paths.

## Testing

- `uv run --directory llama-index-core pytest tests/chat_engine/test_simple.py -q`
- `uv run --directory llama-index-core pytest tests/chat_engine -q`
- `uv run --directory llama-index-core ruff check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py`
- `uv run --directory llama-index-core ruff format --check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py`
- `git diff --check`