### PR TITLE
fix: persist AG-UI frontend tool messages

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -395,7 +395,7 @@ class AGUIChatWorkflow(Workflow):
         ]
 
         new_tool_messages = []
-        for tool_result in backend_tool_calls:
+        for tool_result in [*backend_tool_calls, *frontend_tool_calls]:
             new_tool_messages.append(
                 ChatMessage(
                     role="tool",

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.3"
+version = "0.3.4"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_frontend_tool_messages.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_frontend_tool_messages.py
@@ -1,0 +1,109 @@
+import asyncio
+
+from ag_ui.core import RunAgentInput, UserMessage
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.llms.mock import MockFunctionCallingLLM
+from llama_index.core.tools import FunctionTool
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow
+
+
+async def backend_calc(x: int, y: int) -> str:
+    return str(x + y)
+
+
+async def frontend_show(message: str) -> str:
+    return ""
+
+
+def test_frontend_tool_calls_are_persisted_as_tool_messages() -> None:
+    backend_tool_call_id = "call_backend_calc"
+    frontend_tool_call_id = "call_frontend_show"
+
+    def generate_response(messages: list[ChatMessage], **kwargs: object) -> ChatMessage:
+        if any(message.role == MessageRole.TOOL for message in messages):
+            return ChatMessage(role=MessageRole.ASSISTANT, content="done")
+
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    ToolSelection(
+                        tool_id=backend_tool_call_id,
+                        tool_name="backend_calc",
+                        tool_kwargs={"x": 2, "y": 3},
+                    ),
+                    ToolSelection(
+                        tool_id=frontend_tool_call_id,
+                        tool_name="frontend_show",
+                        tool_kwargs={"message": "5"},
+                    ),
+                ]
+            },
+        )
+
+    workflow = AGUIChatWorkflow(
+        llm=MockFunctionCallingLLM(
+            response_generator=generate_response,
+            is_chat_model=True,
+        ),
+        backend_tools=[
+            FunctionTool.from_defaults(
+                async_fn=backend_calc,
+                name="backend_calc",
+                description="Add numbers server-side",
+            )
+        ],
+        frontend_tools=[
+            FunctionTool.from_defaults(
+                async_fn=frontend_show,
+                name="frontend_show",
+                description="Show a message in the UI",
+            )
+        ],
+        timeout=30,
+    )
+
+    async def run_workflow() -> list[ChatMessage]:
+        handler = workflow.run(
+            input_data=RunAgentInput(
+                threadId="thread",
+                runId="run",
+                state={},
+                tools=[],
+                context=[],
+                forwardedProps={},
+                messages=[
+                    UserMessage(
+                        id="user_msg",
+                        role="user",
+                        content="Compute 2+3 and show the result.",
+                    )
+                ],
+            )
+        )
+        async for _ in handler.stream_events():
+            pass
+        await handler
+        return await handler.ctx.store.get("chat_history")
+
+    chat_history = asyncio.run(run_workflow())
+    claimed_tool_call_ids = {
+        tool_call.tool_id
+        for message in chat_history
+        if message.role == MessageRole.ASSISTANT
+        for tool_call in (message.additional_kwargs or {}).get("tool_calls", [])
+    }
+    replied_tool_call_ids = {
+        (message.additional_kwargs or {}).get("tool_call_id")
+        for message in chat_history
+        if message.role == MessageRole.TOOL
+    }
+
+    assert claimed_tool_call_ids == {
+        backend_tool_call_id,
+        frontend_tool_call_id,
+    }
+    assert claimed_tool_call_ids <= replied_tool_call_ids

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary

- persist frontend tool-call results as tool-role messages before the AG-UI workflow suspends
- keep every assistant `tool_call_id` paired with a matching `tool_call_id` entry in stored `chat_history`
- cover a full mixed backend + frontend tool-call workflow, including the persisted pairing invariant
- retain the integration lock entry sync from package version 0.3.1 to current 0.3.2

Fixes #22066.

## Root cause

`aggregate_tool_calls()` partitions collected results into backend and frontend calls, but builds `new_tool_messages` only from the backend list. When the workflow returns `StopEvent` for a frontend round trip, the preceding assistant message therefore contains a frontend tool call with no matching tool-role message in persisted history. The next provider request can reject that orphan pairing.

The production change iterates backend results followed by frontend results; the existing stop/loop control flow is unchanged.

## Current-main and duplicate audit

Rechecked against `main@67514f634`: the backend-only loop remains. Three fixes are open. #22067 is earlier but adds placeholder behavior and keeps its regression script at repository root. The later #22288 has the same one-line production change but a mocked-context test; its visible approval is from `author_association=NONE`. This PR keeps an in-package full workflow test that asserts every assistant tool-call id has a persisted tool response.

## Validation

Rebased onto `main@67514f634` and validated with Python 3.12.13 while importing this worktree:

- `pytest tests -q` -> `4 passed`
- targeted Ruff check -> passed
- targeted Ruff format check -> passed
- `git diff --check origin/main...HEAD` -> passed

The pytest warnings are existing assertion-rewrite AST deprecations from the package environment, not warnings emitted by the patch. AI assistance was used for source comparison, rebasing, and validation; I reviewed the final diff and evidence.