### PR TITLE
Harden HWP reader decompression

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
@@ -13,6 +13,8 @@ class HWPReader(BaseReader):
     Args: None.
     """
 
+    MAX_DECOMPRESSED_SECTION_BYTES = 100 * 1024 * 1024
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.FILE_HEADER_SECTION = "FileHeader"
@@ -86,12 +88,32 @@ class HWPReader(BaseReader):
         header_data = header.read()
         return (header_data[36] & 1) == 1
 
+    def _decompress_section(self, data: bytes) -> bytes:
+        decompressor = zlib.decompressobj(-15)
+        unpacked_data = decompressor.decompress(
+            data, self.MAX_DECOMPRESSED_SECTION_BYTES + 1
+        )
+        if len(unpacked_data) > self.MAX_DECOMPRESSED_SECTION_BYTES:
+            raise ValueError(
+                "Decompressed HWP section exceeds "
+                f"{self.MAX_DECOMPRESSED_SECTION_BYTES} bytes"
+            )
+
+        tail = decompressor.flush()
+        if len(unpacked_data) + len(tail) > self.MAX_DECOMPRESSED_SECTION_BYTES:
+            raise ValueError(
+                "Decompressed HWP section exceeds "
+                f"{self.MAX_DECOMPRESSED_SECTION_BYTES} bytes"
+            )
+
+        return unpacked_data + tail
+
     def get_text_from_section(self, load_file, section):
         bodytext = load_file.openstream(section)
         data = bodytext.read()
 
         unpacked_data = (
-            zlib.decompress(data, -15) if self.is_compressed(load_file) else data
+            self._decompress_section(data) if self.is_compressed(load_file) else data
         )
         size = len(unpacked_data)
 

--- a/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
@@ -1,3 +1,8 @@
+import io
+import zlib
+
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.hwp import HWPReader
 
@@ -5,3 +10,39 @@ from llama_index.readers.hwp import HWPReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HWPReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def _raw_deflate(data: bytes) -> bytes:
+    compressor = zlib.compressobj(wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+class _FakeHWPFile:
+    def __init__(self, section_data: bytes) -> None:
+        header = bytearray(37)
+        header[36] = 1
+        self._streams = {
+            "FileHeader": bytes(header),
+            "BodyText/Section0": section_data,
+        }
+
+    def openstream(self, name: str) -> io.BytesIO:
+        return io.BytesIO(self._streams[name])
+
+
+def test_decompress_section_preserves_small_raw_deflate() -> None:
+    reader = HWPReader()
+    data = b"small section payload"
+
+    assert reader._decompress_section(_raw_deflate(data)) == data
+
+
+def test_get_text_from_section_rejects_oversized_decompressed_data() -> None:
+    reader = HWPReader()
+    reader.MAX_DECOMPRESSED_SECTION_BYTES = 8
+    compressed_section = _raw_deflate(b"A" * 32)
+
+    with pytest.raises(ValueError, match="Decompressed HWP section exceeds"):
+        reader.get_text_from_section(
+            _FakeHWPFile(compressed_section), "BodyText/Section0"
+        )


### PR DESCRIPTION
## Summary
- add bounded raw-deflate decompression for compressed HWP sections
- reject sections that expand beyond 100 MiB before parsing records
- add regression coverage for normal raw deflate data and oversized compressed sections

Fixes #22101.

## Tests
- `UV_CACHE_DIR=/private/tmp/uv-cache-llama-index UV_PROJECT_ENVIRONMENT=/private/tmp/llama-index-hwp-env uv run pytest -q tests/test_readers_hwp.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-llama-index UV_PROJECT_ENVIRONMENT=/private/tmp/llama-index-hwp-env uv run ruff check llama_index/readers/hwp/base.py tests/test_readers_hwp.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-llama-index UV_PROJECT_ENVIRONMENT=/private/tmp/llama-index-hwp-env uv run ruff format --check llama_index/readers/hwp/base.py tests/test_readers_hwp.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/llama-index-hwp-pycache /private/tmp/llama-index-hwp-env/bin/python -m py_compile llama_index/readers/hwp/base.py tests/test_readers_hwp.py`