### PR TITLE
fix: close integration reader resources

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
@@ -39,6 +39,11 @@ except ImportError:
 FilePath = Union[str, Path]
 
 
+def _read_file_as_base64(file_path: str) -> str:
+    with open(file_path, "rb") as f:
+        return base64.b64encode(f.read()).decode()
+
+
 def retry_decorator(func, wait_seconds: int = 1):
     def wrap(*args, **kwargs):
         while True:
@@ -124,7 +129,7 @@ class AlibabaCloudAISearchDocumentReader(BasePydanticReader):
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
             document = CreateDocumentAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=_read_file_as_base64(file_path),
                 file_name=file_name,
                 file_type=file_type,
             )
@@ -262,7 +267,7 @@ class AlibabaCloudAISearchImageReader(AlibabaCloudAISearchDocumentReader):
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
             document = CreateImageAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=_read_file_as_base64(file_path),
                 file_name=file_name,
                 file_type=file_type,
             )

--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/tests/test_readers_alibabacloud_aisearch.py
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/tests/test_readers_alibabacloud_aisearch.py
@@ -1,8 +1,11 @@
+from io import BytesIO
+
 from llama_index.readers.alibabacloud_aisearch import (
     AlibabaCloudAISearchDocumentReader,
     AlibabaCloudAISearchImageReader,
 )
 from llama_index.core.readers.base import BasePydanticReader
+from llama_index.readers.alibabacloud_aisearch.base import _read_file_as_base64
 
 
 def test_class():
@@ -14,3 +17,24 @@ def test_class():
         b.__name__ for b in AlibabaCloudAISearchImageReader.__mro__
     ]
     assert BasePydanticReader.__name__ in names_of_base_classes
+
+
+def test_read_file_as_base64_closes_file(monkeypatch):
+    class ClosingBytesIO(BytesIO):
+        was_closed = False
+
+        def close(self):
+            self.was_closed = True
+            super().close()
+
+    file_obj = ClosingBytesIO(b"hello")
+
+    def fake_open(file_path, mode):
+        assert file_path == "doc.txt"
+        assert mode == "rb"
+        return file_obj
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    assert _read_file_as_base64("doc.txt") == "aGVsbG8="
+    assert file_obj.was_closed

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
@@ -40,8 +40,8 @@ class HuggingFaceFSReader(BaseReader):
                 with open(tmp / "tmp.jsonl.gz", "wb") as fp:
                     fp.write(test_data)
 
-                f = gzip.open(tmp / "tmp.jsonl.gz", "rb")
-                raw = f.read()
+                with gzip.open(tmp / "tmp.jsonl.gz", "rb") as f:
+                    raw = f.read()
                 data = raw.decode()
         else:
             data = test_data.decode()

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/tests/test_readers_huggingface.py
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/tests/test_readers_huggingface.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.huggingface_fs import HuggingFaceFSReader
 
@@ -5,3 +6,29 @@ from llama_index.readers.huggingface_fs import HuggingFaceFSReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HuggingFaceFSReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_load_dicts_closes_gzip_file(monkeypatch):
+    class FakeFileSystem:
+        def read_bytes(self, path):
+            return b"compressed"
+
+    class ClosingBytesIO(BytesIO):
+        was_closed = False
+
+        def close(self):
+            self.was_closed = True
+            super().close()
+
+    gzip_file = ClosingBytesIO(b'{"text": "hello"}\n')
+
+    def fake_gzip_open(*args, **kwargs):
+        return gzip_file
+
+    monkeypatch.setattr("gzip.open", fake_gzip_open)
+
+    reader = HuggingFaceFSReader.__new__(HuggingFaceFSReader)
+    reader.fs = FakeFileSystem()
+
+    assert reader.load_dicts("repo/data.jsonl.gz") == [{"text": "hello"}]
+    assert gzip_file.was_closed

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
@@ -305,7 +305,8 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
     if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    gzip_file = gzip.open(file.file).read()
+    with gzip.open(file.file) as f:
+        gzip_file = f.read()
     return UploadFile(
         file=io.BytesIO(gzip_file),
         size=len(gzip_file),

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/tests/test_readers_sec_filings.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/tests/test_readers_sec_filings.py
@@ -1,3 +1,6 @@
+from io import BytesIO
+
+import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.sec_filings import SECFilingsLoader
 
@@ -5,3 +8,36 @@ from llama_index.readers.sec_filings import SECFilingsLoader
 def test_class():
     names_of_base_classes = [b.__name__ for b in SECFilingsLoader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_ungz_file_closes_gzip_reader(monkeypatch):
+    pytest.importorskip("fastapi")
+    section = pytest.importorskip(
+        "llama_index.readers.sec_filings.prepline_sec_filings.api.section"
+    )
+
+    class ClosingBytesIO(BytesIO):
+        was_closed = False
+
+        def close(self):
+            self.was_closed = True
+            super().close()
+
+    source = ClosingBytesIO(b"plain text")
+    monkey_gzip = ClosingBytesIO(b"plain text")
+
+    class Upload:
+        filename = "filing.txt.gz"
+        content_type = "application/gzip"
+        file = source
+
+    class GzipOpen:
+        def __call__(self, file):
+            assert file is source
+            return monkey_gzip
+
+    monkeypatch.setattr(section.gzip, "open", GzipOpen())
+    result = section.ungz_file(Upload())
+
+    assert result.file.read() == b"plain text"
+    assert monkey_gzip.was_closed

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
@@ -30,7 +30,8 @@ class StripeDocsReader(BaseReader):
         self._limit = limit
 
     def _load_url(self, url: str) -> str:
-        return urllib.request.urlopen(url).read()
+        with urllib.request.urlopen(url) as response:
+            return response.read()
 
     def _load_sitemap(self) -> str:
         return self._load_url(STRIPE_SITEMAP_URL)

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/tests/test_readers_stripe_docs.py
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/tests/test_readers_stripe_docs.py
@@ -1,0 +1,21 @@
+from llama_index.readers.stripe_docs import StripeDocsReader
+
+
+def test_load_url_closes_response(monkeypatch):
+    class Response:
+        was_closed = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.was_closed = True
+
+        def read(self):
+            return b"<xml />"
+
+    response = Response()
+    monkeypatch.setattr("urllib.request.urlopen", lambda url: response)
+
+    assert StripeDocsReader()._load_url("https://example.com/sitemap.xml") == b"<xml />"
+    assert response.was_closed

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
@@ -64,37 +64,39 @@ class GalaxiaClient:
         query: str,
     ) -> Union[dict, None]:
         conn = http.client.HTTPSConnection(self.api_url)
+        try:
+            flag_init = False
+            for i in range(self.n_retries):
+                init_res = self.initialize(conn, query)
 
-        flag_init = False
-        for i in range(self.n_retries):
-            init_res = self.initialize(conn, query)
+                if "operationId" in init_res:
+                    flag_init = True
+                    break
 
-            if "operationId" in init_res:
-                flag_init = True
-                break
+                time.sleep(self.wait_time * i)
 
-            time.sleep(self.wait_time * i)
+            if not flag_init:
+                # failed to init
+                return None
 
-        if not flag_init:
-            # failed to init
-            return None
+            flag_proc = False
+            for i in range(1, self.n_retries + 1):
+                time.sleep(self.wait_time * i)
+                status = self.check_status(conn, init_res)
 
-        flag_proc = False
-        for i in range(1, self.n_retries + 1):
-            time.sleep(self.wait_time * i)
-            status = self.check_status(conn, init_res)
+                if status["status"] == "processed":
+                    flag_proc = True
+                    break
 
-            if status["status"] == "processed":
-                flag_proc = True
-                break
+            if flag_proc:
+                res = self.get_result(conn, init_res)
+                return res["result"]["resultItems"]
 
-        if flag_proc:
-            res = self.get_result(conn, init_res)
-            return res["result"]["resultItems"]
-
-        else:
-            # failed to process
-            return None
+            else:
+                # failed to process
+                return None
+        finally:
+            conn.close()
 
 
 class GalaxiaRetriever(BaseRetriever):

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/tests/test_retrievers_galaxia.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/tests/test_retrievers_galaxia.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.retrievers.galaxia import GalaxiaRetriever
+from llama_index.retrievers.galaxia.base import GalaxiaClient
 
 
 def test_retrieve():
@@ -51,3 +52,33 @@ def test_retrieve():
     assert result[0].text == expected_result[0].text
     assert result[0].score == expected_result[0].score
     assert result[0].metadata == expected_result[0].metadata
+
+
+def test_galaxia_client_closes_connection(monkeypatch):
+    conn = MagicMock()
+    monkeypatch.setattr("http.client.HTTPSConnection", lambda api_url: conn)
+
+    client = GalaxiaClient("example.com", "api-key", "kb", n_retries=1, wait_time=0)
+    monkeypatch.setattr(client, "initialize", lambda conn, query: {"operationId": "op"})
+    monkeypatch.setattr(
+        client, "check_status", lambda conn, init_res: {"status": "processed"}
+    )
+    monkeypatch.setattr(
+        client,
+        "get_result",
+        lambda conn, init_res: {"result": {"resultItems": [{"text": "result"}]}},
+    )
+
+    assert client.retrieve("question") == [{"text": "result"}]
+    conn.close.assert_called_once()
+
+
+def test_galaxia_client_closes_connection_on_init_failure(monkeypatch):
+    conn = MagicMock()
+    monkeypatch.setattr("http.client.HTTPSConnection", lambda api_url: conn)
+
+    client = GalaxiaClient("example.com", "api-key", "kb", n_retries=1, wait_time=0)
+    monkeypatch.setattr(client, "initialize", lambda conn, query: {})
+
+    assert client.retrieve("question") is None
+    conn.close.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #22026.

This closes the resource leaks called out in the issue across the affected integrations:

- `llama-index-readers-huggingface-fs`: close the `gzip.open()` reader after decoding gzipped JSONL content.
- `llama-index-readers-alibabacloud-aisearch`: close local file handles when base64-encoding document/image uploads.
- `llama-index-readers-stripe-docs`: close `urllib.request.urlopen()` responses after reading sitemap XML.
- `llama-index-readers-sec-filings`: close the gzip reader used by `ungz_file()`.
- `llama-index-retrievers-galaxia`: close the `HTTPSConnection` in `finally`, including failed init/process paths.

## Validation

```bash
cd llama-index-integrations/readers/llama-index-readers-huggingface-fs && uv run -- pytest tests/test_readers_huggingface.py -q
cd llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch && uv run -- pytest tests/test_readers_alibabacloud_aisearch.py -q
cd llama-index-integrations/readers/llama-index-readers-sec-filings && uv run -- pytest tests/test_readers_sec_filings.py -q
cd llama-index-integrations/retrievers/llama-index-retrievers-galaxia && uv run -- pytest tests/test_retrievers_galaxia.py -q
cd llama-index-integrations/readers/llama-index-readers-stripe-docs && uv run --python 3.12 -- pytest tests/test_readers_stripe_docs.py -q
uv run ruff format --check <changed python files>
uv run ruff check <changed python files>
```

Notes:

- `llama-index-readers-sec-filings` reports `1 passed, 1 skipped` in my local package env because the generated API module depends on optional `fastapi`, which is not installed by that package's default test environment.
- `llama-index-readers-stripe-docs` could not install under Python 3.13 locally because `tree-sitter-languages==1.10.2` has no cp313 wheel; I reran it successfully with Python 3.12.

## AI assistance

This PR was prepared with AI assistance. I reviewed the diff, kept the scope to the resource leaks reported in #22026, and validated the changed packages with the commands above.
