### PR TITLE
fix: keep OneDrive downloads within target dir

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -267,7 +267,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         """
         # Extract download URL and filename from the provided item.
         file_download_url = item["@microsoft.graph.downloadUrl"]
-        file_name = item["name"]
+        file_name = os.path.basename(item["name"])
 
         # Download the file.
         file_data = requests.get(file_download_url)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,3 +1,6 @@
+import os
+from unittest.mock import MagicMock, patch
+
 import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.microsoft_onedrive import OneDriveReader
@@ -31,6 +34,28 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+def test_download_file_by_url_keeps_file_in_local_dir(tmp_path):
+    reader = OneDriveReader.__new__(OneDriveReader)
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir()
+    item = {
+        "name": "../traversal.txt",
+        "@microsoft.graph.downloadUrl": "https://example.test/file",
+    }
+    response = MagicMock()
+    response.content = b"safe contents"
+
+    with patch("requests.get", return_value=response):
+        downloaded_path = reader._download_file_by_url(item, str(download_dir))
+
+    assert os.path.realpath(downloaded_path).startswith(
+        os.path.realpath(download_dir) + os.sep
+    )
+    assert os.path.basename(downloaded_path) == "traversal.txt"
+    assert os.path.exists(downloaded_path)
+    assert not (tmp_path / "traversal.txt").exists()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- sanitize OneDrive item names before writing downloaded files
- keep downloads inside the caller-provided local directory even when remote metadata contains path components
- add a regression test for a `../` filename returned by Microsoft Graph metadata

## Root Cause

`OneDriveReader._download_file_by_url()` used the remote `item["name"]` value directly in `os.path.join(local_dir, file_name)`. If Microsoft Graph metadata contains a path traversal sequence such as `../traversal.txt`, the reader writes outside `local_dir`.

This replacement PR keeps the minimal remediation from the closed, unmerged #21872: strip directory components with `os.path.basename()` before constructing the local path.

Fixes #21867.

## Validation

- `uv run --project llama-index-integrations/readers/llama-index-readers-microsoft-onedrive --no-sync pytest llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py -q`
- `uv run --with ruff ruff check llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py`
- `uv run --with ruff ruff format --check llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py`
- `git diff --check origin/main..HEAD`
