### PR TITLE
fix: close HotpotQA evaluator file handles

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,20 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
-                    os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
                 response = requests.get(url, stream=True)
 
                 # Define the size of each chunk
                 chunk_size = 1024
 
                 # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                with open(
+                    os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
+                ) as save_file:
+                    for chunk in tqdm.tqdm(
+                        response.iter_content(chunk_size=chunk_size)
+                    ):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +73,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.load(f)
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:

--- a/llama-index-core/tests/evaluation/test_hotpotqa.py
+++ b/llama-index-core/tests/evaluation/test_hotpotqa.py
@@ -1,0 +1,63 @@
+import builtins
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llama_index.core.evaluation.benchmarks import hotpotqa
+
+
+class _Response:
+    def iter_content(self, chunk_size: int) -> list[bytes]:
+        return [b'{"answer": ', b'"ok"}']
+
+
+def test_download_datasets_closes_download_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    opened_files: list[Any] = []
+    real_open = builtins.open
+
+    def tracking_open(*args: Any, **kwargs: Any) -> Any:
+        file_obj = real_open(*args, **kwargs)
+        opened_files.append(file_obj)
+        return file_obj
+
+    monkeypatch.setattr(hotpotqa, "get_cache_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(hotpotqa.requests, "get", lambda *_, **__: _Response())
+    monkeypatch.setattr(builtins, "open", tracking_open)
+
+    paths = hotpotqa.HotpotQAEvaluator()._download_datasets()
+
+    assert Path(paths["hotpot_dev_distractor"]).read_text() == '{"answer": "ok"}'
+    assert opened_files
+    assert all(file_obj.closed for file_obj in opened_files)
+
+
+def test_run_closes_dataset_file_before_query_engine_validation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dataset_path = tmp_path / "dev_distractor.json"
+    dataset_path.write_text(
+        json.dumps([{"question": "Where?", "answer": "Here", "context": []}])
+    )
+    opened_files: list[Any] = []
+    real_open = builtins.open
+
+    def tracking_open(*args: Any, **kwargs: Any) -> Any:
+        file_obj = real_open(*args, **kwargs)
+        opened_files.append(file_obj)
+        return file_obj
+
+    class Evaluator(hotpotqa.HotpotQAEvaluator):
+        def _download_datasets(self) -> dict[str, str]:
+            return {"hotpot_dev_distractor": str(dataset_path)}
+
+    monkeypatch.setattr(builtins, "open", tracking_open)
+
+    with pytest.raises(AssertionError, match="query_engine must be"):
+        Evaluator().run(query_engine=object())  # type: ignore[arg-type]
+
+    assert opened_files
+    assert all(file_obj.closed for file_obj in opened_files)


### PR DESCRIPTION
## Summary

- close the HotpotQA download output file on success and exceptions
- close the benchmark dataset input file after JSON loading
- add focused regression coverage for both `_download_datasets()` and `run()` resource lifetimes

Fixes #21956.

## Root cause

`HotpotQAEvaluator` used two bare `open()` calls: one for the streamed dataset download and one for reading the cached dataset. Neither handle was guaranteed to close, and a download exception could retain a partial-file descriptor.

Both operations now use context managers without changing download or evaluation behavior.

## Current-main and related-PR audit

Rechecked against `main@67514f634`: both bare handles remain. The older open #21458 closes only the download output, leaves the dataset-read handle open, and also carries an unrelated vector-store async change; its current rollup has three failed Python test jobs. This PR is a clean single commit covering both locations named by #21956 with direct closure tests.

## Validation

Rebased onto `main@67514f634` and validated with Python 3.13.12 while importing this worktree:

- `pytest tests/evaluation/test_hotpotqa.py -q` -> `2 passed`
- targeted Ruff check -> passed
- targeted Ruff format check -> passed
- `git diff --check origin/main...HEAD` -> passed

AI assistance was used for source comparison, rebasing, and validation; I reviewed the final diff and evidence.