### PR TITLE
fix: handle MCP prompt content block variants

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -27,7 +27,13 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.llms import (
+    AudioBlock,
+    ChatMessage,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
 
 
 class StreamingHandler(logging.Handler):
@@ -64,6 +70,71 @@ def enable_sse(command_or_url: str) -> bool:
     elif "/sse/" in url.path:
         return True
     return False
+
+
+def _audio_format_from_mime_type(mime_type: str) -> Optional[str]:
+    if not mime_type.startswith("audio/"):
+        return None
+    return mime_type.split("/", 1)[1] or None
+
+
+def _resource_link_to_block(content: types.ResourceLink) -> Any:
+    mime_type = content.mimeType
+    url = str(content.uri)
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(url=url, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(url=url, format=_audio_format_from_mime_type(mime_type))
+    return DocumentBlock(
+        url=url,
+        title=content.title or content.name,
+        document_mimetype=mime_type,
+    )
+
+
+def _embedded_resource_to_block(content: types.EmbeddedResource) -> Any:
+    resource = content.resource
+    if isinstance(resource, types.TextResourceContents):
+        return TextBlock(text=resource.text)
+
+    mime_type = resource.mimeType
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(image=resource.blob, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(
+            audio=resource.blob,
+            format=_audio_format_from_mime_type(mime_type),
+        )
+    return DocumentBlock(
+        data=resource.blob,
+        title=str(resource.uri),
+        document_mimetype=mime_type,
+    )
+
+
+def _content_to_blocks(content: types.ContentBlock) -> List[Any]:
+    if isinstance(content, types.TextContent):
+        return [TextBlock(text=content.text)]
+    if isinstance(content, types.ImageContent):
+        return [
+            ImageBlock(
+                image=content.data,
+                image_mimetype=content.mimeType,
+            )
+        ]
+    if isinstance(content, types.AudioContent):
+        return [
+            AudioBlock(
+                audio=content.data,
+                format=_audio_format_from_mime_type(content.mimeType),
+            )
+        ]
+    if isinstance(content, types.EmbeddedResource):
+        return [_embedded_resource_to_block(content)]
+    if isinstance(content, types.ResourceLink):
+        return [_resource_link_to_block(content)]
+
+    raise ValueError(f"Unsupported content type: {type(content)}")
 
 
 class DefaultInMemoryTokenStorage(TokenStorage):
@@ -379,32 +450,11 @@ class BasicMCPClient(ClientSession):
             prompt = await session.get_prompt(prompt_name, arguments)
             llama_messages = []
             for message in prompt.messages:
-                if isinstance(message.content, types.TextContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[TextBlock(text=message.content.text)],
-                        )
+                llama_messages.append(
+                    ChatMessage(
+                        role=message.role,
+                        blocks=_content_to_blocks(message.content),
                     )
-                elif isinstance(message.content, types.ImageContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[
-                                ImageBlock(
-                                    image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
-                                )
-                            ],
-                        )
-                    )
-                elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported content type: {type(message.content)}"
-                    )
+                )
 
             return llama_messages

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -3,7 +3,8 @@ from httpx import AsyncClient
 import pytest
 
 from llama_index.tools.mcp import BasicMCPClient
-from llama_index.tools.mcp.client import enable_sse
+from llama_index.core.llms import AudioBlock, DocumentBlock, ImageBlock, TextBlock
+from llama_index.tools.mcp.client import _content_to_blocks, enable_sse
 from mcp import types
 
 
@@ -259,3 +260,82 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+def test_content_to_blocks_handles_audio_content():
+    blocks = _content_to_blocks(
+        types.AudioContent(type="audio", data="aGVsbG8=", mimeType="audio/wav")
+    )
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], AudioBlock)
+    assert blocks[0].audio == b"aGVsbG8="
+    assert blocks[0].format == "wav"
+
+
+def test_content_to_blocks_handles_embedded_text_resource():
+    blocks = _content_to_blocks(
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri="resource://note", mimeType="text/plain", text="embedded text"
+            ),
+        )
+    )
+
+    assert blocks == [TextBlock(text="embedded text")]
+
+
+def test_content_to_blocks_handles_embedded_blob_resource():
+    blocks = _content_to_blocks(
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.BlobResourceContents(
+                uri="resource://doc",
+                mimeType="application/pdf",
+                blob="aGVsbG8=",
+            ),
+        )
+    )
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], DocumentBlock)
+    assert blocks[0].data == b"aGVsbG8="
+    assert blocks[0].document_mimetype == "application/pdf"
+    assert blocks[0].title == "resource://doc"
+
+
+def test_content_to_blocks_handles_embedded_image_resource():
+    blocks = _content_to_blocks(
+        types.EmbeddedResource(
+            type="resource",
+            resource=types.BlobResourceContents(
+                uri="resource://image",
+                mimeType="image/png",
+                blob="aGVsbG8=",
+            ),
+        )
+    )
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], ImageBlock)
+    assert blocks[0].image == b"aGVsbG8="
+    assert blocks[0].image_mimetype == "image/png"
+
+
+def test_content_to_blocks_handles_resource_link():
+    blocks = _content_to_blocks(
+        types.ResourceLink(
+            type="resource_link",
+            uri="resource://doc",
+            name="doc",
+            title="Document",
+            mimeType="application/pdf",
+        )
+    )
+
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], DocumentBlock)
+    assert str(blocks[0].url) == "resource://doc"
+    assert blocks[0].title == "Document"
+    assert blocks[0].document_mimetype == "application/pdf"


### PR DESCRIPTION
## Summary
- map MCP prompt AudioContent, EmbeddedResource, and ResourceLink values into existing LlamaIndex content blocks
- keep existing TextContent and ImageContent handling behind a shared conversion helper
- add focused coverage for audio content, embedded text/blob/image resources, and resource links

Fixes #21270.

## Root cause
BasicMCPClient.get_prompt() only converted TextContent and ImageContent. Valid MCP prompt content variants such as AudioContent, EmbeddedResource, and ResourceLink were rejected before they could be represented as LlamaIndex message blocks.

## Tests
- uv run --directory llama-index-integrations/tools/llama-index-tools-mcp -- pytest tests/test_client.py -q -k "content_to_blocks"
- uv run --directory llama-index-integrations/tools/llama-index-tools-mcp -- ruff check llama_index/tools/mcp/client.py tests/test_client.py
- uv run --directory llama-index-integrations/tools/llama-index-tools-mcp -- ruff format --check llama_index/tools/mcp/client.py tests/test_client.py
- env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --directory llama-index-integrations/tools/llama-index-tools-mcp -- pytest tests/test_client.py -q

Note: the full test command needs proxy environment variables unset locally because httpx otherwise picks up a socks5 proxy and fails before exercising the client code when socksio is not installed.

AI assistance was used to inspect the issue, draft the patch, and run validation; I reviewed the changes before publishing.