### PR TITLE
docs(elasticsearch): document client lifecycle in aquery (closes #11641)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -511,6 +511,11 @@ class ElasticsearchStore(BasePydanticVectorStore):
         """
         Asynchronous query index for top k most similar nodes.
 
+        Note: the underlying AsyncVectorStore (self._store) maintains a persistent
+        client connection. Do NOT wrap client calls in ``async with self.client:`` —
+        doing so creates a new connection per call and causes ServerDisconnectedError
+        under concurrent load (see issue #11641). Call self._store methods directly.
+
         Args:
             query_embedding (VectorStoreQuery): query embedding
             custom_query: Optional. custom query function that takes in the es query


### PR DESCRIPTION
## Summary
Documents the client lifecycle in ElasticsearchStore.aquery to prevent regression of issue #11641.

## Problem
Issue #11641 reported ServerDisconnectedError when running >10 concurrent queries through AsyncElasticsearch. The root cause was wrapping client calls in `async with self.client:`, which creates a new connection per call instead of reusing the persistent connection.

## Solution
The `aquery` method was already refactored to call `self._store.search()` directly (maintaining a persistent client). This PR adds a docstring note to prevent future regressions:

> Do NOT wrap client calls in `async with self.client:` — doing so creates a new connection per call and causes ServerDisconnectedError under concurrent load (see issue #11641).

## Testing
No code change — only a documentation note. The existing test suite covers the aquery method behavior.

Closes #11641