### PR TITLE
Fix RedisKVStore get_all with decoded keys

### DIFF
--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py
@@ -153,12 +153,17 @@ class RedisKVStore(BaseKVStore):
             return None
         return json.loads(val_str)
 
+    @staticmethod
+    def _decode_redis_key(key: Any) -> str:
+        """Decode Redis hash keys returned as bytes or already-decoded strings."""
+        return key.decode() if isinstance(key, bytes) else key
+
     def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
         """Get all values from the store."""
         collection_kv_dict = {}
         for key, val_str in self._redis_client.hscan_iter(name=collection):
             value = dict(json.loads(val_str))
-            collection_kv_dict[key.decode()] = value
+            collection_kv_dict[self._decode_redis_key(key)] = value
         return collection_kv_dict
 
     async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
@@ -166,7 +171,7 @@ class RedisKVStore(BaseKVStore):
         collection_kv_dict = {}
         async for key, val_str in self._async_redis_client.hscan_iter(name=collection):
             value = dict(json.loads(val_str))
-            collection_kv_dict[key.decode()] = value
+            collection_kv_dict[self._decode_redis_key(key)] = value
         return collection_kv_dict
 
     def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-kvstore-redis"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index kvstore redis integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py
@@ -1,3 +1,6 @@
+import asyncio
+import json
+
 from llama_index.core.storage.kvstore.types import BaseKVStore
 from llama_index.storage.kvstore.redis import RedisKVStore
 
@@ -5,3 +8,54 @@ from llama_index.storage.kvstore.redis import RedisKVStore
 def test_class():
     names_of_base_classes = [b.__name__ for b in RedisKVStore.__mro__]
     assert BaseKVStore.__name__ in names_of_base_classes
+
+
+class MockRedisClient:
+    def __init__(self, entries):
+        self.entries = entries
+
+    def hscan_iter(self, name):
+        return iter(self.entries)
+
+
+class MockAsyncRedisClient:
+    def __init__(self, entries):
+        self.entries = entries
+
+    async def hscan_iter(self, name):
+        for entry in self.entries:
+            yield entry
+
+
+def test_get_all_decodes_byte_keys():
+    redis_client = MockRedisClient([(b"doc1", json.dumps({"hash": "abc"}).encode())])
+    kvstore = RedisKVStore(
+        redis_client=redis_client,
+        async_redis_client=MockAsyncRedisClient([]),
+    )
+
+    assert kvstore.get_all() == {"doc1": {"hash": "abc"}}
+
+
+def test_get_all_accepts_decoded_string_keys():
+    redis_client = MockRedisClient([("doc1", json.dumps({"hash": "abc"}))])
+    kvstore = RedisKVStore(
+        redis_client=redis_client,
+        async_redis_client=MockAsyncRedisClient([]),
+    )
+
+    assert kvstore.get_all() == {"doc1": {"hash": "abc"}}
+
+
+def test_aget_all_accepts_decoded_string_keys():
+    async def _run_test():
+        kvstore = RedisKVStore(
+            redis_client=MockRedisClient([]),
+            async_redis_client=MockAsyncRedisClient(
+                [("doc1", json.dumps({"hash": "abc"}))]
+            ),
+        )
+
+        assert await kvstore.aget_all() == {"doc1": {"hash": "abc"}}
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
# Description

Fixes #22115.

`RedisKVStore.get_all()` and `aget_all()` assumed Redis hash keys are always returned as bytes and unconditionally called `key.decode()`. When users configure Redis with `decode_responses=True`, redis-py returns hash keys as strings instead, which raises `AttributeError` during ingestion/docstore duplicate checks.

This PR adds a small key-decoding helper that preserves the existing bytes behavior while accepting already-decoded string keys. It also adds unit coverage for sync and async `get_all` with decoded keys, plus the existing bytes behavior.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Validated with:

- `uv run --with pytest --with redis pytest llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py -q` -> `4 passed`
- `uv run --with ruff ruff check llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py` -> `All checks passed!`
- `uv run --with ruff ruff format --check llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/pyproject.toml` -> `2 files already formatted`
- `git diff --check` -> passed

Note: local `uv run` rewrote `uv.lock` as validation noise; I restored it, so this PR only changes the Redis kvstore package source, tests, and package version.