### PR TITLE
fix(huggingface): drop removed huggingface-hub[inference] extra (#21549)

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-huggingface-api"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings huggingface api integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -35,7 +35,7 @@ license = "MIT"
 dependencies = [
     "llama-index-utils-huggingface>=0.4.0,<0.5",
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.31.0",
+    "huggingface-hub>=0.31.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-huggingface-api"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1904,7 +1904,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", extras = ["inference"], specifier = ">=0.31.0" },
+    { name = "huggingface-hub", specifier = ">=0.31.0" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
     { name = "llama-index-utils-huggingface", specifier = ">=0.4.0,<0.5" },
 ]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-huggingface"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index embeddings huggingface integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -35,7 +35,7 @@ license = "MIT"
 dependencies = [
     "sentence-transformers>=2.6.1",
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.19.0",
+    "huggingface-hub>=0.19.0",
 ]
 
 [tool.codespell]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/uv.lock
@@ -1898,7 +1898,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-huggingface"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1930,7 +1930,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", extras = ["inference"], specifier = ">=0.19.0" },
+    { name = "huggingface-hub", specifier = ">=0.19.0" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
     { name = "sentence-transformers", specifier = ">=2.6.1" },
 ]

--- a/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
+++ b/llama-index-utils/llama-index-utils-huggingface/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-utils-huggingface"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index utils for huggingface integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -35,7 +35,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "llama-index-core>=0.13.0,<0.15",
-    "huggingface-hub[inference]>=0.19.0",
+    "huggingface-hub>=0.19.0",
 ]
 
 [tool.codespell]

--- a/llama-index-utils/llama-index-utils-huggingface/uv.lock
+++ b/llama-index-utils/llama-index-utils-huggingface/uv.lock
@@ -1885,7 +1885,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-utils-huggingface"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1917,7 +1917,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", extras = ["inference"], specifier = ">=0.19.0" },
+    { name = "huggingface-hub", specifier = ">=0.19.0" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
 ]
 


### PR DESCRIPTION
# Description

The `[inference]` optional-dependency extra was **removed from `huggingface-hub` in v1.x** — the `InferenceClient` / `AsyncInferenceClient` classes were promoted into the core package and no longer require any extra. Three packages in this repo still declare the non-existent extra `huggingface-hub[inference]`, so every modern install (which resolves `huggingface-hub` 1.x) emits:

```
warning: The package `huggingface-hub==1.14.0` does not have an extra named `inference`
```

This is harmless functionally (the inference client ships in core), but it is noisy and strict resolvers flag it.

**Fix:** replace `huggingface-hub[inference]` with `huggingface-hub` (keeping the existing version floors) in the three affected packages, and bump each package's patch version:

| Package | Floor kept | Version |
| --- | --- | --- |
| `llama-index-utils-huggingface` | `>=0.19.0` | 0.5.0 → 0.5.1 |
| `llama-index-embeddings-huggingface` | `>=0.19.0` | 0.7.0 → 0.7.1 |
| `llama-index-embeddings-huggingface-api` | `>=0.31.0` | 0.5.0 → 0.5.1 |

Both embedding packages import `AsyncInferenceClient`/`InferenceClient` directly from `huggingface_hub` (they resolve from core), and in the existing lockfiles `huggingface-hub` already resolves to `1.14.0` whose dependency set contains no `aiohttp`/`minijinja` — so dropping the (no-op) extra does **not** change the resolved dependency graph. The `uv.lock` `requires-dist` metadata was updated to match `pyproject.toml` (no re-resolution, to avoid unrelated transitive churn).

Fixes #21549

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

This is a packaging-metadata fix, so the behavior is validated by (a) the disappearance of the spurious extra warning and (b) the packages' existing test suites continuing to pass.

**Before / after the change (`uv sync` in `llama-index-utils-huggingface`):**

```
# before (huggingface-hub[inference]>=0.19.0)
Resolved 199 packages in 604ms
warning: The package `huggingface-hub==1.14.0` does not have an extra named `inference`

# after (huggingface-hub>=0.19.0)
Resolved 199 packages in 909ms
Installed 192 packages in 511ms
```

**Existing unit tests (run per package with `uv run -- pytest`):**

```
# llama-index-embeddings-huggingface-api
......                                                                   [100%]
6 passed in 8.36s

# llama-index-embeddings-huggingface
........                                                                 [100%]
8 passed, 5 warnings in 46.14s
```

(The 5 warnings are pre-existing and unrelated — an `hf_xet` deprecation and the already-deprecated `HuggingFaceInferenceAPIEmbedding` shim.)

**Pre-commit hooks** on the changed files all pass (`check-toml`, `toml-sort-fix`, `codespell`, `prettier`, etc.).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (this change removes a warning)
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
