### PR TITLE
fix(core): preserve oversized leaf nodes in CodeSplitter

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/code.py
+++ b/llama-index-core/llama_index/core/node_parser/text/code.py
@@ -196,7 +196,15 @@ class CodeSplitter(TextSplitter):
                 if len(current_chunk) > 0:
                     new_chunks.append(current_chunk)
                 current_chunk = ""
-                new_chunks.extend(self._chunk_node(child, text_bytes, last_end))
+                if child.children:
+                    new_chunks.extend(self._chunk_node(child, text_bytes, last_end))
+                else:
+                    # Leaf node bigger than the limit (e.g. a long string
+                    # literal or comment). It has no sub-structure to recurse
+                    # into, so hard-split its text to preserve the content
+                    # instead of silently dropping it.
+                    leaf_text = text_bytes[last_end : child.end_byte].decode("utf-8")
+                    new_chunks.extend(self._split_oversized_leaf(leaf_text, max_size))
             else:
                 # Calculate what adding this child would do to current chunk size
                 new_chunk_text = current_chunk + text_bytes[
@@ -224,6 +232,47 @@ class CodeSplitter(TextSplitter):
         if len(current_chunk) > 0:
             new_chunks.append(current_chunk)
         return new_chunks
+
+    def _split_oversized_leaf(self, text: str, max_size: int) -> List[str]:
+        """
+        Hard-split text from a leaf node that exceeds the size limit.
+
+        A leaf AST node (such as a long string literal or comment) has no
+        children to recurse into, so its text is split directly to keep the
+        content within the size limit instead of dropping it.
+
+        Args:
+            text (str): The leaf node text to split.
+            max_size (int): The maximum chunk size, in characters or tokens
+                depending on ``count_mode``.
+
+        Returns:
+            List[str]: Chunks that respect ``max_size`` where possible. A piece
+                that cannot be reduced further (e.g. a single character whose
+                token count already exceeds ``max_size``) is kept as-is rather
+                than dropped.
+
+        """
+        if not text:
+            return []
+
+        if self.count_mode == "char":
+            return [text[i : i + max_size] for i in range(0, len(text), max_size)]
+
+        # Token mode: greedily accumulate characters while staying within the
+        # token budget. This keeps the split reversible (decoding token ids is
+        # not guaranteed for an arbitrary tokenizer).
+        chunks: List[str] = []
+        current = ""
+        for char in text:
+            if current and len(self._tokenizer(current + char)) > max_size:
+                chunks.append(current)
+                current = char
+            else:
+                current += char
+        if current:
+            chunks.append(current)
+        return chunks
 
     def split_text(self, text: str) -> List[str]:
         """

--- a/llama-index-core/tests/text_splitter/test_code_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_code_splitter.py
@@ -406,3 +406,45 @@ def complex_function():
     assert len(nodes) >= 1
     assert isinstance(nodes[0], TextNode)
     assert "def complex_function():" in nodes[0].text
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_oversized_leaf_not_dropped_char_mode() -> None:
+    """A leaf node larger than max_chars must be split, not silently dropped."""
+    if "CI" in os.environ:
+        return
+
+    # A single string literal whose content is one large AST leaf node that
+    # exceeds max_chars. Previously the leaf was dropped, losing the content.
+    long_str = "A" * 800
+    text = f'x = "{long_str}"\ny = 1\n'
+
+    code_splitter = CodeSplitter(language="python", max_chars=100)
+    chunks = code_splitter.split_text(text)
+
+    # All 800 characters of the string body are preserved across the chunks.
+    assert sum(chunk.count("A") for chunk in chunks) == 800
+    # Each chunk respects the character limit.
+    assert all(len(chunk) <= 100 for chunk in chunks)
+    # Surrounding code is still present.
+    assert any("y = 1" in chunk for chunk in chunks)
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_oversized_leaf_not_dropped_token_mode() -> None:
+    """A leaf node larger than max_tokens must be split, not silently dropped."""
+    if "CI" in os.environ:
+        return
+
+    from llama_index.core.utils import get_tokenizer
+
+    tokenizer = get_tokenizer()
+    long_str = "A" * 800
+    text = f'x = "{long_str}"\ny = 1\n'
+
+    code_splitter = CodeSplitter(language="python", count_mode="token", max_tokens=20)
+    chunks = code_splitter.split_text(text)
+
+    assert sum(chunk.count("A") for chunk in chunks) == 800
+    assert all(len(tokenizer(chunk)) <= 20 for chunk in chunks)
+    assert any("y = 1" in chunk for chunk in chunks)


### PR DESCRIPTION
# Description

`CodeSplitter._chunk_node()` recursively subdivides AST nodes that exceed the size limit (`max_chars` / `max_tokens`). When the oversized node is a **leaf** — a node with no AST children, such as a long string literal, a long comment/docstring, or a single minified line — the recursive call iterates an empty `node.children`, returns `[]`, and **the node's source bytes are silently dropped from the output**.

This is silent data loss during chunking: any code containing a token larger than the limit loses that content from the index, which is especially harmful for code-RAG.

**Reproduction (on `main`):**

```python
from llama_index.core.node_parser.text.code import CodeSplitter

code = 'x = "' + "A" * 800 + '"\ny = 1\n'        # 813 chars
chunks = CodeSplitter(language="python", max_chars=100).split_text(code)

print(chunks)                                     # ['x =', '"', '"', 'y = 1']
print(sum(len(c) for c in chunks))                # 10  -> 800-char string body lost
print(sum(c.count("A") for c in chunks))          # 0
```

**Root cause:** in the `child_size > max_size` branch, `_chunk_node(child, ...)` is called unconditionally. For a leaf child it has no sub-structure to recurse into and returns nothing, so the child's text is never emitted.

**Fix:** when an oversized child has no children, hard-split its text via a new `_split_oversized_leaf()` helper instead of recursing into nothing:
- `char` mode: fixed-size character windows.
- `token` mode: a reversible greedy accumulation of characters within the token budget (decoding token ids back to text is not guaranteed for an arbitrary tokenizer).

A piece that cannot be reduced further (e.g. a single character whose token count already exceeds the limit) is kept as-is rather than dropped — consistent with the oversized-unit handling recently added to `TokenTextSplitter` / `SentenceSplitter` (#21900).

After the fix, the reproduction above preserves all 800 characters across size-bounded chunks, and normal code is split exactly as before.

Fixes the data-loss behavior described above (discovered while reviewing the splitter recursion logic).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`, which the template excludes from version bumps)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Two new tests were added to `tests/text_splitter/test_code_splitter.py` (`test_oversized_leaf_not_dropped_char_mode` and `test_oversized_leaf_not_dropped_token_mode`), following the existing test conventions in that file. They assert the full string body is preserved across chunks and that every chunk respects the size limit.

**New tests pass:**

```
tests/text_splitter/test_code_splitter.py::test_oversized_leaf_not_dropped_char_mode PASSED
tests/text_splitter/test_code_splitter.py::test_oversized_leaf_not_dropped_token_mode PASSED
2 passed
```

**Mutation check** — reverting the fix makes the new tests fail (they catch the bug):

```
>       assert sum(chunk.count("A") for chunk in chunks) == 800
E       assert 0 == 800
2 failed
```

**Full CodeSplitter suite — no regressions** (run locally with `CI` unset so every test executes, since the existing tests early-return under CI):

```
tests/text_splitter/test_code_splitter.py 17 passed
tests/text_splitter/ ............ 40 passed
```

**Lint/format/type checks pass** on the changed files:

```
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
