### PR TITLE
fix: cap HWP section decompression

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
@@ -13,13 +13,19 @@ class HWPReader(BaseReader):
     Args: None.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        max_decompressed_section_size: int = 100 * 1024 * 1024,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.FILE_HEADER_SECTION = "FileHeader"
         self.HWP_SUMMARY_SECTION = "\x05HwpSummaryInformation"
         self.SECTION_NAME_LENGTH = len("Section")
         self.BODYTEXT_SECTION = "BodyText"
         self.HWP_TEXT_TAGS = [67]
+        self.max_decompressed_section_size = max_decompressed_section_size
 
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
@@ -86,12 +92,26 @@ class HWPReader(BaseReader):
         header_data = header.read()
         return (header_data[36] & 1) == 1
 
+    def _decompress_section(self, data: bytes) -> bytes:
+        decompressor = zlib.decompressobj(-15)
+        max_size = self.max_decompressed_section_size
+        decompressed = decompressor.decompress(data, max_size + 1)
+
+        if len(decompressed) > max_size or decompressor.unconsumed_tail:
+            raise ValueError(f"HWP section decompressed data exceeds {max_size} bytes")
+
+        decompressed += decompressor.flush(max_size + 1 - len(decompressed))
+        if len(decompressed) > max_size:
+            raise ValueError(f"HWP section decompressed data exceeds {max_size} bytes")
+
+        return decompressed
+
     def get_text_from_section(self, load_file, section):
         bodytext = load_file.openstream(section)
         data = bodytext.read()
 
         unpacked_data = (
-            zlib.decompress(data, -15) if self.is_compressed(load_file) else data
+            self._decompress_section(data) if self.is_compressed(load_file) else data
         )
         size = len(unpacked_data)
 

--- a/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
@@ -1,3 +1,7 @@
+import zlib
+
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.hwp import HWPReader
 
@@ -5,3 +9,22 @@ from llama_index.readers.hwp import HWPReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HWPReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def _raw_deflate(data: bytes) -> bytes:
+    compressor = zlib.compressobj(wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+def test_decompress_section_allows_data_within_limit():
+    reader = HWPReader(max_decompressed_section_size=32)
+    data = b"hwp section text"
+
+    assert reader._decompress_section(_raw_deflate(data)) == data
+
+
+def test_decompress_section_rejects_data_over_limit():
+    reader = HWPReader(max_decompressed_section_size=8)
+
+    with pytest.raises(ValueError, match="exceeds 8 bytes"):
+        reader._decompress_section(_raw_deflate(b"a" * 64))


### PR DESCRIPTION
Fixes #22101.

## Summary

- Add a bounded raw-deflate decompression path for compressed HWP body sections.
- Default the per-section decompressed output limit to 100 MB, while allowing callers to override `max_decompressed_section_size` on `HWPReader`.
- Add focused tests covering normal raw-deflate decompression and rejection once the decompressed section exceeds the configured limit.

## Root cause

`HWPReader.get_text_from_section()` called `zlib.decompress(data, -15)` directly for compressed HWP sections. A small malicious section could therefore expand without an output-size guard before the parser inspects record headers.

## Validation

From `llama-index-integrations/readers/llama-index-readers-hwp`:

- `uv run -- pytest tests/test_readers_hwp.py -q` -> `3 passed`
- `uv run -- ruff check llama_index/readers/hwp/base.py tests/test_readers_hwp.py` -> `All checks passed!`
- `uv run -- ruff format --check llama_index/readers/hwp/base.py tests/test_readers_hwp.py` -> `2 files already formatted`
- `git diff --check` -> passed

## AI assistance

AI assistance was used to inspect the issue and local HWP reader code, screen for duplicate PRs, implement this small bounded-decompression change, and run the validation commands above. I reviewed the final diff and test results.