### PR TITLE
fix(core): recognize ~~~ fenced code blocks in MarkdownNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/markdown.py
+++ b/llama-index-core/llama_index/core/node_parser/file/markdown.py
@@ -54,11 +54,25 @@ class MarkdownNodeParser(NodeParser):
         # Keep track of (markdown level, text) for headers
         header_stack: List[tuple[int, str]] = []
         code_block = False
+        # The fence character ("`" or "~") that opened the current code block.
+        code_block_fence = ""
 
         for line in lines:
-            # Track if we're inside a code block to avoid parsing headers in code
-            if line.lstrip().startswith("```"):
-                code_block = not code_block
+            # Track if we're inside a fenced code block to avoid parsing headers
+            # in code. Per CommonMark, a fence is 3+ backticks (```) or 3+
+            # tildes (~~~), and is closed only by a fence using the same
+            # character.
+            fence_match = re.match(r"^\s*(`{3,}|~{3,})", line)
+            if fence_match:
+                fence_char = fence_match.group(1)[0]
+                if not code_block:
+                    code_block = True
+                    code_block_fence = fence_char
+                elif fence_char == code_block_fence:
+                    code_block = False
+                    code_block_fence = ""
+                # A fence using a different character while already inside a
+                # code block is part of the code content, so it does not toggle.
                 current_section += line + "\n"
                 continue
 

--- a/llama-index-core/tests/node_parser/test_markdown.py
+++ b/llama-index-core/tests/node_parser/test_markdown.py
@@ -202,3 +202,60 @@ Content
     assert splits[0].metadata == {"header_path": "/"}
     assert splits[1].metadata == {"header_path": "/Main Header/"}
     assert splits[2].metadata == {"header_path": "/Main Header/"}
+
+
+def test_tilde_fenced_code_block() -> None:
+    """`#` lines inside a ~~~ fenced code block must not be parsed as headers."""
+    markdown_parser = MarkdownNodeParser()
+
+    splits = markdown_parser.get_nodes_from_documents(
+        [
+            Document(
+                text="""# Header 1
+
+~~~
+# not a header
+more code
+~~~
+
+Body text
+"""
+            )
+        ]
+    )
+
+    # The whole section stays together; the fenced "# not a header" line is not
+    # treated as a header, so there is no spurious extra split.
+    assert len(splits) == 1
+    assert splits[0].metadata == {"header_path": "/"}
+    assert "# not a header" in splits[0].text
+    assert "Body text" in splits[0].text
+
+
+def test_mixed_fence_characters() -> None:
+    """A ``` line inside a ~~~ block is code content and must not close it."""
+    markdown_parser = MarkdownNodeParser()
+
+    splits = markdown_parser.get_nodes_from_documents(
+        [
+            Document(
+                text="""# Header 1
+
+~~~
+```
+# still inside the tilde fence
+~~~
+
+# Header 2
+Body
+"""
+            )
+        ]
+    )
+
+    # Two sections: the tilde-fenced block belongs to "Header 1" (the inner
+    # ``` and "# still inside ..." do not split it), and "Header 2" follows.
+    assert len(splits) == 2
+    assert splits[0].metadata == {"header_path": "/"}
+    assert "# still inside the tilde fence" in splits[0].text
+    assert splits[1].text == "# Header 2\nBody"


### PR DESCRIPTION
# Description

`MarkdownNodeParser` tracks fenced code blocks so that `#` lines inside code are not parsed as Markdown headers — but it only recognizes **backtick** fences (` ``` `). **Tilde fences (`~~~`) are valid CommonMark / GitHub-Flavored Markdown** (CommonMark §4.5: *"a code fence is a sequence of at least three consecutive backtick characters or tildes"*), and they are not detected. As a result, a `#` line inside a `~~~` block is wrongly treated as a header, producing spurious node splits and a corrupted `header_path` hierarchy.

Tilde fences are common in technical docs that need to embed backtick examples (e.g. showing a ` ``` ` block *inside* a fenced example), and in Markdown generated from reStructuredText.

**Reproduction (on `main`):**

```python
from llama_index.core.node_parser.file.markdown import MarkdownNodeParser
from llama_index.core.schema import Document

text = "# Title\n\n~~~\n# not a header\n~~~\n\nbody\n"
nodes = MarkdownNodeParser().get_nodes_from_documents([Document(text=text)])
for n in nodes:
    print(repr(n.text))

# main (buggy) -> TWO nodes; "# not a header" is treated as a real header:
#   '# Title\n\n~~~'
#   '# not a header\n~~~\n\nbody'
```

**Fix:** detect both ` ``` ` and `~~~` fences (3+ of either character) and track the fence character that opened the block, closing it only on a fence using the **same** character (per CommonMark). A fence of the other character inside an open block is treated as code content. Backtick-only documents are completely unaffected (identical toggling behavior).

After the fix the example above yields a single node and `# not a header` stays inside the code block.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`, which the template excludes from version bumps)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Two new tests in `tests/node_parser/test_markdown.py`:
- `test_tilde_fenced_code_block` — a `#` line inside a `~~~` block does not create a spurious split.
- `test_mixed_fence_characters` — a ` ``` ` line inside a `~~~` block is code content and does not close the block.

**New tests pass:**

```
tests/node_parser/test_markdown.py::test_tilde_fenced_code_block PASSED
tests/node_parser/test_markdown.py::test_mixed_fence_characters PASSED
2 passed
```

**Mutation check** — reverting the fix makes the new tests fail (they catch the bug):

```
>       assert len(splits) == 2
E       AssertionError: assert 1 == 2
2 failed
```

**No regressions** — full Markdown suite and the broader node-parser suite:

```
tests/node_parser/test_markdown.py 9 passed
tests/node_parser/ 42 passed, 7 skipped, 5 xfailed
```

The existing `test_header_splits_with_indented_code_blocks` (backtick fences) still passes unchanged.

**Lint/format/type checks pass** on the changed files:

```
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
