### PR TITLE
fix: preserve multiblock chat history writes

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -14,6 +14,7 @@ from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponseAsyncGen,
     ChatResponseGen,
+    TextBlock,
 )
 from llama_index.core.base.response.schema import Response, StreamingResponse
 from llama_index.core.memory import BaseMemory
@@ -40,6 +41,11 @@ def is_function(message: ChatMessage) -> bool:
         "tool_calls" in message.additional_kwargs
         and len(message.additional_kwargs["tool_calls"]) > 0
     )
+
+
+def _set_message_content(message: ChatMessage, content: str) -> None:
+    """Update streamed message text without using the legacy content setter."""
+    message.blocks = [TextBlock(text=content)]
 
 
 class ChatResponseMode(str, Enum):
@@ -191,7 +197,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())  # final message
                 self.response = final_text.strip()
                 memory.put(chat.message)
         except Exception as e:
@@ -250,7 +256,7 @@ class StreamingAgentChatResponse:
             if self.is_function is not None:  # if loop has gone through iteration
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
-                chat.message.content = final_text.strip()  # final message
+                _set_message_content(chat.message, final_text.strip())  # final message
                 self.response = final_text.strip()
                 await memory.aput(chat.message)
         except Exception as e:

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -2,16 +2,30 @@ import gc
 import asyncio
 from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.base.llms.types import (
+    ChatResponse,
     ChatMessage,
     CompletionResponse,
     CompletionResponseGen,
+    TextBlock,
 )
-from typing import Any
+from typing import Any, AsyncIterator, Iterator
 from llama_index.core.llms.callbacks import llm_completion_callback
 from llama_index.core.llms.mock import MockLLM
 import pytest
-from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.base.llms.types import MessageRole
 from llama_index.core.chat_engine.simple import SimpleChatEngine
+from llama_index.core.chat_engine.types import StreamingAgentChatResponse
+
+
+class MockMemory:
+    def __init__(self) -> None:
+        self.messages: list[ChatMessage] = []
+
+    def put(self, message: ChatMessage) -> None:
+        self.messages.append(message)
+
+    async def aput(self, message: ChatMessage) -> None:
+        self.messages.append(message)
 
 
 def test_simple_chat_engine() -> None:
@@ -82,6 +96,45 @@ async def test_simple_chat_engine_astream_response_text_without_draining():
     assert response.response != ""
     assert str(response) == response.response
     assert "Hello World!" in str(response)
+
+
+def test_streaming_response_write_history_handles_multiblock_message():
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[TextBlock(text="old text"), TextBlock(text="kept block")],
+    )
+
+    def chat_stream() -> Iterator[ChatResponse]:
+        yield ChatResponse(message=message, delta="new ")
+        yield ChatResponse(message=message, delta="text")
+
+    memory = MockMemory()
+    response = StreamingAgentChatResponse(chat_stream=chat_stream())
+
+    response.write_response_to_history(memory)  # type: ignore[arg-type]
+
+    assert memory.messages == [message]
+    assert message.blocks == [TextBlock(text="new text")]
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_awrite_history_handles_multiblock_message():
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[TextBlock(text="old text"), TextBlock(text="kept block")],
+    )
+
+    async def chat_stream() -> AsyncIterator[ChatResponse]:
+        yield ChatResponse(message=message, delta="new ")
+        yield ChatResponse(message=message, delta="text")
+
+    memory = MockMemory()
+    response = StreamingAgentChatResponse(achat_stream=chat_stream())
+
+    await response.awrite_response_to_history(memory)  # type: ignore[arg-type]
+
+    assert memory.messages == [message]
+    assert message.blocks == [TextBlock(text="new text")]
 
 
 def test_simple_chat_engine_astream_exception_handling():


### PR DESCRIPTION
Fixes #21679.

## Summary

- Avoid assigning through `ChatMessage.content` when streaming history writeback finalizes an assistant message.
- Replace the streamed message blocks with a single `TextBlock` containing the accumulated text, matching the maintainer review guidance.
- Cover both synchronous and asynchronous `StreamingAgentChatResponse` history writeback paths, including removal of stale extra blocks.

## Root cause

`StreamingAgentChatResponse.write_response_to_history()` and `awrite_response_to_history()` assign the accumulated stream through `chat.message.content`. That legacy setter rejects messages with multiple blocks, so history persistence raises `ValueError` after a multi-block streamed response.

## Validation

Rebased onto current `main` (`67514f634`) and validated with Python 3.12.13:

- `PYTHONPATH=. python -m pytest tests/chat_engine/test_simple.py -q` -> `7 passed, 1 existing event-loop deprecation warning`
- `PYTHONPATH=. python -m ruff check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py` -> passed
- `PYTHONPATH=. python -m ruff format --check llama_index/core/chat_engine/types.py tests/chat_engine/test_simple.py` -> passed
- `git diff --check` -> passed

The linked issue remains open and current `main` still contains the failing `.content` assignments in both writeback paths. AI assistance was used for source inspection, rebasing, and validation; I reviewed the final diff and test evidence.