### PR TITLE
fix(core): skip empty nodes in HTMLNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/html.py
+++ b/llama-index-core/llama_index/core/node_parser/file/html.py
@@ -88,16 +88,19 @@ class HTMLNodeParser(NodeParser):
                 last_tag = tag.name
                 current_section += f"{tag_text.strip()}\n"
             else:
-                html_nodes.append(
-                    self._build_node_from_split(
-                        current_section.strip(), node, {"tag": last_tag}
+                # Skip empty sections (e.g. a container tag whose only children
+                # are themselves extracted tags) to avoid emitting blank nodes.
+                if current_section.strip():
+                    html_nodes.append(
+                        self._build_node_from_split(
+                            current_section.strip(), node, {"tag": last_tag}
+                        )
                     )
-                )
                 if isinstance(tag, Tag):
                     last_tag = tag.name
                 current_section = f"{tag_text}\n"
 
-        if current_section:
+        if current_section.strip():
             html_nodes.append(
                 self._build_node_from_split(
                     current_section.strip(), node, {"tag": last_tag}

--- a/llama-index-core/tests/node_parser/test_html.py
+++ b/llama-index-core/tests/node_parser/test_html.py
@@ -169,3 +169,40 @@ def test_neighbor_tags_splits() -> None:
         ]
     )
     assert len(splits) == 1
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="Requires beautifulsoup4.",
+    condition=importlib.util.find_spec("bs4") is None,
+)
+def test_no_empty_nodes_for_container_tags() -> None:
+    # A container tag whose only children are themselves extracted tags yields
+    # no text of its own; it previously produced a spurious empty node.
+    html_parser = HTMLNodeParser(tags=["section", "p"])
+
+    splits = html_parser.get_nodes_from_documents(
+        [
+            Document(
+                text="""
+<!DOCTYPE html>
+<html>
+<body>
+    <section>
+        <p>First paragraph.</p>
+    </section>
+    <section></section>
+    <p>Second paragraph.</p>
+</body>
+</html>
+    """
+            )
+        ]
+    )
+
+    # No blank nodes should be emitted for the text-less <section> tags.
+    assert all(split.text.strip() for split in splits)
+    assert [split.text for split in splits] == [
+        "First paragraph.",
+        "Second paragraph.",
+    ]


### PR DESCRIPTION
# Description

`HTMLNodeParser` emits a **spurious blank node** whenever a parsed tag has no text of its own. This happens when a container tag (`<section>`, `<div>`, …) in the parse list has only children that are themselves extracted tags, or when a tag is empty. `_extract_text_from_tag()` returns `""` for such tags, but the section is still flushed into a node — producing empty-text nodes that pollute the index (wasted embeddings, retrieval noise, misleading `tag` metadata).

**Reproduction (on `main`):**

```python
from llama_index.core.node_parser.file.html import HTMLNodeParser
from llama_index.core.schema import Document

parser = HTMLNodeParser(tags=["section", "p"])
nodes = parser.get_nodes_from_documents(
    [Document(text="<section><p>Hello world</p></section>")]
)
for n in nodes:
    print(repr(n.metadata["tag"]), repr(n.text))

# main (buggy):
#   'section' ''            <- spurious empty node
#   'p'       'Hello world'
```

**Fix:** only build a node when the accumulated section has non-whitespace content — in both the mid-loop flush and the final flush. This mirrors how `SentenceSplitter` drops whitespace-only chunks. Non-empty sections are unaffected.

After the fix the example yields a single node (`'p'`, `'Hello world'`).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`, which the template excludes from version bumps)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Added `test_no_empty_nodes_for_container_tags` to `tests/node_parser/test_html.py`, following the file's existing `xfail`-when-`bs4`-missing convention. It asserts no blank nodes are produced for text-less container tags and that real content is preserved.

**New test passes:**

```
tests/node_parser/test_html.py::test_no_empty_nodes_for_container_tags PASSED
```

**Mutation check** — reverting the fix makes the new test fail (it catches the bug):

```
>       assert all(split.text.strip() for split in splits)
E       assert False
1 failed
```

**No regressions** — full HTML suite and the broader node-parser suite (run with `beautifulsoup4` installed):

```
tests/node_parser/test_html.py 6 passed
tests/node_parser/ 46 passed, 7 skipped
```

**Lint/format/type checks pass** on the changed files:

```
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
