### PR TITLE
fix(core): respect mmr_threshold=0 in MMR embedding search

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -115,7 +115,7 @@ def get_top_k_mmr_embeddings(
     A mmr_threshold of 1 will check similarity the query and ignore previous results.
 
     """
-    threshold = mmr_threshold or 0.5
+    threshold = mmr_threshold if mmr_threshold is not None else 0.5
     similarity_fn = similarity_fn or default_similarity_fn
 
     if embedding_ids is None or embedding_ids == []:

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -71,3 +71,40 @@ def test_get_top_k_mmr_embeddings() -> None:
         result_similarities_no_mmr, result_similarities
     ):
         assert np.isclose(result_no_mmr, result_with_mmr, atol=0.00001)
+
+
+def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
+    """
+    An explicit mmr_threshold of 0 must request maximum diversity.
+
+    The docstring promises that "a mmr_threshold of 0 will strongly avoid
+    similarity to previous results". Because 0 is falsy, ``mmr_threshold or 0.5``
+    silently discarded the value and fell back to 0.5, so the parameter was
+    ignored whenever a caller explicitly asked for full diversity.
+    """
+    query_embedding = [1.0, 0.0]
+    # index 0: relevant to the query
+    # index 1: a near-duplicate of index 0 (redundant)
+    # index 2: orthogonal to the query (maximally diverse)
+    embeddings = [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]]
+
+    # With full diversity (threshold=0) the second pick must be the orthogonal
+    # node, not the duplicate of the first pick.
+    _, result_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=2, mmr_threshold=0.0
+    )
+    assert result_ids == [0, 2]
+
+    # A threshold of 0 must behave differently from the 0.5 default, which keeps
+    # the redundant high-similarity node.
+    _, default_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=2, mmr_threshold=0.5
+    )
+    assert default_ids == [0, 1]
+    assert result_ids != default_ids
+
+    # Leaving mmr_threshold unset still applies the 0.5 default.
+    _, unset_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=2
+    )
+    assert unset_ids == [0, 1]


### PR DESCRIPTION
# Description

`get_top_k_mmr_embeddings` (the MMR reranking used by the built-in
`SimpleVectorStore`) computed its diversity threshold with:

```python
threshold = mmr_threshold or 0.5
```

Because `0` is falsy in Python, an explicit `mmr_threshold=0` is silently
replaced by `0.5`. This makes the documented behavior unreachable — the
docstring states:

> A mmr_threshold of 0 will strongly avoid similarity to previous results.

A user requesting maximum diversity (e.g.
`index.as_retriever(vector_store_query_mode="mmr", vector_store_kwargs={"mmr_threshold": 0})`)
silently gets the default balanced reranking instead.

### Fix

Apply the default only when the parameter is genuinely unset:

```python
threshold = mmr_threshold if mmr_threshold is not None else 0.5
```

`mmr_threshold=None` (unset) and all non-zero values are unchanged, so this is
fully backwards compatible.

### Impact (concrete)

Query `[1, 0]` with three candidates — a relevant doc, a near-duplicate of it,
and an orthogonal (diverse) doc:

| `mmr_threshold` | Before | After |
|---|---|---|
| `0` (max diversity) | `[relevant, duplicate]` | `[relevant, diverse]` |
| `0.5` (default) | `[relevant, duplicate]` | `[relevant, duplicate]` (unchanged) |
| unset | `[relevant, duplicate]` | `[relevant, duplicate]` (unchanged) |

Before the fix, asking for maximum diversity returned a redundant duplicate,
defeating the purpose of MMR.

# New Package?

- [ ] Yes
- [x] No

# Version Bump?

- [ ] Yes
- [x] No

(`llama-index-core` is exempt from version bumps per the contributing guide.)

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added `test_get_top_k_mmr_embeddings_threshold_zero`, which asserts that
`mmr_threshold=0` selects the diverse node rather than the redundant duplicate,
and that the default (`0.5`) and unset behaviors are unchanged. It is a true
regression test — it fails on `main` and passes with this fix.

- [x] Added new unit tests
- [x] I stared at the code and made sure it makes sense

```
$ pytest tests/indices/query/test_embedding_utils.py -q
..                                                                       [100%]
2 passed in 0.02s
```

Mutation check (fix reverted to `mmr_threshold or 0.5`):

```
>       assert result_ids == [0, 2]
E       assert [0, 1] == [0, 2]
1 failed
```

# Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make lint` (ruff, ruff-format, mypy, codespell) — all pass
