### PR TITLE
fix(openai): use prefix matching for reasoning model detection

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -93,6 +93,7 @@ from llama_index.llms.openai.utils import (
     openai_modelname_to_contextsize,
     resolve_openai_credentials,
     resolve_tool_choice,
+    supports_reasoning_model,
     to_openai_message_dicts,
 )
 
@@ -314,8 +315,11 @@ class OpenAIResponses(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # Reasoning models reject custom temperature when reasoning is active.
+        if supports_reasoning_model(model) and (
+            reasoning_options is None
+            or reasoning_options.get("effort", "none") != "none"
+        ):
             temperature = 1.0
 
         super().__init__(
@@ -421,10 +425,14 @@ class OpenAIResponses(FunctionCallingLLM):
             "user": self.user,
         }
 
-        if self.model in O1_MODELS and self.reasoning_options is not None:
+        if supports_reasoning_model(self.model) and self.reasoning_options is not None:
             model_kwargs["reasoning"] = self.reasoning_options
 
-        if self.reasoning_options is not None or self.model in O1_MODELS:
+        reasoning_active = (
+            supports_reasoning_model(self.model)
+            or self.reasoning_options is not None
+        )
+        if reasoning_active:
             params_to_exclude_for_reasoning = {
                 "top_p",
                 "temperature",

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -100,6 +100,24 @@ O1_MODELS_WITHOUT_FUNCTION_CALLING = {
     "o1-mini-2024-09-12",
 }
 
+
+def supports_reasoning_model(model: str) -> bool:
+    """Return whether a model uses OpenAI reasoning/O-series behavior.
+
+    Known models are resolved via ``O1_MODELS``. Prefix matching covers newly
+    released dated snapshots (e.g. ``gpt-5.9-2027-01-01``) before they are
+    added to the allowlist.
+    """
+    if model in O1_MODELS:
+        return True
+
+    return (
+        model in ("o1", "o3", "o4")
+        or model.startswith(("o1-", "o3-", "o4-"))
+        or model.startswith(("gpt-5", "gpt-5."))
+    )
+
+
 GPT4_MODELS: Dict[str, int] = {
     # stable model names:
     #   resolves to gpt-4-0314 before 2023-06-27,

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.9"
+version = "0.7.10"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1009,3 +1009,59 @@ def test__parse_response_output(response_output: List[ResponseOutputItem]):
     assert [
         block for block in result.message.blocks if isinstance(block, ThinkingBlock)
     ][3].content == "hello\nworld"
+
+
+def test_supports_reasoning_model_prefix_matching() -> None:
+    from llama_index.llms.openai.utils import supports_reasoning_model
+
+    assert supports_reasoning_model("gpt-5.2-2025-12-11") is True
+    assert supports_reasoning_model("gpt-5.9-2027-01-01") is True
+    assert supports_reasoning_model("o3-mini") is True
+    assert supports_reasoning_model("gpt-4o") is False
+    assert supports_reasoning_model("gpt-4o-mini") is False
+
+
+def test_get_model_kwargs_unlisted_reasoning_snapshot() -> None:
+    """Unlisted GPT-5 snapshots must forward reasoning and strip sampling params."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(
+                model="gpt-5.9-2027-01-01",
+                reasoning_options={"effort": "low"},
+                api_key="sk-test",
+            )
+
+    kwargs = llm._get_model_kwargs()
+
+    assert kwargs["reasoning"] == {"effort": "low"}
+    assert "top_p" not in kwargs
+    assert "temperature" not in kwargs
+
+
+def test_get_model_kwargs_unlisted_reasoning_snapshot_without_options() -> None:
+    """Unlisted reasoning models still reject sampling params by default."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(
+                model="gpt-5.9-2027-01-01",
+                api_key="sk-test",
+            )
+
+    kwargs = llm._get_model_kwargs()
+
+    assert "reasoning" not in kwargs
+    assert "top_p" not in kwargs
+    assert "temperature" not in kwargs
+
+
+def test_constructor_preserves_temperature_when_reasoning_effort_none() -> None:
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(
+                model="gpt-5.2-2025-12-11",
+                temperature=0.3,
+                reasoning_options={"effort": "none"},
+                api_key="sk-test",
+            )
+
+    assert llm.temperature == 0.3


### PR DESCRIPTION
OpenAIResponses gated reasoning behavior on exact O1_MODELS lookups. New dated GPT-5 snapshots not yet in the dict silently dropped reasoning_options and still sent top_p/temperature, causing 400 errors.

Add supports_reasoning_model() with prefix matching and use it in OpenAIResponses for temperature override, reasoning forwarding, and sampling-parameter stripping.

Fixes #20459

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
