### PR TITLE
fix: _marshal_llm_to_json skips prose brackets before the JSON payload

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -23,16 +23,69 @@ def _marshal_llm_to_json(output: str) -> str:
     """
     output = output.strip()
 
+    # We can't simply pick whichever opening delimiter comes first, because the
+    # surrounding prose may contain a stray bracket (e.g.
+    # "See [1] for details: {...}") that precedes the real payload. Instead we
+    # enumerate every balanced bracket region (tracking nesting and ignoring
+    # delimiters inside string literals) and prefer the largest region that is
+    # itself parseable as JSON. This skips prose brackets such as "[1]" or
+    # "[thinking]" in favor of the actual JSON value.
+    closing = {"{": "}", "[": "]"}
+    candidates = []
+    for left, char in enumerate(output):
+        if char not in closing:
+            continue
+
+        stack = [closing[char]]
+        in_string = False
+        escaped = False
+        for right in range(left + 1, len(output)):
+            cur = output[right]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif cur == "\\":
+                    escaped = True
+                elif cur == '"':
+                    in_string = False
+                continue
+
+            if cur == '"':
+                in_string = True
+            elif cur in closing:
+                stack.append(closing[cur])
+            elif cur in ("}", "]"):
+                if stack and cur == stack[-1]:
+                    stack.pop()
+                    if not stack:
+                        candidates.append((left, right))
+                        break
+                else:
+                    # Mismatched closer; this opener doesn't start valid JSON.
+                    break
+
+    if candidates:
+        # Prefer the largest region that parses as JSON; otherwise the largest.
+        def _parses(span: tuple) -> bool:
+            try:
+                json.loads(output[span[0] : span[1] + 1])
+                return True
+            except (json.JSONDecodeError, ValueError):
+                return False
+
+        best = max(candidates, key=lambda s: (_parses(s), s[1] - s[0]))
+        left, right = best
+        return output[left : right + 1]
+
+    # Fall back to the original heuristic if no balanced region was found.
     left_square = output.find("[")
     left_brace = output.find("{")
-
     if (left_square < left_brace and left_square != -1) or left_brace == -1:
         left = left_square
         right = output.rfind("]")
     else:
         left = left_brace
         right = output.rfind("}")
-
     return output[left : right + 1]
 
 

--- a/llama-index-core/tests/output_parsers/test_utils.py
+++ b/llama-index-core/tests/output_parsers/test_utils.py
@@ -1,4 +1,8 @@
-from llama_index.core.output_parsers.utils import extract_json_str
+from llama_index.core.output_parsers.utils import (
+    _marshal_llm_to_json,
+    extract_json_str,
+    parse_json_markdown,
+)
 
 
 def test_extract_json_str() -> None:
@@ -22,3 +26,17 @@ Here is the valid JSON:
 }\
 """
     assert extract_json_str(input) == expected
+
+
+def test_marshal_object_after_prose_with_square_brackets() -> None:
+    # An LLM commonly emits prose containing '[' before the real JSON object;
+    # the leading bracket must not hijack extraction.
+    text = 'See [1] for details: {"answer": 42}'
+    assert _marshal_llm_to_json(text) == '{"answer": 42}'
+    assert parse_json_markdown(text) == {"answer": 42}
+
+
+def test_marshal_object_with_inner_array_after_prose() -> None:
+    text = 'Sure! [thinking] Here: {"a": [1, 2], "b": 3}'
+    assert _marshal_llm_to_json(text) == '{"a": [1, 2], "b": 3}'
+    assert parse_json_markdown(text) == {"a": [1, 2], "b": 3}


### PR DESCRIPTION
## Problem

`_marshal_llm_to_json` decided between the array and object branch by whichever of `[` or `{` appeared **first**, then sliced from there to the matching last bracket:

```python
left_square = output.find("[")
left_brace = output.find("{")
if (left_square < left_brace and left_square != -1) or left_brace == -1:
    left, right = left_square, output.rfind("]")
else:
    left, right = left_brace, output.rfind("}")
return output[left : right + 1]
```

When prose precedes the payload and contains a `[`, the stray bracket wins:

| input | returned (before) |
|---|---|
| `See [1] for details: {"answer": 42}` | `[1]` |
| `Sure! [thinking] Here: {"a": [1, 2], "b": 3}` | `[thinking] Here: {"a": [1, 2]` (invalid) |

Both reach `_marshal_llm_to_json` via `parse_json_markdown`, so an LLM that prefixes its JSON with any bracketed prose yields a wrong or unparseable result.

## Fix

Enumerate balanced bracket regions (tracking nesting, ignoring delimiters inside string literals) and return the largest region that parses as JSON, falling back to the original first-delimiter heuristic when no balanced region is found. This skips prose brackets like `[1]` / `[thinking]` in favor of the real value.

## Test

Adds two regression tests in `tests/output_parsers/test_utils.py` for the cases above (asserting both the raw substring and `parse_json_markdown` round-trip). Full `tests/output_parsers/` suite passes (13 tests).