### PR TITLE
fix: keep all nodes per document in IngestionPipeline upserts (re-submit of #22046, not a dup of #21456)

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -474,21 +474,21 @@ class IngestionPipeline(BaseModel):
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
-        deduped_nodes_to_run = {}
+        deduped_nodes_to_run = []
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
             existing_hash = self.docstore.get_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
-                deduped_nodes_to_run[ref_doc_id] = node
+                deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
                 self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
 
                 if self.vector_store is not None:
                     self.vector_store.delete(ref_doc_id)
 
-                deduped_nodes_to_run[ref_doc_id] = node
+                deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
@@ -504,7 +504,7 @@ class IngestionPipeline(BaseModel):
                 if self.vector_store is not None:
                     self.vector_store.delete(ref_doc_id)
 
-        return list(deduped_nodes_to_run.values())
+        return deduped_nodes_to_run
 
     @staticmethod
     def _node_batcher(
@@ -710,21 +710,21 @@ class IngestionPipeline(BaseModel):
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
-        deduped_nodes_to_run = {}
+        deduped_nodes_to_run = []
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
             existing_hash = await self.docstore.aget_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
-                deduped_nodes_to_run[ref_doc_id] = node
+                deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
                 await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
 
                 if self.vector_store is not None:
                     await self.vector_store.adelete(ref_doc_id)
 
-                deduped_nodes_to_run[ref_doc_id] = node
+                deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
@@ -740,7 +740,7 @@ class IngestionPipeline(BaseModel):
                 if self.vector_store is not None:
                     await self.vector_store.adelete(ref_doc_id)
 
-        return list(deduped_nodes_to_run.values())
+        return deduped_nodes_to_run
 
     @dispatcher.span
     async def arun(

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -9,8 +9,16 @@ from llama_index.core.ingestion.pipeline import IngestionPipeline, DocstoreStrat
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.node_parser import SentenceSplitter, MarkdownElementNodeParser
 from llama_index.core.readers import ReaderConfig, StringIterableReader
-from llama_index.core.schema import Document, TransformComponent, BaseNode
+from llama_index.core.schema import (
+    Document,
+    TransformComponent,
+    BaseNode,
+    TextNode,
+    NodeRelationship,
+    RelatedNodeInfo,
+)
 from llama_index.core.storage.docstore import SimpleDocumentStore
+from llama_index.core.vector_stores import SimpleVectorStore
 
 
 def test_build_pipeline() -> None:
@@ -276,6 +284,39 @@ def test_pipeline_dedup_within_single_batch() -> None:
     )
 
 
+def _nodes_sharing_ref_doc(ref_doc_id: str, count: int) -> list[BaseNode]:
+    nodes: list[BaseNode] = [
+        TextNode(text=f"chunk {i}", id_=f"node-{i}") for i in range(count)
+    ]
+    for node in nodes:
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+            node_id=ref_doc_id
+        )
+    return nodes
+
+
+def test_pipeline_upserts_keep_all_nodes_per_doc() -> None:
+    """
+    Regression test: with the UPSERTS strategy, every node belonging to the
+    same source document must be ingested. `_handle_upserts` previously keyed a
+    dict by `ref_doc_id` and overwrote earlier nodes, so only the last chunk of
+    each document survived and the rest were silently dropped.
+    """
+    nodes = _nodes_sharing_ref_doc("source-doc", 5)
+    pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=SimpleDocumentStore(),
+        vector_store=SimpleVectorStore(),
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+
+    result = pipeline.run(nodes=nodes)
+
+    assert {n.id_ for n in result} == {n.id_ for n in nodes}, (
+        "all nodes sharing a ref_doc_id must be kept, not collapsed to one"
+    )
+
+
 @pytest.mark.skipif(cpu_count() < 2, reason="requires at least 2 CPUs")
 def test_pipeline_parallel_cache_populated() -> None:
     num_workers = 2
@@ -490,6 +531,24 @@ async def test_async_pipeline_dedup_duplicates_only() -> None:
 
     nodes = await pipeline.arun(documents=documents)
     assert len(nodes) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_upserts_keep_all_nodes_per_doc() -> None:
+    """Async counterpart of ``test_pipeline_upserts_keep_all_nodes_per_doc``."""
+    nodes = _nodes_sharing_ref_doc("source-doc", 5)
+    pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=SimpleDocumentStore(),
+        vector_store=SimpleVectorStore(),
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+
+    result = await pipeline.arun(nodes=nodes)
+
+    assert {n.id_ for n in result} == {n.id_ for n in nodes}, (
+        "all nodes sharing a ref_doc_id must be kept, not collapsed to one"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Re-submitting #22046, which was auto-closed as a duplicate of #21456. These are different bugs in the same file: #21456 merges multi-worker cache snapshots back into the parent pipeline (issue #21300, the parallel-run path); this PR fixes silent node loss in `_handle_upserts` / `_ahandle_upserts`. They do not overlap.

`IngestionPipeline._handle_upserts` (and the async `_ahandle_upserts`) collected the nodes to ingest in a dict keyed by `ref_doc_id`:

```python
deduped_nodes_to_run = {}
for node in nodes:
    ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
    ...
    deduped_nodes_to_run[ref_doc_id] = node   # overwrites previous node of same doc
return list(deduped_nodes_to_run.values())
```

Every node produced from one source document shares a single `ref_doc_id`, so each assignment overwrote the previous one. Only the **last** chunk of each document survived; all earlier chunks were silently dropped and never embedded or stored. The sibling `_handle_duplicates` already collects into a list and keeps every node, which is the intended behavior.

This path runs when a docstore and a vector store are configured with the `UPSERTS` / `UPSERTS_AND_DELETE` strategy and pre-split nodes are passed to the pipeline.

### Reproduction (before this fix)

```python
from llama_index.core.ingestion import IngestionPipeline, DocstoreStrategy
from llama_index.core.storage.docstore import SimpleDocumentStore
from llama_index.core.vector_stores import SimpleVectorStore
from llama_index.core.node_parser import SentenceSplitter
from llama_index.core.schema import Document

doc = Document(text=("Sentence one. " * 50) + ("Sentence two. " * 50), id_="doc1")
nodes = SentenceSplitter(chunk_size=20, chunk_overlap=0).get_nodes_from_documents([doc])  # 20 chunks

pipe = IngestionPipeline(
    transformations=[],
    docstore=SimpleDocumentStore(),
    vector_store=SimpleVectorStore(),
    docstore_strategy=DocstoreStrategy.UPSERTS,
)
print(len(pipe.run(nodes=nodes)))  # prints 1 (19 chunks lost); should be 20
```

### Fix

Collect the nodes in a list instead of a dict keyed by `ref_doc_id`, mirroring `_handle_duplicates`, so all nodes for a document are retained. Applied to both the sync and async paths.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] No (change is in `llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_pipeline_upserts_keep_all_nodes_per_doc` and its async counterpart feed multiple nodes sharing one `ref_doc_id` through an upsert pipeline and assert all are returned. They fail on `main` (only 1 node returned) and pass with this change.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I added new unit tests to cover this change
