### PR TITLE
fix: don't mark *args/**kwargs as required tool parameters

### DIFF
--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -1,4 +1,4 @@
-from inspect import signature
+from inspect import Parameter, signature
 from typing import (
     Any,
     Awaitable,
@@ -39,6 +39,12 @@ def create_schema_from_function(
 
     for param_name in params:
         if param_name in ignore_fields:
+            continue
+
+        if params[param_name].kind in (
+            Parameter.VAR_POSITIONAL,
+            Parameter.VAR_KEYWORD,
+        ):
             continue
 
         param_type = params[param_name].annotation

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -98,6 +98,27 @@ def test_create_schema_from_function_with_field_annotated() -> None:
     assert instance.x == 5  # type: ignore
 
 
+def test_create_schema_skips_variadic_args_kwargs() -> None:
+    def fn(q: str, *args: int, **kwargs: int) -> None:
+        pass
+
+    schema = create_schema_from_function("TestSchema", fn).model_json_schema()
+
+    assert "args" not in schema["properties"]
+    assert "kwargs" not in schema["properties"]
+    assert schema["required"] == ["q"]
+
+
+def test_create_schema_keeps_real_param_named_kwargs() -> None:
+    def fn(kwargs: dict) -> None:
+        pass
+
+    schema = create_schema_from_function("TestSchema", fn).model_json_schema()
+
+    assert "kwargs" in schema["properties"]
+    assert schema["required"] == ["kwargs"]
+
+
 def test_create_schema_with_date_and_metadata():
     def sample_func(
         birth_date: Annotated[


### PR DESCRIPTION
# Description

`create_schema_from_function` now skips parameters whose kind is VAR_POSITIONAL (*args) or VAR_KEYWORD (**kwargs) when generating the tool schema. The check is on param.kind, so a regular parameter literally named args/kwargs is still included.

Fixes #22134

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
