### PR TITLE
fix(mcp): handle inline nested objects in McpToolSpec.create_model_from_json_schema

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -93,6 +93,8 @@ class TypeResolutionMixin:
             return self._create_list_type(schema, defs)
         if self._is_simple_object(schema):
             return self._create_dict_type(schema, defs)
+        if self._is_inline_nested_object(schema):
+            return self._create_nested_model(schema, defs)
         return json_type_mapping.get(json_type, str)
 
 
@@ -128,6 +130,26 @@ class TypeCreationMixin:
             and additional_props is not False
             and isinstance(additional_props, dict)
         )
+
+    def _is_inline_nested_object(self: "McpToolSpec", schema: dict) -> bool:
+        """Check if schema is an inline nested object (has properties defined directly)."""
+        return schema.get("type") == "object" and "properties" in schema
+
+    def _create_nested_model(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+        """Create a nested Pydantic model from an inline object schema."""
+        import hashlib
+
+        # Generate a unique model name based on schema content
+        schema_str = str(sorted(schema.get("properties", {}).keys()))
+        schema_hash = hashlib.md5(schema_str.encode()).hexdigest()[:8]
+        model_name = f"NestedModel_{schema_hash}"
+
+        # Use the title from schema if available
+        if "title" in schema:
+            model_name = schema["title"]
+
+        # Create the nested model recursively
+        return self._create_model(schema, model_name, defs)
 
     def _extract_ref_name(self: "McpToolSpec", ref_path: str) -> str:
         """Extract reference name from $ref path."""

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -777,3 +777,63 @@ async def test_aget_tools_from_mcp_url_propagates_combined_params(
     # Verify merged params
     assert add_tool.partial_params == {"a": 1.0, "user_id": "global", "b": 2.0}
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+# --- Tests for nested object schema handling ---
+
+
+base_test_cases = [
+    pytest.param(
+        {
+            "properties": {
+                "nested": {
+                    "properties": {
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                    "required": ["value"],
+                    "type": "object",
+                },
+            },
+            "required": ["nested"],
+            "type": "object",
+        },
+        id="nested-object",
+    ),
+    pytest.param(
+        {
+            "$defs": {
+                "Inner": {
+                    "properties": {
+                        "value": {"title": "Value", "type": "string"},
+                    },
+                    "required": ["value"],
+                    "title": "Inner",
+                    "type": "object",
+                },
+            },
+            "properties": {
+                "nested": {"$ref": "#/$defs/Inner"},
+            },
+            "required": ["nested"],
+            "type": "object",
+        },
+        id="referenced-nested-object",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "json_schema",
+    [
+        *base_test_cases,
+    ],
+)
+def test_create_model_from_json_schema(client: BasicMCPClient, json_schema: dict):
+    """Converting a JSON schema into a Pydantic model and back to a JSON schema should yield the original schema."""
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+    pydantic_model = tool_spec.create_model_from_json_schema(json_schema)
+    json_schema_from_pydantic_model = pydantic_model.model_json_schema()
+
+    del json_schema_from_pydantic_model["title"]
+
+    assert json_schema == json_schema_from_pydantic_model


### PR DESCRIPTION
The `McpToolSpec.create_model_from_json_schema` method in `llama_index/tools/mcp/tool_spec_mixins.py` was not handling inline nested objects correctly. When a property had `type: "object"` with its own `properties` and `required` fields (not via `$ref`), the method treated it as a bare `Dict` type, losing the nested schema structure.

The root cause was in the `_resolve_basic_type` method, which only checked for simple objects (those with `additionalProperties`) but not for inline nested objects (those with `properties`). This caused inline nested objects to fall through to the default type mapping, returning a bare `Dict` instead of recursively creating a nested Pydantic model.

The fix adds a new helper method `_is_inline_nested_object` to detect schemas with inline nested properties, and a new method `_create_nested_model` to recursively build Pydantic models for these nested objects. The logic is inserted before the default type mapping fallback in `_resolve_basic_type`, ensuring inline nested objects are properly handled. The fix also includes a regression test to verify that both inline nested objects and referenced nested objects (via `$ref`) work correctly.

Fixes #22141
