### PR TITLE
fix(tools/mcp): preserve inline object properties in create_model_from_json_schema (#22141)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -237,7 +237,7 @@ class McpToolSpec(
         if model_name in self.properties_cache:
             return self.properties_cache[model_name]
 
-        fields = self._extract_fields(schema, defs)
+        fields = self._extract_fields(schema, defs, model_name)
         model = create_model(model_name, **fields)
         self.properties_cache[model_name] = model
         return model

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -20,6 +20,8 @@ class TypeResolutionMixin:
         self: "McpToolSpec",
         field_schema: dict,
         defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
     ) -> Any:
         """Resolve the Python type from a field schema."""
         if "$ref" in field_schema:
@@ -27,8 +29,12 @@ class TypeResolutionMixin:
         if "enum" in field_schema:
             return Literal[tuple(field_schema["enum"])]
         if "anyOf" in field_schema:
-            return self._resolve_union_type(field_schema, defs)
-        return self._resolve_basic_type(field_schema, defs)
+            return self._resolve_union_type(
+                field_schema, defs, field_name, parent_model_name
+            )
+        return self._resolve_basic_type(
+            field_schema, defs, field_name, parent_model_name
+        )
 
     def _resolve_reference(
         self: "McpToolSpec",
@@ -59,10 +65,13 @@ class TypeResolutionMixin:
         self: "McpToolSpec",
         schema: dict,
         defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
     ) -> Any:
         """Resolve a Union type (anyOf)."""
         union_types = [
-            self._resolve_union_option(option, defs) for option in schema["anyOf"]
+            self._resolve_union_option(option, defs, field_name, parent_model_name)
+            for option in schema["anyOf"]
         ]
         return Union[tuple(union_types)] if len(union_types) > 1 else union_types[0]
 
@@ -70,6 +79,8 @@ class TypeResolutionMixin:
         self: "McpToolSpec",
         option: dict,
         defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
     ) -> Any:
         """Resolve a single option in a union type."""
         if "$ref" in option:
@@ -78,28 +89,42 @@ class TypeResolutionMixin:
             return Literal[tuple(option["enum"])]
         if option.get("type") == "null":
             return type(None)
-        return self._resolve_basic_type(option, defs)
+        return self._resolve_basic_type(option, defs, field_name, parent_model_name)
 
     def _resolve_basic_type(
         self: "McpToolSpec",
         schema: dict,
         defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
     ) -> Any:
         """Resolve a basic JSON Schema type."""
         json_type = schema.get("type", "string")
         json_type = json_type[0] if isinstance(json_type, list) else json_type
 
         if self._is_simple_array(schema):
-            return self._create_list_type(schema, defs)
+            return self._create_list_type(schema, defs, field_name, parent_model_name)
+        if self._is_object_with_properties(schema):
+            return self._create_inline_object_model(
+                schema, defs, field_name, parent_model_name
+            )
         if self._is_simple_object(schema):
             return self._create_dict_type(schema, defs)
         return json_type_mapping.get(json_type, str)
 
 
 class TypeCreationMixin:
-    def _create_list_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+    def _create_list_type(
+        self: "McpToolSpec",
+        schema: dict,
+        defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
+    ) -> type:
         """Create a List type from schema."""
-        item_type = self._resolve_field_type(schema["items"], defs)
+        item_type = self._resolve_field_type(
+            schema["items"], defs, field_name, parent_model_name
+        )
         return List[item_type]
 
     def _create_dict_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
@@ -115,6 +140,17 @@ class TypeCreationMixin:
 
         return Dict[str, Any]
 
+    def _create_inline_object_model(
+        self: "McpToolSpec",
+        schema: dict,
+        defs: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
+    ) -> type:
+        """Create a Pydantic model for an inline object schema."""
+        model_name = self._get_inline_model_name(schema, field_name, parent_model_name)
+        return self._create_model(schema, model_name, defs)
+
     def _is_simple_array(self: "McpToolSpec", schema: dict) -> bool:
         """Check if schema is a simple array type."""
         return schema.get("type") == "array" and "items" in schema
@@ -129,13 +165,41 @@ class TypeCreationMixin:
             and isinstance(additional_props, dict)
         )
 
+    def _is_object_with_properties(self: "McpToolSpec", schema: dict) -> bool:
+        """Check if schema is an object type with declared properties."""
+        return schema.get("type") == "object" and "properties" in schema
+
+    def _get_inline_model_name(
+        self: "McpToolSpec",
+        schema: dict,
+        field_name: str | None = None,
+        parent_model_name: str | None = None,
+    ) -> str:
+        """Build a stable model name for inline object schemas."""
+        if schema.get("title"):
+            return schema["title"]
+
+        parts = [parent_model_name, field_name]
+        raw_name = "".join(part or "" for part in parts) or "InlineObject"
+        return "".join(
+            segment.capitalize()
+            for segment in "".join(
+                char if char.isalnum() else " " for char in raw_name
+            ).split()
+        )
+
     def _extract_ref_name(self: "McpToolSpec", ref_path: str) -> str:
         """Extract reference name from $ref path."""
         return ref_path.split("#/$defs/")[-1]
 
 
 class FieldExtractionMixin:
-    def _extract_fields(self: "McpToolSpec", schema: dict, defs: dict) -> dict:
+    def _extract_fields(
+        self: "McpToolSpec",
+        schema: dict,
+        defs: dict,
+        model_name: str | None = None,
+    ) -> dict:
         """Extract Pydantic fields from schema."""
         properties = self._get_properties(schema)
         required_fields = set(schema.get("required", []))
@@ -146,7 +210,9 @@ class FieldExtractionMixin:
 
         fields = {}
         for field_name, field_schema in properties.items():
-            field_type = self._resolve_field_type(field_schema, defs)
+            field_type = self._resolve_field_type(
+                field_schema, defs, field_name, schema.get("title") or model_name
+            )
             default_value, final_type = self._set_field_default(
                 field_name,
                 required_fields,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -136,6 +136,41 @@ def test_schema_structure_exact_match(client: BasicMCPClient):
     assert set(json_schema["required"]) == {"name", "method", "lst"}
 
 
+def test_create_model_from_json_schema_preserves_nested_inline_object():
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22141
+
+    Inline object properties should be converted to nested Pydantic models instead
+    of falling back to a bare Dict that drops the object's declared properties.
+    """
+    schema = {
+        "properties": {
+            "nested": {
+                "properties": {"value": {"title": "Value", "type": "string"}},
+                "required": ["value"],
+                "type": "object",
+            },
+        },
+        "required": ["nested"],
+        "type": "object",
+    }
+
+    model = McpToolSpec(None, allowed_tools=[]).create_model_from_json_schema(schema)
+    json_schema = model.model_json_schema()
+    nested_schema = json_schema["properties"]["nested"]
+
+    if "$ref" in nested_schema:
+        nested_schema = json_schema["$defs"][nested_schema["$ref"].split("/")[-1]]
+
+    assert nested_schema["type"] == "object"
+    assert nested_schema["properties"]["value"]["type"] == "string"
+    assert nested_schema["required"] == ["value"]
+
+    model(nested={"value": "ok"})
+    with pytest.raises(ValueError):
+        model(nested={})
+
+
 def test_resolve_union_option_with_enum(client: BasicMCPClient):
     """
     Regression test for https://github.com/run-llama/llama_index/issues/20109


### PR DESCRIPTION
## Description

Inline object schemas (`"type": "object"` with `"properties"`) in MCP tool input schemas were being silently converted to `Dict[str, Any]`, which discarded the declared properties and their types. This meant the LLM would see a generic dict instead of structured nested fields, making it impossible for the agent to correctly populate nested object parameters.

## Root Cause

In `_resolve_basic_type()`, objects without `additionalProperties` fell through to the `json_type_mapping` fallback (`object` → `Dict[str, Any]`), losing all declared properties.

## Changes

### `tool_spec_mixins.py`

- **New `_is_object_with_properties()`** — detects inline object schemas (type=object with properties)
- **New `_create_inline_object_model()`** — creates a Pydantic sub-model for each inline object
- **New `_get_inline_model_name()`** — builds stable, human-readable model names using parent model and field name context
- Threaded `field_name` and `parent_model_name` through `_resolve_field_type` → `_resolve_basic_type` → `_create_list_type`/`_resolve_union_type`/`_resolve_union_option` → `_create_inline_object_model` chain, enabling recursive nested object handling

### `base.py`

- Pass `model_name` to `_extract_fields()` so inline models get meaningful names

### Test

- Added `test_create_model_from_json_schema_preserves_nested_inline_object` — verifies nested object schemas produce proper Pydantic models with correct types, required fields, and validation

## Edge Cases Verified

- Simple nested inline objects ✅
- Multiple nested inline fields ✅
- Inline objects as array items ✅
- Deeply nested (3 levels) inline objects ✅
- Optional inline objects (not in required) ✅
- Inline objects with enum fields ✅
- Inline objects with descriptions ✅
- Empty properties schema ✅
- Non-object properties (string, integer, boolean, number) ✅

Closes #22141