### PR TITLE
Fix ReAct parser keyword detection

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -87,9 +87,9 @@ class ReActOutputParser(BaseOutputParser):
             ```
         """
         # Use regex to find properly formatted keywords at line boundaries
-        thought_match = re.search(r"Thought:", output, re.MULTILINE)
-        action_match = re.search(r"Action:", output, re.MULTILINE)
-        answer_match = re.search(r"Answer:", output, re.MULTILINE)
+        thought_match = re.search(r"^Thought:", output, re.MULTILINE)
+        action_match = re.search(r"^Action:", output, re.MULTILINE)
+        answer_match = re.search(r"^Answer:", output, re.MULTILINE)
 
         thought_idx = thought_match.start() if thought_match else None
         action_idx = action_match.start() if action_match else None

--- a/llama-index-core/tests/agent/react/test_react_output_parser.py
+++ b/llama-index-core/tests/agent/react/test_react_output_parser.py
@@ -1,8 +1,10 @@
 from llama_index.core.agent.react.output_parser import (
+    ReActOutputParser,
     extract_final_response,
     extract_tool_use,
     parse_action_reasoning_step,
 )
+from llama_index.core.agent.react.types import ResponseReasoningStep
 
 
 def test_parse_action_reasoning_step() -> None:
@@ -206,3 +208,18 @@ Answer: Answer contains Legislative Action: here is the legislative action conte
         answer
         == "Answer contains Legislative Action: here is the legislative action content."
     )
+
+
+def test_react_output_parser_ignores_action_keyword_inside_thought() -> None:
+    mock_input_text = """\
+Thought: The phrase Action: is part of this thought, not a tool call.
+Answer: final answer
+"""
+
+    reasoning_step = ReActOutputParser().parse(mock_input_text)
+
+    assert isinstance(reasoning_step, ResponseReasoningStep)
+    assert reasoning_step.thought == (
+        "The phrase Action: is part of this thought, not a tool call."
+    )
+    assert reasoning_step.response == "final answer"


### PR DESCRIPTION
## Summary
- Anchor ReAct parser keyword detection to line starts for `Thought:`, `Action:`, and `Answer:`
- Add a regression test for final-answer parsing when the thought text contains the phrase `Action:`

## Why
`ReActOutputParser.parse()` intended to detect properly formatted keywords at line boundaries, but the regex searched for keywords anywhere in the output. A thought like `The phrase Action: is part of this thought` could be misclassified as a tool call and fail parsing.

## Tests
- `python -m pytest llama-index-core/tests/agent/react/test_react_output_parser.py -q`
- `python -m pytest llama-index-core/tests/agent/react -q`