### PR TITLE
fix: deepcopy agent configs in AgentWorkflow to prevent shared mutable state

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -138,7 +138,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                 "Initial state is not supported per-agent in AgentWorkflow"
             )
 
-        self.agents = {cfg.name: cfg for cfg in agents}
+        self.agents = {cfg.name: copy.deepcopy(cfg) for cfg in agents}
         if len(agents) == 1:
             root_agent = agents[0].name
         elif root_agent is None:

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -726,3 +726,23 @@ async def test_run_id_default(
     assert handler.run_id is not None
     assert isinstance(handler.run_id, str)
     handler.cancel()
+
+
+def test_agents_stored_by_deepcopy():
+    """Test that AgentWorkflow deepcopies agent configs so two workflows don't share mutable state."""
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[add],
+        llm=MockFunctionCallingLLM(),
+        system_prompt="original",
+    )
+
+    workflow1 = AgentWorkflow(agents=[agent])
+    workflow2 = AgentWorkflow(agents=[agent])
+
+    # Mutate the agent config stored in workflow1
+    workflow1.agents["agent"].system_prompt = "mutated"
+
+    # workflow2 should be unaffected
+    assert workflow2.agents["agent"].system_prompt == "original"


### PR DESCRIPTION
## Problem

`AgentWorkflow.__init__` stores agent configs by reference:
```python
self.agents = {cfg.name: cfg for cfg in agents}
```

This means if the same `BaseTool` instance or agent config is shared across multiple `AgentWorkflow` instances, they share mutable state — mutating one workflow's agent affects the other.

## Fix

Apply `copy.deepcopy()` to each agent config before storing:
```python
self.agents = {cfg.name: copy.deepcopy(cfg) for cfg in agents}
```

`copy` was already imported in the file.

## Test

Added `test_agents_stored_by_deepcopy` which creates two `AgentWorkflow` instances from the same agent, mutates one, and verifies the other is unaffected.

Fixes #22146

🤖 Generated with [Claude Code](https://claude.com/claude-code)