### PR TITLE
fix(memory): count tokens for ToolCallBlock, ThinkingBlock, CitableBlock, CitationBlock

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -358,11 +358,12 @@ class Memory(BaseMemory):
                     CitableBlock,
                     CitationBlock,
                     ThinkingBlock,
+                    ToolCallBlock,
                 ]
             ] = []
 
             for block in message_or_blocks.blocks:
-                if not isinstance(block, (CachePoint, ToolCallBlock)):
+                if not isinstance(block, CachePoint):
                     blocks.append(block)
 
             # Estimate the token count for the additional kwargs
@@ -380,7 +381,7 @@ class Memory(BaseMemory):
                 blocks = []
                 for msg in messages:
                     for block in msg.blocks:
-                        if not isinstance(block, (CachePoint, ToolCallBlock)):
+                        if not isinstance(block, CachePoint):
                             blocks.append(block)
 
                 # Estimate the token count for the additional kwargs
@@ -437,6 +438,35 @@ class Memory(BaseMemory):
                 token_count += self.audio_token_size_estimate
             elif isinstance(block, DocumentBlock):
                 token_count += self.document_token_size_estimate
+            elif isinstance(block, ToolCallBlock):
+                token_count += len(
+                    self.tokenizer_fn(
+                        block.tool_name + " " + str(block.tool_kwargs)
+                    )
+                )
+            elif isinstance(block, ThinkingBlock):
+                token_count += block.num_tokens or len(
+                    self.tokenizer_fn(block.content or "")
+                )
+            elif isinstance(block, CitableBlock):
+                token_count += len(
+                    self.tokenizer_fn(block.title + " " + block.source)
+                )
+                for inner in block.content:
+                    if isinstance(inner, TextBlock):
+                        token_count += len(self.tokenizer_fn(inner.text))
+                    elif isinstance(inner, ImageBlock):
+                        token_count += self.image_token_size_estimate
+                    else:
+                        token_count += self.document_token_size_estimate
+            elif isinstance(block, CitationBlock):
+                token_count += len(
+                    self.tokenizer_fn(block.title + " " + block.source)
+                )
+                if isinstance(block.cited_content, TextBlock):
+                    token_count += len(self.tokenizer_fn(block.cited_content.text))
+                else:
+                    token_count += self.image_token_size_estimate
 
         return token_count
 

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -440,18 +440,14 @@ class Memory(BaseMemory):
                 token_count += self.document_token_size_estimate
             elif isinstance(block, ToolCallBlock):
                 token_count += len(
-                    self.tokenizer_fn(
-                        block.tool_name + " " + str(block.tool_kwargs)
-                    )
+                    self.tokenizer_fn(block.tool_name + " " + str(block.tool_kwargs))
                 )
             elif isinstance(block, ThinkingBlock):
                 token_count += block.num_tokens or len(
                     self.tokenizer_fn(block.content or "")
                 )
             elif isinstance(block, CitableBlock):
-                token_count += len(
-                    self.tokenizer_fn(block.title + " " + block.source)
-                )
+                token_count += len(self.tokenizer_fn(block.title + " " + block.source))
                 for inner in block.content:
                     if isinstance(inner, TextBlock):
                         token_count += len(self.tokenizer_fn(inner.text))
@@ -460,9 +456,7 @@ class Memory(BaseMemory):
                     else:
                         token_count += self.document_token_size_estimate
             elif isinstance(block, CitationBlock):
-                token_count += len(
-                    self.tokenizer_fn(block.title + " " + block.source)
-                )
+                token_count += len(self.tokenizer_fn(block.title + " " + block.source))
                 if isinstance(block.cited_content, TextBlock):
                     token_count += len(self.tokenizer_fn(block.cited_content.text))
                 else:


### PR DESCRIPTION
## Summary

`Memory._estimate_token_count()` excluded `ToolCallBlock` from the scanned blocks entirely (it was filtered out alongside `CachePoint`), and had no counting branch for `ThinkingBlock`, `CitableBlock`, or `CitationBlock` — even though these three types were admitted into the `blocks` list.

For tool-using agents with substantial `tool_kwargs`, the FIFO queue accumulates far more real tokens than `Memory` believes, leaving the history well above `token_limit` and eventually surfacing as provider-side "prompt is too long" (HTTP 400) errors.

Fixes #21950

## Changes

- `llama-index-core/llama_index/core/memory/memory.py`:
  - Remove `ToolCallBlock` from the `CachePoint`-only exclusion so it enters the blocks list.
  - Add counting branch for `ToolCallBlock`: tokenize `tool_name + str(tool_kwargs)`.
  - Add counting branch for `ThinkingBlock`: use `num_tokens` when available, else tokenize `content`.
  - Add counting branch for `CitableBlock`: tokenize `title + source`, then recurse into inner `content` blocks.
  - Add counting branch for `CitationBlock`: tokenize `title + source`, then count `cited_content`.