### PR TITLE
fix(core): default MetadataFilters condition to AND when None

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/utils.py
+++ b/llama-index-core/llama_index/core/vector_stores/utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional, Tuple, Callable, Mapping, cast
+from typing import Any, Dict, Optional, Tuple, Callable, Mapping
 
 from llama_index.core.schema import (
     BaseNode,
@@ -107,7 +107,7 @@ def build_metadata_filter_fn(
     if not filter_list or not metadata_filters:
         return lambda _: True
 
-    filter_condition = cast(MetadataFilters, metadata_filters.condition)
+    filter_condition = metadata_filters.condition or FilterCondition.AND
 
     def filter_fn(node_id: str) -> bool:
         def _process_filter_match(

--- a/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
+++ b/llama-index-core/tests/vector_stores/test_metadata_filters_logic.py
@@ -52,6 +52,21 @@ def test_and_condition_matches_expected_nodes() -> None:
     assert fn("n3")
 
 
+def test_none_condition_defaults_to_and() -> None:
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="rank", operator=FilterOperator.NE, value="a"),
+            MetadataFilter(key="weight", operator=FilterOperator.GTE, value=2.0),
+        ],
+        condition=None,
+    )
+    fn = build_metadata_filter_fn(_METADATA_BY_ID.__getitem__, filters)
+
+    assert not fn("n1")
+    assert fn("n2")
+    assert fn("n3")
+
+
 def test_or_condition_matches_expected_nodes() -> None:
     filters = MetadataFilters(
         filters=[


### PR DESCRIPTION
# Description

`build_metadata_filter_fn` — the in-core metadata filter used by `SimpleVectorStore.query` and `delete_nodes` — raised `ValueError: Invalid filter condition: None` when a `MetadataFilters` had `condition=None`, even though the field is typed `Optional[FilterCondition]` (with `FilterCondition.AND` as the default), so `None` is a valid value.

The integration vector stores all normalize a missing condition to AND — e.g. `condition or "and"` / `condition or FilterCondition.AND` in Chroma, Pinecone, Weaviate, Databricks, Firestore, and OceanBase. So `MetadataFilters(filters=[...], condition=None)` filters correctly on those stores but crashes on the in-core `SimpleVectorStore`.

This defaults `None` to `FilterCondition.AND` so the in-core store behaves consistently with the rest of the ecosystem. (The now-unused `cast` import is also dropped.)

Fixes # (no separate issue — this mirrors the convention already used across the integration vector stores)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] No (the `llama-index-core` package is exempt per this template)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_none_condition_defaults_to_and` to `tests/vector_stores/test_metadata_filters_logic.py`, asserting that `condition=None` filters identically to `FilterCondition.AND`. It fails before this change (`ValueError: Invalid filter condition: None`) and passes after. The full `tests/vector_stores/` suite (43 tests) passes locally.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` and `ruff format` (lint + format clean)
