### PR TITLE
Fix MemosReader default endpoint and metadata

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-memos/llama_index/readers/memos/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-memos/llama_index/readers/memos/base.py
@@ -36,7 +36,7 @@ class MemosReader(BaseReader):
         realUrl = self._memoUrl
 
         if not params:
-            realUrl = urljoin(self._memoUrl, "all", False)
+            realUrl = urljoin(f"{self._memoUrl}/", "all")
 
         try:
             req = requests.get(realUrl, params)
@@ -53,7 +53,7 @@ class MemosReader(BaseReader):
             extra_info = {
                 "creator": memo["creator"],
                 "resource_list": memo["resourceList"],
-                id: memo["id"],
+                "id": memo["id"],
             }
             documents.append(Document(text=content, extra_info=extra_info))
 

--- a/llama-index-integrations/readers/llama-index-readers-memos/tests/test_readers_memos.py
+++ b/llama-index-integrations/readers/llama-index-readers-memos/tests/test_readers_memos.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.memos import MemosReader
 
@@ -5,3 +7,40 @@ from llama_index.readers.memos import MemosReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in MemosReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_load_data_uses_memo_all_endpoint_by_default():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"data": []}
+
+        docs = MemosReader("https://example.com/").load_data()
+
+        assert docs == []
+        mock_get.assert_called_once_with("https://example.com/api/memo/all", {})
+
+
+def test_load_data_sets_string_id_metadata_key():
+    payload = {
+        "data": [
+            {
+                "id": 7,
+                "content": "hello",
+                "creator": "me",
+                "resourceList": [],
+            }
+        ]
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.json.return_value = payload
+
+        docs = MemosReader("https://example.com/").load_data(params={"creator": "me"})
+
+        assert len(docs) == 1
+        assert docs[0].text == "hello"
+        assert docs[0].metadata["id"] == 7
+        assert docs[0].metadata["creator"] == "me"
+        assert docs[0].metadata["resource_list"] == []
+        mock_get.assert_called_once_with(
+            "https://example.com/api/memo", {"creator": "me"}
+        )


### PR DESCRIPTION
#Summary
This PR fixes two issues in `MemosReader`:

- Preserve the `/memo` path when constructing the default `/all` endpoint so requests are sent to `/api/memo/all`.
- Use the string `"id"` as the metadata key instead of the built-in `id` function.

### Tests

Added regression tests covering:

- The default request URL.
- The metadata contents, including the `"id"` key.

Verified locally with:
uv run -- pytest tests/test_readers_memos.py -q
