### PR TITLE
Fix MMR zero threshold handling

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -115,7 +115,7 @@ def get_top_k_mmr_embeddings(
     A mmr_threshold of 1 will check similarity the query and ignore previous results.
 
     """
-    threshold = mmr_threshold or 0.5
+    threshold = 0.5 if mmr_threshold is None else mmr_threshold
     similarity_fn = similarity_fn or default_similarity_fn
 
     if embedding_ids is None or embedding_ids == []:

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -71,3 +71,15 @@ def test_get_top_k_mmr_embeddings() -> None:
         result_similarities_no_mmr, result_similarities
     ):
         assert np.isclose(result_no_mmr, result_with_mmr, atol=0.00001)
+
+
+def test_get_top_k_mmr_embeddings_respects_zero_threshold() -> None:
+    """Test Maximum Marginal Relevance with an explicit zero threshold."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.9, 0.0], [0.0, 1.0]]
+
+    _, result_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, mmr_threshold=0
+    )
+
+    assert result_ids == [0, 2, 1]

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -74,7 +74,7 @@ def test_get_top_k_mmr_embeddings() -> None:
 
 
 def test_get_top_k_mmr_embeddings_respects_zero_threshold() -> None:
-    """Test Maximum Marginal Relevance with an explicit zero threshold."""
+    """Test that an explicit zero threshold does not use the MMR default."""
     query_embedding = [1.0, 0.0]
     embeddings = [[1.0, 0.0], [0.9, 0.0], [0.0, 1.0]]
 


### PR DESCRIPTION
## Summary

Fixes an MMR retrieval edge case where `mmr_threshold=0` was treated the same as an omitted threshold.

`get_top_k_mmr_embeddings()` documents that a threshold of `0` should strongly avoid similarity to previous results, but the implementation used `mmr_threshold or 0.5`, causing explicit `0` to fall back to the default `0.5`.

## Changes

- Preserve explicit `mmr_threshold=0`
- Continue using `0.5` only when `mmr_threshold is None`
- Add a focused unit test for the zero-threshold behavior

## Testing

```bash
UV_CACHE_DIR=/private/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/private/tmp/uv-python uv run --python /Users/aditya/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -- pytest tests/indices/query/test_embedding_utils.py
```

Result: `2 passed`