### PR TITLE
fix(readers): use asyncio_run in readability web reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/readability_web/base.py
@@ -1,8 +1,8 @@
-import asyncio
 import unicodedata
 from pathlib import Path
 from typing import Callable, Dict, List, Literal, Optional
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.node_parser.interface import TextSplitter
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
@@ -16,8 +16,7 @@ def nfkc_normalize(text: str) -> str:
 
 
 def async_to_sync(awaitable):
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(awaitable)
+    return asyncio_run(awaitable)
 
 
 class ReadabilityWebPageReader(BaseReader):


### PR DESCRIPTION
Problem: the `readability_web` reader has a local `async_to_sync()` helper that calls `asyncio.get_event_loop().run_until_complete(...)` directly. LlamaIndex already has `llama_index.core.async_utils.asyncio_run()` for sync wrappers, including the case where a loop is already running.

Before / after: before, this reader bypassed the shared async runner and directly grabbed the event loop. After, it delegates to `asyncio_run()`, matching the pattern used by other sync wrappers in `llama_index.core` while preserving the public `load_data()` behavior.

Verification:
- `python -m py_compile llama-index-integrations\readers\llama-index-readers-web\llama_index\readers\web\readability_web\base.py`