### PR TITLE
fix: honor agent structured_output_fn/output_cls inside AgentWorkflow

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -576,15 +576,26 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             output.tool_calls.extend(cur_tool_calls)  # type: ignore
             await ctx.store.set("current_tool_calls", [])
 
-            if self.structured_output_fn is not None:
+            # The workflow-level structured output config takes precedence. When
+            # the workflow defines none, fall back to the running agent's own
+            # structured_output_fn / output_cls so a FunctionAgent configured
+            # with structured output still produces it inside an AgentWorkflow.
+            if self.structured_output_fn is not None or self.output_cls is not None:
+                structured_output_fn = self.structured_output_fn
+                output_cls = self.output_cls
+            else:
+                structured_output_fn = agent.structured_output_fn
+                output_cls = agent.output_cls
+
+            if structured_output_fn is not None:
                 try:
-                    if inspect.iscoroutinefunction(self.structured_output_fn):
-                        output.structured_response = await self.structured_output_fn(
+                    if inspect.iscoroutinefunction(structured_output_fn):
+                        output.structured_response = await structured_output_fn(
                             messages
                         )
                     else:
                         output.structured_response = cast(
-                            Dict[str, Any], self.structured_output_fn(messages)
+                            Dict[str, Any], structured_output_fn(messages)
                         )
                     ctx.write_event_to_stream(
                         AgentStreamStructuredOutput(output=output.structured_response)
@@ -594,7 +605,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                         f"There was a problem with the generation of the structured output: {e}",
                         stacklevel=2,
                     )
-            if self.output_cls is not None:
+            if output_cls is not None:
                 try:
                     llm_input = [*messages]
                     if agent.system_prompt:
@@ -603,7 +614,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                             *llm_input,
                         ]
                     output.structured_response = await generate_structured_response(
-                        messages=llm_input, llm=agent.llm, output_cls=self.output_cls
+                        messages=llm_input, llm=agent.llm, output_cls=output_cls
                     )
                     ctx.write_event_to_stream(
                         AgentStreamStructuredOutput(output=output.structured_response)

--- a/llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py
+++ b/llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py
@@ -286,6 +286,89 @@ async def test_astructured_output_fn_agentworkflow(
 
 
 @pytest.mark.asyncio
+async def test_agent_output_cls_in_agentworkflow(
+    function_agent_output_cls: FunctionAgent,
+) -> None:
+    """The agent's own output_cls should be honored when the workflow sets none."""
+    wf = AgentWorkflow(
+        agents=[function_agent_output_cls],
+        root_agent=function_agent_output_cls.name,
+    )
+    handler = wf.run(user_msg="test")
+    streaming_event = False
+    async for event in handler.stream_events():
+        if isinstance(event, AgentStreamStructuredOutput):
+            streaming_event = True
+    assert streaming_event
+
+    response = await handler
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(hello="hello", world=1)
+
+
+@pytest.mark.asyncio
+async def test_agent_structured_fn_in_agentworkflow(
+    function_agent_struct_fn: FunctionAgent,
+) -> None:
+    """The agent's own structured_output_fn should be honored when the workflow sets none."""
+    wf = AgentWorkflow(
+        agents=[function_agent_struct_fn],
+        root_agent=function_agent_struct_fn.name,
+    )
+    handler = wf.run(user_msg="test")
+    streaming_event = False
+    async for event in handler.stream_events():
+        if isinstance(event, AgentStreamStructuredOutput):
+            streaming_event = True
+    assert streaming_event
+
+    response = await handler
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(hello="bonjour", world=2)
+
+
+@pytest.mark.asyncio
+async def test_agent_astructured_fn_in_agentworkflow(
+    function_agent_astruct_fn: FunctionAgent,
+) -> None:
+    """An async structured_output_fn on the agent should also be honored via the workflow."""
+    wf = AgentWorkflow(
+        agents=[function_agent_astruct_fn],
+        root_agent=function_agent_astruct_fn.name,
+    )
+    handler = wf.run(user_msg="test")
+    async for _ in handler.stream_events():
+        pass
+
+    response = await handler
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(
+        hello="guten tag", world=3
+    )
+
+
+@pytest.mark.asyncio
+async def test_workflow_structured_output_overrides_agent(
+    function_agent_struct_fn: FunctionAgent,
+) -> None:
+    """A workflow-level structured_output_fn takes precedence over the agent's own."""
+    wf = AgentWorkflow(
+        agents=[function_agent_struct_fn],
+        root_agent=function_agent_struct_fn.name,
+        structured_output_fn=astructured_function_fn,
+    )
+    handler = wf.run(user_msg="test")
+    async for _ in handler.stream_events():
+        pass
+
+    response = await handler
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(
+        hello="guten tag", world=3
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(condition=skip_condition, reason="OPENAI_API_KEY is not available.")
 async def test_multi_agent_openai() -> None:
     from llama_index.llms.openai import OpenAI


### PR DESCRIPTION
# Description

Fixes #22159

A `FunctionAgent` configured with its own `structured_output_fn` (or `output_cls`) produced structured output when run directly via `agent.run()`, but the same agent silently ignored that config when executed through an `AgentWorkflow`.

The cause is in `AgentWorkflow.parse_agent_output`: on agent completion it only consulted the workflow-level `self.structured_output_fn` / `self.output_cls`, never the running agent's. The single-agent path (`BaseWorkflowAgent.parse_agent_output`) reads the agent's own config, hence the inconsistency.

The fix falls back to the running agent's `structured_output_fn` / `output_cls` when the workflow defines none. Workflow-level config still takes precedence, so existing behavior is unchanged when it's set.

Scope note: this targets the normal completion path (the one in the reported repro). The `return_direct` short-circuit in `aggregate_tool_results` doesn't generate structured output, but that's already symmetric with the standalone agent path (`BaseWorkflowAgent` doesn't either), so it's left as-is to avoid introducing a new inconsistency.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added to `tests/agent/workflow/test_agent_with_structured_output.py`:
- agent-level `output_cls` honored via `AgentWorkflow`
- agent-level sync `structured_output_fn` honored via `AgentWorkflow`
- agent-level async `structured_output_fn` honored via `AgentWorkflow`
- workflow-level `structured_output_fn` still overrides the agent's

All structured-output tests pass locally (`uv run pytest tests/agent/workflow/test_agent_with_structured_output.py -k "not openai"`).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective

<!-- oss-radar:idempotency=auto-20260627-150945.w8.run-llama_llama_index.22159 -->
