### PR TITLE
Skip variadic parameters in tool schemas

### DIFF
--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -1,4 +1,4 @@
-from inspect import signature
+from inspect import Parameter, signature
 from typing import (
     Any,
     Awaitable,
@@ -37,12 +37,14 @@ def create_schema_from_function(
     ignore_fields = ignore_fields or []
     params = signature(func).parameters
 
-    for param_name in params:
+    for param_name, param in params.items():
         if param_name in ignore_fields:
             continue
+        if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+            continue
 
-        param_type = params[param_name].annotation
-        param_default = params[param_name].default
+        param_type = param.annotation
+        param_default = param.default
         description = None
         json_schema_extra: dict[str, Any] = {}
 
@@ -67,10 +69,10 @@ def create_schema_from_function(
         elif param_type == datetime.time:
             json_schema_extra.setdefault("format", "time")
 
-        if param_type is params[param_name].empty:
+        if param_type is param.empty:
             param_type = Any
 
-        if param_default is params[param_name].empty:
+        if param_default is param.empty:
             # Required field
             fields[param_name] = (
                 param_type,

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -32,6 +32,18 @@ def test_create_schema_from_function() -> None:
     assert "required" not in schema
 
 
+def test_create_schema_from_function_skips_variadic_params() -> None:
+    """Variadic params are implementation details, not LLM-fillable fields."""
+
+    def test_fn(query: str, *args: str, **kwargs: str) -> None:
+        """Test function."""
+
+    SchemaCls = create_schema_from_function("test_schema", test_fn)
+    schema = SchemaCls.model_json_schema()
+    assert set(schema["properties"]) == {"query"}
+    assert schema["required"] == ["query"]
+
+
 def test_create_schema_from_function_with_field() -> None:
     """Test create_schema_from_function with pydantic.Field."""
 


### PR DESCRIPTION
## Summary
- skip `*args` and `**kwargs` when deriving tool schemas from function signatures
- keep regular required/optional parameters unchanged
- add a regression test so variadic implementation details are not exposed as LLM-fillable fields

Fixes #22134.

## Tests
- `uv run --group dev pytest tests/tools/test_utils.py -q`
- `uv run --group dev pytest tests/tools/test_base.py::test_function_tool tests/tools/test_base.py::test_tool_fn_schema tests/tools/test_base.py::test_fn_schema_docstring_descriptions -q`
- `uv run --group dev ruff check llama_index/core/tools/utils.py tests/tools/test_utils.py`
