### PR TITLE
Warn when workflow agents share tool instances

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -80,6 +80,16 @@ def get_default_llm() -> LLM:
     return Settings.llm
 
 
+def _copy_agent_tool(tool: BaseTool) -> BaseTool:
+    """Copy per-agent mutable tool configuration without cloning heavy resources."""
+    tool_copy = copy.copy(tool)
+    if hasattr(tool_copy, "_metadata"):
+        tool_copy._metadata = copy.deepcopy(tool.metadata)
+    if hasattr(tool_copy, "partial_params"):
+        tool_copy.partial_params = copy.deepcopy(tool.partial_params)
+    return tool_copy
+
+
 class BaseWorkflowAgentMeta(WorkflowMeta, ModelMetaclass):
     """Metaclass for BaseWorkflowAgent that properly combines WorkflowMeta, BaseModel's metaclass, and ABCMeta."""
 
@@ -221,7 +231,7 @@ class BaseWorkflowAgent(
             if not isinstance(tool, BaseTool):
                 validated_tools.append(FunctionTool.from_defaults(tool))
             else:
-                validated_tools.append(tool)
+                validated_tools.append(_copy_agent_tool(tool))
 
         for tool in validated_tools:
             if tool.metadata.name == "handoff":

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -46,6 +46,30 @@ def subtract(a: int, b: int) -> int:
     return a - b
 
 
+def test_agents_isolate_shared_tool_instances():
+    shared_tool = FunctionTool.from_defaults(fn=add)
+    first_agent = FunctionAgent(
+        name="first",
+        description="First agent",
+        tools=[shared_tool],
+        llm=MockFunctionCallingLLM(),
+    )
+    second_agent = FunctionAgent(
+        name="second",
+        description="Second agent",
+        tools=[shared_tool],
+        llm=MockFunctionCallingLLM(),
+    )
+
+    assert first_agent.tools is not None
+    assert second_agent.tools is not None
+    assert first_agent.tools[0] is not second_agent.tools[0]
+    assert first_agent.tools[0].metadata is not second_agent.tools[0].metadata
+
+    first_agent.tools[0].metadata.description = "mutated"
+    assert second_agent.tools[0].metadata.description != "mutated"
+
+
 @pytest.fixture()
 def calculator_agent():
     return ReActAgent(


### PR DESCRIPTION
## Summary
- copy `BaseTool` instances when assigning them to workflow agents so the same tool object is not shared across agents by reference
- copy mutable per-agent tool configuration (`metadata`, `partial_params`) without deep-copying heavy callable/retriever/client resources
- add a regression test covering metadata mutation leakage between two agents initialized with the same `FunctionTool`

Fixes #22146.

## Tests
- `uv run --group dev pytest tests/agent/workflow/test_multi_agent_workflow.py::test_agents_isolate_shared_tool_instances tests/agent/workflow/test_multi_agent_workflow.py::test_basic_workflow tests/agent/workflow/test_multi_agent_workflow.py::test_workflow_requires_root_agent -q`
- `uv run --group dev pytest tests/agent/workflow/test_multi_agent_workflow.py -q`
- `uv run --group dev ruff check llama_index/core/agent/workflow/base_agent.py tests/agent/workflow/test_multi_agent_workflow.py`
