### PR TITLE
fix(core): use word tokenization for stopword removal in SemanticDoubleMergingSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -359,7 +359,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         # Remove punctuations
         text = text.translate(str.maketrans("", "", string.punctuation))
         # Remove stopwords
-        tokens = globals_helper.punkt_tokenizer.tokenize(text)
+        tokens = re.findall(r"\w+", text)
         filtered_words = [w for w in tokens if w not in self.language_config.stopwords]
 
         return " ".join(filtered_words)

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -144,3 +144,15 @@ def test_embed_model_single_sentence_document() -> None:
     nodes = splitter.get_nodes_from_documents([single_doc])
     assert len(nodes) == 1
     assert nodes[0].get_content() == "Only one sentence here."
+
+
+def test_clean_text_advanced() -> None:
+    """Test that _clean_text_advanced properly filters out stopwords from a string."""
+    from llama_index.core.utils import globals_helper
+
+    splitter = SemanticDoubleMergingSplitterNodeParser()
+    splitter.language_config.stopwords = set(globals_helper.stopwords)
+    cleaned = splitter._clean_text_advanced(
+        "this is a test text containing some stopwords like the and a"
+    )
+    assert cleaned == "test text containing stopwords like"


### PR DESCRIPTION
# Description

Fix stopword removal in `SemanticDoubleMergingSplitterNodeParser`.

The internal `_clean_text_advanced` method was using the sentence-level `punkt_tokenizer.tokenize` on punctuation-free text. This caused the entire string to be treated as a single token, rendering the stopword filter ineffective. This PR changes the tokenizer to use `re.findall(r"\w+", text)` to correctly extract word-level tokens, matching existing word-tokenization conventions in the repository.

Fixes #22166

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

* [ ] Yes
* [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

* [ ] Yes
* [x] No (Changes are in `llama-index-core`)

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* [x] I added new unit tests to cover this change
* [ ] I believe this change is already covered by existing unit tests

Validated locally by running:

```bash
uv run pytest llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
```

Result: `4 passed, 6 skipped`.

## Suggested Checklist

* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added Google Colab support for the newly added notebooks
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective
* [x] New and existing unit tests pass locally with my changes
* [x] I ran `uv run ruff check` and `uv run black --check`
