### PR TITLE
Fix SemanticDoubleMergingSplitter stopword cleanup

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -359,7 +359,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         # Remove punctuations
         text = text.translate(str.maketrans("", "", string.punctuation))
         # Remove stopwords
-        tokens = globals_helper.punkt_tokenizer.tokenize(text)
+        tokens = text.split()
         filtered_words = [w for w in tokens if w not in self.language_config.stopwords]
 
         return " ".join(filtered_words)

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -124,6 +124,15 @@ def test_embed_model_path_returns_nodes() -> None:
     assert all(len(n.get_content()) > 0 for n in nodes)
 
 
+def test_clean_text_advanced_removes_stopwords() -> None:
+    splitter = SemanticDoubleMergingSplitterNodeParser()
+    splitter.language_config.stopwords = {"a", "and", "is", "some", "the", "this"}
+
+    text = "this is a test text containing some stopwords like the and a"
+
+    assert splitter._clean_text_advanced(text) == "test text containing stopwords like"
+
+
 def test_embed_model_similarity_in_range() -> None:
     """_similarity with embed_model returns a value in [0, 1] (cosine-like)."""
     embed = MockEmbedding(embed_dim=4)


### PR DESCRIPTION
## Summary
- replace sentence-level Punkt tokenization with word-level splitting after `_clean_text_advanced` lowercases and removes punctuation
- add a regression test showing stopwords are removed from `SemanticDoubleMergingSplitterNodeParser` cleaned text

## Root cause
`_clean_text_advanced` stripped punctuation before calling the Punkt sentence tokenizer. With no sentence-boundary punctuation left, Punkt returned the whole text as one token, so individual stopwords were never compared or removed.

Fixes #22166.

## Validation
- `uv run --project llama-index-core python - <<'PY' ...` reproduced the issue before the fix: output still contained stopwords and the assertion failed
- `uv run --project llama-index-core python - <<'PY' ...` after the fix: output `test text containing stopwords like`
- `uv run --project llama-index-core pytest llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py -q` -> `4 passed, 6 skipped`
- `uv run --project llama-index-core ruff check llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py`
- `uv run --project llama-index-core ruff format --check llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py`

AI assistance was used to identify and draft this small fix; I reviewed the code path and verified it locally.