### PR TITLE
Fix tool schema generation for variadic parameters

### DIFF
--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -1,4 +1,4 @@
-from inspect import signature
+from inspect import Parameter, signature
 from typing import (
     Any,
     Awaitable,
@@ -39,6 +39,11 @@ def create_schema_from_function(
 
     for param_name in params:
         if param_name in ignore_fields:
+            continue
+        if params[param_name].kind in (
+            Parameter.VAR_POSITIONAL,
+            Parameter.VAR_KEYWORD,
+        ):
             continue
 
         param_type = params[param_name].annotation

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -32,6 +32,19 @@ def test_create_schema_from_function() -> None:
     assert "required" not in schema
 
 
+def test_create_schema_from_function_ignores_variadic_parameters() -> None:
+    """Test that *args and **kwargs are not exposed as tool parameters."""
+
+    def test_fn(query: str, *args: str, **kwargs: str) -> None:
+        """Test variadic inputs."""
+
+    SchemaCls = create_schema_from_function("test_schema", test_fn)
+    schema = SchemaCls.model_json_schema()
+
+    assert schema["properties"] == {"query": {"title": "Query", "type": "string"}}
+    assert schema["required"] == ["query"]
+
+
 def test_create_schema_from_function_with_field() -> None:
     """Test create_schema_from_function with pydantic.Field."""
 


### PR DESCRIPTION
## Summary

Fixes #22134.

`create_schema_from_function` previously treated variadic `*args` and `**kwargs` as normal tool parameters. For functions such as:

```python
def search(query: str, **kwargs: str) -> None: ...
```

this exposed a phantom `kwargs` property in the generated JSON schema and marked it as required, which can make strict tool/function-calling providers reject the schema.

## Changes

- Skip `inspect.Parameter.VAR_POSITIONAL` and `inspect.Parameter.VAR_KEYWORD` when building tool schemas.
- Add a regression test covering `*args` and `**kwargs`, asserting only regular parameters are exposed.

## Validation

- Before the fix, `tests/tools/test_utils.py::test_create_schema_from_function_ignores_variadic_parameters` failed because `args` and `kwargs` were present in schema properties.
- `uv run --directory llama-index-core pytest tests/tools/test_utils.py -q`
- `uv run --directory llama-index-core pytest tests/tools/test_utils.py tests/tools/test_base.py -q`
- `uv run ruff format --check llama-index-core/llama_index/core/tools/utils.py llama-index-core/tests/tools/test_utils.py`
- `uv run ruff check llama-index-core/llama_index/core/tools/utils.py llama-index-core/tests/tools/test_utils.py`
