### PR TITLE
fix: apply retriever weights in reciprocal rank fusion

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -124,7 +124,8 @@ class QueryFusionRetriever(BaseRetriever):
         hash_to_node = {}
 
         # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        for (_, retriever_idx), nodes_with_scores in results.items():
+            retriever_weight = self._retriever_weights[retriever_idx]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +133,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += retriever_weight * 1.0 / (rank + k)
 
         # sort results
         reranked_results = dict(

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -4,12 +4,17 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.retrievers.fusion_retriever import FUSION_MODES
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
 
 class MockRetriever(BaseRetriever):
+    def __init__(self, nodes=None):
+        self._nodes = nodes
+        super().__init__()
+
     def _retrieve(self, query_bundle: QueryBundle):
-        return [NodeWithScore(node=TextNode(text="result"), score=1.0)]
+        return self._nodes or [NodeWithScore(node=TextNode(text="result"), score=1.0)]
 
 
 @pytest.mark.asyncio
@@ -33,3 +38,31 @@ async def test_aretrieve_uses_async_query_generation():
     await retriever.aretrieve("test query")
 
     assert async_called
+
+
+def test_reciprocal_rerank_uses_retriever_weights():
+    retriever_0 = MockRetriever(
+        [
+            NodeWithScore(node=TextNode(text="node_A"), score=0.9),
+            NodeWithScore(node=TextNode(text="node_B"), score=0.8),
+        ]
+    )
+    retriever_1 = MockRetriever(
+        [
+            NodeWithScore(node=TextNode(text="node_C"), score=0.9),
+            NodeWithScore(node=TextNode(text="node_D"), score=0.8),
+        ]
+    )
+
+    retriever = QueryFusionRetriever(
+        retrievers=[retriever_0, retriever_1],
+        llm=MockLLM(),
+        mode=FUSION_MODES.RECIPROCAL_RANK,
+        retriever_weights=[1.0, 0.0],
+        num_queries=1,
+        use_async=False,
+    )
+
+    results = retriever.retrieve("test query")
+
+    assert [node.node.get_content() for node in results] == ["node_A", "node_B"]


### PR DESCRIPTION
## Summary

- Fixes #21444.
- Applies `retriever_weights` when `QueryFusionRetriever` uses reciprocal rank fusion.
- Adds a regression test covering `retriever_weights=[1.0, 0.0]` with `mode=FUSION_MODES.RECIPROCAL_RANK`.

## Root cause

`_reciprocal_rerank_fusion()` iterated over `results.values()`, which discarded the `(query, retriever_idx)` key. Without `retriever_idx`, the reciprocal rank score always used an implicit equal weight.

## Fix

The method now iterates over `results.items()`, reads the retriever index from the key, and scales each reciprocal-rank contribution by `self._retriever_weights[retriever_idx]`.

## Validation

- `uv run --frozen --project llama-index-core pytest llama-index-core/tests/retrievers/test_fusion_retriever.py -q`
- `uv run --frozen --project llama-index-core ruff format --check llama-index-core/llama_index/core/retrievers/fusion_retriever.py llama-index-core/tests/retrievers/test_fusion_retriever.py`
- `uv run --frozen --project llama-index-core ruff check llama-index-core/llama_index/core/retrievers/fusion_retriever.py llama-index-core/tests/retrievers/test_fusion_retriever.py`

## AI assistance

I used AI assistance to help trace the narrow code path and draft this small patch, then manually reviewed the diff and validated it with the commands above.
