### PR TITLE
fix: use agent structured output in workflows

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -576,15 +576,21 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             output.tool_calls.extend(cur_tool_calls)  # type: ignore
             await ctx.store.set("current_tool_calls", [])
 
-            if self.structured_output_fn is not None:
+            structured_output_fn = self.structured_output_fn
+            output_cls = self.output_cls
+            if structured_output_fn is None and output_cls is None:
+                structured_output_fn = agent.structured_output_fn
+                output_cls = agent.output_cls
+
+            if structured_output_fn is not None:
                 try:
-                    if inspect.iscoroutinefunction(self.structured_output_fn):
-                        output.structured_response = await self.structured_output_fn(
+                    if inspect.iscoroutinefunction(structured_output_fn):
+                        output.structured_response = await structured_output_fn(
                             messages
                         )
                     else:
                         output.structured_response = cast(
-                            Dict[str, Any], self.structured_output_fn(messages)
+                            Dict[str, Any], structured_output_fn(messages)
                         )
                     ctx.write_event_to_stream(
                         AgentStreamStructuredOutput(output=output.structured_response)
@@ -594,7 +600,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                         f"There was a problem with the generation of the structured output: {e}",
                         stacklevel=2,
                     )
-            if self.output_cls is not None:
+            if output_cls is not None:
                 try:
                     llm_input = [*messages]
                     if agent.system_prompt:
@@ -603,7 +609,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
                             *llm_input,
                         ]
                     output.structured_response = await generate_structured_response(
-                        messages=llm_input, llm=agent.llm, output_cls=self.output_cls
+                        messages=llm_input, llm=agent.llm, output_cls=output_cls
                     )
                     ctx.write_event_to_stream(
                         AgentStreamStructuredOutput(output=output.structured_response)

--- a/llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py
+++ b/llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py
@@ -248,6 +248,26 @@ async def test_structured_output_agentworkflow(
 
 
 @pytest.mark.asyncio
+async def test_agentworkflow_uses_agent_output_cls(
+    function_agent_output_cls: FunctionAgent,
+) -> None:
+    wf = AgentWorkflow(
+        agents=[function_agent_output_cls],
+        root_agent=function_agent_output_cls.name,
+    )
+    handler = wf.run(user_msg="test")
+    streaming_event = False
+    async for event in handler.stream_events():
+        if isinstance(event, AgentStreamStructuredOutput):
+            streaming_event = True
+
+    response = await handler
+    assert streaming_event
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(hello="hello", world=1)
+
+
+@pytest.mark.asyncio
 async def test_structured_output_fn_agentworkflow(
     function_agent_output_cls: FunctionAgent,
 ) -> None:
@@ -261,6 +281,26 @@ async def test_structured_output_fn_agentworkflow(
         pass
 
     response = await handler
+    assert "Success with the FunctionAgent" in str(response.response)
+    assert response.get_pydantic_model(Structure) == Structure(hello="bonjour", world=2)
+
+
+@pytest.mark.asyncio
+async def test_agentworkflow_uses_agent_structured_output_fn(
+    function_agent_struct_fn: FunctionAgent,
+) -> None:
+    wf = AgentWorkflow(
+        agents=[function_agent_struct_fn],
+        root_agent=function_agent_struct_fn.name,
+    )
+    handler = wf.run(user_msg="test")
+    streaming_event = False
+    async for event in handler.stream_events():
+        if isinstance(event, AgentStreamStructuredOutput):
+            streaming_event = True
+
+    response = await handler
+    assert streaming_event
     assert "Success with the FunctionAgent" in str(response.response)
     assert response.get_pydantic_model(Structure) == Structure(hello="bonjour", world=2)
 


### PR DESCRIPTION
## Summary
- Fixes #22159.
- Makes `AgentWorkflow` fall back to the active agent's `structured_output_fn` / `output_cls` when the workflow itself does not define structured output handling.
- Preserves workflow-level `structured_output_fn` / `output_cls` precedence when those are configured.

## Root cause
`AgentWorkflow` finalization called `agent.finalize(...)` but then only consulted `self.structured_output_fn` and `self.output_cls`. As a result, structured output configured on a `FunctionAgent` worked with `agent.run(...)` but was ignored when the same agent ran inside an `AgentWorkflow`.

## Test plan
- Reproduced before the fix: `test_agentworkflow_uses_agent_structured_output_fn` failed because no `AgentStreamStructuredOutput` event was emitted.
- `uv run --frozen --project llama-index-core pytest llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py::test_agentworkflow_uses_agent_structured_output_fn -q`
- `uv run --frozen --project llama-index-core pytest llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py -q`
- `uv run --frozen --project llama-index-core pytest llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py -q`
- `uv run --frozen --project llama-index-core ruff format --check llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py`
- `uv run --frozen --project llama-index-core ruff check llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py llama-index-core/tests/agent/workflow/test_agent_with_structured_output.py`