### PR TITLE
fix(core): reject invalid node identity kwargs

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -49,6 +49,7 @@ from llama_index.core.bridge.pydantic import (
     field_serializer,
     field_validator,
     model_serializer,
+    model_validator,
 )
 from llama_index.core.bridge.pydantic_core import CoreSchema
 from llama_index.core.instrumentation import DispatcherSpanMixin
@@ -271,6 +272,22 @@ class BaseNode(BaseComponent):
 
     # hash is computed on local field, during the validation process
     model_config = ConfigDict(populate_by_name=True, validate_assignment=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_identity_kwargs(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            invalid_keys = tuple(
+                key for key in ("document_id", "doc_id", "ref_doc_id") if key in data
+            )
+            if invalid_keys:
+                joined_keys = ", ".join(invalid_keys)
+                raise ValueError(
+                    f"{cls.__name__} does not accept {joined_keys}; set "
+                    "relationships[NodeRelationship.SOURCE] = "
+                    "RelatedNodeInfo(node_id=...) instead."
+                )
+        return data
 
     id_: str = Field(
         default_factory=lambda: str(uuid.uuid4()), description="Unique ID of the node."

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -12,10 +12,15 @@ from llama_index.core.schema import (
     ImageNode,
     MediaResource,
     MetadataMode,
+    Node,
+    NodeRelationship,
+    RelatedNodeInfo,
     NodeWithScore,
     ObjectType,
     TextNode,
 )
+from llama_index.core.vector_stores.utils import node_to_metadata_dict
+from llama_index.core.bridge.pydantic import ValidationError
 
 
 @pytest.fixture()
@@ -86,6 +91,42 @@ def test_text_node_with_text_resource():
     assert text_node.text == "This is a test"
 
 
+@pytest.mark.parametrize("bad_kwarg", ["document_id", "doc_id", "ref_doc_id"])
+def test_text_node_rejects_identity_kwargs(bad_kwarg: str) -> None:
+    with pytest.raises(
+        ValidationError,
+        match=rf"TextNode does not accept {bad_kwarg}; set relationships\[NodeRelationship\.SOURCE\]",
+    ):
+        TextNode(text="This is a test", **{bad_kwarg: "source-node"})
+
+
+@pytest.mark.parametrize("bad_kwarg", ["document_id", "doc_id", "ref_doc_id"])
+def test_node_rejects_identity_kwargs(bad_kwarg: str) -> None:
+    with pytest.raises(
+        ValidationError,
+        match=rf"Node does not accept {bad_kwarg}; set relationships\[NodeRelationship\.SOURCE\]",
+    ):
+        Node(
+            text_resource=MediaResource(text="This is a test"),
+            **{bad_kwarg: "source-node"},
+        )
+
+
+def test_text_node_source_relationship_propagates_identity() -> None:
+    source_node_id = "source-node"
+    node = TextNode(text="This is a test")
+    node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+        node_id=source_node_id
+    )
+
+    assert node.ref_doc_id == source_node_id
+
+    metadata = node_to_metadata_dict(node)
+    assert metadata["document_id"] == source_node_id
+    assert metadata["doc_id"] == source_node_id
+    assert metadata["ref_doc_id"] == source_node_id
+
+
 def test_text_node_metadata_separator_consistency() -> None:
     """
     Test that metadata_separator works consistently on TextNode.
@@ -132,6 +173,13 @@ def test_text_node_metadata_separator_consistency() -> None:
     )
     doc_content = doc.get_content(MetadataMode.LLM)
     assert content_correct == doc_content
+
+
+def test_document_doc_id_alias_is_preserved() -> None:
+    doc = Document(doc_id="test")
+
+    assert doc.id_ == "test"
+    assert doc.doc_id == "test"
 
 
 def test_text_node_metadata_separator_roundtrip() -> None:

--- a/llama-index-core/tests/vector_stores/test_utils.py
+++ b/llama-index-core/tests/vector_stores/test_utils.py
@@ -23,10 +23,8 @@ def source_node():
 
 
 @pytest.fixture
-def text_node(source_node: Document):
-    return TextNode(
-        id_="text_node", text="Hello, world!", ref_doc_id=source_node.ref_doc_id
-    )
+def text_node():
+    return TextNode(id_="text_node", text="Hello, world!")
 
 
 @pytest.fixture

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/unstructured/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/unstructured/base.py
@@ -216,7 +216,6 @@ class UnstructuredReader(BaseReader):
                 node = TextNode(
                     text=element.text,
                     metadata=_merge_metadata(element, sequence_number),
-                    doc_id=hash_id,
                     id_=hash_id,
                     **doc_kwargs,
                 )

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_readers_file.py
@@ -1,4 +1,5 @@
 from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import NodeRelationship, TextNode
 from llama_index.readers.file import (
     DocxReader,
     EpubReader,
@@ -13,6 +14,7 @@ from llama_index.readers.file import (
     PandasCSVReader,
     PDFReader,
     PptxReader,
+    UnstructuredReader,
     VideoAudioReader,
     XMLReader,
     ImageTabularChartReader,
@@ -67,3 +69,53 @@ def test_classes():
 
     names_of_base_classes = [b.__name__ for b in ImageTabularChartReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+    names_of_base_classes = [b.__name__ for b in UnstructuredReader.__mro__]
+    assert BaseReader.__name__ in names_of_base_classes
+
+
+class _FakeMetadata:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeElement:
+    def __init__(self, text, metadata, hash_id):
+        self.text = text
+        self.metadata = _FakeMetadata(metadata)
+        self._hash_id = hash_id
+
+    def __str__(self):
+        return self.text
+
+    def id_to_hash(self, sequence_number):
+        return f"{self._hash_id}-{sequence_number}"
+
+
+def test_unstructured_reader_split_documents_preserves_source_relationship():
+    reader = object.__new__(UnstructuredReader)
+    reader.allowed_metadata_types = (str, int, float, type(None))
+    reader.excluded_metadata_keys = {"orig_elements"}
+
+    docs = reader._create_documents(
+        elements=[
+            _FakeElement(
+                text="chunk one",
+                metadata={"filename": "sample.txt", "file_path": "sample.txt"},
+                hash_id="chunk",
+            )
+        ],
+        document_kwargs=None,
+        extra_info=None,
+        split_documents=True,
+        excluded_metadata_keys=None,
+    )
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], TextNode)
+    assert docs[0].id_ == "chunk-0"
+    assert docs[0].relationships[NodeRelationship.SOURCE].node_id == "sample.txt"
+    assert docs[0].ref_doc_id == "sample.txt"


### PR DESCRIPTION
# Description

Passing `document_id`, `doc_id`, or `ref_doc_id` into node constructors currently looks valid, but those names are not node fields. Pydantic drops them, the node never gains a SOURCE relationship, and `node_to_metadata_dict()` emits `"None"` for the top-level identity metadata fields.

This change rejects those invalid node constructor kwargs with a clear validation error, keeps SOURCE relationships as the canonical identity path, preserves the existing `Document(doc_id=...)` compatibility adapter, and updates `UnstructuredReader`'s split-document path to keep hashed `id_` values while attaching SOURCE relationships instead of passing `doc_id` into `TextNode`.

Fixes #19292

Related: #21749 covered the same validation direction and helped shape this narrower shared-authority fix, but it closed unmerged.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Verification:
- [x] `cd llama-index-core && rtk uv run -- pytest tests/schema/test_schema.py -q`
- [x] `cd llama-index-core && rtk uv run -- pytest tests/vector_stores/test_utils.py -q`
- [x] `cd llama-index-integrations/readers/llama-index-readers-file && rtk uv run -- pytest tests/test_readers_file.py -q`
- [ ] `cd llama-index-core && rtk uv run -- pytest` (`2 failed, 1442 passed, 22 skipped, 5 xfailed`; both failures reproduce on `origin/main`: `tests/callbacks/test_llama_debug.py::test_get_event_stats`, `tests/schema/test_media_resource.py::test_hash`)
- [x] `cd llama-index-integrations/readers/llama-index-readers-file && rtk uv run -- pytest`
- [x] `rtk uv run make format`
- [ ] `rtk uv run make lint` (`make lint` rewrites unrelated files on `origin/main` (`docs/examples/agent/Chatbot_SEC.ipynb`, `docs/api_reference/pyproject.toml`))
- [x] `cd llama-index-core && rtk uv run -- mypy llama_index`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

