### PR TITLE
populate response text on streaming chat response when writing to memory

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/types.py
+++ b/llama-index-core/llama_index/core/chat_engine/types.py
@@ -192,6 +192,7 @@ class StreamingAgentChatResponse:
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
                 chat.message.content = final_text.strip()  # final message
+                self.response = final_text.strip()
                 memory.put(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))
@@ -250,6 +251,7 @@ class StreamingAgentChatResponse:
                 # NOTE: this is to handle the special case where we consume some of the
                 # chat stream, but not all of it (e.g. in react agent)
                 chat.message.content = final_text.strip()  # final message
+                self.response = final_text.strip()
                 await memory.aput(chat.message)
         except Exception as e:
             dispatcher.event(StreamChatErrorEvent(exception=e))

--- a/llama-index-core/tests/chat_engine/test_simple.py
+++ b/llama-index-core/tests/chat_engine/test_simple.py
@@ -73,6 +73,17 @@ async def test_simple_chat_engine_astream():
     assert "What is the capital of the moon?" in response.unformatted_response
 
 
+@pytest.mark.asyncio
+async def test_simple_chat_engine_astream_response_text_without_draining():
+    engine = SimpleChatEngine.from_defaults()
+    response = await engine.astream_chat("Hello World!")
+    await response.awrite_response_to_history_task
+
+    assert response.response != ""
+    assert str(response) == response.response
+    assert "Hello World!" in str(response)
+
+
 def test_simple_chat_engine_astream_exception_handling():
     """
     Test that an exception thrown while retrieving the streamed LLM response gets bubbled up to the user.


### PR DESCRIPTION
# Description

`write_response_to_history` and `awrite_response_to_history` now assign the final streamed text to `self.response`, so `str(resp)` and `resp.response` return the text without requiring the generator to be drained (sync and async).

Fixes #22178

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [X] No

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [X] I added new unit tests to cover this change
- [X] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I ran `uv run make format; uv run make lint` to appease the lint gods
