### PR TITLE
Handle empty list outputs in FunctionTool as text

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -303,7 +303,7 @@ class FunctionTool(AsyncBaseTool):
             ),
         ):
             return [raw_output]
-        elif isinstance(raw_output, list) and all(
+        elif isinstance(raw_output, list) and raw_output and all(
             isinstance(
                 item,
                 (
@@ -321,7 +321,7 @@ class FunctionTool(AsyncBaseTool):
             return raw_output
         elif isinstance(raw_output, (BaseNode, Document)):
             return [TextBlock(text=raw_output.get_content())]
-        elif isinstance(raw_output, list) and all(
+        elif isinstance(raw_output, list) and raw_output and all(
             isinstance(item, (BaseNode, Document)) for item in raw_output
         ):
             return [TextBlock(text=item.get_content()) for item in raw_output]

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -538,3 +538,15 @@ def test_function_tool_output_document_and_text_blocks() -> None:
     assert isinstance(tool_output.blocks[0], DocumentBlock)
     assert isinstance(tool_output.blocks[1], TextBlock)
     assert tool_output.content == "Summary of the document"
+
+
+def test_function_tool_output_empty_list_as_text() -> None:
+    def get_empty_list() -> list:
+        return []
+
+    tool = FunctionTool.from_defaults(get_empty_list)
+    tool_output = tool.call()
+
+    assert len(tool_output.blocks) == 1
+    assert isinstance(tool_output.blocks[0], TextBlock)
+    assert tool_output.content == "[]"


### PR DESCRIPTION
﻿## Summary
- Treat empty list returns from `FunctionTool` as ordinary tool output text (`"[]"`).
- Keep non-empty `ContentBlock`, `Document`, and `BaseNode` lists on their existing structured-output paths.
- Add a regression test for empty list tool output.

## Motivation
`FunctionTool._parse_tool_output()` used `all(...)` to detect homogeneous lists. Since `all([])` is true, an empty list return was interpreted as a structured block list and produced `ToolOutput(blocks=[])`, leaving the tool content empty. Empty lists are ordinary Python return values and should be represented consistently through the fallback text path.

## Tests
- `.venv\Scripts\python.exe -m pytest llama-index-core\tests\tools\test_base.py::test_function_tool_output_empty_list_as_text -q`
- `.venv\Scripts\python.exe -m pytest llama-index-core\tests\tools\test_base.py -q`
- `.venv\Scripts\python.exe -m pytest llama-index-core\tests\tools -q`
- `.venv\Scripts\python.exe -m ruff check llama-index-core\llama_index\core\tools\function_tool.py llama-index-core\tests\tools\test_base.py`
- `git diff --check`
