### PR TITLE
🔒 Security: block getattr/hasattr dunder string bypass in _validate_generated_code

### DIFF
--- a/llama-index-integrations/program/llama-index-program-evaporate/llama_index/program/evaporate/extractor.py
+++ b/llama-index-integrations/program/llama-index-program-evaporate/llama_index/program/evaporate/extractor.py
@@ -187,6 +187,20 @@ def _validate_generated_code(code: str) -> None:
                 f"Generated code accesses a dunder attribute '{node.attr}' "
                 f"which is not allowed in the sandbox"
             )
+        # Block getattr/hasattr calls with dunder string arguments, which
+        # bypass the ast.Attribute check (e.g. getattr(type, '__subclasses__')).
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in ("getattr", "hasattr") and len(node.args) >= 2:
+                arg = node.args[1]
+                if (
+                    isinstance(arg, ast.Constant)
+                    and isinstance(arg.value, str)
+                    and arg.value.startswith("__")
+                ):
+                    raise RuntimeError(
+                        f"Generated code calls '{node.func.id}' with dunder "
+                        f"string '{arg.value}' which is not allowed in the sandbox"
+                    )
 
 
 def _restricted_import(


### PR DESCRIPTION
## Summary

Fix a sandbox validation bypass in `_validate_generated_code()`.

### Vulnerability

The AST validator blocks dunder access via `ast.Attribute` nodes (e.g. `type.__subclasses__`), but `getattr()`
and `hasattr()` calls with dunder string constants bypass this check:

```python
# Blocked by existing check (ast.Attribute):
type.__subclasses__

# Bypasses existing check (string constant, not ast.Attribute):
getattr(type, '__subclasses__')
```

### Fix

Adds an `ast.Call` inspection for `getattr`/`hasattr` where the second argument is
a string constant starting with `__`. This prevents sandbox escape via dunder access
through `getattr` chains.