### PR TITLE
Isolate AG-UI initial state copies

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -84,6 +85,10 @@ DEFAULT_STATE_PROMPT = """<state>
 """
 
 
+def _copy_initial_state(initial_state: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return copy.deepcopy(initial_state) if initial_state is not None else {}
+
+
 class InputEvent(StartEvent):
     input_data: RunAgentInput
 
@@ -136,7 +141,7 @@ class AGUIChatWorkflow(Workflow):
         self.backend_tools = {
             tool.metadata.name: tool for tool in validated_backend_tools
         }
-        self.initial_state = initial_state or {}
+        self.initial_state = _copy_initial_state(initial_state)
         self.system_prompt = system_prompt
 
     def _snapshot_messages(self, ctx: Context, chat_history: List[ChatMessage]) -> None:
@@ -184,7 +189,7 @@ class AGUIChatWorkflow(Workflow):
                 state.pop("messages", None)
             else:
                 # initial state is not provided, use the default state
-                state = self.initial_state.copy()
+                state = _copy_initial_state(self.initial_state)
 
             # Save state to context for tools to use
             await ctx.store.set("state", state)

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.1"
+version = "0.3.2"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from llama_index.core.llms.mock import MockFunctionCallingLLM
+from llama_index.protocols.ag_ui.agent import AGUIChatWorkflow, _copy_initial_state
+from llama_index.protocols.ag_ui.router import get_default_workflow_factory
+
+
+def test_workflow_copies_initial_state_from_caller():
+    source_state = {"items": [], "user": {"roles": []}}
+    workflow = AGUIChatWorkflow(
+        llm=MockFunctionCallingLLM(),
+        initial_state=source_state,
+    )
+
+    workflow.initial_state["items"].append("alpha")
+    workflow.initial_state["user"]["roles"].append("admin")
+
+    assert source_state == {"items": [], "user": {"roles": []}}
+
+
+def test_default_workflow_factory_returns_isolated_initial_state():
+    source_state = {"items": [], "user": {"roles": []}}
+    factory = get_default_workflow_factory(
+        llm=MockFunctionCallingLLM(),
+        initial_state=source_state,
+    )
+
+    first = asyncio.run(factory())
+    second = asyncio.run(factory())
+    first.initial_state["items"].append("alpha")
+    first.initial_state["user"]["roles"].append("admin")
+
+    assert second.initial_state == {"items": [], "user": {"roles": []}}
+    assert source_state == {"items": [], "user": {"roles": []}}
+
+
+def test_copy_initial_state_copies_nested_values():
+    source_state = {"items": [], "user": {"roles": []}}
+
+    first = _copy_initial_state(source_state)
+    second = _copy_initial_state(source_state)
+    first["items"].append("alpha")
+    first["user"]["roles"].append("admin")
+
+    assert second == {"items": [], "user": {"roles": []}}
+    assert source_state == {"items": [], "user": {"roles": []}}


### PR DESCRIPTION
## Summary
- Deep-copy AG-UI `initial_state` when a workflow is constructed.
- Deep-copy the stored default state before using it for a run, so nested values do not leak across runs.
- Add regression tests for caller-state and factory-created workflow isolation.

Closes #22069

## Tests
- `.venv\Scripts\python.exe -m pytest llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py -q`
- `.venv\Scripts\python.exe -m ruff check llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_initial_state.py`
- `git diff --check`

AI assistance was used to inspect the reported failure path and draft the initial patch; I reviewed the changed code and validated it with the tests above.