### PR TITLE
Fix tool schema varargs and splitter stopword cleanup

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -359,7 +359,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         # Remove punctuations
         text = text.translate(str.maketrans("", "", string.punctuation))
         # Remove stopwords
-        tokens = globals_helper.punkt_tokenizer.tokenize(text)
+        tokens = text.split()
         filtered_words = [w for w in tokens if w not in self.language_config.stopwords]
 
         return " ".join(filtered_words)

--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -1,4 +1,4 @@
-from inspect import signature
+from inspect import Parameter, signature
 from typing import (
     Any,
     Awaitable,
@@ -37,12 +37,15 @@ def create_schema_from_function(
     ignore_fields = ignore_fields or []
     params = signature(func).parameters
 
-    for param_name in params:
+    for param_name, param in params.items():
         if param_name in ignore_fields:
             continue
 
-        param_type = params[param_name].annotation
-        param_default = params[param_name].default
+        if param.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+            continue
+
+        param_type = param.annotation
+        param_default = param.default
         description = None
         json_schema_extra: dict[str, Any] = {}
 
@@ -67,10 +70,10 @@ def create_schema_from_function(
         elif param_type == datetime.time:
             json_schema_extra.setdefault("format", "time")
 
-        if param_type is params[param_name].empty:
+        if param_type is param.empty:
             param_type = Any
 
-        if param_default is params[param_name].empty:
+        if param_default is param.empty:
             # Required field
             fields[param_name] = (
                 param_type,

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -144,3 +144,16 @@ def test_embed_model_single_sentence_document() -> None:
     nodes = splitter.get_nodes_from_documents([single_doc])
     assert len(nodes) == 1
     assert nodes[0].get_content() == "Only one sentence here."
+
+
+def test_clean_text_advanced_removes_stopwords_by_word() -> None:
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(
+        embed_model=MockEmbedding(embed_dim=4),
+    )
+    splitter.language_config.stopwords = {"the", "and", "is"}
+
+    cleaned = splitter._clean_text_advanced(
+        "The quick brown fox is fast, and the dog is nearby."
+    )
+
+    assert cleaned == "quick brown fox fast dog nearby"

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -32,6 +32,17 @@ def test_create_schema_from_function() -> None:
     assert "required" not in schema
 
 
+def test_create_schema_from_function_ignores_var_args() -> None:
+    def search(query: str, *args: str, **kwargs) -> str:
+        return query
+
+    SchemaCls = create_schema_from_function("test_schema", search)
+    schema = SchemaCls.model_json_schema()
+
+    assert set(schema["properties"]) == {"query"}
+    assert schema["required"] == ["query"]
+
+
 def test_create_schema_from_function_with_field() -> None:
     """Test create_schema_from_function with pydantic.Field."""
 


### PR DESCRIPTION
## Summary

- skip `*args` and `**kwargs` when building function tool schemas
- use word-level tokens when filtering stopwords in `SemanticDoubleMergingSplitterNodeParser`
- add regression tests for both cases

## Tests

- `cd llama-index-core && .venv\Scripts\python.exe -m pytest tests/tools/test_utils.py tests/node_parser/test_semantic_double_merging_splitter.py -q`
- `cd llama-index-core && uvx ruff check llama_index/core/tools/utils.py llama_index/core/node_parser/text/semantic_double_merging_splitter.py tests/tools/test_utils.py tests/node_parser/test_semantic_double_merging_splitter.py`
- `cd llama-index-core && uvx ruff format --check llama_index/core/tools/utils.py llama_index/core/node_parser/text/semantic_double_merging_splitter.py tests/tools/test_utils.py tests/node_parser/test_semantic_double_merging_splitter.py`
- `git diff --check`

Fixes #22134
Fixes #22166