### PR TITLE
Fix MemosReader default endpoint and metadata

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-memos/llama_index/readers/memos/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-memos/llama_index/readers/memos/base.py
@@ -36,7 +36,7 @@ class MemosReader(BaseReader):
         realUrl = self._memoUrl
 
         if not params:
-            realUrl = urljoin(self._memoUrl, "all", False)
+            realUrl = urljoin(f"{self._memoUrl}/", "all")
 
         try:
             req = requests.get(realUrl, params)
@@ -53,7 +53,7 @@ class MemosReader(BaseReader):
             extra_info = {
                 "creator": memo["creator"],
                 "resource_list": memo["resourceList"],
-                id: memo["id"],
+                "id": memo["id"],
             }
             documents.append(Document(text=content, extra_info=extra_info))
 

--- a/llama-index-integrations/readers/llama-index-readers-memos/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-memos/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-memos"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers memos integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-memos/tests/test_readers_memos.py
+++ b/llama-index-integrations/readers/llama-index-readers-memos/tests/test_readers_memos.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.memos import MemosReader
 
@@ -5,3 +7,40 @@ from llama_index.readers.memos import MemosReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in MemosReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_load_data_uses_memo_all_endpoint_by_default():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.json.return_value = {"data": []}
+
+        docs = MemosReader("https://example.com/").load_data()
+
+        assert docs == []
+        mock_get.assert_called_once_with("https://example.com/api/memo/all", {})
+
+
+def test_load_data_sets_string_id_metadata_key():
+    payload = {
+        "data": [
+            {
+                "id": 7,
+                "content": "hello",
+                "creator": "me",
+                "resourceList": [],
+            }
+        ]
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.json.return_value = payload
+
+        docs = MemosReader("https://example.com/").load_data(params={"creator": "me"})
+
+        assert len(docs) == 1
+        assert docs[0].text == "hello"
+        assert docs[0].metadata["id"] == 7
+        assert docs[0].metadata["creator"] == "me"
+        assert docs[0].metadata["resource_list"] == []
+        mock_get.assert_called_once_with(
+            "https://example.com/api/memo", {"creator": "me"}
+        )


### PR DESCRIPTION
# Description

This PR fixes two issues in the `MemosReader` integration:

- Preserves the `/memo` path when constructing the default endpoint, so requests are sent to `/api/memo/all` instead of `/api/all`.
- Uses the string key `"id"` for document metadata instead of the built-in `id` function, which caused document creation to fail with a validation error.

Fixes # (none)

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

```bash
uv run -- pytest tests/test_readers_memos.py -q