### PR TITLE
Add llama-index-tools-sibfly integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-sibfly/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/README.md
@@ -1,0 +1,64 @@
+# LlamaIndex Tools: SibFly
+
+[SibFly](https://sibfly.com) tool spec for LlamaIndex — **measured ground motion for any US address**.
+
+Give it a US address (or lat/lon) and it tells your agent how fast the ground is
+**sinking or rising, in mm/year**, measured from NASA OPERA Sentinel-1 satellite
+radar (InSAR) — measured, not modeled. Negative mm/year = sinking.
+
+Agent-friendly pricing: **$0.40 per covered report, and misses are free**. A free
+`check_coverage` preflight lets you size a query before spending.
+
+## Install
+
+```bash
+pip install llama-index-tools-sibfly
+export SIBFLY_API_KEY="sf_live_..."
+```
+
+Get a key with free starter credits at [sibfly.com](https://sibfly.com). Agents can
+self-register: `POST https://sibfly.com/api/v1/autonomous/register`.
+
+## Usage
+
+```python
+from llama_index.tools.sibfly import SibflyToolSpec
+
+sibfly = SibflyToolSpec()  # reads SIBFLY_API_KEY
+
+# Free preflight
+print(sibfly.check_coverage(address="1100 Congress Ave, Austin, TX"))
+
+# Paid report ($0.40 if covered)
+doc = sibfly.check_ground_motion(address="1100 Congress Ave, Austin, TX")
+print(doc.text)       # short verdict
+print(doc.metadata)   # structured fields
+
+# Free dry-run preview
+sibfly.check_ground_motion(lat=30.3244, lon=-97.8102, dry_run=True)
+```
+
+Route logic on `metadata["assessment_code"]` — one of `rapid_subsidence`,
+`notable_subsidence`, `stable`, `mild_uplift`, `strong_uplift`.
+
+## Use it in an agent
+
+```python
+from llama_index.tools.sibfly import SibflyToolSpec
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.anthropic import Anthropic
+
+agent = FunctionAgent(
+    tools=SibflyToolSpec().to_tool_list(),
+    llm=Anthropic(model="claude-sonnet-5"),
+)
+```
+
+## Links
+
+- API: <https://sibfly.com> · Docs: <https://sibfly.com/docs> · Agent docs: <https://sibfly.com/llms.txt>
+- OpenAPI: <https://sibfly.com/openapi.json> · MCP: `https://sibfly.com/mcp` (registry: `com.sibfly/ground-motion`)
+
+## License
+
+MIT

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/llama_index/tools/sibfly/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/llama_index/tools/sibfly/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.sibfly.base import SibflyToolSpec
+
+__all__ = ["SibflyToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/llama_index/tools/sibfly/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/llama_index/tools/sibfly/base.py
@@ -1,0 +1,214 @@
+"""SibFly ground-motion tool spec."""
+
+import os
+from typing import Optional
+
+import requests
+
+from llama_index.core.schema import Document
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+DEFAULT_BASE_URL = "https://sibfly.com"
+
+# Fields kept from the raw SibFly response (drop the rest / nulls).
+_KEEP = (
+    "status",
+    "velocity_vertical_mm_yr",
+    "velocity_vertical_in_yr",
+    "velocity_uncertainty_mm_yr",
+    "seasonal_amplitude_mm",
+    "total_motion_mm",
+    "trend",
+    "assessment",
+    "assessment_code",
+    "confidence",
+    "near_threshold",
+    "neighbor_consistent",
+    "data_age_days",
+    "data_freshness",
+    "frame",
+    "pixel_id",
+    "n_measurements",
+    "last_observation",
+    "data_coverage",
+    "covered",
+    "cost_usd",
+    "would_cost_usd",
+    "credits_remaining_usd",
+    "message",
+    "request_id",
+    "error",
+    "code",
+    "top_up_url",
+)
+
+
+class SibflyToolSpec(BaseToolSpec):
+    """
+    SibFly ground-motion tool spec.
+
+    Measured ground motion for any US address. Wraps the SibFly API
+    (https://sibfly.com) so an agent can find out how fast the ground is
+    sinking or rising (mm/year, negative = sinking) under a given address,
+    measured from NASA OPERA Sentinel-1 satellite radar (InSAR) — measured, not
+    modeled. Pricing is agent-friendly: $0.40 per covered report, and misses
+    (out-of-coverage, no-data, too-stale, low-confidence) are free. Use
+    ``check_coverage`` (free) to preflight a point before spending.
+    """
+
+    spec_functions = ["check_ground_motion", "check_coverage"]
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = 60.0,
+    ) -> None:
+        """
+        Initialize with parameters.
+
+        Args:
+            api_key: SibFly API key (``sf_live_...``). Falls back to the
+                ``SIBFLY_API_KEY`` environment variable. An agent can obtain a
+                key with no human in the loop via SibFly's autonomous
+                registration endpoint (``POST /api/v1/autonomous/register``).
+            base_url: SibFly API base URL. Defaults to ``https://sibfly.com``.
+            timeout: Per-request timeout in seconds.
+
+        """
+        api_key = api_key or os.environ.get("SIBFLY_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "A SibFly API key is required. Pass api_key=... or set the "
+                "SIBFLY_API_KEY environment variable. Get a free key at "
+                "https://sibfly.com."
+            )
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _get(self, path: str, params: dict) -> dict:
+        response = requests.get(
+            f"{self.base_url}{path}",
+            params=params,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Accept": "application/json",
+            },
+            timeout=self.timeout,
+        )
+        try:
+            data = response.json()
+        except ValueError:
+            data = None
+        # SibFly errors are structured JSON with a stable ``error`` code (e.g.
+        # 402 insufficient_credits carries a top_up_url) — surface those as data
+        # rather than raising, so the agent can act on them.
+        if response.status_code >= 400 and not (
+            isinstance(data, dict) and (data.get("error") or data.get("code"))
+        ):
+            response.raise_for_status()
+        return data if isinstance(data, dict) else {"raw": data}
+
+    @staticmethod
+    def _params(address, lat, lon) -> dict:
+        if address:
+            return {"address": address}
+        if lat is None or lon is None:
+            raise ValueError("Provide an 'address' or both 'lat' and 'lon'.")
+        return {"lat": lat, "lon": lon}
+
+    @staticmethod
+    def _shape(data: dict) -> dict:
+        out = {k: data[k] for k in _KEEP if data.get(k) is not None}
+        q = data.get("query")
+        if isinstance(q, dict):
+            out["query"] = {
+                k: q[k]
+                for k in ("address", "geocoded_address", "lat", "lon")
+                if q.get(k) is not None
+            }
+        return out
+
+    def check_ground_motion(
+        self,
+        address: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        dry_run: bool = False,
+    ) -> Document:
+        """
+        Measure ground motion (subsidence/uplift) for a US address or point.
+
+        Returns how fast the ground is sinking or rising in mm/year (negative =
+        sinking), measured from NASA satellite radar. Costs $0.40 for a covered
+        report; out-of-coverage / low-quality results are free. Pass
+        ``dry_run=True`` for a free coverage + price preview with no charge.
+
+        Args:
+            address: A US street address, e.g. ``1100 Congress Ave, Austin, TX``.
+                Provide this OR lat+lon.
+            lat: Latitude (use with lon instead of address).
+            lon: Longitude (use with lat instead of address).
+            dry_run: If True, return a free preview (coverage, confidence,
+                would_cost_usd) without buying the report.
+
+        Returns:
+            A Document whose ``text`` is a short verdict and whose ``metadata``
+            holds the structured result (velocity_vertical_mm_yr,
+            assessment_code, confidence, data_age_days, cost_usd, ...). Route
+            logic on ``assessment_code``, not the human ``assessment`` string.
+
+        """
+        params = self._params(address, lat, lon)
+        if dry_run:
+            params["dry_run"] = 1
+        data = self._get("/api/v1/motion", params)
+        shaped = self._shape(data)
+
+        if shaped.get("error"):
+            summary = f"Error: {shaped.get('error')} - {shaped.get('message', '')}"
+        elif shaped.get("velocity_vertical_mm_yr") is not None:
+            summary = (
+                f"{address or 'point'}: {shaped['velocity_vertical_mm_yr']} mm/yr "
+                f"({shaped.get('assessment_code')}), confidence "
+                f"{shaped.get('confidence')}, data ~{shaped.get('data_age_days')} "
+                f"days old. Cost ${shaped.get('cost_usd')}."
+            )
+        else:
+            summary = (
+                f"{address or 'point'}: {shaped.get('status', 'no data')} "
+                f"(free, $0). {shaped.get('message', '')}"
+            ).strip()
+        return Document(text=summary, metadata=shaped)
+
+    def check_coverage(
+        self,
+        address: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+    ) -> Document:
+        """
+        FREE preflight: is a US address/point covered, how stale is the data,
+        and what would a report cost? Always $0. Call this before spending.
+
+        Args:
+            address: A US street address. Provide this OR lat+lon.
+            lat: Latitude (use with lon).
+            lon: Longitude (use with lat).
+
+        Returns:
+            A Document whose ``metadata`` holds ``covered``, ``data_age_days``,
+            and ``would_cost_usd``.
+
+        """
+        data = self._get("/api/v1/coverage", self._params(address, lat, lon))
+        shaped = self._shape(data)
+        if shaped.get("covered"):
+            summary = (
+                f"Covered: would cost ${shaped.get('would_cost_usd')}, data "
+                f"~{shaped.get('data_age_days')} days old."
+            )
+        else:
+            summary = "Not covered at this point (a report would be free)."
+        return Document(text=summary, metadata=shaped)

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/pyproject.toml
@@ -1,0 +1,70 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-cov>=6.1.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+]
+
+[project]
+name = "llama-index-tools-sibfly"
+version = "0.1.0"
+description = "llama-index tools SibFly integration — measured ground motion per US address from NASA InSAR"
+authors = [{name = "SibFly", email = "support@sibfly.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "james-sib"}]
+keywords = ["insar", "ground-motion", "subsidence", "geospatial", "nasa", "agent", "sibfly"]
+dependencies = [
+    "requests>=2.31.0",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[project.urls]
+Homepage = "https://sibfly.com"
+Repository = "https://github.com/james-sib/llama-index-tools-sibfly"
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.sibfly"
+
+[tool.llamahub.class_authors]
+SibflyToolSpec = "james-sib"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-sibfly/tests/test_tools_sibfly.py
+++ b/llama-index-integrations/tools/llama-index-tools-sibfly/tests/test_tools_sibfly.py
@@ -1,0 +1,53 @@
+"""Unit tests for llama-index-tools-sibfly (no network)."""
+
+import pytest
+
+from llama_index.tools.sibfly import SibflyToolSpec
+
+
+def test_requires_key(monkeypatch):
+    monkeypatch.delenv("SIBFLY_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        SibflyToolSpec()
+
+
+def test_spec_functions():
+    spec = SibflyToolSpec(api_key="sf_test")
+    assert "check_ground_motion" in spec.spec_functions
+    assert "check_coverage" in spec.spec_functions
+    tools = spec.to_tool_list()
+    assert len(tools) == 2
+
+
+def test_params_by_address():
+    spec = SibflyToolSpec(api_key="sf_test")
+    assert spec._params("1100 Congress Ave", None, None) == {"address": "1100 Congress Ave"}
+
+
+def test_params_by_coords():
+    spec = SibflyToolSpec(api_key="sf_test")
+    assert spec._params(None, 30.3, -97.8) == {"lat": 30.3, "lon": -97.8}
+
+
+def test_params_requires_location():
+    spec = SibflyToolSpec(api_key="sf_test")
+    with pytest.raises(ValueError):
+        spec._params(None, None, None)
+
+
+def test_shape_keeps_and_drops():
+    shaped = SibflyToolSpec._shape(
+        {
+            "status": "ok",
+            "velocity_vertical_mm_yr": -6.0,
+            "assessment_code": "notable_subsidence",
+            "cost_usd": 0.4,
+            "seasonal_amplitude_mm": None,
+            "internal_debug": "x",
+            "query": {"address": "a", "lat": 1.0, "lon": 2.0, "geocoded_address": None},
+        }
+    )
+    assert shaped["velocity_vertical_mm_yr"] == -6.0
+    assert "seasonal_amplitude_mm" not in shaped
+    assert "internal_debug" not in shaped
+    assert shaped["query"] == {"address": "a", "lat": 1.0, "lon": 2.0}


### PR DESCRIPTION
Adds `llama-index-tools-sibfly` — a `SibflyToolSpec` exposing `check_ground_motion` and `check_coverage`.

**SibFly** returns satellite-**measured** ground motion (subsidence/uplift, mm/year) for any US address, from NASA OPERA Sentinel-1 InSAR. $0.40 per covered report; misses free; agents can self-register.

- PyPI: https://pypi.org/project/llama-index-tools-sibfly/
- Repo: https://github.com/james-sib/llama-index-tools-sibfly
- API: https://sibfly.com

Mirrors the standard tool-package layout. Tests included (no network).