### PR TITLE
fix(node_parser): use word split instead of punkt for stopword removal in SemanticDoubleMergingSplitter

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -358,8 +358,11 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         text = re.sub(r"http\S+|www\S+|https\S+", "", text, flags=re.MULTILINE)
         # Remove punctuations
         text = text.translate(str.maketrans("", "", string.punctuation))
-        # Remove stopwords
-        tokens = globals_helper.punkt_tokenizer.tokenize(text)
-        filtered_words = [w for w in tokens if w not in self.language_config.stopwords]
+        # Remove stopwords (split on whitespace, not sentence-tokenizer -- after
+        # stripping punctuation, punkt returns the whole text as one token so
+        # individual stopwords never match)
+        filtered_words = [
+            w for w in text.split() if w not in self.language_config.stopwords
+        ]
 
         return " ".join(filtered_words)


### PR DESCRIPTION
## Problem

Closes #22166.

`SemanticDoubleMergingSplitterNodeParser._clean_text_advanced` strips punctuation first, then calls `punkt_tokenizer.tokenize(text)` to get tokens for stopword filtering. After punctuation removal, the sentence tokenizer treats the entire input as a single sentence — so `tokens` contains only one element (the full string), and the stopword check `w not in self.language_config.stopwords` never matches individual words.

**Demonstration:**
```python
text = "this is a test text containing some stopwords like the and a"
# after punctuation strip, punkt returns:
tokens = punkt.tokenize(text)  # → ['this is a test text containing some stopwords like the and a']
filtered = [w for w in tokens if w not in stopwords]  # → same full string, nothing removed
```

## Fix

Replace `punkt_tokenizer.tokenize(text)` with `text.split()`. Since punctuation has already been stripped, whitespace splitting correctly yields individual words and lets the stopword filter work as intended:

```python
filtered_words = [
    w for w in text.split() if w not in self.language_config.stopwords
]
```

**After fix:**
```python
# input: "this is a test text containing some stopwords like the and a"
# stopwords: {this, is, a, some, the, and}
# output: ['test', 'text', 'containing', 'stopwords', 'like']
```