### PR TITLE
fix(mcp): resolve inline nested objects in create_model_from_json_schema

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -93,6 +93,10 @@ class TypeResolutionMixin:
             return self._create_list_type(schema, defs)
         if self._is_simple_object(schema):
             return self._create_dict_type(schema, defs)
+        # Inline nested object with its own properties (no $ref, no additionalProperties)
+        if json_type == "object" and "properties" in schema:
+            model_name = schema.get("title", f"InlineModel_{id(schema)}")
+            return self._create_model(schema, model_name, defs)
         return json_type_mapping.get(json_type, str)
 
 


### PR DESCRIPTION
## Problem

Closes #22141.

`McpToolSpec.create_model_from_json_schema` drops nested inline objects — schemas with their own `properties`/`required` defined directly under a `properties` entry instead of via `$ref`/`$defs`.

**Root cause** in `_resolve_basic_type` (`tool_spec_mixins.py`):

```python
if self._is_simple_object(schema):   # requires additionalProperties key — misses inline objects
    return self._create_dict_type(schema, defs)
return json_type_mapping.get(json_type, str)   # "object" → Dict, properties lost
```

`_is_simple_object` only matches schemas that have `additionalProperties`. An inline nested object like:
```json
{"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]}
```
has neither `additionalProperties` nor `$ref`, so it falls through to `json_type_mapping["object"] = Dict` — all nested fields are silently dropped.

## Fix

Add a check for inline nested objects after the existing array/dict branches:

```python
if json_type == "object" and "properties" in schema:
    model_name = schema.get("title", f"InlineModel_{id(schema)}")
    return self._create_model(schema, model_name, defs)
```

This recursively builds a proper Pydantic model for the nested object, preserving all properties and required constraints.

## Testing

All 38 existing tests in `tests/test_tools_mcp.py` pass.

**Before fix:**
```python
model.model_json_schema()
# → {'properties': {'nested': {}}, ...}  # nested fields dropped
```

**After fix:**
```python
model.model_json_schema()
# → {'$defs': {'NestedModel': {'properties': {'value': {'type': 'string'}}, ...}}, ...}
```