### PR TITLE
Respect empty tool spec function lists

### DIFF
--- a/llama-index-core/llama_index/core/tools/tool_spec/base.py
+++ b/llama-index-core/llama_index/core/tools/tool_spec/base.py
@@ -68,7 +68,8 @@ class BaseToolSpec:
         func_to_metadata_mapping: Optional[Dict[str, ToolMetadata]] = None,
     ) -> List[FunctionTool]:
         """Convert tool spec to list of tools."""
-        spec_functions = spec_functions or self.spec_functions
+        if spec_functions is None:
+            spec_functions = self.spec_functions
         func_to_metadata_mapping = func_to_metadata_mapping or {}
         tool_list = []
         for func_spec in spec_functions:

--- a/llama-index-core/tests/tools/tool_spec/test_base.py
+++ b/llama-index-core/tests/tools/tool_spec/test_base.py
@@ -172,6 +172,11 @@ def test_tool_spec_subset() -> None:
     )
 
 
+def test_tool_spec_empty_subset() -> None:
+    """Test empty tool spec subset."""
+    assert TestToolSpec().to_tool_list(spec_functions=[]) == []
+
+
 @pytest.mark.asyncio
 async def test_async_tool_spec() -> None:
     """Test tool spec."""


### PR DESCRIPTION
# Description

This PR fixes `BaseToolSpec.to_tool_list()` so that passing an explicit empty list (`spec_functions=[]`) returns an empty list of tools instead of falling back to `self.spec_functions`.

Previously, the implementation used:

```python
spec_functions = spec_functions or self.spec_functions
```

which treated an empty list the same as `None`. This made it impossible to explicitly request an empty subset of tools.

This change only falls back to `self.spec_functions` when `spec_functions` is `None`, preserving the expected behavior for an explicitly provided empty list.

Fixes # (none)

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Tests run locally:

```bash
uv run --directory llama-index-core pytest tests/tools/tool_spec/test_base.py -q
```

Result:

```text
9 passed in 0.05s
```

