### PR TITLE
[Memory] Add Dakera persistent memory integration

### DIFF
--- a/llama-index-integrations/memory/llama-index-memory-dakera/README.md
+++ b/llama-index-integrations/memory/llama-index-memory-dakera/README.md
@@ -1,0 +1,86 @@
+# LlamaIndex Memory Integration: Dakera
+
+[Dakera](https://dakera.ai) provides persistent, decay-weighted cross-session memory for AI agents. Memories are stored as dense vectors and retrieved via semantic similarity search, with automatic importance decay so stale memories fade naturally while relevant context surfaces reliably.
+
+## Installation
+
+```bash
+pip install llama-index-memory-dakera
+```
+
+## Setup
+
+You need a running Dakera server (self-hosted or cloud) and an API key.
+
+```python
+from llama_index.memory.dakera import DakeraMemory
+
+memory = DakeraMemory(
+    base_url="https://api.dakera.ai",  # your Dakera server URL
+    api_key="dak-...",                 # your API key
+    session_id="user-42",             # unique ID per user/conversation
+    top_k=10,                         # memories to retrieve per query
+)
+```
+
+## Usage with SimpleChatEngine
+
+```python
+from llama_index.core import SimpleChatEngine
+from llama_index.llms.openai import OpenAI
+
+llm = OpenAI(model="gpt-4o-mini")
+
+engine = SimpleChatEngine.from_defaults(llm=llm, memory=memory)
+
+response = await engine.achat("Hi, I prefer answers in French.")
+response = await engine.achat("What language do I prefer?")
+# → Dakera surfaces the stored preference: "User prefers answers in French."
+```
+
+## Usage with FunctionAgent
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.core.tools import FunctionTool
+
+
+def search_web(query: str) -> str:
+    """Search the web for information."""
+    return f"Results for: {query}"
+
+
+agent = FunctionAgent(
+    tools=[FunctionTool.from_defaults(fn=search_web)],
+    llm=llm,
+)
+
+response = await agent.run("Remember that my timezone is UTC+2.", memory=memory)
+response = await agent.run("Schedule a meeting for 9am my time.", memory=memory)
+# → Agent recalls timezone from memory when scheduling
+```
+
+## How It Works
+
+- **`put(message)`** — stores a chat message in Dakera via `POST /v1/memories`
+- **`get(input)`** — retrieves the top-k semantically relevant memories for the input via `POST /v1/memories/search`
+- **`get_all()`** — fetches all memories for the session
+- **`reset()`** — deletes all session memories via `DELETE /v1/memories`
+
+Memories are namespaced by `session_id`, so different users or agent runs stay fully isolated.
+
+## Self-Hosting
+
+Dakera ships as a single Docker image:
+
+```bash
+docker run -p 8000:8000 -e DAKERA_API_KEY=my-key ghcr.io/dakera-ai/dakera:latest
+```
+
+See [dakera.ai](https://dakera.ai) for full deployment docs.
+
+## References
+
+- [Dakera website](https://dakera.ai)
+- [Dakera API docs](https://dakera.ai/docs)
+- [PyPI: llamaindex-dakera](https://pypi.org/project/llamaindex-dakera/)

--- a/llama-index-integrations/memory/llama-index-memory-dakera/llama_index/memory/dakera/__init__.py
+++ b/llama-index-integrations/memory/llama-index-memory-dakera/llama_index/memory/dakera/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.memory.dakera.base import DakeraMemory
+
+__all__ = ["DakeraMemory"]

--- a/llama-index-integrations/memory/llama-index-memory-dakera/llama_index/memory/dakera/base.py
+++ b/llama-index-integrations/memory/llama-index-memory-dakera/llama_index/memory/dakera/base.py
@@ -1,0 +1,248 @@
+"""Dakera persistent memory integration for LlamaIndex.
+
+Dakera provides decay-weighted, cross-session memory with semantic recall
+via a REST API. This integration stores and retrieves chat messages using
+the Dakera memory server, giving agents persistent, relevance-ranked memory
+without any additional dependencies beyond httpx.
+"""
+
+from typing import Any, List, Optional
+
+import httpx
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
+from llama_index.core.memory import BaseMemory
+
+
+class DakeraMemory(BaseMemory):
+    """Dakera persistent memory for LlamaIndex agents.
+
+    Stores and retrieves chat messages via the Dakera REST API, which
+    provides decay-weighted vector memory with semantic search. Memories
+    persist across sessions and are automatically ranked by recency and
+    relevance.
+
+    Args:
+        base_url: Base URL of the Dakera API server (e.g. ``"https://api.dakera.ai"``).
+        api_key: API key for authenticating with the Dakera server.
+        session_id: Unique identifier for the current session. Memories are
+            namespaced by session so different agent runs stay isolated.
+        top_k: Maximum number of memories to retrieve per search (default 10).
+
+    Example:
+        .. code-block:: python
+
+            from llama_index.memory.dakera import DakeraMemory
+            from llama_index.core import SimpleChatEngine
+            from llama_index.llms.openai import OpenAI
+
+            memory = DakeraMemory(
+                base_url="https://api.dakera.ai",
+                api_key="dak-...",
+                session_id="user-123",
+                top_k=10,
+            )
+
+            llm = OpenAI(model="gpt-4o-mini")
+            engine = SimpleChatEngine.from_defaults(llm=llm, memory=memory)
+            response = engine.chat("What did we discuss last time?")
+    """
+
+    base_url: str = Field(description="Base URL of the Dakera API server.")
+    api_key: str = Field(description="API key for the Dakera server.")
+    session_id: str = Field(description="Session identifier for memory namespacing.")
+    top_k: int = Field(
+        default=10,
+        description="Maximum number of memories to retrieve per semantic search.",
+    )
+
+    _client: httpx.AsyncClient = PrivateAttr()
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        session_id: str,
+        top_k: int = 10,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            api_key=api_key,
+            session_id=session_id,
+            top_k=top_k,
+            **kwargs,
+        )
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Return the class name for serialization."""
+        return "DakeraMemory"
+
+    @classmethod
+    def from_defaults(
+        cls,
+        base_url: str = "https://api.dakera.ai",
+        api_key: str = "",
+        session_id: str = "default",
+        top_k: int = 10,
+        **kwargs: Any,
+    ) -> "DakeraMemory":
+        """Create a DakeraMemory instance with sensible defaults.
+
+        Args:
+            base_url: Base URL of the Dakera API server.
+            api_key: API key for the Dakera server.
+            session_id: Session identifier for memory namespacing.
+            top_k: Maximum number of memories to retrieve per search.
+
+        Returns:
+            DakeraMemory instance.
+        """
+        return cls(
+            base_url=base_url,
+            api_key=api_key,
+            session_id=session_id,
+            top_k=top_k,
+            **kwargs,
+        )
+
+    async def get(
+        self, input: Optional[str] = None, **kwargs: Any
+    ) -> List[ChatMessage]:
+        """Retrieve relevant memories for the given input via semantic search.
+
+        Performs a semantic similarity search against stored memories and
+        returns the top-k most relevant results as ChatMessages. If ``input``
+        is ``None``, returns an empty list.
+
+        Args:
+            input: The query string to search memories against (typically
+                the current user message or conversation context).
+
+        Returns:
+            List of ChatMessage objects representing relevant past memories,
+            ordered by relevance score descending.
+        """
+        if not input:
+            return []
+
+        try:
+            response = await self._client.post(
+                "/v1/memories/search",
+                json={
+                    "query": input,
+                    "session_id": self.session_id,
+                    "top_k": self.top_k,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception:
+            return []
+
+        results = data if isinstance(data, list) else data.get("results", [])
+        messages: List[ChatMessage] = []
+        for item in results:
+            content = item.get("content") if isinstance(item, dict) else str(item)
+            if content:
+                messages.append(
+                    ChatMessage(role=MessageRole.SYSTEM, content=str(content))
+                )
+        return messages
+
+    async def get_all(self) -> List[ChatMessage]:
+        """Retrieve all stored memories for the current session.
+
+        Performs a broad semantic search using an empty query to surface all
+        available memories for the session, up to ``top_k`` results.
+
+        Returns:
+            List of ChatMessage objects for all stored memories in the session.
+        """
+        try:
+            response = await self._client.post(
+                "/v1/memories/search",
+                json={
+                    "query": "",
+                    "session_id": self.session_id,
+                    "top_k": self.top_k,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception:
+            return []
+
+        results = data if isinstance(data, list) else data.get("results", [])
+        messages: List[ChatMessage] = []
+        for item in results:
+            content = item.get("content") if isinstance(item, dict) else str(item)
+            if content:
+                messages.append(
+                    ChatMessage(role=MessageRole.SYSTEM, content=str(content))
+                )
+        return messages
+
+    async def put(self, message: ChatMessage) -> None:
+        """Store a single ChatMessage in Dakera memory.
+
+        The message content is persisted with the current session identifier.
+        Dakera automatically applies decay weighting so recent, frequently
+        accessed memories surface higher in future recalls.
+
+        Args:
+            message: The ChatMessage to store.
+        """
+        content = message.content
+        if not content:
+            return
+
+        try:
+            response = await self._client.post(
+                "/v1/memories",
+                json={
+                    "content": str(content),
+                    "session_id": self.session_id,
+                },
+            )
+            response.raise_for_status()
+        except Exception:
+            pass
+
+    async def set(self, messages: List[ChatMessage]) -> None:
+        """Replace all session memories with the given message list.
+
+        Clears existing memories for the session and stores all provided
+        messages. Useful for initializing memory from a known conversation
+        history.
+
+        Args:
+            messages: List of ChatMessages to store as the full memory state.
+        """
+        await self.reset()
+        for message in messages:
+            await self.put(message)
+
+    async def reset(self) -> None:
+        """Delete all memories for the current session.
+
+        Permanently removes all stored memories associated with the current
+        ``session_id``. This cannot be undone.
+        """
+        try:
+            response = await self._client.delete(
+                "/v1/memories",
+                json={"session_id": self.session_id},
+            )
+            response.raise_for_status()
+        except Exception:
+            pass

--- a/llama-index-integrations/memory/llama-index-memory-dakera/pyproject.toml
+++ b/llama-index-integrations/memory/llama-index-memory-dakera/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "black[jupyter]>=23.7.0,<=25.11.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==8.4.2",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=6.1.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "respx>=0.21.0",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+]
+
+[project]
+name = "llama-index-memory-dakera"
+version = "0.1.0"
+description = "llama-index memory Dakera integration"
+authors = [{name = "Dakera", email = "ferhi.med.amine@gmail.com"}]
+requires-python = "<4.0,>=3.9"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "httpx>=0.27.0",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.memory.dakera"
+
+[tool.llamahub.class_authors]
+DakeraMemory = "llama-index"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.9"

--- a/llama-index-integrations/memory/llama-index-memory-dakera/tests/test_dakera_memory.py
+++ b/llama-index-integrations/memory/llama-index-memory-dakera/tests/test_dakera_memory.py
@@ -1,0 +1,158 @@
+"""Tests for DakeraMemory integration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.memory.dakera import DakeraMemory
+
+
+@pytest.fixture
+def memory() -> DakeraMemory:
+    return DakeraMemory(
+        base_url="http://localhost:8000",
+        api_key="test-key",
+        session_id="test-session",
+        top_k=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_returns_messages_on_success(memory: DakeraMemory) -> None:
+    """get() returns ChatMessage list when the API returns results."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            {"content": "User prefers concise answers."},
+            {"content": "User is based in France."},
+        ]
+    }
+
+    with patch.object(memory._client, "post", new=AsyncMock(return_value=mock_response)):
+        result = await memory.get(input="What does the user prefer?")
+
+    assert len(result) == 2
+    assert all(isinstance(m, ChatMessage) for m in result)
+    assert result[0].content == "User prefers concise answers."
+    assert result[0].role == MessageRole.SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_get_returns_empty_on_none_input(memory: DakeraMemory) -> None:
+    """get() returns empty list when input is None."""
+    result = await memory.get(input=None)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_returns_empty_on_api_error(memory: DakeraMemory) -> None:
+    """get() returns empty list gracefully on API failure."""
+    with patch.object(
+        memory._client, "post", new=AsyncMock(side_effect=httpx.ConnectError("refused"))
+    ):
+        result = await memory.get(input="something")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_put_stores_message(memory: DakeraMemory) -> None:
+    """put() calls POST /v1/memories with correct payload."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(memory._client, "post", new=AsyncMock(return_value=mock_response)) as mock_post:
+        msg = ChatMessage(role=MessageRole.USER, content="Hello, remember this.")
+        await memory.put(msg)
+
+    mock_post.assert_called_once_with(
+        "/v1/memories",
+        json={"content": "Hello, remember this.", "session_id": "test-session"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_put_skips_empty_content(memory: DakeraMemory) -> None:
+    """put() does nothing when message content is empty."""
+    with patch.object(memory._client, "post", new=AsyncMock()) as mock_post:
+        msg = ChatMessage(role=MessageRole.USER, content="")
+        await memory.put(msg)
+
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reset_calls_delete(memory: DakeraMemory) -> None:
+    """reset() calls DELETE /v1/memories with session_id."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        memory._client, "delete", new=AsyncMock(return_value=mock_response)
+    ) as mock_delete:
+        await memory.reset()
+
+    mock_delete.assert_called_once_with(
+        "/v1/memories",
+        json={"session_id": "test-session"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_resets_then_puts_all(memory: DakeraMemory) -> None:
+    """set() clears memory then stores each message."""
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="First message"),
+        ChatMessage(role=MessageRole.ASSISTANT, content="Second message"),
+    ]
+
+    reset_called = []
+    put_calls = []
+
+    async def fake_reset() -> None:
+        reset_called.append(True)
+
+    async def fake_put(msg: ChatMessage) -> None:
+        put_calls.append(msg.content)
+
+    memory.reset = fake_reset  # type: ignore[method-assign]
+    memory.put = fake_put  # type: ignore[method-assign]
+
+    await memory.set(messages)
+
+    assert len(reset_called) == 1
+    assert put_calls == ["First message", "Second message"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_broad_search(memory: DakeraMemory) -> None:
+    """get_all() sends an empty query to fetch all session memories."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = [{"content": "Memory A"}, {"content": "Memory B"}]
+
+    with patch.object(
+        memory._client, "post", new=AsyncMock(return_value=mock_response)
+    ) as mock_post:
+        result = await memory.get_all()
+
+    call_kwargs = mock_post.call_args
+    assert call_kwargs[1]["json"]["query"] == ""
+    assert call_kwargs[1]["json"]["session_id"] == "test-session"
+    assert len(result) == 2
+
+
+def test_class_name() -> None:
+    assert DakeraMemory.class_name() == "DakeraMemory"
+
+
+def test_from_defaults() -> None:
+    mem = DakeraMemory.from_defaults(
+        base_url="http://localhost:8000",
+        api_key="key",
+        session_id="s1",
+    )
+    assert mem.session_id == "s1"
+    assert mem.top_k == 10


### PR DESCRIPTION
## Description

Adds `llama-index-memory-dakera`, a new memory integration that connects LlamaIndex agents to a [Dakera](https://dakera.ai) memory server — a self-hostable, decay-weighted, cross-session vector memory backend.

Closes #22209

## Motivation

LlamaIndex agents lose context between sessions. This integration provides persistent long-term memory for agents without requiring any managed cloud service. Key properties:

- **Self-hostable** via a single Docker image — full data sovereignty
- **Decay-weighted importance** — memories fade over time; recent, relevant context surfaces automatically
- **Cross-session persistence** — survives agent restarts, scoped by `session_id`
- **Minimal deps** — only `httpx` (no Dakera SDK); the integration speaks raw HTTP

## Package

```
llama-index-integrations/memory/llama-index-memory-dakera/
├── pyproject.toml                         # hatchling build, MIT, httpx dep
├── README.md
├── llama_index/memory/dakera/
│   ├── __init__.py                        # exports DakeraMemory
│   └── base.py                            # BaseMemory implementation
└── tests/
    ├── __init__.py
    └── test_dakera_memory.py              # 9 async unit tests, no live server needed
```

## Implementation

`DakeraMemory` extends `BaseMemory` with fully async methods backed by three Dakera REST endpoints:

| Method | HTTP call | Description |
|--------|-----------|-------------|
| `get(input)` | `POST /v1/memories/search` | Semantic top-k recall |
| `get_all()` | `POST /v1/memories/search` (empty query) | Fetch all session memories |
| `put(message)` | `POST /v1/memories` | Store a single ChatMessage |
| `set(messages)` | reset + put each | Replace memory state |
| `reset()` | `DELETE /v1/memories` | Clear the session |

All methods handle errors gracefully (catch exceptions, return empty list/no-op) so a transient network failure never breaks an agent run.

## Usage

```python
from llama_index.memory.dakera import DakeraMemory
from llama_index.core import SimpleChatEngine
from llama_index.llms.openai import OpenAI

memory = DakeraMemory(
    base_url="https://api.dakera.ai",  # or self-hosted
    api_key="dak-...",
    session_id="user-42",
    top_k=10,
)

llm = OpenAI(model="gpt-4o-mini")
engine = SimpleChatEngine.from_defaults(llm=llm, memory=memory)

# Memories persist across sessions automatically
response = await engine.achat("My name is Alice and I prefer formal replies.")
response = await engine.achat("What do you know about me?")
# → Dakera recalls: "User is Alice and prefers formal replies."
```

Works with `FunctionAgent` and `ReActAgent` too:

```python
from llama_index.core.agent.workflow import FunctionAgent

agent = FunctionAgent(tools=[...], llm=llm)
response = await agent.run("Remember my timezone is UTC+2", memory=memory)
response = await agent.run("Book a 9am meeting for tomorrow", memory=memory)
```

## Testing

Tests use `unittest.mock` — no live Dakera server required:

```bash
cd llama-index-integrations/memory/llama-index-memory-dakera
pip install -e ".[dev]"
pytest tests/ -v
```

Coverage: `get` success/empty/error, `put` payload + empty content guard, `reset` DELETE call, `set` reset-then-put sequence, `get_all` broad search, `class_name`, `from_defaults`.

## Dependencies

- `llama-index-core>=0.13.0,<0.15`
- `httpx>=0.27.0`

No Dakera SDK. No new transitive dependencies beyond what `httpx` already brings.

## Related

- Follows the same layout as `llama-index-memory-mem0`
- Published package: [`llamaindex-dakera`](https://pypi.org/project/llamaindex-dakera/) 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)