### PR TITLE
fixed sonnet-5 support for function calling models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -143,7 +143,7 @@ ANTHROPIC_NO_TEMP_MODELS: Tuple[str, ...] = (
 
 
 def is_function_calling_model(modelname: str) -> bool:
-    return "-3" in modelname or "-4" in modelname
+    return "-3" in modelname or "-4" in modelname or "-5" in modelname
 
 
 def anthropic_modelname_to_contextsize(modelname: str) -> int:


### PR DESCRIPTION
# Description

Fixed the `is_function_calling_model` function in the _llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py_ to also accept models with -5 in their name.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
