### PR TITLE
fix(dashscope): send query_history in retriever payload

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/retriever.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/retriever.py
@@ -186,7 +186,7 @@ class DashScopeCloudRetriever(BaseRetriever):
         }
         # extract query_history for multi-turn query rewrite
         if "query_history" in kwargs:
-            params["query_hisory"] = kwargs.get("query_history")
+            params["query_history"] = kwargs.get("query_history")
 
         response_data = utils.post(self.base_url, headers=self.headers, params=params)
         nodes = []

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-indices-managed-dashscope"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index indices managed-dashscope integration"
 authors = [{name = "Ruixue Ding", email = "ada.drx@alibaba-inc.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-dashscope/tests/test_indices_managed_dashscope.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-dashscope/tests/test_indices_managed_dashscope.py
@@ -1,7 +1,42 @@
 from llama_index.indices.managed.dashscope import DashScopeCloudIndex
 from llama_index.core.indices.managed.base import BaseManagedIndex
+from llama_index.core.schema import QueryBundle, TextNode
+from llama_index.indices.managed.dashscope.retriever import DashScopeCloudRetriever
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in DashScopeCloudIndex.__mro__]
     assert BaseManagedIndex.__name__ in names_of_base_classes
+
+
+def test_retrieve_sends_query_history_param(mocker):
+    mocker.patch(
+        "llama_index.indices.managed.dashscope.retriever.utils.get_pipeline_id",
+        return_value="pipeline-id",
+    )
+    captured_params = {}
+
+    def mock_post(base_url, headers, params):
+        captured_params.update(params)
+        node = TextNode(text="result")
+        return {"nodes": [{"node": node.model_dump(), "score": 1.0}]}
+
+    mocker.patch(
+        "llama_index.indices.managed.dashscope.retriever.utils.post",
+        side_effect=mock_post,
+    )
+
+    retriever = DashScopeCloudRetriever(
+        index_name="test-index",
+        api_key="test-api-key",
+        workspace_id="test-workspace",
+    )
+    query_history = [{"role": "user", "content": "previous question"}]
+
+    nodes = retriever._retrieve(
+        QueryBundle("current question"), query_history=query_history
+    )
+
+    assert captured_params["query_history"] == query_history
+    assert "query_hisory" not in captured_params
+    assert len(nodes) == 1


### PR DESCRIPTION
# Description

Fixes a typo in the DashScope managed retriever request payload. The public `retrieve()` / `aretrieve()` APIs accept `query_history`, but `_retrieve()` was sending it as `query_hisory`.

This updates the outgoing key to `query_history`, adds a mocked unit test to verify the payload without making live DashScope API calls, and bumps `llama-index-indices-managed-dashscope` from `0.5.0` to `0.5.1` for the package fix.

No linked issue.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Focused validation:

```bash
PYTHONPATH=llama-index-core:llama-index-instrumentation/src:llama-index-integrations/indices/llama-index-indices-managed-dashscope \
.venv/bin/python -m pytest llama-index-integrations/indices/llama-index-indices-managed-dashscope/tests/test_indices_managed_dashscope.py -q
```

Result: `2 passed, 1 warning`.

Additional checks:

```bash
git diff --check
.venv/bin/python -m ruff check \
  llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/retriever.py \
  llama-index-integrations/indices/llama-index-indices-managed-dashscope/tests/test_indices_managed_dashscope.py
.venv/bin/python -m ruff format --check \
  llama-index-integrations/indices/llama-index-indices-managed-dashscope/llama_index/indices/managed/dashscope/retriever.py \
  llama-index-integrations/indices/llama-index-indices-managed-dashscope/tests/test_indices_managed_dashscope.py
```

Results: passed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
