### PR TITLE
Clarify FactExtractionMemoryBlock condense prompt to return a full snapshot

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
@@ -161,7 +161,7 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
 
             # The condensed response replaces the fact list wholesale, so only
             # apply it when it actually contains facts - otherwise an empty or
-            # unparseable response would silently wipe the stored facts.
+            # unparsable response would silently wipe the stored facts.
             if condensed_facts:
                 self.facts = condensed_facts
 

--- a/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
@@ -37,13 +37,16 @@ If no new facts are present, return: <facts></facts>""")
 
 DEFAULT_FACT_CONDENSE_PROMPT = RichPromptTemplate("""You are a precise fact condensing system designed to identify key information from conversations.
 
+The condensed list you return completely replaces the existing facts, so it must be the full, self-contained snapshot of everything worth keeping - not just newly added or changed facts.
+
 INSTRUCTIONS:
 1. Review the current list of existing facts
-2. Condense the facts into a more concise list, less than {{ max_facts }} facts
-3. Focus on factual information like preferences, personal details, requirements, constraints, or context
-4. Format each fact as a separate <fact> XML tag
-5. Do not include opinions, summaries, or interpretations - only extract explicit information
-6. Do not duplicate facts that are already in the existing facts list
+2. Return a single, complete list of fewer than {{ max_facts }} facts
+3. Merge related facts and drop semantically redundant ones so that each fact appears only once
+4. Preserve every distinct piece of information - only remove a fact when it duplicates or is fully covered by another fact you keep
+5. Focus on factual information like preferences, personal details, requirements, constraints, or context
+6. Do not include opinions, summaries, or interpretations - only the explicit information already present
+7. Format each fact as a separate <fact> XML tag
 
 <existing_facts>
 {{ existing_facts }}
@@ -54,9 +57,7 @@ Return ONLY the condensed facts in this exact format:
   <fact>Specific fact 1</fact>
   <fact>Specific fact 2</fact>
   <!-- More facts as needed -->
-</facts>
-
-If no new facts are present, return: <facts></facts>""")
+</facts>""")
 
 
 def get_default_llm() -> LLM:
@@ -156,8 +157,13 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
                 max_facts=self.max_facts,
             )
             response = await self.llm.achat(messages=[*messages, *prompt_messages])
-            new_facts = self._parse_facts_xml(response.message.content or "")
-            self.facts = new_facts
+            condensed_facts = self._parse_facts_xml(response.message.content or "")
+
+            # The condensed response replaces the fact list wholesale, so only
+            # apply it when it actually contains facts - otherwise an empty or
+            # unparseable response would silently wipe the stored facts.
+            if condensed_facts:
+                self.facts = condensed_facts
 
     def _parse_facts_xml(self, xml_text: str) -> List[str]:
         """Parse facts from XML format."""

--- a/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
+++ b/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
@@ -55,12 +55,13 @@ def test_condense_branch_replaces_facts_wholesale() -> None:
     rather than being appended. (A real LLM is required to verify the prompt
     itself yields a full snapshot; this only pins the downstream behavior.)
     """
-    llm = _ScriptedLLM(
-        scripted_responses=[
-            "<facts><fact>d</fact></facts>",  # extraction adds one new fact
-            "<facts><fact>x</fact><fact>y</fact></facts>",  # condensed snapshot
-        ]
-    )
+    # MockLLM's __init__ has a fixed signature, so assign the subclass field
+    # after construction (as in tests/llms/test_callbacks.py's _SecretMockLLM).
+    llm = _ScriptedLLM()
+    llm.scripted_responses = [
+        "<facts><fact>d</fact></facts>",  # extraction adds one new fact
+        "<facts><fact>x</fact><fact>y</fact></facts>",  # condensed snapshot
+    ]
     block = FactExtractionMemoryBlock(llm=llm, facts=["a", "b", "c"], max_facts=3)
 
     # Putting a message triggers extraction (-> 4 facts > max 3) then condense.
@@ -71,13 +72,12 @@ def test_condense_branch_replaces_facts_wholesale() -> None:
 
 
 def test_condense_empty_response_preserves_existing_facts() -> None:
-    """An empty or unparseable condense response must not wipe the stored facts."""
-    llm = _ScriptedLLM(
-        scripted_responses=[
-            "<facts><fact>d</fact></facts>",  # extraction pushes list over max
-            "<facts></facts>",  # empty condense response
-        ]
-    )
+    """An empty or unparsable condense response must not wipe the stored facts."""
+    llm = _ScriptedLLM()
+    llm.scripted_responses = [
+        "<facts><fact>d</fact></facts>",  # extraction pushes list over max
+        "<facts></facts>",  # empty condense response
+    ]
     block = FactExtractionMemoryBlock(llm=llm, facts=["a", "b", "c"], max_facts=3)
 
     asyncio_run(block._aput([ChatMessage(role=MessageRole.USER, content="hello")]))

--- a/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
+++ b/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
@@ -1,0 +1,86 @@
+from typing import Any, List, Sequence
+
+from llama_index.core.async_utils import asyncio_run
+from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.memory.memory_blocks.fact import (
+    DEFAULT_FACT_CONDENSE_PROMPT,
+    FactExtractionMemoryBlock,
+)
+
+
+class _ScriptedLLM(MockLLM):
+    """A MockLLM that returns pre-scripted responses, one per ``achat`` call."""
+
+    scripted_responses: List[str] = Field(default_factory=list)
+
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        content = self.scripted_responses.pop(0)
+        return ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content=content)
+        )
+
+
+def test_condense_prompt_requests_full_deduplicated_snapshot() -> None:
+    """The condense prompt must ask for the complete deduplicated snapshot.
+
+    The condensed output replaces the stored facts wholesale, so the prompt has
+    to request the full list - not just newly added facts - and must not carry
+    the ambiguous 'do not duplicate ... existing facts' instruction that implied
+    incremental (delta-only) output. See issue #21103.
+    """
+    messages = DEFAULT_FACT_CONDENSE_PROMPT.format_messages(
+        existing_facts="<fact>user likes tea</fact>", max_facts=5
+    )
+    rendered = "\n".join(str(message.content) for message in messages)
+
+    # The existing facts are injected into the prompt.
+    assert "user likes tea" in rendered
+    # It positively states the output replaces the stored facts (full snapshot).
+    assert "completely replaces the existing facts" in rendered
+    # The ambiguous, incremental-implying instructions are gone.
+    assert (
+        "Do not duplicate facts that are already in the existing facts list"
+        not in rendered
+    )
+    assert "If no new facts are present" not in rendered
+
+
+def test_condense_branch_replaces_facts_wholesale() -> None:
+    """Plumbing-level contract the condense prompt is written to satisfy: once the
+    fact list exceeds max_facts, the condensed response REPLACES the stored facts
+    rather than being appended. (A real LLM is required to verify the prompt
+    itself yields a full snapshot; this only pins the downstream behavior.)
+    """
+    llm = _ScriptedLLM(
+        scripted_responses=[
+            "<facts><fact>d</fact></facts>",  # extraction adds one new fact
+            "<facts><fact>x</fact><fact>y</fact></facts>",  # condensed snapshot
+        ]
+    )
+    block = FactExtractionMemoryBlock(llm=llm, facts=["a", "b", "c"], max_facts=3)
+
+    # Putting a message triggers extraction (-> 4 facts > max 3) then condense.
+    asyncio_run(block._aput([ChatMessage(role=MessageRole.USER, content="hello")]))
+
+    # The condensed snapshot fully replaces the previous facts.
+    assert block.facts == ["x", "y"]
+
+
+def test_condense_empty_response_preserves_existing_facts() -> None:
+    """An empty or unparseable condense response must not wipe the stored facts."""
+    llm = _ScriptedLLM(
+        scripted_responses=[
+            "<facts><fact>d</fact></facts>",  # extraction pushes list over max
+            "<facts></facts>",  # empty condense response
+        ]
+    )
+    block = FactExtractionMemoryBlock(llm=llm, facts=["a", "b", "c"], max_facts=3)
+
+    asyncio_run(block._aput([ChatMessage(role=MessageRole.USER, content="hello")]))
+
+    # The empty condense output is ignored; the pre-condense facts are kept.
+    assert block.facts == ["a", "b", "c", "d"]

--- a/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
+++ b/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
@@ -25,7 +25,8 @@ class _ScriptedLLM(MockLLM):
 
 
 def test_condense_prompt_requests_full_deduplicated_snapshot() -> None:
-    """The condense prompt must ask for the complete deduplicated snapshot.
+    """
+    The condense prompt must ask for the complete deduplicated snapshot.
 
     The condensed output replaces the stored facts wholesale, so the prompt has
     to request the full list - not just newly added facts - and must not carry
@@ -50,7 +51,8 @@ def test_condense_prompt_requests_full_deduplicated_snapshot() -> None:
 
 
 def test_condense_branch_replaces_facts_wholesale() -> None:
-    """Plumbing-level contract the condense prompt is written to satisfy: once the
+    """
+    Plumbing-level contract the condense prompt is written to satisfy: once the
     fact list exceeds max_facts, the condensed response REPLACES the stored facts
     rather than being appended. (A real LLM is required to verify the prompt
     itself yields a full snapshot; this only pins the downstream behavior.)


### PR DESCRIPTION
## Description

`DEFAULT_FACT_CONDENSE_PROMPT` (used by `FactExtractionMemoryBlock`) was ambiguous about whether the LLM should return a **full deduplicated snapshot** of the facts or only **incremental new facts** — reported in #21103.

The condense path replaces the stored facts wholesale:

```python
condensed = self._parse_facts_xml(response.message.content or "")
self.facts = condensed  # full replacement
```

so the prompt must ask for the complete list. But it was copied from the extraction prompt and inherited two instructions that imply *incremental* output:
- `Do not duplicate facts that are already in the existing facts list`
- `If no new facts are present, return: <facts></facts>`

Under that reading the model can return few/no facts, and because the result replaces `self.facts`, the stored facts get gutted or wiped.

## Changes

- **Reword `DEFAULT_FACT_CONDENSE_PROMPT`** to state explicitly that the returned list *completely replaces* the existing facts and must be the full, self-contained snapshot; deduplication is about semantic content (each fact appears once). Removed the two incremental-implying instructions. The **extraction prompt is unchanged** — its append semantics make those instructions correct there.
- **Guard the condense write** so an empty or unparseable response can't silently wipe the stored facts (`if condensed_facts: self.facts = condensed_facts`).
- **Add unit tests** covering the prompt wording, the wholesale-replace behavior, and the empty-response guard.

Fixes #21103

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests: `llama-index-core/tests/memory/test_fact_extraction_memory_block.py`

## Version Bump?

No version bump included — this is a prompt clarification plus a small safety guard in `llama-index-core`. Happy to add a patch bump if the maintainers prefer.