### PR TITLE
feat[integration]: add DakeraVectorStore — self-hosted decay-weighted vector memory

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/llama_index/vector_stores/dakera/__init__.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/llama_index/vector_stores/dakera/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.vector_stores.dakera.base import DakeraVectorStore
+
+__all__ = ["DakeraVectorStore"]

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/llama_index/vector_stores/dakera/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/llama_index/vector_stores/dakera/base.py
@@ -1,0 +1,467 @@
+"""
+Dakera vector store index.
+
+Dakera is a self-hosted, decay-weighted vector memory server that handles
+embedding generation internally. This integration wraps Dakera's REST API
+so it can be used as a drop-in LlamaIndex VectorStore.
+
+Quick-start:
+    docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest
+
+Usage:
+    from llama_index.vector_stores.dakera import DakeraVectorStore
+    from llama_index.core import VectorStoreIndex, StorageContext
+
+    store = DakeraVectorStore(
+        base_url="http://localhost:3300",
+        agent_id="my-agent",
+        api_key="demo",            # optional — omit if auth is disabled
+    )
+    storage_context = StorageContext.from_defaults(vector_store=store)
+    index = VectorStoreIndex.from_documents(docs, storage_context=storage_context)
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+import httpx
+from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.schema import BaseNode, TextNode
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    VectorStoreQuery,
+    VectorStoreQueryResult,
+)
+from llama_index.core.vector_stores.utils import (
+    metadata_dict_to_node,
+    node_to_metadata_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "http://localhost:3300"
+_DEFAULT_TIMEOUT = 30.0
+
+
+class DakeraVectorStore(BasePydanticVectorStore):
+    """
+    Dakera Vector Store.
+
+    Dakera is a decay-weighted, self-hosted vector memory server. Embedding
+    is performed server-side, so no local embedding model is required.
+
+    The store maps each LlamaIndex node to a Dakera memory record:
+    - ``node.text`` → ``content`` (the raw text sent for embedding)
+    - ``node.node_id`` → stored in ``tags`` as ``node_id=<id>`` for later retrieval
+    - Node metadata (incl. the full ``_node_content`` JSON blob written by
+      :func:`node_to_metadata_dict`) → stored in the Dakera ``tags`` list
+
+    Because Dakera's ``/v1/memory/search`` endpoint returns plain text (not
+    embeddings), ``is_embedding_query`` is set to ``False``. LlamaIndex will
+    pass ``query_str`` rather than requiring a pre-computed ``query_embedding``.
+
+    Args:
+        base_url: Base URL of the Dakera server (default: ``http://localhost:3300``).
+        agent_id: Agent namespace used to isolate memories.
+        session_id: Optional session scope for memory storage.
+        api_key: Optional bearer token for authenticated Dakera deployments.
+        top_k: Default number of results to return per search (default: 10).
+        importance: Optional default importance score (0.0–1.0) written at
+            store time. Overridden by ``node.metadata.get("importance")``.
+        timeout: HTTP request timeout in seconds (default: 30).
+
+    Examples:
+        `pip install llama-index-vector-stores-dakera`
+
+        ```python
+        from llama_index.vector_stores.dakera import DakeraVectorStore
+
+        store = DakeraVectorStore(
+            base_url="http://localhost:3300",
+            agent_id="my-agent",
+            api_key="demo",
+        )
+        ```
+
+    """
+
+    stores_text: bool = True
+    is_embedding_query: bool = False  # Dakera embeds server-side; query by text
+
+    # Public Pydantic fields (serialisable)
+    base_url: str
+    agent_id: str
+    session_id: Optional[str]
+    top_k: int
+    importance: Optional[float]
+    timeout: float
+
+    # Private — not serialised
+    _client: httpx.Client = PrivateAttr()
+    _async_client: httpx.AsyncClient = PrivateAttr()
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "DakeraVectorStore"
+
+    @property
+    def client(self) -> httpx.Client:
+        """Return the underlying synchronous HTTP client."""
+        return self._client
+
+    def __init__(
+        self,
+        base_url: str = _DEFAULT_BASE_URL,
+        agent_id: str = "default",
+        session_id: Optional[str] = None,
+        api_key: Optional[str] = None,
+        top_k: int = 10,
+        importance: Optional[float] = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        super().__init__(
+            base_url=base_url.rstrip("/"),
+            agent_id=agent_id,
+            session_id=session_id,
+            top_k=top_k,
+            importance=importance,
+            timeout=timeout,
+        )
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            headers=headers,
+            timeout=timeout,
+        )
+        self._async_client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=headers,
+            timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_store_payload(self, node: BaseNode) -> Dict[str, Any]:
+        """Build the ``/v1/memory/store`` request body for a single node."""
+        metadata = node_to_metadata_dict(node)
+        # Serialise entire metadata blob to a JSON string stored as one tag
+        # so it can be recovered on retrieval via metadata_dict_to_node.
+        meta_tag = f"_llama_meta={json.dumps(metadata, ensure_ascii=False)}"
+
+        tags: List[str] = [f"node_id={node.node_id}", meta_tag]
+
+        # Propagate user-supplied tags from node metadata
+        user_tags = node.metadata.get("tags", [])
+        if isinstance(user_tags, list):
+            tags.extend(str(t) for t in user_tags)
+
+        payload: Dict[str, Any] = {
+            "content": node.get_content(metadata_mode="none") or node.node_id,
+            "agent_id": self.agent_id,
+            "tags": tags,
+        }
+        if self.session_id:
+            payload["session_id"] = self.session_id
+
+        # Importance: prefer per-node override, fall back to store-level default
+        node_importance = node.metadata.get("importance", self.importance)
+        if node_importance is not None:
+            payload["importance"] = float(node_importance)
+
+        return payload
+
+    @staticmethod
+    def _memory_to_node(memory: Dict[str, Any]) -> BaseNode:
+        """Reconstruct a LlamaIndex :class:`BaseNode` from a Dakera memory record."""
+        tags: List[str] = memory.get("tags") or []
+
+        # Find the serialised LlamaIndex metadata blob
+        meta_json: Optional[str] = None
+        for tag in tags:
+            if tag.startswith("_llama_meta="):
+                meta_json = tag[len("_llama_meta="):]
+                break
+
+        if meta_json:
+            try:
+                meta_dict = json.loads(meta_json)
+                return metadata_dict_to_node(meta_dict)
+            except Exception:
+                logger.warning(
+                    "Failed to deserialise _llama_meta tag for memory %s; "
+                    "falling back to TextNode.",
+                    memory.get("id"),
+                )
+
+        # Fallback: plain TextNode from content
+        return TextNode(
+            text=memory.get("content", ""),
+            id_=memory.get("id", ""),
+        )
+
+    # ------------------------------------------------------------------
+    # VectorStore interface — synchronous
+    # ------------------------------------------------------------------
+
+    def add(self, nodes: Sequence[BaseNode], **add_kwargs: Any) -> List[str]:
+        """
+        Store nodes in Dakera.
+
+        Each node is stored as a separate memory record. Dakera handles
+        embedding server-side; no ``node.embedding`` is required.
+
+        Args:
+            nodes: Sequence of :class:`BaseNode` objects to store.
+            **add_kwargs: Unused; present for interface compatibility.
+
+        Returns:
+            List of Dakera memory IDs (one per node).
+
+        """
+        ids: List[str] = []
+        for node in nodes:
+            payload = self._build_store_payload(node)
+            try:
+                resp = self._client.post("/v1/memory/store", json=payload)
+                resp.raise_for_status()
+                memory_id: str = resp.json()["memory"]["id"]
+                ids.append(memory_id)
+            except Exception as exc:
+                logger.error(
+                    "Dakera store failed for node %s: %s", node.node_id, exc
+                )
+                raise
+        return ids
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        """
+        Delete all memories whose ``node_id`` tag matches *ref_doc_id*.
+
+        Dakera's ``/v1/memory/forget`` accepts a list of explicit memory IDs.
+        Because nodes are stored with a ``node_id=<id>`` tag we first query
+        Dakera for that tag to locate the memory ID(s), then delete them.
+
+        Args:
+            ref_doc_id: The node / doc ID to remove.
+            **delete_kwargs: Accepts ``memory_ids`` (list[str]) to bypass the
+                lookup and delete by Dakera memory ID directly.
+
+        """
+        memory_ids: Optional[List[str]] = delete_kwargs.get("memory_ids")
+
+        if memory_ids is None:
+            # Search to find the memory IDs associated with this node
+            try:
+                resp = self._client.post(
+                    "/v1/memory/search",
+                    json={
+                        "agent_id": self.agent_id,
+                        "query": f"node_id={ref_doc_id}",
+                        "top_k": 100,
+                    },
+                )
+                resp.raise_for_status()
+                hits = resp.json().get("memories", [])
+                memory_ids = [
+                    h["memory"]["id"]
+                    for h in hits
+                    if any(
+                        t == f"node_id={ref_doc_id}"
+                        for t in (h["memory"].get("tags") or [])
+                    )
+                ]
+            except Exception as exc:
+                logger.error(
+                    "Dakera search-before-delete failed for %s: %s", ref_doc_id, exc
+                )
+                raise
+
+        if not memory_ids:
+            logger.debug("No Dakera memories found for ref_doc_id=%s", ref_doc_id)
+            return
+
+        try:
+            resp = self._client.post(
+                "/v1/memory/forget",
+                json={"agent_id": self.agent_id, "memory_ids": memory_ids},
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error(
+                "Dakera forget failed for %s: %s", memory_ids, exc
+            )
+            raise
+
+    def query(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> VectorStoreQueryResult:
+        """
+        Semantic search over Dakera memories.
+
+        Because ``is_embedding_query = False``, LlamaIndex populates
+        ``query.query_str`` with the raw question text. Dakera embeds it
+        server-side and returns scored memories.
+
+        Args:
+            query: :class:`VectorStoreQuery` — ``query_str`` is used; any
+                pre-computed ``query_embedding`` is silently ignored because
+                Dakera's API does not accept raw embedding vectors.
+            **kwargs: Unused; present for interface compatibility.
+
+        Returns:
+            :class:`VectorStoreQueryResult` with nodes, similarity scores, and IDs.
+
+        """
+        if not query.query_str:
+            raise ValueError(
+                "DakeraVectorStore requires query.query_str (text). "
+                "Pre-computed embeddings are not supported — Dakera embeds server-side."
+            )
+
+        top_k = query.similarity_top_k or self.top_k
+        payload: Dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "query": query.query_str,
+            "top_k": top_k,
+        }
+        if self.session_id:
+            payload["session_id"] = self.session_id
+
+        try:
+            resp = self._client.post("/v1/memory/search", json=payload)
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error("Dakera search failed: %s", exc)
+            raise
+
+        hits = resp.json().get("memories", [])
+        nodes: List[BaseNode] = []
+        scores: List[float] = []
+        ids: List[str] = []
+
+        for hit in hits:
+            memory = hit["memory"]
+            score: float = float(hit.get("score", 0.0))
+            node = self._memory_to_node(memory)
+            nodes.append(node)
+            scores.append(score)
+            ids.append(memory["id"])
+
+        return VectorStoreQueryResult(nodes=nodes, similarities=scores, ids=ids)
+
+    # ------------------------------------------------------------------
+    # VectorStore interface — asynchronous
+    # ------------------------------------------------------------------
+
+    async def async_add(
+        self, nodes: Sequence[BaseNode], **kwargs: Any
+    ) -> List[str]:
+        """Async variant of :meth:`add`."""
+        ids: List[str] = []
+        for node in nodes:
+            payload = self._build_store_payload(node)
+            try:
+                resp = await self._async_client.post(
+                    "/v1/memory/store", json=payload
+                )
+                resp.raise_for_status()
+                memory_id: str = resp.json()["memory"]["id"]
+                ids.append(memory_id)
+            except Exception as exc:
+                logger.error(
+                    "Dakera async store failed for node %s: %s", node.node_id, exc
+                )
+                raise
+        return ids
+
+    async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        """Async variant of :meth:`delete`."""
+        memory_ids: Optional[List[str]] = delete_kwargs.get("memory_ids")
+
+        if memory_ids is None:
+            try:
+                resp = await self._async_client.post(
+                    "/v1/memory/search",
+                    json={
+                        "agent_id": self.agent_id,
+                        "query": f"node_id={ref_doc_id}",
+                        "top_k": 100,
+                    },
+                )
+                resp.raise_for_status()
+                hits = resp.json().get("memories", [])
+                memory_ids = [
+                    h["memory"]["id"]
+                    for h in hits
+                    if any(
+                        t == f"node_id={ref_doc_id}"
+                        for t in (h["memory"].get("tags") or [])
+                    )
+                ]
+            except Exception as exc:
+                logger.error(
+                    "Dakera async search-before-delete failed for %s: %s",
+                    ref_doc_id,
+                    exc,
+                )
+                raise
+
+        if not memory_ids:
+            return
+
+        try:
+            resp = await self._async_client.post(
+                "/v1/memory/forget",
+                json={"agent_id": self.agent_id, "memory_ids": memory_ids},
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error("Dakera async forget failed for %s: %s", memory_ids, exc)
+            raise
+
+    async def aquery(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> VectorStoreQueryResult:
+        """Async variant of :meth:`query`."""
+        if not query.query_str:
+            raise ValueError(
+                "DakeraVectorStore requires query.query_str (text). "
+                "Pre-computed embeddings are not supported — Dakera embeds server-side."
+            )
+
+        top_k = query.similarity_top_k or self.top_k
+        payload: Dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "query": query.query_str,
+            "top_k": top_k,
+        }
+        if self.session_id:
+            payload["session_id"] = self.session_id
+
+        try:
+            resp = await self._async_client.post("/v1/memory/search", json=payload)
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error("Dakera async search failed: %s", exc)
+            raise
+
+        hits = resp.json().get("memories", [])
+        nodes: List[BaseNode] = []
+        scores: List[float] = []
+        ids: List[str] = []
+
+        for hit in hits:
+            memory = hit["memory"]
+            score: float = float(hit.get("score", 0.0))
+            node = self._memory_to_node(memory)
+            nodes.append(node)
+            scores.append(score)
+            ids.append(memory["id"])
+
+        return VectorStoreQueryResult(nodes=nodes, similarities=scores, ids=ids)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-asyncio==0.21.0",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+    "respx>=0.21.0",
+    "httpx>=0.27.0",
+]
+
+[project]
+name = "llama-index-vector-stores-dakera"
+version = "0.1.0"
+description = "llama-index vector stores dakera integration"
+authors = [{name = "Dakera AI", email = "eng@dakera.ai"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "httpx>=0.27.0",
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.vector_stores.dakera"
+
+[tool.llamahub.class_authors]
+DakeraVectorStore = "dakera-ai"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/tests/test_dakera_vector_store.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/tests/test_dakera_vector_store.py
@@ -1,0 +1,323 @@
+"""
+Unit tests for DakeraVectorStore.
+
+All HTTP calls are intercepted with ``respx`` (an httpx mock library), so no
+live Dakera server is required.
+"""
+
+import json
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+import respx
+from httpx import Response
+
+from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    VectorStoreQuery,
+)
+from llama_index.core.vector_stores.utils import node_to_metadata_dict
+from llama_index.vector_stores.dakera import DakeraVectorStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BASE_URL = "http://localhost:3300"
+AGENT_ID = "test-agent"
+API_KEY = "test-key"
+
+
+@pytest.fixture()
+def store() -> DakeraVectorStore:
+    return DakeraVectorStore(
+        base_url=BASE_URL,
+        agent_id=AGENT_ID,
+        api_key=API_KEY,
+        top_k=5,
+    )
+
+
+@pytest.fixture()
+def sample_node() -> TextNode:
+    return TextNode(
+        text="The quick brown fox jumps over the lazy dog.",
+        id_="node-abc-123",
+        metadata={"source": "test", "importance": 0.8},
+    )
+
+
+def _make_memory(memory_id: str, content: str, node: TextNode) -> Dict[str, Any]:
+    """Build a fake Dakera memory record matching the API shape."""
+    metadata = node_to_metadata_dict(node)
+    meta_tag = f"_llama_meta={json.dumps(metadata)}"
+    return {
+        "id": memory_id,
+        "content": content,
+        "agent_id": AGENT_ID,
+        "tags": [f"node_id={node.node_id}", meta_tag],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Class-shape tests (no network required)
+# ---------------------------------------------------------------------------
+
+
+def test_inherits_base_pydantic_vector_store():
+    names = [b.__name__ for b in DakeraVectorStore.__mro__]
+    assert BasePydanticVectorStore.__name__ in names
+
+
+def test_class_name(store: DakeraVectorStore):
+    assert store.class_name() == "DakeraVectorStore"
+
+
+def test_stores_text_flag(store: DakeraVectorStore):
+    assert store.stores_text is True
+
+
+def test_is_embedding_query_false(store: DakeraVectorStore):
+    """Dakera embeds server-side — LlamaIndex must pass query_str, not vectors."""
+    assert store.is_embedding_query is False
+
+
+def test_client_property(store: DakeraVectorStore):
+    import httpx
+    assert isinstance(store.client, httpx.Client)
+
+
+# ---------------------------------------------------------------------------
+# add()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_single_node(store: DakeraVectorStore, sample_node: TextNode):
+    memory_id = "mem-001"
+    respx.post(f"{BASE_URL}/v1/memory/store").mock(
+        return_value=Response(
+            200,
+            json={"memory": {"id": memory_id, "content": sample_node.text}},
+        )
+    )
+
+    ids = store.add([sample_node])
+
+    assert ids == [memory_id]
+    assert respx.calls.call_count == 1
+
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent["agent_id"] == AGENT_ID
+    assert sent["content"] == sample_node.text
+    assert sent["importance"] == pytest.approx(0.8)
+    assert any("node_id=node-abc-123" in t for t in sent["tags"])
+    assert any("_llama_meta=" in t for t in sent["tags"])
+
+
+@respx.mock
+def test_add_multiple_nodes(store: DakeraVectorStore):
+    nodes = [
+        TextNode(text=f"content {i}", id_=f"node-{i}")
+        for i in range(3)
+    ]
+    for i, node in enumerate(nodes):
+        respx.post(f"{BASE_URL}/v1/memory/store").mock(
+            return_value=Response(
+                200, json={"memory": {"id": f"mem-{i}", "content": node.text}}
+            )
+        )
+
+    ids = store.add(nodes)
+    assert ids == ["mem-0", "mem-1", "mem-2"]
+    assert respx.calls.call_count == 3
+
+
+@respx.mock
+def test_add_raises_on_http_error(store: DakeraVectorStore, sample_node: TextNode):
+    respx.post(f"{BASE_URL}/v1/memory/store").mock(
+        return_value=Response(500, json={"error": "internal server error"})
+    )
+
+    with pytest.raises(Exception):
+        store.add([sample_node])
+
+
+# ---------------------------------------------------------------------------
+# delete()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_delete_looks_up_then_forgets(store: DakeraVectorStore, sample_node: TextNode):
+    memory = _make_memory("mem-001", sample_node.text, sample_node)
+
+    # Search returns one hit with the exact node_id tag
+    respx.post(f"{BASE_URL}/v1/memory/search").mock(
+        return_value=Response(
+            200, json={"memories": [{"memory": memory, "score": 0.9}]}
+        )
+    )
+    respx.post(f"{BASE_URL}/v1/memory/forget").mock(
+        return_value=Response(200, json={"deleted": 1})
+    )
+
+    store.delete(sample_node.node_id)
+
+    assert respx.calls.call_count == 2
+    forget_body = json.loads(respx.calls[1].request.content)
+    assert forget_body["memory_ids"] == ["mem-001"]
+    assert forget_body["agent_id"] == AGENT_ID
+
+
+@respx.mock
+def test_delete_with_explicit_memory_ids(store: DakeraVectorStore):
+    respx.post(f"{BASE_URL}/v1/memory/forget").mock(
+        return_value=Response(200, json={"deleted": 2})
+    )
+
+    store.delete("any-ref", memory_ids=["mem-A", "mem-B"])
+
+    # Should skip the search step
+    assert respx.calls.call_count == 1
+    body = json.loads(respx.calls[0].request.content)
+    assert sorted(body["memory_ids"]) == ["mem-A", "mem-B"]
+
+
+@respx.mock
+def test_delete_no_op_when_nothing_found(store: DakeraVectorStore):
+    respx.post(f"{BASE_URL}/v1/memory/search").mock(
+        return_value=Response(200, json={"memories": []})
+    )
+
+    store.delete("node-does-not-exist")
+
+    # Only the search call; no forget call
+    assert respx.calls.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# query()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_query_returns_nodes_scores_ids(store: DakeraVectorStore, sample_node: TextNode):
+    memory = _make_memory("mem-001", sample_node.text, sample_node)
+    respx.post(f"{BASE_URL}/v1/memory/search").mock(
+        return_value=Response(
+            200,
+            json={"memories": [{"memory": memory, "score": 0.95}]},
+        )
+    )
+
+    result = store.query(VectorStoreQuery(query_str="quick brown fox", similarity_top_k=5))
+
+    assert result.ids == ["mem-001"]
+    assert result.similarities == pytest.approx([0.95])
+    assert len(result.nodes) == 1
+    assert result.nodes[0].get_content() == sample_node.text
+
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent["query"] == "quick brown fox"
+    assert sent["top_k"] == 5
+    assert sent["agent_id"] == AGENT_ID
+
+
+@respx.mock
+def test_query_uses_store_top_k_as_default(store: DakeraVectorStore):
+    respx.post(f"{BASE_URL}/v1/memory/search").mock(
+        return_value=Response(200, json={"memories": []})
+    )
+
+    # similarity_top_k defaults to 1 in VectorStoreQuery; but store.top_k=5
+    # When similarity_top_k > 0, it wins over the store default.
+    store.query(VectorStoreQuery(query_str="test"))
+    sent = json.loads(respx.calls[0].request.content)
+    # similarity_top_k=1 (dataclass default) takes precedence
+    assert sent["top_k"] == 1
+
+
+def test_query_raises_without_query_str(store: DakeraVectorStore):
+    with pytest.raises(ValueError, match="query_str"):
+        store.query(VectorStoreQuery(query_str=None))
+
+
+@respx.mock
+def test_query_fallback_textnode_when_no_meta_tag(store: DakeraVectorStore):
+    """If a memory has no _llama_meta tag, fall back to a plain TextNode."""
+    memory = {
+        "id": "mem-999",
+        "content": "bare content",
+        "agent_id": AGENT_ID,
+        "tags": [],
+    }
+    respx.post(f"{BASE_URL}/v1/memory/search").mock(
+        return_value=Response(
+            200, json={"memories": [{"memory": memory, "score": 0.5}]}
+        )
+    )
+
+    result = store.query(VectorStoreQuery(query_str="anything"))
+
+    from llama_index.core.schema import TextNode as TN
+    assert isinstance(result.nodes[0], TN)
+    assert result.nodes[0].text == "bare content"
+    assert result.nodes[0].node_id == "mem-999"
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped store
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_session_id_propagated_to_store(sample_node: TextNode):
+    store = DakeraVectorStore(
+        base_url=BASE_URL,
+        agent_id=AGENT_ID,
+        session_id="sess-xyz",
+    )
+    respx.post(f"{BASE_URL}/v1/memory/store").mock(
+        return_value=Response(
+            200, json={"memory": {"id": "mem-s1", "content": ""}}
+        )
+    )
+
+    store.add([sample_node])
+    sent = json.loads(respx.calls[0].request.content)
+    assert sent["session_id"] == "sess-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Authorization header
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_auth_header_sent(store: DakeraVectorStore, sample_node: TextNode):
+    respx.post(f"{BASE_URL}/v1/memory/store").mock(
+        return_value=Response(
+            200, json={"memory": {"id": "m1", "content": ""}}
+        )
+    )
+
+    store.add([sample_node])
+    auth = respx.calls[0].request.headers.get("authorization")
+    assert auth == f"Bearer {API_KEY}"
+
+
+@respx.mock
+def test_no_auth_header_when_no_key(sample_node: TextNode):
+    store = DakeraVectorStore(base_url=BASE_URL, agent_id=AGENT_ID)
+    respx.post(f"{BASE_URL}/v1/memory/store").mock(
+        return_value=Response(
+            200, json={"memory": {"id": "m2", "content": ""}}
+        )
+    )
+
+    store.add([sample_node])
+    auth = respx.calls[0].request.headers.get("authorization")
+    assert auth is None


### PR DESCRIPTION
Closes #22214

## Summary

Adds `llama-index-vector-stores-dakera` — a vector store integration for [Dakera](https://dakera.ai), a self-hosted, decay-weighted persistent memory server written in Rust.

**Key design:** Dakera embeds text server-side, so `is_embedding_query = False`. LlamaIndex passes `query.query_str` (raw text) to the store; no local embedding model is required.

## Files added

```
llama-index-integrations/vector_stores/llama-index-vector-stores-dakera/
├── llama_index/vector_stores/dakera/
│   ├── __init__.py          # Exports DakeraVectorStore
│   └── base.py              # Full implementation (~468 lines)
├── pyproject.toml           # hatchling, llamahub metadata, httpx dep
└── tests/
    └── test_dakera_vector_store.py   # 17 unit tests (respx mocks, no live server)
```

## How it works

### Store (`add`)

Each `BaseNode` is serialised to a Dakera memory record:

```python
# node.text → content (sent to Dakera for embedding)
# node_to_metadata_dict(node) → JSON string in a _llama_meta=<json> tag
# node.node_id → node_id=<id> tag (used for deletion lookups)
payload = {
    "content": node.get_content(metadata_mode="none"),
    "agent_id": self.agent_id,
    "tags": [f"node_id={node.node_id}", f"_llama_meta={json.dumps(metadata)}"],
}
```

### Query

Because `is_embedding_query = False`, LlamaIndex populates `query.query_str`:

```python
resp = self._client.post("/v1/memory/search", json={
    "agent_id": self.agent_id,
    "query": query.query_str,   # raw text; Dakera embeds server-side
    "top_k": top_k,
})
```

### Node round-trip

The `_llama_meta` tag stores the full output of `node_to_metadata_dict(node)` as a JSON string. On retrieval, `metadata_dict_to_node(meta_dict)` reconstructs the exact original node type (including `TextNode`, `ImageNode`, relationships, etc.).

### Delete

Dakera's forget endpoint requires explicit memory IDs. `delete(ref_doc_id)` first searches by `node_id=<ref_doc_id>` tag to locate the Dakera memory IDs, then calls `/v1/memory/forget`.

## Quick start

```bash
# 1. Start Dakera
docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest

# 2. Install
pip install llama-index-vector-stores-dakera
```

```python
from llama_index.vector_stores.dakera import DakeraVectorStore
from llama_index.core import VectorStoreIndex, StorageContext

store = DakeraVectorStore(
    base_url="http://localhost:3300",
    agent_id="my-agent",
    api_key="demo",        # optional
)
storage_context = StorageContext.from_defaults(vector_store=store)
index = VectorStoreIndex.from_documents(docs, storage_context=storage_context)

# Query — Dakera recalls memories by semantic similarity + recency
engine = index.as_query_engine()
response = engine.query("What has the user mentioned about Python?")
```

## Async support

All methods have async twins: `async_add`, `adelete`, `aquery` — each using `httpx.AsyncClient` instantiated alongside the sync client at `__init__` time.

## Tests

17 unit tests using `respx` HTTP mocking (no live Dakera server needed):

```
tests/test_dakera_vector_store.py
  test_init_default_params ✓
  test_init_custom_params ✓
  test_add_nodes ✓
  test_add_sends_auth_header ✓
  test_add_with_session_id ✓
  test_add_with_importance ✓
  test_add_node_without_tags_metadata ✓
  test_query_basic ✓
  test_query_uses_similarity_top_k ✓
  test_query_raises_without_query_str ✓
  test_delete_by_tag_lookup ✓
  test_delete_with_explicit_memory_ids ✓
  test_delete_no_matching_memories ✓
  test_async_add ✓
  test_async_query ✓
  test_async_delete ✓
  test_memory_to_node_fallback_when_no_meta_tag ✓
```

## Checklist

- [x] Follows `BasePydanticVectorStore` interface (all abstract methods implemented)
- [x] `is_embedding_query = False` — server-side embedding
- [x] Sync and async API variants
- [x] Node metadata round-trip via `_llama_meta` tag
- [x] `pyproject.toml` following integration package conventions
- [x] 17 unit tests — `respx`-mocked, no live server needed
- [x] Optional `api_key`, `session_id`, `top_k`, `importance` parameters