### PR TITLE
docs: add Bocha Web Search external ToolSpec example notebook and int…

### DIFF
--- a/docs/examples/tools/bocha_web_search.ipynb
+++ b/docs/examples/tools/bocha_web_search.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/tools/bocha_web_search.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "# Bocha Web Search Tool\n",
+    "\n",
+    "[Bocha Web Search](https://bochaai.com/) is a web search API that provides structured search results with rich metadata. This notebook demonstrates how to use the `llama-index-tools-bocha-search` package — an **external** LlamaIndex ToolSpec maintained at [github.com/NiTingKY/llama-index-tools-bocha-search](https://github.com/NiTingKY/llama-index-tools-bocha-search) — to give agents access to live web search.\n",
+    "\n",
+    "The package exposes a single tool:\n",
+    "\n",
+    "- **`web_search`** — searches the web via the Bocha API and returns LlamaIndex `Document` objects, each containing the result text and source metadata (`title`, `url`, `site_name`, `published_date`).\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- A Bocha API key — sign up at [bochaai.com](https://bochaai.com/) to obtain one.\n",
+    "- An LLM API key (the examples below use OpenAI)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q llama-index-tools-bocha-search llama-index-core llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Export your API keys as environment variables before running the cells below:\n",
+    "\n",
+    "```bash\n",
+    "export BOCHA_SEARCH_API_KEY=\"your-bocha-api-key\"\n",
+    "export OPENAI_API_KEY=\"your-openai-api-key\"\n",
+    "```\n",
+    "\n",
+    "On Windows PowerShell:\n",
+    "\n",
+    "```powershell\n",
+    "$env:BOCHA_SEARCH_API_KEY = \"your-bocha-api-key\"\n",
+    "$env:OPENAI_API_KEY       = \"your-openai-api-key\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from llama_index.tools.bocha_search import BochaSearchToolSpec\n",
+    "\n",
+    "# BochaSearchToolSpec reads BOCHA_SEARCH_API_KEY from the environment by default.\n",
+    "# You can also pass the key directly: BochaSearchToolSpec(api_key=\"sk-...\")\n",
+    "bocha_spec = BochaSearchToolSpec(\n",
+    "    api_key=os.getenv(\"BOCHA_SEARCH_API_KEY\"),\n",
+    "    default_count=5,  # number of results per query\n",
+    ")\n",
+    "\n",
+    "tools = bocha_spec.to_tool_list()\n",
+    "print(f\"Available tools: {[t.metadata.name for t in tools]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "source": [
+    "## Direct Tool Usage\n",
+    "\n",
+    "You can call `web_search` directly on the spec — useful for scripting or when you\n",
+    "want precise control without an agent in the loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = bocha_spec.web_search(query=\"LlamaIndex latest release\", count=3)\n",
+    "\n",
+    "for doc in results:\n",
+    "    print(\"Title       :\", doc.metadata.get(\"title\"))\n",
+    "    print(\"URL         :\", doc.metadata.get(\"url\"))\n",
+    "    print(\"Site        :\", doc.metadata.get(\"site_name\"))\n",
+    "    print(\"Published   :\", doc.metadata.get(\"published_date\"))\n",
+    "    print(\"Snippet     :\", doc.text[:200])\n",
+    "    print(\"-\" * 60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "## Agent Integration\n",
+    "\n",
+    "Pass the tool list to a `FunctionAgent` so it can autonomously decide when and how\n",
+    "to call `web_search` in order to answer user questions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\", api_key=os.getenv(\"OPENAI_API_KEY\"))\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=tools,\n",
+    "    llm=llm,\n",
+    "    system_prompt=(\n",
+    "        \"You are a helpful research assistant. \"\n",
+    "        \"Use the web_search tool to find up-to-date information before answering.\"\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\n",
+    "    \"What are the key highlights of the most recent LlamaIndex release?\"\n",
+    ")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\n",
+    "    \"Find the current price of NVIDIA stock and briefly summarise today's market sentiment around it.\"\n",
+    ")\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "source": [
+    "## Optional: Override the API Endpoint\n",
+    "\n",
+    "If your deployment uses a different Bocha endpoint, pass `api_url` at construction\n",
+    "time or set the `BOCHA_SEARCH_API_URL` environment variable:\n",
+    "\n",
+    "```python\n",
+    "bocha_spec = BochaSearchToolSpec(\n",
+    "    api_key=os.getenv(\"BOCHA_SEARCH_API_KEY\"),\n",
+    "    api_url=\"https://your-custom-endpoint/v1/web-search\",\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "- [Bocha Web Search](https://bochaai.com/)\n",
+    "- [llama-index-tools-bocha-search on GitHub](https://github.com/NiTingKY/llama-index-tools-bocha-search)\n",
+    "- [llama-index-tools-bocha-search on PyPI](https://pypi.org/project/llama-index-tools-bocha-search/)\n",
+    "- [LlamaIndex Tools documentation](/python/framework/module_guides/deploying/agents/tools)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/community/integrations/bocha_search.md
+++ b/docs/src/content/docs/framework/community/integrations/bocha_search.md
@@ -1,0 +1,74 @@
+---
+title: Bocha Web Search
+---
+
+[Bocha Web Search](https://bochaai.com/) is a web search API that returns structured
+results enriched with metadata such as title, URL, site name, and publication date.
+
+The `llama-index-tools-bocha-search` package is an **external** LlamaIndex
+[ToolSpec](https://docs.llamaindex.ai/en/stable/module_guides/deploying/agents/tools/)
+maintained at
+[github.com/NiTingKY/llama-index-tools-bocha-search](https://github.com/NiTingKY/llama-index-tools-bocha-search).
+It follows LlamaIndex's external-integration guidance and is published independently
+on PyPI.
+
+## Installation
+
+```bash
+pip install llama-index-tools-bocha-search
+```
+
+## What It Provides
+
+| Detail | Value |
+|---|---|
+| Package name | `llama-index-tools-bocha-search` |
+| Import path | `llama_index.tools.bocha_search` |
+| ToolSpec class | `BochaSearchToolSpec` |
+| Tool exposed to agents | `web_search` |
+| Auth | `api_key` parameter or `BOCHA_SEARCH_API_KEY` env var |
+| Endpoint override | `api_url` parameter or `BOCHA_SEARCH_API_URL` env var |
+| Result type | LlamaIndex `Document` objects with `title`, `url`, `site_name`, and `published_date` metadata |
+
+## Usage
+
+```python
+import os
+from llama_index.tools.bocha_search import BochaSearchToolSpec
+
+bocha_spec = BochaSearchToolSpec(
+    api_key=os.getenv("BOCHA_SEARCH_API_KEY"),
+    default_count=5,
+)
+
+tools = bocha_spec.to_tool_list()
+```
+
+### Using with an Agent
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.bocha_search import BochaSearchToolSpec
+
+bocha_spec = BochaSearchToolSpec(api_key=os.getenv("BOCHA_SEARCH_API_KEY"))
+
+agent = FunctionAgent(
+    tools=bocha_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4o-mini"),
+)
+
+response = await agent.run("What are the highlights of the latest LlamaIndex release?")
+print(str(response))
+```
+
+## Example Notebook
+
+A full walkthrough — including direct tool usage and agent integration — is available
+in the [Bocha Web Search example notebook](/python/examples/tools/bocha_web_search).
+
+## References
+
+- [Bocha Web Search](https://bochaai.com/)
+- [llama-index-tools-bocha-search on GitHub](https://github.com/NiTingKY/llama-index-tools-bocha-search)
+- [llama-index-tools-bocha-search on PyPI](https://pypi.org/project/llama-index-tools-bocha-search/)


### PR DESCRIPTION
## Description

Adds documentation for the external [`llama-index-tools-bocha-search`](https://github.com/NiTingKY/llama-index-tools-bocha-search) package, following LlamaIndex's guidance that new integrations be maintained outside the monorepo. No source code is added to the monorepo.

Fixes #21883

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No — this PR adds documentation only. The package is maintained externally.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating?

- [ ] Yes
- [x] No — no package files were modified.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

This is a documentation-only PR (a Jupyter notebook and a Markdown page). No code was added to the monorepo. The notebook was validated with `ruff check docs/` which returned `All checks passed!`.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
