### PR TITLE
fix: SageMaker streaming corrupts generated text via lstrip/rstrip char sets

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
@@ -62,8 +62,14 @@ class IOHandler(BaseIOHandler):
         return json.load(codecs.getreader("utf-8")(response))[0]["generated_text"]
 
     def deserialize_streaming_output(self, response: bytes) -> str:
+        # str.lstrip/rstrip treat their argument as a set of characters, not a
+        # literal affix, so they also eat leading/trailing characters of the
+        # generated text itself (e.g. '[{"generated_text":"the answer"}]'
+        # became 'he answer'). Remove the JSON envelope as exact affixes.
         response_str = (
-            response.decode("utf-8").lstrip('[{"generated_text":"').rstrip('"}]')
+            response.decode("utf-8")
+            .removeprefix('[{"generated_text":"')
+            .removesuffix('"}]')
         )
         clean_response = '{"response":"' + response_str + '"}'
 

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
@@ -62,18 +62,13 @@ class IOHandler(BaseIOHandler):
         return json.load(codecs.getreader("utf-8")(response))[0]["generated_text"]
 
     def deserialize_streaming_output(self, response: bytes) -> str:
-        # str.lstrip/rstrip treat their argument as a set of characters, not a
-        # literal affix, so they also eat leading/trailing characters of the
-        # generated text itself (e.g. '[{"generated_text":"the answer"}]'
-        # became 'he answer'). Remove the JSON envelope as exact affixes.
-        response_str = (
-            response.decode("utf-8")
-            .removeprefix('[{"generated_text":"')
-            .removesuffix('"}]')
-        )
-        clean_response = '{"response":"' + response_str + '"}'
-
-        return json.loads(clean_response)["response"]
+        # The streaming payload is the same JSON envelope as the non-streaming
+        # output ([{"generated_text": "..."}]), so parse it directly like
+        # deserialize_output. The previous lstrip/rstrip stripping treated the
+        # envelope as a character set and silently truncated generated text that
+        # started or ended with any of those characters (e.g.
+        # '[{"generated_text":"the answer"}]' returned 'he answer').
+        return json.loads(response.decode("utf-8"))[0]["generated_text"]
 
     def remove_prefix(self, raw_text: str, prompt: str) -> str:
         return raw_text[len(prompt) :]

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-sagemaker-endpoint"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms sagemaker endpoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
@@ -1,7 +1,28 @@
+import pytest
+
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.sagemaker_endpoint import SageMakerLLM
+from llama_index.llms.sagemaker_endpoint.utils import IOHandler
 
 
 def test_embedding_class():
     names_of_base_classes = [b.__name__ for b in SageMakerLLM.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        # Regression: lstrip/rstrip treated the envelope as a character set,
+        # so generated text starting with any of its characters (t, g, d, a,
+        # e, n, r, x, _, etc.) or ending with '"', '}' or ']' was corrupted.
+        (b'[{"generated_text":"the answer is 42"}]', "the answer is 42"),
+        (b'[{"generated_text":"great and neat"}]', "great and neat"),
+        (b'[{"generated_text":"data engineering"}]', "data engineering"),
+        (b'[{"generated_text":"result: {}"}]', "result: {}"),
+        (b'[{"generated_text":"Hello world"}]', "Hello world"),
+    ],
+)
+def test_deserialize_streaming_output_preserves_text(payload, expected):
+    handler = IOHandler()
+    assert handler.deserialize_streaming_output(payload) == expected

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
@@ -21,6 +21,8 @@ def test_embedding_class():
         (b'[{"generated_text":"data engineering"}]', "data engineering"),
         (b'[{"generated_text":"result: {}"}]', "result: {}"),
         (b'[{"generated_text":"Hello world"}]', "Hello world"),
+        # Escaped quotes inside the generated text are preserved by json parsing.
+        (b'[{"generated_text":"he said \\"hi\\""}]', 'he said "hi"'),
     ],
 )
 def test_deserialize_streaming_output_preserves_text(payload, expected):

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/uv.lock
@@ -1001,7 +1001,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1859,7 +1859,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-sagemaker-endpoint"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`IOHandler.deserialize_streaming_output` in `llama-index-llms-sagemaker-endpoint` removed the `[{"generated_text":"` / `"}]` envelope with `str.lstrip` / `str.rstrip`, which treat their argument as a set of characters rather than a literal affix. After the envelope, stripping continued into the payload itself, so generated text starting with any character from the set (`t`, `g`, `d`, `a`, `e`, `n`, `r`, `x`, `_`, ...) or ending with `"`, `}`, `]` was silently truncated:

```python
IOHandler().deserialize_streaming_output(b'[{"generated_text":"the answer is 42"}]')
# returned 'he answer is 42'
```

The streaming payload is the same JSON envelope as the non-streaming output (`[{"generated_text": "..."}]`), so this parses it directly with `json.loads(...)[0]["generated_text"]`, matching the sibling `deserialize_output` method in the same file. That is more robust to envelope formatting and escaped characters than affix stripping and keeps the two code paths consistent. Parametrized regression tests cover leading words made of set characters ("the", "great", "data"), text ending in `}`, escaped quotes, and the previously-working happy path; the failing cases fail on the old implementation.

Fixes #22221

## New Package?

- [x] No

## Version Bump?

- [x] Yes (0.5.0 -> 0.5.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`uv run --python 3.12 -- pytest` in the package: 7 passed with the fix; reverting to the original `lstrip`/`rstrip` implementation while keeping the tests yields 4 failed, confirming the tests exercise the bug.

Transparency note per CONTRIBUTING's AI guidelines: this bug was found and the patch drafted with AI assistance (Claude Code); I reviewed the change and validated it by running the reproduction above and the package test suite before and after the fix. The direct-`json.loads` approach also matches a suggestion raised by Dosu on the linked issue.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods (pre-commit hooks on the changed files: ruff, ruff-format, mypy, codespell all pass)