### PR TITLE
fix: SiliconFlow astream_chat crashes when streamed content contains "data: "

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
@@ -519,27 +519,31 @@ class SiliconFlow(FunctionCallingLLM):
                     response.raise_for_status()
                     response_txt = ""
                     response_role = "assistant"
-                    async for line in response.content.iter_any():
-                        line = cast(bytes, line).decode("utf-8")
-                        chunks = list(filter(None, line.split("data: ")))
-                        for chunk in chunks:
-                            if chunk.strip() == "[DONE]":
-                                break
-                            chunk_json = json.loads(chunk)
-                            delta: dict = chunk_json["choices"][0]["delta"]
-                            response_role = delta.get("role") or response_role
-                            delta_txt = delta["content"] or ""
-                            response_txt += delta_txt
-                            tool_calls = delta.get("tool_calls")
-                            yield ChatResponse(
-                                message=ChatMessage(
-                                    content=response_txt,
-                                    role=response_role,
-                                    additional_kwargs={"tool_calls": tool_calls},
-                                ),
-                                delta=delta_txt,
-                                raw=line,
-                            )
+                    # Iterate server-sent events line by line, mirroring
+                    # stream_chat. Splitting raw reads on "data: " corrupted
+                    # events whose content contained that string and broke on
+                    # events spanning multiple reads.
+                    async for raw_line in response.content:
+                        line = cast(bytes, raw_line).decode("utf-8")
+                        if not line.startswith("data:"):
+                            continue
+                        if line.strip() == "data: [DONE]":
+                            break
+                        chunk_json = json.loads(line[5:])
+                        delta: dict = chunk_json["choices"][0]["delta"]
+                        response_role = delta.get("role") or response_role
+                        delta_txt = delta["content"] or ""
+                        response_txt += delta_txt
+                        tool_calls = delta.get("tool_calls")
+                        yield ChatResponse(
+                            message=ChatMessage(
+                                content=response_txt,
+                                role=response_role,
+                                additional_kwargs={"tool_calls": tool_calls},
+                            ),
+                            delta=delta_txt,
+                            raw=chunk_json,
+                        )
 
         return gen()
 

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-siliconflow"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms siliconflow integration"
 authors = [{name = "nightosong"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
@@ -53,6 +53,39 @@ class MockAsyncResponse:
         return self._json_data
 
 
+class MockStreamContent:
+    """Mimics aiohttp's StreamReader: async line iteration and iter_any."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        return self._lines()
+
+    async def _lines(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def iter_any(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class MockAsyncStreamResponse:
+    def __init__(self, chunks):
+        self.status = 200
+        self.content = MockStreamContent(chunks)
+
+    def raise_for_status(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
 def test_llm_class():
     names_of_base_classes = [b.__name__ for b in SiliconFlow.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
@@ -206,29 +239,6 @@ async def test_astream_chat():
         b"data: [DONE]\n",
     ]
 
-    # Create a mock async response with iter_any method
-    class MockStreamContent:
-        def __init__(self, chunks):
-            self._chunks = chunks
-
-        async def iter_any(self):
-            for chunk in self._chunks:
-                yield chunk
-
-    class MockAsyncStreamResponse:
-        def __init__(self, chunks):
-            self.status = 200
-            self.content = MockStreamContent(chunks)
-
-        def raise_for_status(self):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            pass
-
     mock_response = MockAsyncStreamResponse(stream_chunks)
 
     llm = SiliconFlow(api_key="test_api_key")
@@ -278,3 +288,36 @@ async def test_astream_chat():
             headers=llm._headers,
             timeout=llm.timeout,
         )
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_content_containing_data_prefix():
+    """
+    Regression test: streamed content containing the literal string "data: "
+    must not corrupt event parsing.
+
+    The async generator used to split raw reads on "data: ", so a delta whose
+    text contained that substring was cut apart and json.loads raised
+    JSONDecodeError mid-stream.
+    """
+    messages = [ChatMessage(role=MessageRole.USER, content="Hello")]
+
+    stream_chunks = [
+        b'data: {"id": "1", "choices": [{"delta": {"role": "assistant", "content": "the log shows data: 42 here"}}]}\n',
+        b"data: [DONE]\n",
+    ]
+
+    mock_response = MockAsyncStreamResponse(stream_chunks)
+
+    llm = SiliconFlow(api_key="test_api_key")
+
+    with mock.patch("aiohttp.ClientSession.post", return_value=mock_response):
+        stream = await llm.astream_chat(messages)
+
+        responses = []
+        async for response in stream:
+            responses.append(response)
+
+        assert len(responses) == 1
+        assert responses[0].delta == "the log shows data: 42 here"
+        assert responses[0].message.content == "the log shows data: 42 here"

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/uv.lock
@@ -992,7 +992,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1824,7 +1824,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-siliconflow"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# Description

`SiliconFlow.astream_chat` parsed the SSE stream by reading raw byte chunks (`response.content.iter_any()`) and splitting them on the string `"data: "`. Any event whose delta content contained that literal substring (log excerpts, SSE examples, code) was cut apart and `json.loads` raised `JSONDecodeError` mid-stream; events spanning multiple network reads broke the same way. The sync `stream_chat` already iterates lines and checks the `data:` prefix, so identical model output streamed fine synchronously and crashed asynchronously.

This PR makes the async generator mirror the sync one: iterate the response line by line (`async for raw_line in response.content`, aiohttp's buffered line iteration, which also removes the arbitrary-chunk-boundary failure mode), skip non-`data:` lines, check for `data: [DONE]`, and parse `line[5:]`. `raw` now carries the parsed event dict, matching the sync path, instead of the undecoded read.

Fixes #22223

## New Package?

- [x] No

## Version Bump?

- [x] Yes (0.5.0 -> 0.5.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`uv run --python 3.12 -- pytest` in the package: 7 passed with the fix. Reverting only the `base.py` hunk while keeping the tests yields 1 failed (the new regression test, with the exact `JSONDecodeError` from the issue) and 6 passed, confirming the test exercises the bug. The existing `test_astream_chat` mock was extended to mimic aiohttp's `StreamReader` line iteration (it keeps `iter_any` too, so it exercises both implementations).

Transparency note per CONTRIBUTING's AI guidelines: this bug was found and the patch drafted with AI assistance (Claude Code); I reviewed the change and validated it by running the reproduction in the issue and the package test suite before and after the fix.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods (pre-commit hooks on the changed files: ruff, ruff-format, mypy, codespell all pass)