### PR TITLE
fix: close leaked file handles in HotpotQA benchmark

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
+++ b/llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py
@@ -35,18 +35,20 @@ class HotpotQAEvaluator:
             url = DEV_DISTRACTOR_URL
             try:
                 os.makedirs(dataset_full_path, exist_ok=True)
-                save_file = open(
+                with open(
                     os.path.join(dataset_full_path, "dev_distractor.json"), "wb"
-                )
-                response = requests.get(url, stream=True)
+                ) as save_file:
+                    response = requests.get(url, stream=True)
 
-                # Define the size of each chunk
-                chunk_size = 1024
+                    # Define the size of each chunk
+                    chunk_size = 1024
 
-                # Loop over the chunks and parse the JSON data
-                for chunk in tqdm.tqdm(response.iter_content(chunk_size=chunk_size)):
-                    if chunk:
-                        save_file.write(chunk)
+                    # Loop over the chunks and parse the JSON data
+                    for chunk in tqdm.tqdm(
+                        response.iter_content(chunk_size=chunk_size)
+                    ):
+                        if chunk:
+                            save_file.write(chunk)
             except Exception as e:
                 if os.path.exists(dataset_full_path):
                     print(
@@ -71,8 +73,8 @@ class HotpotQAEvaluator:
         print("Evaluating on dataset:", dataset)
         print("-------------------------------------")
 
-        f = open(dataset_path)
-        query_objects = json.loads(f.read())
+        with open(dataset_path) as f:
+            query_objects = json.loads(f.read())
         if queries_fraction:
             queries_to_load = int(len(query_objects) * queries_fraction)
         else:


### PR DESCRIPTION
## Summary
`HotpotQAEvaluator` opens two files with a bare `open()` and never closes them, leaking a file descriptor on every benchmark run:

- `_download_datasets()` opens `dev_distractor.json` for writing and streams the download into it, but never closes the handle.
- `run()` opens the dataset file to load the queries and never closes it.

Both are now wrapped in `with` blocks, matching the context-manager style already used elsewhere in this file. No behavior change beyond deterministic closing (previously the handles were released only on garbage collection).

File: `llama-index-core/llama_index/core/evaluation/benchmarks/hotpotqa.py`