### PR TITLE
fix: parse SageMaker streaming output as JSON

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
@@ -62,12 +62,8 @@ class IOHandler(BaseIOHandler):
         return json.load(codecs.getreader("utf-8")(response))[0]["generated_text"]
 
     def deserialize_streaming_output(self, response: bytes) -> str:
-        response_str = (
-            response.decode("utf-8").lstrip('[{"generated_text":"').rstrip('"}]')
-        )
-        clean_response = '{"response":"' + response_str + '"}'
-
-        return json.loads(clean_response)["response"]
+        response_json = json.loads(response.decode("utf-8"))
+        return response_json[0]["generated_text"]
 
     def remove_prefix(self, raw_text: str, prompt: str) -> str:
         return raw_text[len(prompt) :]

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
@@ -1,7 +1,21 @@
+import json
+
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.sagemaker_endpoint import SageMakerLLM
+from llama_index.llms.sagemaker_endpoint.utils import IOHandler
 
 
 def test_embedding_class():
     names_of_base_classes = [b.__name__ for b in SageMakerLLM.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_deserialize_streaming_output_preserves_generated_text():
+    handler = IOHandler()
+    generated_text = 'the data answer ends with "'
+    response = json.dumps(
+        [{"generated_text": generated_text}],
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    assert handler.deserialize_streaming_output(response) == generated_text


### PR DESCRIPTION
## Summary
- parse SageMaker streaming responses as JSON instead of trimming a JSON envelope with `lstrip` / `rstrip`
- preserve generated text that starts or ends with characters from the old trim set
- add regression coverage for generated text that starts with affected characters and ends with an escaped quote

Fixes #22221.

## Tests
- `python -m pytest tests -q`
- `python -m ruff check llama_index/llms/sagemaker_endpoint/utils.py tests/test_llms_sagemaker_endpoint.py`
- `git diff --check`