### PR TITLE
fix: Maritalk streaming strips only the leading 'data: ' SSE prefix

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-maritalk/llama_index/llms/maritalk/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-maritalk/llama_index/llms/maritalk/base.py
@@ -296,7 +296,7 @@ class Maritalk(LLM):
                 content = ""
                 for line in response.iter_lines():
                     if line.startswith(b"data: "):
-                        response_data = line.replace(b"data: ", b"").decode("utf-8")
+                        response_data = line.removeprefix(b"data: ").decode("utf-8")
                         if response_data:
                             parsed_data = json.loads(response_data)
                             if "text" in parsed_data:
@@ -357,7 +357,7 @@ class Maritalk(LLM):
                             content = ""
                             async for line in response.aiter_lines():
                                 if line.startswith("data: "):
-                                    response_data = line.replace("data: ", "")
+                                    response_data = line.removeprefix("data: ")
                                     if response_data:
                                         parsed_data = json.loads(response_data)
                                         if "text" in parsed_data:

--- a/llama-index-integrations/llms/llama-index-llms-maritalk/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-maritalk/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-maritalk"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index llms maritalk integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<3.12"

--- a/llama-index-integrations/llms/llama-index-llms-maritalk/tests/test_llms_maritalk.py
+++ b/llama-index-integrations/llms/llama-index-llms-maritalk/tests/test_llms_maritalk.py
@@ -1,0 +1,77 @@
+import asyncio
+from unittest import mock
+
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.llms.maritalk import Maritalk
+
+
+def test_llm_class():
+    names_of_base_classes = [b.__name__ for b in Maritalk.__mro__]
+    assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_stream_chat_preserves_data_prefix_substring():
+    """
+    Text containing the literal 'data: ' must not be corrupted.
+
+    Regression: the SSE prefix was stripped with ``line.replace(b"data: ", b"")``,
+    which removes every occurrence, so a delta like 'see data: here' became
+    'see here'. Only the leading 'data: ' prefix should be removed.
+    """
+    lines = [
+        b'data: {"text":"see data: here"}',
+        b'data: {"text":"!"}',
+    ]
+    mock_response = mock.Mock()
+    mock_response.ok = True
+    mock_response.iter_lines.return_value = iter(lines)
+
+    llm = Maritalk(api_key="test-key")
+    with mock.patch("requests.post", return_value=mock_response):
+        responses = list(
+            llm.stream_chat([ChatMessage(role=MessageRole.USER, content="hi")])
+        )
+
+    assert [r.delta for r in responses] == ["see data: here", "!"]
+    assert responses[-1].message.content == "see data: here!"
+
+
+def test_astream_chat_preserves_data_prefix_substring():
+    """Async counterpart of the streaming 'data: ' corruption regression."""
+    lines = [
+        'data: {"text":"see data: here"}',
+        'data: {"text":"!"}',
+    ]
+
+    class _MockStream:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def aiter_lines(self):
+            for line in lines:
+                yield line
+
+    class _MockAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return _MockStream()
+
+    async def run():
+        with mock.patch("httpx.AsyncClient", return_value=_MockAsyncClient()):
+            gen = await Maritalk(api_key="test-key").astream_chat(
+                [ChatMessage(role=MessageRole.USER, content="hi")]
+            )
+            return [r.delta async for r in gen]
+
+    assert asyncio.run(run()) == ["see data: here", "!"]

--- a/llama-index-integrations/llms/llama-index-llms-maritalk/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-maritalk/uv.lock
@@ -601,7 +601,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1288,7 +1288,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-maritalk"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1320,7 +1320,7 @@ requires-dist = [{ name = "llama-index-core", specifier = ">=0.13.0,<0.15" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "ipython", specifier = "==8.10.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2" },


### PR DESCRIPTION
# Description

`Maritalk.stream_chat` and `Maritalk.astream_chat` removed the SSE `data: ` prefix from each streamed line with `replace("data: ", "")`, which deletes **every** occurrence in the line rather than only the leading prefix. When the model's generated text contains the substring `data: `, it was stripped out of the JSON value, corrupting the delta (and sometimes producing invalid JSON):

```python
line = 'data: {"text":"see data: here"}'
line.replace("data: ", "")   # -> {"text":"see here"}  (delta becomes "see here")
```

This replaces both the sync (`bytes`) and async (`str`) prefix stripping with `removeprefix`, so only the leading `data: ` is removed and the payload is preserved. The `startswith` guards already ensure the prefix is present.

Fixes #22227

## New Package?

- [x] No

## Version Bump?

- [x] Yes (0.6.0 -> 0.6.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

This package had no test suite; this PR adds one. The sync and async streaming tests mock the HTTP client and feed a chunk whose text contains `data: `, asserting the delta is preserved. `uv run --python 3.11 -- pytest` in the package: 3 passed with the fix; reverting only the `base.py` change while keeping the tests yields 2 failed, confirming the tests exercise the bug.

Transparency note per CONTRIBUTING's AI guidelines: this bug was found and the patch drafted with AI assistance (Claude Code); I reviewed the change and validated it by running the reproduction above and the new tests before and after the fix.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods (pre-commit hooks on changed files: ruff, ruff-format, mypy, codespell, toml-sort all pass)