### PR TITLE
[Docs]: add DProvenanceKit integration to observability docs

### DIFF
--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -708,6 +708,53 @@ print(f"Response: {response}")
 
 These partner integrations use our legacy `CallbackManager` or third-party calls.
 
+### DProvenanceKit
+
+[DProvenanceKit](https://github.com/Therealdk8890/DProvenanceKitPython) is an open-source
+(Apache-2.0) reasoning observability and regression-testing toolkit for AI agents, with zero
+third-party dependencies in its core. It records each LlamaIndex run as a queryable, diffable
+trace with a structural fingerprint of the execution path, and can fail CI when a run's
+reasoning drifts from a golden baseline — for example a dropped retrieval step or a looping
+tool call. The integration attaches through the `CallbackManager`.
+
+#### Usage Pattern
+
+```bash
+pip install "dprovenancekit[llama-index]"
+```
+
+```python
+from llama_index.core import Settings
+from dprovenancekit import DProvenanceKit, SQLiteTraceStore
+from dprovenancekit.integrations.llama_index import (
+    DProvenanceLlamaIndexCallbackHandler,
+    LlamaIndexTraceEvent,
+)
+
+kit = DProvenanceKit(LlamaIndexTraceEvent)
+store = SQLiteTraceStore(LlamaIndexTraceEvent, "traces.sqlite")
+
+# The handler records into an active run
+with kit.run(context_id="qa-session", store=store) as run:
+    handler = DProvenanceLlamaIndexCallbackHandler(run)
+    Settings.callback_manager.add_handler(handler)
+
+    # Execute queries normally; they are recorded to the trace store
+    response = index.as_query_engine().query("What did the author do growing up?")
+
+# Flush buffered events so the recorded run is durable before the script exits
+store.flush()
+```
+
+Recorded traces can then be queried, diffed against a golden run, and gated in CI with the
+`dprovenancekit gate` CLI, the pytest plugin, or the GitHub Action.
+
+#### Guides
+
+- [DProvenanceKit repository and documentation](https://github.com/Therealdk8890/DProvenanceKitPython)
+- [LlamaIndex adapter usage](https://github.com/Therealdk8890/DProvenanceKitPython#llamaindex)
+- [dprovenancekit on PyPI](https://pypi.org/project/dprovenancekit/)
+
 ### Langfuse
 
 This integration is deprecated. We recommend using the new instrumentation-based integration with Langfuse as described [here](https://langfuse.com/docs/integrations/llama-index/get-started).


### PR DESCRIPTION
# Description

Adds a DProvenanceKit section to the observability integrations page
(`docs/src/content/docs/framework/module_guides/observability/index.md`). Documentation only —
no code, no new packages, no version bumps.

[DProvenanceKit](https://github.com/Therealdk8890/DProvenanceKitPython) is an Apache-2.0
reasoning observability and regression-testing toolkit for AI agents, with a stdlib-only core.
Its LlamaIndex adapter (`pip install "dprovenancekit[llama-index]"`) records each LlamaIndex run
as a queryable, diffable trace via a `CallbackManager` handler; recorded traces carry a
structural fingerprint of the execution path and can gate CI against a golden baseline run.

Per CONTRIBUTING.md, the integration is maintained in its own repository and published to PyPI
independently (package: `dprovenancekit`), so this PR intentionally adds no `pyproject.toml` to
the monorepo.

Because the adapter attaches through the legacy `CallbackManager` API rather than the newer
`instrumentation` module, I placed the section under "Other Partner `One-Click` Integrations
(Legacy Modules)", matching the heading conventions of the neighboring entries
(`#### Usage Pattern` / `#### Guides`). Happy to move it or adjust the formatting if you prefer.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No — documentation only; the integration lives in its own repository and publishes to PyPI independently.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No — no package in this monorepo is touched.

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- Documentation-only change; no code paths in this repository are affected.
- The code example was executed end-to-end against the released package before submission
  (dprovenancekit 0.3.1, llama-index-core 0.14.23, offline via `MockLLM`/`MockEmbedding`):
  the `CallbackManager` handler recorded all events for the run, and the trace was verified
  durable in the SQLite store.
- The handler's recording behavior is additionally covered by the adapter's test suite in the
  DProvenanceKit repository.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Transparency note

I am the author and maintainer of DProvenanceKit. This PR was drafted with AI assistance. The
install command and code example were executed against the released package before submission.
