### PR TITLE
Fix Vearch query flag handling and delete call

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/llama_index/vector_stores/vearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/llama_index/vector_stores/vearch/base.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List, Optional
 
 import numpy as np
 
-from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
@@ -43,6 +43,8 @@ class VearchVectorStore(BasePydanticVectorStore):
     using_db_name: str
     using_table_name: str
     url: str
+    flag: int = 0
+    field_list: List[dict] = Field(default_factory=list)
     _vearch: vearch_cluster.VearchCluster = PrivateAttr()
 
     def __init__(
@@ -53,6 +55,7 @@ class VearchVectorStore(BasePydanticVectorStore):
         **kwargs: Any,
     ) -> None:
         """Initialize vearch vector store."""
+        flag = kwargs.pop("flag", 0)
         if path_or_url is None:
             raise ValueError("Please input url of cluster")
 
@@ -70,6 +73,7 @@ class VearchVectorStore(BasePydanticVectorStore):
             using_db_name=db_name,
             using_table_name=table_name,
             url=path_or_url,
+            flag=flag,
         )
         self._vearch = vearch_cluster.VearchCluster(path_or_url)
 
@@ -245,6 +249,10 @@ class VearchVectorStore(BasePydanticVectorStore):
         if query.filters is not None:
             for filter_ in query.filters.legacy_filters():
                 meta_filters[filter_.key] = filter_.value
+        meta_field_list = ["ref_doc_id", "text"]
+        meta_field_list.extend(
+            field["field"] for field in getattr(self, "field_list", [])
+        )
         if self.flag:
             meta_field_list = self._vearch.get_space(
                 self.using_db_name, self.using_table_name
@@ -335,7 +343,7 @@ class VearchVectorStore(BasePydanticVectorStore):
                 "size": 10000,
             }
             self._vearch.delete_by_query(
-                self, self.using_db_name, self.using_table_name, queries
+                self.using_db_name, self.using_table_name, queries
             )
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-vearch"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index vector_stores vearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/tests/test_vector_stores_vearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/tests/test_vector_stores_vearch.py
@@ -1,7 +1,94 @@
+import sys
+import types
+
+import numpy as np
+
+vearch_cluster = types.ModuleType("vearch_cluster")
+vearch_cluster.VearchCluster = object
+sys.modules.setdefault("vearch_cluster", vearch_cluster)
+
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from llama_index.core.vector_stores.types import VectorStoreQuery
 from llama_index.vector_stores.vearch import VearchVectorStore
+import llama_index.vector_stores.vearch.base as vearch_base
+
+
+class FakeVearchClient:
+    def __init__(self) -> None:
+        self.last_search = None
+        self.delete_calls = []
+        self.get_space_calls = []
+
+    def get_space(self, db_name, table_name):
+        self.get_space_calls.append((db_name, table_name))
+        return ["ref_doc_id", "text", "text_embedding", "topic"]
+
+    def search(self, db_name, table_name, query_data):
+        self.last_search = (db_name, table_name, query_data)
+        return {"hits": {"hits": []}}
+
+    def delete_by_query(self, db_name, table_name, queries):
+        self.delete_calls.append((db_name, table_name, queries))
+
+
+def build_store(monkeypatch, fake_client, **kwargs):
+    monkeypatch.setattr(
+        vearch_base.vearch_cluster, "VearchCluster", lambda path_or_url: fake_client
+    )
+    return VearchVectorStore(
+        path_or_url="http://localhost:9001",
+        table_name="test_table",
+        db_name="test_db",
+        **kwargs,
+    )
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in VearchVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def test_constructor_persists_flag_and_cluster_query_uses_space_fields(monkeypatch):
+    fake_client = FakeVearchClient()
+    store = build_store(monkeypatch, fake_client, flag=1)
+
+    store.query(
+        VectorStoreQuery(query_embedding=np.array([1.0, 0.0]), similarity_top_k=3)
+    )
+
+    assert store.flag == 1
+    assert fake_client.get_space_calls == [("test_db", "test_table")]
+    assert fake_client.last_search[2]["fields"] == ["ref_doc_id", "text", "topic"]
+
+
+def test_standalone_query_uses_initialized_fields_without_get_space(monkeypatch):
+    fake_client = FakeVearchClient()
+    store = build_store(monkeypatch, fake_client, flag=0)
+    store._get_matadata_field([{"topic": "vearch"}])
+
+    store.query(
+        VectorStoreQuery(query_embedding=np.array([1.0, 0.0]), similarity_top_k=2)
+    )
+
+    assert fake_client.get_space_calls == []
+    assert fake_client.last_search[2]["fields"] == ["ref_doc_id", "text", "topic"]
+
+
+def test_delete_uses_bound_client_delete_by_query(monkeypatch):
+    fake_client = FakeVearchClient()
+    store = build_store(monkeypatch, fake_client)
+
+    store.delete("doc-1")
+
+    assert fake_client.delete_calls == [
+        (
+            "test_db",
+            "test_table",
+            {
+                "query": {
+                    "filter": [{"term": {"ref_doc_id": ["doc-1"], "operator": "and"}}]
+                },
+                "size": 10000,
+            },
+        )
+    ]


### PR DESCRIPTION
# Description

Fixes local Vearch vector store bugs around query mode state, standalone query field selection, and delete call argument handling.

This change:
- persists the `flag` constructor option so `query()` can select the intended Vearch path
- initializes standalone query return fields from the fields stored by this integration
- fixes `delete_by_query` invocation to use the bound client method signature
- adds fake-client unit tests without requiring a real Vearch cluster
- bumps `llama-index-vector-stores-vearch` from `0.6.0` to `0.6.1`

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Tested with:
- `.venv/bin/ruff format --check llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/llama_index/vector_stores/vearch/base.py llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/tests/test_vector_stores_vearch.py`
- `.venv/bin/ruff check llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/llama_index/vector_stores/vearch/base.py llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/tests/test_vector_stores_vearch.py`
- `.venv/bin/python -m pytest llama-index-integrations/vector_stores/llama-index-vector-stores-vearch/tests/test_vector_stores_vearch.py -q`
- `git diff --check`