### PR TITLE
Fix unhandled exceptions escaping apredict_and_call/predict_and_call on unknown tool names and task failures

### DIFF
--- a/llama-index-core/llama_index/core/llms/function_calling.py
+++ b/llama-index-core/llama_index/core/llms/function_calling.py
@@ -281,6 +281,7 @@ class FunctionCallingLLM(LLM):
         from llama_index.core.tools.calling import (
             acall_tool_with_selection,
         )
+        from llama_index.core.tools.types import ToolOutput
 
         if not self.metadata.is_function_calling_model:
             return await super().apredict_and_call(
@@ -307,7 +308,23 @@ class FunctionCallingLLM(LLM):
             acall_tool_with_selection(tool_call, tools, verbose=verbose)
             for tool_call in tool_calls
         ]
-        tool_outputs = await asyncio.gather(*tool_tasks)
+        raw_outputs = await asyncio.gather(*tool_tasks, return_exceptions=True)
+        for r in raw_outputs:
+            if isinstance(r, asyncio.CancelledError):
+                raise r
+        tool_outputs = [
+            ToolOutput(
+                content=f"Unexpected error during tool execution: {r}",
+                tool_name="unknown",
+                raw_input={},
+                raw_output=str(r),
+                is_error=True,
+                exception=r if isinstance(r, Exception) else None,
+            )
+            if isinstance(r, BaseException)
+            else r
+            for r in raw_outputs
+        ]
         tool_outputs_with_error = [
             tool_output for tool_output in tool_outputs if tool_output.is_error
         ]

--- a/llama-index-core/llama_index/core/tools/calling.py
+++ b/llama-index-core/llama_index/core/tools/calling.py
@@ -69,6 +69,14 @@ def call_tool_with_selection(
 
     tools_by_name = {tool.metadata.name: tool for tool in tools}
     name = tool_call.tool_name
+    if name not in tools_by_name:
+        return ToolOutput(
+            content=f"Tool '{name}' not found. Available tools: {list(tools_by_name.keys())}",
+            tool_name=name,
+            raw_input=tool_call.tool_kwargs,
+            raw_output=f"Tool '{name}' not found",
+            is_error=True,
+        )
     if verbose:
         arguments_str = json.dumps(tool_call.tool_kwargs)
         print("=== Calling Function ===")
@@ -92,6 +100,14 @@ async def acall_tool_with_selection(
 
     tools_by_name = {tool.metadata.name: tool for tool in tools}
     name = tool_call.tool_name
+    if name not in tools_by_name:
+        return ToolOutput(
+            content=f"Tool '{name}' not found. Available tools: {list(tools_by_name.keys())}",
+            tool_name=name,
+            raw_input=tool_call.tool_kwargs,
+            raw_output=f"Tool '{name}' not found",
+            is_error=True,
+        )
     if verbose:
         arguments_str = json.dumps(tool_call.tool_kwargs)
         print("=== Calling Function ===")

--- a/llama-index-core/tests/llms/test_function_calling.py
+++ b/llama-index-core/tests/llms/test_function_calling.py
@@ -187,3 +187,89 @@ def test_tool_required_compatibility_with_support(
         args, kwargs = mock_prepare.call_args
         assert "tool_required" in kwargs
         assert kwargs["tool_required"] is True
+
+
+@pytest.fixture()
+def unknown_tool_selection() -> ToolSelection:
+    return ToolSelection(
+        tool_id="",
+        tool_name="nonexistent_tool",
+        tool_kwargs={},
+    )
+
+
+def test_predict_and_call_unknown_tool_returns_error(
+    person_tool: FunctionTool, unknown_tool_selection: ToolSelection
+) -> None:
+    """Test predict_and_call returns ToolOutput with error when tool name not found instead of raising KeyError."""
+    llm = MockFunctionCallingLLM([unknown_tool_selection])
+    response = llm.predict_and_call(tools=[person_tool])
+    assert len(response.sources) == 1
+    assert response.sources[0].is_error
+    assert "nonexistent_tool" in response.sources[0].content
+    assert "not found" in response.sources[0].content
+
+
+@pytest.mark.asyncio
+async def test_apredict_and_call_unknown_tool_returns_error(
+    person_tool: FunctionTool, unknown_tool_selection: ToolSelection
+) -> None:
+    """Test apredict_and_call returns ToolOutput with error when tool name not found instead of raising KeyError."""
+    llm = MockFunctionCallingLLM([unknown_tool_selection])
+    response = await llm.apredict_and_call(tools=[person_tool])
+    assert len(response.sources) == 1
+    assert response.sources[0].is_error
+    assert "nonexistent_tool" in response.sources[0].content
+    assert "not found" in response.sources[0].content
+
+
+@pytest.mark.asyncio
+async def test_apredict_and_call_parallel_unknown_tool_returns_error(
+    person_tool: FunctionTool, unknown_tool_selection: ToolSelection
+) -> None:
+    """Test apredict_and_call with parallel tool calls doesn't orphan tasks when a tool name is not found."""
+    llm = MockFunctionCallingLLM([unknown_tool_selection, unknown_tool_selection])
+    response = await llm.apredict_and_call(
+        tools=[person_tool], allow_parallel_tool_calls=True
+    )
+    assert len(response.sources) == 2
+    assert all(source.is_error for source in response.sources)
+    assert all("not found" in source.content for source in response.sources)
+
+
+@pytest.mark.asyncio
+async def test_apredict_and_call_parallel_survives_task_exception(
+    person_tool: FunctionTool, person_tool_selection: ToolSelection, monkeypatch
+) -> None:
+    """
+    A raised exception (not just an is_error ToolOutput) in one parallel tool
+    task must not propagate out of apredict_and_call and must not prevent
+    sibling tasks from completing. Regression test for return_exceptions=True.
+    """
+    import llama_index.core.tools.calling as calling_module
+
+    call_count = {"n": 0}
+    original_acall_tool_with_selection = calling_module.acall_tool_with_selection
+
+    async def flaky_acall_tool_with_selection(tool_call, tools, verbose=False):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise ConnectionResetError("simulated network failure")
+        return await original_acall_tool_with_selection(tool_call, tools, verbose)
+
+    monkeypatch.setattr(
+        calling_module, "acall_tool_with_selection", flaky_acall_tool_with_selection
+    )
+
+    llm = MockFunctionCallingLLM([person_tool_selection, person_tool_selection])
+    response = await llm.apredict_and_call(
+        tools=[person_tool], allow_parallel_tool_calls=True
+    )
+
+    assert len(response.sources) == 2
+    # Both fail (Person() with no args also fails validation), but the key
+    # assertion is that the raw exception from gather was converted into an
+    # error ToolOutput instead of propagating and crashing apredict_and_call.
+    contents = [s.content for s in response.sources]
+    assert any("simulated network failure" in c for c in contents)
+    assert all(s.is_error for s in response.sources)


### PR DESCRIPTION
## Summary

Fixes #22233

`apredict_and_call` (and its sync counterpart `predict_and_call`) could leak
unhandled exceptions from concurrent tool execution instead of returning a
normal error result. This PR closes two concrete gaps and adds regression
tests for both.

## Problem

`call_tool_with_selection` / `acall_tool_with_selection` looked up
`tools_by_name[name]` directly. If the LLM returned a tool name that wasn't
in the tool list (hallucinated or stale), this raised a raw `KeyError`
instead of returning an error `ToolOutput` like every other tool failure
path in the codebase does.

In `apredict_and_call`, that `KeyError` — or any other exception raised
before `acall_tool`'s own `try/except` (e.g. from `adapt_to_async_tool`) —
propagated straight out of a bare `asyncio.gather(*tool_tasks)`. When one
task in a `gather` group raises without `return_exceptions=True`, the
exception surfaces immediately while sibling tasks are left running
unmanaged in the background instead of being surfaced as a clean result.

## Changes

**`llama_index/core/tools/calling.py`**
- `call_tool_with_selection` and `acall_tool_with_selection` now check
  `name not in tools_by_name` up front and return an `is_error=True`
  `ToolOutput` with a descriptive message, instead of letting `KeyError`
  propagate.

**`llama_index/core/llms/function_calling.py`**
- `apredict_and_call` now uses
  `asyncio.gather(*tool_tasks, return_exceptions=True)`. Any exception
  result is converted into an error `ToolOutput` so one failing task can't
  take down the whole batch.
- `asyncio.CancelledError` is explicitly re-raised rather than converted,
  to preserve cooperative cancellation semantics (it's a `BaseException`,
  not a regular error, and shouldn't be silently absorbed into a fake
  "error" result).

**`tests/llms/test_function_calling.py`**
- Unknown tool name returns an error `ToolOutput` (sync + async).
- Unknown tool name in a parallel (`allow_parallel_tool_calls=True`) batch
  doesn't leave siblings unmanaged.
- A task raising an unrelated exception mid-`gather`, alongside a sibling
  task, doesn't crash `apredict_and_call` and is converted to an error
  result.

## Note on the linked issue discussion

The bot analysis on #22233 noted that `acall_tool`'s `try/except` already
catches most tool-execution failures, and that's correct — but
`adapt_to_async_tool(tool)` inside `acall_tool` is called **outside** that
`try/except`, and the tool-name lookup in
`call_tool_with_selection`/`acall_tool_with_selection` happens **before**
`acall_tool` is even reached. Both are real, narrow gaps where a single
failure could escape unshielded into the bare `asyncio.gather`. This PR
addresses those two specific gaps with `return_exceptions=True` and the
tool-name check, rather than the broader "critical DoS" framing in the
original issue.

## Testing
uv run ruff check llama_index/core/tools/calling.py llama_index/core/llms/function_calling.py tests/llms/test_function_calling.py
uv run pytest tests/tools/ tests/llms/ tests/chat_engine/ -v 

All checks pass. `131 passed, 4 skipped` (skips/warnings are pre-existing
and unrelated to this change).