### PR TITLE
feat: add max_retries and timeout parameters to VoyageEmbedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/llama_index/embeddings/voyageai/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/llama_index/embeddings/voyageai/base.py
@@ -6,8 +6,9 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Generator, List, Optional, Tuple, Union
 
-import voyageai
 from PIL import Image
+
+import voyageai
 
 try:
     from voyageai.video_utils import Video
@@ -82,6 +83,22 @@ class VoyageEmbedding(MultiModalEmbedding):
         voyage_api_key (Optional[str]): Voyage API key. Defaults to None.
             You can either specify the key here or store it as an environment variable.
 
+        max_retries (Optional[int]): Maximum number of retries for API requests. Defaults to 3.
+
+        timeout (Optional[float]): Timeout for API requests. Defaults to 60.0.
+
+        embed_batch_size (Optional[int]): Batch size for embedding. Defaults to None.
+
+        truncation (Optional[bool]): Whether to truncate the input text if it exceeds the model's maximum token limit.
+            Defaults to None, which means truncation is enabled for multimodal models and disabled for text
+            models.
+
+        output_dtype (Optional[str]): Output data type for embeddings. Defaults to None.
+
+        output_dimension (Optional[int]): Output dimension for embeddings. Defaults to None.
+
+        callback_manager (Optional[CallbackManager]): Callback manager for handling callbacks. Defaults to None.
+
     """
 
     _client: voyageai.Client = PrivateAttr(None)
@@ -94,6 +111,8 @@ class VoyageEmbedding(MultiModalEmbedding):
         self,
         model_name: str,
         voyage_api_key: Optional[str] = None,
+        max_retries: Optional[int] = 3,
+        timeout: Optional[float] = 60.0,
         embed_batch_size: Optional[int] = None,
         truncation: Optional[bool] = None,
         output_dtype: Optional[str] = None,
@@ -123,6 +142,19 @@ class VoyageEmbedding(MultiModalEmbedding):
         if embed_batch_size is None:
             embed_batch_size = MAX_BATCH_SIZE
 
+        if voyage_api_key is None:
+            voyage_api_key = os.environ.get("VOYAGE_API_KEY")
+            if voyage_api_key is None:
+                raise ValueError(
+                    "Voyage API key must be provided either as an argument or as an environment variable."
+                )
+
+        if max_retries is None:
+            max_retries = 3
+
+        if timeout is None:
+            timeout = 60.0
+
         super().__init__(
             model_name=model_name,
             embed_batch_size=embed_batch_size,
@@ -130,8 +162,12 @@ class VoyageEmbedding(MultiModalEmbedding):
             **kwargs,
         )
 
-        self._client = voyageai.Client(api_key=voyage_api_key)
-        self._aclient = voyageai.AsyncClient(api_key=voyage_api_key)
+        self._client = voyageai.Client(
+            api_key=voyage_api_key, max_retries=max_retries, timeout=timeout
+        )
+        self._aclient = voyageai.AsyncClient(
+            api_key=voyage_api_key, max_retries=max_retries, timeout=timeout
+        )
         self.truncation = truncation
         self.output_dtype = output_dtype
         self.output_dimension = output_dimension

--- a/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-voyageai"
-version = "0.6.1"
+version = "0.6.2"
 description = "llama-index embeddings voyageai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/tests/test_embeddings_voyageai.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/tests/test_embeddings_voyageai.py
@@ -134,6 +134,61 @@ def test_context_model_detection():
     assert regular_emb.model_name not in CONTEXT_MODELS
 
 
+# Unit tests for max_retries / timeout retry mechanism
+
+
+@patch("llama_index.embeddings.voyageai.base.voyageai.AsyncClient")
+@patch("llama_index.embeddings.voyageai.base.voyageai.Client")
+def test_retry_and_timeout_passed_to_clients(mock_client, mock_aclient):
+    """max_retries and timeout are forwarded to both sync and async clients."""
+    VoyageEmbedding(
+        model_name="voyage-2",
+        voyage_api_key="NOT_A_VALID_KEY",
+        max_retries=7,
+        timeout=12.5,
+    )
+
+    for mock in (mock_client, mock_aclient):
+        _, kwargs = mock.call_args
+        assert kwargs["max_retries"] == 7
+        assert kwargs["timeout"] == 12.5
+
+
+@patch("llama_index.embeddings.voyageai.base.voyageai.AsyncClient")
+@patch("llama_index.embeddings.voyageai.base.voyageai.Client")
+def test_retry_and_timeout_defaults(mock_client, mock_aclient):
+    """None values fall back to defaults (3 retries, 60.0s timeout)."""
+    VoyageEmbedding(
+        model_name="voyage-2",
+        voyage_api_key="NOT_A_VALID_KEY",
+        max_retries=None,
+        timeout=None,
+    )
+
+    for mock in (mock_client, mock_aclient):
+        _, kwargs = mock.call_args
+        assert kwargs["max_retries"] == 3
+        assert kwargs["timeout"] == 60.0
+
+
+def test_missing_api_key_raises(monkeypatch):
+    """No api key argument and no env var raises a clear error."""
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="Voyage API key must be provided"):
+        VoyageEmbedding(model_name="voyage-2", voyage_api_key=None)
+
+
+@patch("llama_index.embeddings.voyageai.base.voyageai.AsyncClient")
+@patch("llama_index.embeddings.voyageai.base.voyageai.Client")
+def test_api_key_from_env(mock_client, mock_aclient, monkeypatch):
+    """API key is read from VOYAGE_API_KEY env var when not passed."""
+    monkeypatch.setenv("VOYAGE_API_KEY", "ENV_KEY")
+    VoyageEmbedding(model_name="voyage-2")
+
+    _, kwargs = mock_client.call_args
+    assert kwargs["api_key"] == "ENV_KEY"
+
+
 # Unit tests for _build_batches method
 
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/uv.lock
@@ -1988,7 +1988,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-embeddings-voyageai"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -2021,7 +2021,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "voyageai", marker = "python_full_version >= '3.9' and python_full_version < '3.13'", specifier = ">=0.3.6,<0.4.0" },
+    { name = "voyageai", marker = "python_full_version >= '3.9' and python_full_version < '3.13'", specifier = ">=0.3.7,<0.4.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/uv.lock
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-voyageai/uv.lock
@@ -2021,7 +2021,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-    { name = "voyageai", marker = "python_full_version >= '3.9' and python_full_version < '3.13'", specifier = ">=0.3.7,<0.4.0" },
+    { name = "voyageai", marker = "python_full_version >= '3.9' and python_full_version < '3.13'", specifier = ">=0.3.6,<0.4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Description

Leverage Voyage Client Retry and Timeout Parameters to handle failed embedding attempts on VoyageEmbedding

Also in this change:
- Document all available params clearly so use (or AI agents) know what and how to set them

Fixes #22238

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
