### PR TITLE
fix(groq): replace decommissioned llama3-70b-8192 model references

### DIFF
--- a/docs/examples/llm/groq.ipynb
+++ b/docs/examples/llm/groq.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llm = Groq(model=\"llama3-70b-8192\", api_key=\"your_api_key\")"
+    "llm = Groq(model=\"openai/gpt-oss-120b\", api_key=\"your_api_key\")"
    ]
   },
   {

--- a/llama-index-integrations/llms/llama-index-llms-groq/llama_index/llms/groq/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-groq/llama_index/llms/groq/base.py
@@ -15,7 +15,7 @@ class Groq(OpenAILike):
         from llama_index.llms.groq import Groq
 
         # Set up the Groq class with the required model and API key
-        llm = Groq(model="llama3-70b-8192", api_key="your_api_key")
+        llm = Groq(model="openai/gpt-oss-120b", api_key="your_api_key")
 
         # Call the complete method with a query
         response = llm.complete("Explain the importance of low latency LLMs")

--- a/llama-index-integrations/llms/llama-index-llms-groq/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-groq/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-groq"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms groq integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-groq/tests/test_integration_groq.py
+++ b/llama-index-integrations/llms/llama-index-llms-groq/tests/test_integration_groq.py
@@ -7,16 +7,17 @@ from llama_index.llms.groq import Groq
 
 @pytest.mark.skipif("GROQ_API_KEY" not in os.environ, reason="No Groq API key")
 def test_completion():
-    groq = Groq(model="llama3-70b-8192", temperature=0, max_tokens=2)
+    groq = Groq(model="openai/gpt-oss-120b", temperature=0, max_tokens=256)
     resp = groq.complete("hello")
-    assert resp.text == "Hello"
+    assert isinstance(resp.text, str)
+    assert len(resp.text.strip()) > 0
 
 
 @pytest.mark.skipif("GROQ_API_KEY" not in os.environ, reason="No Groq API key")
 def test_stream_completion():
-    groq = Groq(model="llama3-70b-8192", temperature=0, max_tokens=2)
+    groq = Groq(model="openai/gpt-oss-120b", temperature=0, max_tokens=256)
     stream = groq.stream_complete("hello")
-    text = None
+    text = ""
     for chunk in stream:
         text = chunk.text
-    assert text == "Hello"
+    assert len(text.strip()) > 0


### PR DESCRIPTION
# Description

The Groq docs example (`docs/examples/llm/groq.ipynb`), the `Groq` class docstring, and the integration tests all referenced `llama3-70b-8192`, which Groq deprecated on 2025-05-31 and has since decommissioned. The documented example now fails for all users, and the integration tests fail with a valid `GROQ_API_KEY` with:

`Error code: 400 - The model llama3-70b-8192 has been decommissioned and is no longer supported.`

This PR replaces the decommissioned model with `openai/gpt-oss-120b`. This model was chosen over `llama-3.3-70b-versatile` (Groq's originally recommended replacement) because that model itself entered deprecation on 2026-06-17 per [Groq's deprecations page](https://console.groq.com/docs/deprecations), so using it would recreate this issue shortly.

The integration tests were also updated: they previously asserted an exact response string (`resp.text == "Hello"`) with `max_tokens=2`, which is brittle across models — and `openai/gpt-oss-120b` is a reasoning model, so a 2-token budget yields empty visible output. The tests now assert a non-empty completion with an adequate token budget, making them model-agnostic.

Verified against the live Groq API: the old model returns `400 model_decommissioned`; the replacement completes successfully. All package tests pass locally (3 passed).

Note: `docs/examples/cookbooks/llama3_cookbook_groq.ipynb` also references decommissioned models, but as that cookbook is specifically about Llama 3 (and most Llama-family models on Groq are now deprecated), it likely needs a broader rework — happy to follow up in a separate PR if maintainers have a preferred direction.

AI assistance was used for investigation and drafting; all changes were reviewed and verified locally against the live Groq API.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

The package's existing integration tests exercise this change directly — they now run against the supported model, with assertions made model-agnostic. Verified locally with a live `GROQ_API_KEY`: 3 passed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods