### PR TITLE
Add request-scoped partial params for function tools

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -1,6 +1,9 @@
 import asyncio
 import contextvars
 import inspect
+from copy import deepcopy
+from dataclasses import replace
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -14,7 +17,6 @@ from typing import (
     Tuple,
     get_origin,
 )
-import re
 
 if TYPE_CHECKING:
     from llama_index.core.bridge.langchain import StructuredTool, Tool
@@ -30,7 +32,7 @@ from llama_index.core.base.llms.types import (
     DocumentBlock,
     VideoBlock,
 )
-from llama_index.core.bridge.pydantic import BaseModel, FieldInfo
+from llama_index.core.bridge.pydantic import BaseModel, FieldInfo, create_model
 from llama_index.core.tools.types import AsyncBaseTool, ToolMetadata, ToolOutput
 from llama_index.core.tools.utils import create_schema_from_function
 from llama_index.core.schema import BaseNode, Document
@@ -269,6 +271,40 @@ class FunctionTool(AsyncBaseTool):
     def metadata(self) -> ToolMetadata:
         """Metadata."""
         return self._metadata
+
+    def with_partial_params(self, partial_params: Dict[str, Any]) -> "FunctionTool":
+        """
+        Return a tool view with additional partial parameters applied.
+
+        This is useful when the same tool should expose different schemas per request.
+        The returned tool hides the supplied parameters from its metadata schema and
+        injects their values at call time without mutating the original tool.
+        """
+        all_partial_params = {**self.partial_params, **partial_params}
+        partial_param_names = set(all_partial_params)
+        fn_schema = self.metadata.fn_schema
+
+        if fn_schema is not None:
+            fields = {
+                field_name: (field_info.annotation or Any, deepcopy(field_info))
+                for field_name, field_info in fn_schema.model_fields.items()
+                if field_name not in partial_param_names
+            }
+            fn_schema = create_model(f"{fn_schema.__name__}Partial", **fields)
+
+        tool = FunctionTool(
+            fn=self._fn,
+            metadata=replace(self.metadata, fn_schema=fn_schema),
+            async_fn=self._async_fn,
+            callback=self._callback,
+            async_callback=self._async_callback,
+            partial_params=all_partial_params,
+        )
+        tool.requires_context = self.requires_context
+        tool.ctx_param_name = self.ctx_param_name
+        tool._field_defaults = dict(self._field_defaults)
+        tool._real_fn = self._real_fn
+        return tool
 
     @property
     def fn(self) -> Callable[..., Any]:

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -225,6 +225,76 @@ def test_function_tool_partial_params() -> None:
     assert tool(x=1, y=3).raw_input == {"args": (), "kwargs": {"x": 1, "y": 3}}
 
 
+def test_function_tool_with_partial_params_returns_request_scoped_view() -> None:
+    class LookupSchema(BaseModel):
+        query: str
+        client_id: str
+        debug_mode: bool = False
+
+    def lookup_client(query: str, client_id: str, debug_mode: bool = False) -> str:
+        return f"{client_id}: {query}: {debug_mode}"
+
+    tool = FunctionTool.from_defaults(
+        lookup_client,
+        fn_schema=LookupSchema,
+    )
+
+    user_tool = tool.with_partial_params({"client_id": "client-123"})
+
+    assert tool.metadata.fn_schema is LookupSchema
+    assert tool.partial_params == {}
+    assert user_tool.partial_params == {"client_id": "client-123"}
+
+    assert tool.metadata.fn_schema is not None
+    original_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "client_id" in original_schema["properties"]
+
+    assert user_tool.metadata.fn_schema is not None
+    request_schema = user_tool.metadata.fn_schema.model_json_schema()
+    assert "client_id" not in request_schema["properties"]
+    assert "query" in request_schema["properties"]
+    assert "debug_mode" in request_schema["properties"]
+
+    assert user_tool(query="renewal").raw_output == "client-123: renewal: False"
+    assert user_tool(query="renewal").raw_input == {
+        "args": (),
+        "kwargs": {"client_id": "client-123", "query": "renewal"},
+    }
+    assert tool(query="renewal", client_id="admin-picked").raw_output == (
+        "admin-picked: renewal: False"
+    )
+
+
+def test_function_tool_with_partial_params_preserves_existing_partial_params() -> None:
+    def lookup_client(query: str, client_id: str, debug_mode: bool = False) -> str:
+        return f"{client_id}: {query}: {debug_mode}"
+
+    tool = FunctionTool.from_defaults(
+        lookup_client,
+        partial_params={"debug_mode": False},
+    )
+
+    user_tool = tool.with_partial_params({"client_id": "client-123"})
+
+    assert user_tool.partial_params == {
+        "debug_mode": False,
+        "client_id": "client-123",
+    }
+
+    assert tool.metadata.fn_schema is not None
+    original_schema = tool.metadata.fn_schema.model_json_schema()
+    assert "client_id" in original_schema["properties"]
+    assert "debug_mode" not in original_schema["properties"]
+
+    assert user_tool.metadata.fn_schema is not None
+    request_schema = user_tool.metadata.fn_schema.model_json_schema()
+    assert "query" in request_schema["properties"]
+    assert "client_id" not in request_schema["properties"]
+    assert "debug_mode" not in request_schema["properties"]
+
+    assert user_tool(query="renewal").raw_output == "client-123: renewal: False"
+
+
 @pytest.mark.asyncio
 async def test_function_tool_partial_params_async() -> None:
     async def test_function(x: int, y: int) -> str:


### PR DESCRIPTION
## Summary
- add `FunctionTool.with_partial_params()` for request-scoped tool views
- hide additional partial parameters from the returned tool metadata schema without mutating the original tool
- preserve existing `partial_params` injection behavior for sync and async calls

This gives applications a lightweight way to vary tool parameter visibility per request without rebuilding the original tool list or mutating shared tool metadata. It is intended as a small step toward the use case described in #21229, not a replacement for the broader tool middleware discussion.

## Validation
- `uv run --project . --with ruff --no-sync ruff check llama-index-core/llama_index/core/tools/function_tool.py llama-index-core/tests/tools/test_base.py`
- `PYTHONPATH=E:\Industry Codebases\oss-contributions\llama_index\llama-index-core uv run --project . --with pytest --with pytest-asyncio --no-sync pytest -q llama-index-core/tests/tools/test_base.py`

## AI assistance transparency
- AI assistance was used while drafting and reviewing this small additive API/test change.
- I reviewed the implementation against the existing `FunctionTool` patterns and validated it with the lint/test commands above.