### PR TITLE
fix: TextBlock.amerge no longer emits an empty block on oversized first split

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -272,7 +272,12 @@ class TextBlock(BaseContentBlock):
                 current_block_texts.append(split.text)
                 current_block_tokens += split_tokens
             else:
-                merged_blocks.append(TextBlock(text=" ".join(current_block_texts)))
+                # Guard against flushing an empty block when the very first split
+                # already exceeds chunk_size (current_block_texts is still empty),
+                # which would emit a spurious TextBlock(text="").  Matches the
+                # guarded final flush below and BaseRecursiveContentBlock.amerge.
+                if current_block_texts:
+                    merged_blocks.append(TextBlock(text=" ".join(current_block_texts)))
                 current_block_texts = [split.text]
                 current_block_tokens = split_tokens
 

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -296,6 +296,18 @@ async def test_chat_message_asplit_non_recursive_types(
 
 
 @pytest.mark.asyncio
+async def test_text_block_amerge_no_empty_block_when_first_split_oversized():
+    """Merge must not emit an empty TextBlock when the first split exceeds chunk_size."""
+    merged = await TextBlock.amerge(
+        [TextBlock(text="X" * 10), TextBlock(text="ab")],
+        chunk_size=3,
+        tokenizer=lambda s: list(s),
+    )
+    assert [block.text for block in merged] == ["X" * 10, "ab"]
+    assert all(block.text != "" for block in merged)
+
+
+@pytest.mark.asyncio
 async def test_chat_message_asplit_recursive_types(png_1px, mock_pdf_bytes):
     chat_message = ChatMessage(
         blocks=[


### PR DESCRIPTION
## Description

`TextBlock.amerge` (`llama-index-core/.../base/llms/types.py`) flushes its accumulator on the `else` branch **without checking it is non-empty**. When the very first split already exceeds `chunk_size` (so `current_block_texts` is still empty), it appends a spurious `TextBlock(text="")`.

The method's **own final flush** guards this (`if current_block_texts:`), and so does the sibling **`BaseRecursiveContentBlock.amerge`** (`if cur_blocks:`) — this branch was the odd one out.

An empty text block then propagates into `ChatMessage.blocks` (via `ChatMessage.amerge`) and through the public sync `TextBlock.merge` API. Downstream, some providers reject empty text content blocks (e.g. Anthropic errors on empty text).

### Reproduction (on `main`)
```python
import asyncio
from llama_index.core.base.llms.types import TextBlock

r = asyncio.run(TextBlock.amerge(
    [TextBlock(text="X"*10), TextBlock(text="ab")],
    chunk_size=3, tokenizer=lambda s: list(s),
))
print([b.text for b in r])   # ['', 'XXXXXXXXXX', 'ab']  <- leading empty block
```

## Fix

Add the missing `if current_block_texts:` guard before the `else`-branch flush — matching the final flush and `BaseRecursiveContentBlock.amerge`.

## Test

`test_text_block_amerge_no_empty_block_when_first_split_oversized` — asserts no empty block is emitted (and normal merges are unaffected). Fails without the fix (mutation-checked); `ruff` clean.