### PR TITLE
fix(core): refresh agent state prompt after tool updates

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -450,6 +450,7 @@ class BaseWorkflowAgent(
             "formatted_input_with_state", default=False
         )
         if state and not formatted_input_with_state:
+            llm_input[-1] = llm_input[-1].model_copy(deep=True)
             # update last message with current state
             for block in llm_input[-1].blocks[::-1]:
                 if isinstance(block, TextBlock):
@@ -683,6 +684,7 @@ class BaseWorkflowAgent(
         await ctx.store.set("current_tool_calls", cur_tool_calls)
 
         await self.handle_tool_call_results(ctx, tool_call_results, memory)
+        await ctx.store.set("formatted_input_with_state", False)
 
         if any(
             tool_call_result.return_direct and not tool_call_result.tool_output.is_error

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -451,6 +451,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             "formatted_input_with_state", default=False
         )
         if state and not formatted_input_with_state:
+            llm_input[-1] = llm_input[-1].model_copy(deep=True)
             # update last message with current state
             for block in llm_input[-1].blocks[::-1]:
                 if isinstance(block, TextBlock):
@@ -705,6 +706,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         await ctx.store.set("current_tool_calls", cur_tool_calls)
 
         await agent.handle_tool_call_results(ctx, tool_call_results, memory)
+        await ctx.store.set("formatted_input_with_state", False)
 
         # set the next agent, if needed
         # the handoff tool sets this

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -365,6 +365,62 @@ async def test_workflow_with_state():
 
 
 @pytest.mark.asyncio
+async def test_workflow_refreshes_state_prompt_after_tool_updates():
+    """Test workflow state prompt refreshes after a tool mutates state."""
+    captured_inputs: List[List[ChatMessage]] = []
+
+    async def update_state(ctx: Context) -> str:
+        state = await ctx.store.get("state")
+        state["counter"] = 1
+        await ctx.store.set("state", state)
+        return "state updated"
+
+    def response_generator(messages: List[ChatMessage], **kwargs) -> ChatMessage:
+        captured_inputs.append(messages)
+        if len(captured_inputs) == 1:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="updating state",
+                additional_kwargs={
+                    "tool_calls": [
+                        ToolSelection(
+                            tool_id="update-state",
+                            tool_name="update_state",
+                            tool_kwargs={},
+                        )
+                    ]
+                },
+            )
+        return ChatMessage(role=MessageRole.ASSISTANT, content="done")
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[update_state],
+        llm=MockFunctionCallingLLM(response_generator=response_generator),
+        streaming=False,
+    )
+
+    workflow = AgentWorkflow(
+        agents=[agent],
+        initial_state={"counter": 0},
+        state_prompt="Current state: {state}. User message: {msg}",
+    )
+
+    memory = ChatMemoryBuffer.from_defaults(tokenizer_fn=lambda text: text.split())
+    handler = workflow.run(user_msg="test", memory=memory)
+    async for _ in handler.stream_events():
+        pass
+
+    response = await handler
+    assert response is not None
+
+    assert "counter': 0" in str(captured_inputs[0][0].content)
+    assert "counter': 1" in str(captured_inputs[1][0].content)
+    assert str(captured_inputs[1][0].content).count("Current state:") == 1
+
+
+@pytest.mark.asyncio
 async def test_agent_with_hitl():
     """Test agent with hitl."""
 

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -498,6 +498,59 @@ async def test_function_agent_with_context_and_chat_message():
 
 
 @pytest.mark.asyncio
+async def test_function_agent_refreshes_state_prompt_after_tool_updates():
+    from llama_index.core.workflow import Context
+
+    captured_inputs: List[List[ChatMessage]] = []
+
+    async def update_state(ctx: Context) -> str:
+        state = await ctx.store.get("state")
+        state["counter"] = 1
+        await ctx.store.set("state", state)
+        return "state updated"
+
+    def response_generator(messages: List[ChatMessage], **kwargs) -> ChatMessage:
+        captured_inputs.append(messages)
+        if len(captured_inputs) == 1:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="updating state",
+                additional_kwargs={
+                    "tool_calls": [
+                        ToolSelection(
+                            tool_id="update-state",
+                            tool_name="update_state",
+                            tool_kwargs={},
+                        )
+                    ]
+                },
+            )
+        return ChatMessage(role=MessageRole.ASSISTANT, content="done")
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[update_state],
+        llm=MockFunctionCallingLLM(response_generator=response_generator),
+        initial_state={"counter": 0},
+        state_prompt="Current state: {state}. User message: {msg}",
+        streaming=False,
+    )
+
+    memory = ChatMemoryBuffer.from_defaults(tokenizer_fn=lambda text: text.split())
+    handler = agent.run(user_msg="test", memory=memory)
+    async for _ in handler.stream_events():
+        pass
+
+    response = await handler
+    assert response is not None
+
+    assert "counter': 0" in str(captured_inputs[0][0].content)
+    assert "counter': 1" in str(captured_inputs[1][0].content)
+    assert str(captured_inputs[1][0].content).count("Current state:") == 1
+
+
+@pytest.mark.asyncio
 async def test_run_id_passthrough(function_agent: FunctionAgent) -> None:
     """Test that run_id kwarg is forwarded to the WorkflowHandler."""
     custom_run_id = "test-run-id-12345"


### PR DESCRIPTION
# Description

Fixes #22248

When `FunctionAgent` or `AgentWorkflow` uses `initial_state` with a `state_prompt`, the first agent step formats the user message with the current state. If a tool mutates `ctx.store["state"]`, the following LLM step should see the updated state.

Before this change, `formatted_input_with_state` stayed `True` after tool results were handled, so the next step skipped state formatting and the LLM received the raw user message instead of the latest state.

This resets `formatted_input_with_state` after tool results are handled in both the single-agent and multi-agent workflow paths. Parser retry/error-correction behavior is left unchanged because the flag is only reset after tool results.

The state prompt is formatted on a deep copy of the final input message, so refreshing the prompt after tool results does not mutate the memory-backed `ChatMessage` or nest previously formatted state text.

This preserves the anti-duplication behavior introduced for #18416/#18417 while allowing tool-driven state mutations to be visible to the next LLM call.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

Change is in `llama-index-core`, which the template excludes from version bumps.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Added regression tests for both paths:

- `FunctionAgent` directly
- `AgentWorkflow` wrapping a `FunctionAgent`

Both tests simulate a tool mutating `ctx.store["state"]` and assert that the next LLM call receives the updated state in the formatted state prompt. They also assert that `"Current state:"` appears only once, covering the memory-backed message mutation edge case raised during review.

Focused validation:

```bash
TIKTOKEN_CACHE_DIR=/Users/russeell/Documents/github\ pr/llama_index/.tiktoken-cache \
python3 -m pytest \
  llama-index-core/tests/agent/workflow/test_single_agent_workflow.py \
  llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py::test_workflow_with_state \
  llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py::test_workflow_refreshes_state_prompt_after_tool_updates \
  -q
```

Result:

```text
15 passed
```

Additional checks:

```bash
python3 -m ruff format --check \
  llama-index-core/llama_index/core/agent/workflow/base_agent.py \
  llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py \
  llama-index-core/tests/agent/workflow/test_single_agent_workflow.py \
  llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py

python3 -m ruff check \
  llama-index-core/llama_index/core/agent/workflow/base_agent.py \
  llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py \
  llama-index-core/tests/agent/workflow/test_single_agent_workflow.py \
  llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py

git diff --check
```

Results: passed.

Note: default `ChatMemoryBuffer` initialization needs the `tiktoken` `cl100k_base` encoding. I pre-cached it locally and ran the workflow tests with `TIKTOKEN_CACHE_DIR` set.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods