### PR TITLE
fix(anthropic): correctly map named tool_choice to Anthropic's object format

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -957,13 +957,33 @@ class Anthropic(FunctionCallingLLM):
         return gen()
 
     def _map_tool_choice_to_anthropic(
-        self, tool_required: bool, allow_parallel_tool_calls: bool
+        self,
+        tool_required: bool,
+        allow_parallel_tool_calls: bool,
+        tool_choice: Optional[str] = None,
     ) -> dict:
         is_thinking_enabled = (
             self.thinking_dict and self.thinking_dict.get("type") == "enabled"
         )
+        disable_parallel_tool_use = not allow_parallel_tool_calls
+
+        # A specific tool name forces tool use, same as tool_required, so it is
+        # subject to the same restriction: Anthropic rejects forced tool use
+        # ("any" or a named tool) when extended thinking is enabled.
+        if tool_choice and tool_choice not in ("auto", "any", "none"):
+            if is_thinking_enabled:
+                return {
+                    "disable_parallel_tool_use": disable_parallel_tool_use,
+                    "type": "auto",
+                }
+            return {
+                "disable_parallel_tool_use": disable_parallel_tool_use,
+                "type": "tool",
+                "name": tool_choice,
+            }
+
         return {
-            "disable_parallel_tool_use": not allow_parallel_tool_calls,
+            "disable_parallel_tool_use": disable_parallel_tool_use,
             "type": "any" if tool_required and not is_thinking_enabled else "auto",
         }
 
@@ -975,6 +995,7 @@ class Anthropic(FunctionCallingLLM):
         verbose: bool = False,
         allow_parallel_tool_calls: bool = False,
         tool_required: bool = False,
+        tool_choice: Optional[str] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Prepare the chat with tools."""
@@ -1009,10 +1030,10 @@ class Anthropic(FunctionCallingLLM):
         # anthropic doesn't like you specifying a tool choice if you don't have any tools
         tool_choice_dict = (
             {}
-            if not tools and not tool_required
+            if not tools and not tool_required and not tool_choice
             else {
                 "tool_choice": self._map_tool_choice_to_anthropic(
-                    tool_required, allow_parallel_tool_calls
+                    tool_required, allow_parallel_tool_calls, tool_choice
                 )
             }
         )

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.11.8"
+version = "0.11.9"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -430,6 +430,51 @@ def test_prepare_chat_with_no_tools_tool_not_required():
     assert len(result["tools"]) == 0
 
 
+def test_map_tool_choice_to_anthropic_named_tool():
+    """A specific tool name must be mapped to Anthropic's {"type": "tool", "name": ...} object."""
+    llm = Anthropic()
+
+    tool_choice = llm._map_tool_choice_to_anthropic(
+        tool_required=False, allow_parallel_tool_calls=False, tool_choice="search_tool"
+    )
+    assert tool_choice == {
+        "disable_parallel_tool_use": True,
+        "type": "tool",
+        "name": "search_tool",
+    }
+
+
+def test_map_tool_choice_to_anthropic_named_tool_with_thinking():
+    """Anthropic rejects forced tool use (named tool) when extended thinking is enabled."""
+    llm = Anthropic(thinking_dict={"type": "enabled", "budget_tokens": 1024})
+
+    tool_choice = llm._map_tool_choice_to_anthropic(
+        tool_required=False, allow_parallel_tool_calls=False, tool_choice="search_tool"
+    )
+    assert tool_choice["type"] == "auto"
+    assert "name" not in tool_choice
+
+
+def test_prepare_chat_with_tools_named_tool_choice():
+    """
+    Regression test: passing a specific tool name via tool_choice (as FunctionAgent's
+    initial_tool_choice does) must produce Anthropic's object format, not the raw
+    tool name string, otherwise the Anthropic API rejects the request with
+    "tool_choice: Input should be an object".
+    """
+    llm = Anthropic()
+
+    result = llm._prepare_chat_with_tools(
+        tools=[search_tool], tool_choice="search_tool"
+    )
+
+    assert result["tool_choice"] == {
+        "disable_parallel_tool_use": True,
+        "type": "tool",
+        "name": "search_tool",
+    }
+
+
 def test_cache_point_to_cache_control() -> None:
     messages = [
         ChatMessage(role="system", blocks=[TextBlock(text="Hello1")]),

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/uv.lock
@@ -2028,7 +2028,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-anthropic"
-version = "0.11.7"
+version = "0.11.9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock", "vertex"] },


### PR DESCRIPTION
## Description

`FunctionAgent.initial_tool_choice` (a plain tool-name string) is forwarded as `tool_choice=<string>` through `**kwargs` in `FunctionCallingLLM.achat_with_tools`. In the Anthropic integration, `_prepare_chat_with_tools` didn't have `tool_choice` as an explicit parameter, so the raw string landed in its own `**kwargs` and got spread into the return dict *after* the properly-computed `tool_choice` object -- silently overwriting it.

This meant Anthropic's API received `tool_choice="my_tool"` (a bare string) instead of `{"type": "tool", "name": "my_tool"}`, causing a live `400 BadRequestError: tool_choice: Input should be an object` any time a FunctionAgent with initial_tool_choice was backed by Anthropic.

Fix mirrors `resolve_tool_choice` in the OpenAI integration (the established pattern for this in the monorepo), and also guards Anthropic's documented constraint that forced tool use is incompatible with extended thinking.

## How Has This Been Tested?
- Verified live against the real Anthropic API (400 error before, success after)
- Added 3 regression tests to test_llms_anthropic.py
- Full package test suite passes (49 passed, 15 skipped)
- `make lint` passes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)