### PR TITLE
Fix relevance/choice-number desync in default_parse_choice_select_answer_fn

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -148,13 +148,11 @@ def default_parse_choice_select_answer_fn(
                 )
         if answer_num > num_choices:
             continue
-        answer_nums.append(answer_num)
         # extract just the first digits after the colon.
         try:
             _answer_relevance = re.findall(
                 r"\d+", line_tokens[1].split(":")[1].strip()
             )[0]
-            answer_relevances.append(float(_answer_relevance))
         except (IndexError, ValueError) as e:
             if not raise_error:
                 continue
@@ -164,6 +162,8 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
+        answer_nums.append(answer_num)
+        answer_relevances.append(float(_answer_relevance))
     return answer_nums, answer_relevances
 
 

--- a/llama-index-core/tests/indices/test_utils.py
+++ b/llama-index-core/tests/indices/test_utils.py
@@ -34,3 +34,16 @@ def test_default_parse_choice_select_answer_fn(answer):
     answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
     assert answer_nums == [2, 4]
     assert answer_relevances == [8, 6]
+
+
+def test_default_parse_choice_select_answer_fn_unparseable_relevance():
+    """A line with a valid doc number but an unparseable relevance is skipped
+    whole, so answer_nums and answer_relevances stay aligned."""
+    from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
+
+    answer = "Doc: 1, Relevance: 9\nDoc: 2, Relevance: high\nDoc: 3, Relevance: 7"
+    answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
+
+    assert answer_nums == [1, 3]
+    assert answer_relevances == [9, 7]
+    assert len(answer_nums) == len(answer_relevances)


### PR DESCRIPTION
# Description

`default_parse_choice_select_answer_fn` returns two parallel lists, `answer_nums` and `answer_relevances`, that callers zip together to map each selected document to its relevance score.

For each line it appends the document number first and only then tries to parse the relevance:

```python
answer_nums.append(answer_num)
try:
    _answer_relevance = re.findall(r"\d+", line_tokens[1].split(":")[1].strip())[0]
    answer_relevances.append(float(_answer_relevance))
except (IndexError, ValueError):
    if not raise_error:
        continue
    ...
```

When a line has a valid document number but a relevance that contains no digits (e.g. `Doc: 2, Relevance: high`), the `continue` skips appending the relevance, but the number was already appended. `answer_nums` ends up one longer than `answer_relevances`, and from that point on the two lists are misaligned.

Consumers zip the lists, so the misalignment is silent and corrupting:
- `LLMRerank` and `ListIndexLLMRetriever` `zip(choice_nodes, relevances)` — every node after the bad line gets the next node's score, and the last node is dropped.
- `DocumentSummaryIndexLLMRetriever` accumulates both lists across batches before zipping, so one bad line shifts all following scores.

Repro on `main`:

```python
from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
answer = "Doc: 1, Relevance: 9\nDoc: 2, Relevance: high\nDoc: 3, Relevance: 7"
nums, rels = default_parse_choice_select_answer_fn(answer, 5)
# nums = [1, 2, 3], rels = [9.0, 7.0]  -> Doc 2 gets Doc 3's score, Doc 3 dropped
```

## Fix

Append the document number only after the relevance is successfully parsed, so a malformed line is skipped as a whole and the two lists stay aligned. With the fix the repro returns `nums = [1, 3]`, `rels = [9.0, 7.0]`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_default_parse_choice_select_answer_fn_unparseable_relevance` in `llama-index-core/tests/indices/test_utils.py`. It fails on `main` (`answer_nums == [1, 2, 3]`) and passes with the fix.

```
uv run pytest tests/indices/test_utils.py tests/postprocessor/test_llm_rerank.py tests/postprocessor/test_structured_llm_rerank.py
# 10 passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes