### PR TITLE
docs: update text-to-image PG notebook imports

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
@@ -22,7 +22,7 @@
     "from llama_index.core.agent.workflow import FunctionAgent\n",
     "from llama_index.llms.openai import OpenAI\n",
     "from llama_index.core.workflow import Context\n",
-    "from llama_index.tools import QueryEngineTool, ToolMetadata"
+    "from llama_index.core.tools import QueryEngineTool, ToolMetadata"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "# define query engine over paul graham's essay\n",
-    "from llama_index import SimpleDirectoryReader, VectorStoreIndex\n",
+    "from llama_index.core import SimpleDirectoryReader, VectorStoreIndex\n",
     "import requests\n",
     "\n",
     "# download paul graham's essay\n",
@@ -83,7 +83,7 @@
    "source": [
     "# Import and initialize our tool spec\n",
     "from llama_index.tools.text_to_image.base import TextToImageToolSpec\n",
-    "from llama_index.llms import OpenAI\n",
+    "from llama_index.llms.openai import OpenAI\n",
     "\n",
     "llm = OpenAI(model=\"gpt-4\")\n",
     "\n",


### PR DESCRIPTION
# Description

Updates stale import paths in the text-to-image Paul Graham example notebook so the user-copyable imports match the current package layout.

Fixes # N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

Notebook-only import cleanup; no package code or package metadata changed.

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Validated the notebook change with:

```bash
jq empty llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
rg -n "from llama_index\.tools import QueryEngineTool, ToolMetadata|from llama_index import SimpleDirectoryReader, VectorStoreIndex|from llama_index\.llms import OpenAI" llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
rg -n "from llama_index\.core\.tools import QueryEngineTool, ToolMetadata|from llama_index\.core import SimpleDirectoryReader, VectorStoreIndex|from llama_index\.llms\.openai import OpenAI" llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
git diff --check -- llama-index-integrations/tools/llama-index-tools-text-to-image/examples/text_to_image-pg.ipynb
```

The focused package test could not be completed locally because the native environment is missing `llama_index_instrumentation`; no dependencies were installed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
