### PR TITLE
fix: support MCP prompt content blocks

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,6 +1,7 @@
 import warnings
 import logging
 import io
+import base64
 
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -13,6 +14,7 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Any,
+    Union,
 )
 from urllib.parse import urlparse, parse_qs
 from httpx import AsyncClient, Timeout
@@ -27,7 +29,91 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.llms import (
+    AudioBlock,
+    ChatMessage,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
+
+
+PromptContentBlock = Union[TextBlock, ImageBlock, AudioBlock, DocumentBlock]
+
+
+def _audio_format_from_mime_type(mime_type: Optional[str]) -> Optional[str]:
+    if not mime_type or "/" not in mime_type:
+        return None
+    return mime_type.split("/", 1)[1].split(";", 1)[0]
+
+
+def _decode_base64_data(data: str) -> bytes:
+    return base64.b64decode(data.encode("utf-8"))
+
+
+def _resource_contents_to_block(
+    resource: Union[types.TextResourceContents, types.BlobResourceContents],
+) -> PromptContentBlock:
+    mime_type = resource.mimeType
+    if isinstance(resource, types.TextResourceContents):
+        return TextBlock(text=resource.text)
+
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(image=resource.blob, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(
+            audio=resource.blob,
+            format=_audio_format_from_mime_type(mime_type),
+        )
+
+    return DocumentBlock(
+        data=_decode_base64_data(resource.blob),
+        document_mimetype=mime_type,
+        title=str(resource.uri),
+    )
+
+
+def _resource_link_to_block(resource_link: types.ResourceLink) -> PromptContentBlock:
+    mime_type = resource_link.mimeType
+    uri = str(resource_link.uri)
+    if mime_type and mime_type.startswith("image/"):
+        return ImageBlock(url=uri, image_mimetype=mime_type)
+    if mime_type and mime_type.startswith("audio/"):
+        return AudioBlock(
+            url=uri,
+            format=_audio_format_from_mime_type(mime_type),
+        )
+
+    return DocumentBlock(
+        url=uri,
+        title=resource_link.title or resource_link.name,
+        document_mimetype=mime_type,
+    )
+
+
+def _mcp_content_to_blocks(content: types.ContentBlock) -> List[PromptContentBlock]:
+    if isinstance(content, types.TextContent):
+        return [TextBlock(text=content.text)]
+    if isinstance(content, types.ImageContent):
+        return [
+            ImageBlock(
+                image=content.data,
+                image_mimetype=content.mimeType,
+            )
+        ]
+    if isinstance(content, types.AudioContent):
+        return [
+            AudioBlock(
+                audio=content.data,
+                format=_audio_format_from_mime_type(content.mimeType),
+            )
+        ]
+    if isinstance(content, types.EmbeddedResource):
+        return [_resource_contents_to_block(content.resource)]
+    if isinstance(content, types.ResourceLink):
+        return [_resource_link_to_block(content)]
+
+    raise ValueError(f"Unsupported content type: {type(content)}")
 
 
 class StreamingHandler(logging.Handler):
@@ -379,32 +465,11 @@ class BasicMCPClient(ClientSession):
             prompt = await session.get_prompt(prompt_name, arguments)
             llama_messages = []
             for message in prompt.messages:
-                if isinstance(message.content, types.TextContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[TextBlock(text=message.content.text)],
-                        )
+                llama_messages.append(
+                    ChatMessage(
+                        role=message.role,
+                        blocks=_mcp_content_to_blocks(message.content),
                     )
-                elif isinstance(message.content, types.ImageContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[
-                                ImageBlock(
-                                    image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
-                                )
-                            ],
-                        )
-                    )
-                elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported content type: {type(message.content)}"
-                    )
+                )
 
             return llama_messages

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,9 +1,11 @@
+import base64
 import os
 from httpx import AsyncClient
 import pytest
 
+from llama_index.core.llms import AudioBlock, DocumentBlock, TextBlock
 from llama_index.tools.mcp import BasicMCPClient
-from llama_index.tools.mcp.client import enable_sse
+from llama_index.tools.mcp.client import _mcp_content_to_blocks, enable_sse
 from mcp import types
 
 
@@ -117,6 +119,56 @@ async def test_get_prompts(client: BasicMCPClient):
     result = await client.get_prompt("analyze_data", {"data": "1,2,3,4,5"})
     assert len(result) > 1
     assert any("1,2,3,4,5" in msg.content for msg in result)
+
+
+def test_mcp_prompt_content_blocks():
+    """Test converting all MCP prompt content variants into LlamaIndex blocks."""
+    audio = types.AudioContent(
+        type="audio",
+        data=base64.b64encode(b"audio").decode("utf-8"),
+        mimeType="audio/wav",
+    )
+    audio_blocks = _mcp_content_to_blocks(audio)
+    assert isinstance(audio_blocks[0], AudioBlock)
+    assert audio_blocks[0].format == "wav"
+
+    embedded_text = types.EmbeddedResource(
+        type="resource",
+        resource=types.TextResourceContents(
+            uri="file:///tmp/context.txt",
+            mimeType="text/plain",
+            text="embedded context",
+        ),
+    )
+    text_blocks = _mcp_content_to_blocks(embedded_text)
+    assert isinstance(text_blocks[0], TextBlock)
+    assert text_blocks[0].text == "embedded context"
+
+    blob = base64.b64encode(b"document bytes").decode("utf-8")
+    embedded_document = types.EmbeddedResource(
+        type="resource",
+        resource=types.BlobResourceContents(
+            uri="file:///tmp/context.pdf",
+            mimeType="application/pdf",
+            blob=blob,
+        ),
+    )
+    document_blocks = _mcp_content_to_blocks(embedded_document)
+    assert isinstance(document_blocks[0], DocumentBlock)
+    assert document_blocks[0].document_mimetype == "application/pdf"
+    assert document_blocks[0].title == "file:///tmp/context.pdf"
+
+    resource_link = types.ResourceLink(
+        type="resource_link",
+        name="manual",
+        title="Operator Manual",
+        uri="https://example.com/manual.pdf",
+        mimeType="application/pdf",
+    )
+    link_blocks = _mcp_content_to_blocks(resource_link)
+    assert isinstance(link_blocks[0], DocumentBlock)
+    assert link_blocks[0].url == "https://example.com/manual.pdf"
+    assert link_blocks[0].title == "Operator Manual"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #21270

`BasicMCPClient.get_prompt()` already converted text and image prompt content, but it raised for other valid MCP prompt content variants.

This maps MCP prompt content into existing LlamaIndex blocks:
- `AudioContent` -> `AudioBlock`
- embedded text resources -> `TextBlock`
- embedded binary resources -> `ImageBlock`, `AudioBlock`, or `DocumentBlock` based on MIME type
- `ResourceLink` -> media/document blocks based on MIME type

Validation:
- `uv run --python 3.12 --directory llama-index-integrations\tools\llama-index-tools-mcp pytest tests/test_client.py -q`
- `uv run --python 3.12 --directory llama-index-integrations\tools\llama-index-tools-mcp ruff check llama_index/tools/mcp/client.py tests/test_client.py`
- `uv run --python 3.12 --directory llama-index-integrations\tools\llama-index-tools-mcp ruff format --check llama_index/tools/mcp/client.py tests/test_client.py`
- `git diff --check`