### PR TITLE
fix: add OneDrive reader request timeouts

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -4,7 +4,7 @@ import logging
 import os
 import tempfile
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from pathlib import Path
 
 import requests
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 # Scope for reading and downloading OneDrive files
 SCOPES = ["Files.Read.All"]
 CLIENTCREDENTIALSCOPES = ["https://graph.microsoft.com/.default"]
+DEFAULT_REQUEST_TIMEOUT = (3.0, 30.0)
 
 
 class _OneDriveResourcePayload(BaseModel):
@@ -73,6 +74,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         default=None, exclude=True
     )
     attach_permission_metadata: bool = False
+    request_timeout: Union[float, Tuple[float, float]] = DEFAULT_REQUEST_TIMEOUT
 
     _is_interactive_auth = PrivateAttr(False)
     _authority = PrivateAttr()
@@ -90,6 +92,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         attach_permission_metadata: bool = False,
         required_exts: Optional[List[str]] = None,
+        request_timeout: Union[float, Tuple[float, float]] = DEFAULT_REQUEST_TIMEOUT,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -104,6 +107,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
             file_extractor=file_extractor,
             attach_permission_metadata=attach_permission_metadata,
             required_exts=required_exts,
+            request_timeout=request_timeout,
             **kwargs,
         )
         self._is_interactive_auth = not client_secret
@@ -232,7 +236,9 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         retries = 0
 
         while retries < max_retries:
-            response = requests.get(endpoint, headers=headers)
+            response = requests.get(
+                endpoint, headers=headers, timeout=self.request_timeout
+            )
             if response.status_code == 200:
                 return response.json()
             # Check for Ratelimit error, this can happen if you query endpoint recursively
@@ -270,7 +276,7 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         file_name = item["name"]
 
         # Download the file.
-        file_data = requests.get(file_download_url)
+        file_data = requests.get(file_download_url, timeout=self.request_timeout)
 
         # Save the downloaded file to the specified local directory.
         file_path = os.path.join(local_dir, file_name)
@@ -714,7 +720,11 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
 
         headers = {"Authorization": f"Bearer {access_token}"}
 
-        response = requests.get(url=permissions_info_endpoint, headers=headers)
+        response = requests.get(
+            url=permissions_info_endpoint,
+            headers=headers,
+            timeout=self.request_timeout,
+        )
         permissions = response.json()
         identity_sets = []
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,6 +1,7 @@
 import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.microsoft_onedrive import OneDriveReader
+from llama_index.readers.microsoft_onedrive.base import DEFAULT_REQUEST_TIMEOUT
 
 test_client_id = "test_client_id"
 test_tenant_id = "test_tenant_id"
@@ -31,6 +32,81 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+def test_onedrive_requests_use_default_timeout(monkeypatch, tmp_path):
+    calls = []
+
+    class MockResponse:
+        status_code = 200
+        content = b"file contents"
+
+        def json(self):
+            return {"value": []}
+
+    def mock_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return MockResponse()
+
+    monkeypatch.setattr(
+        "llama_index.readers.microsoft_onedrive.base.requests.get", mock_get
+    )
+
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+
+    reader._get_items_in_drive_with_maxretries("access-token")
+    reader._download_file_by_url(
+        {
+            "@microsoft.graph.downloadUrl": "https://download.example/file",
+            "name": "a.txt",
+        },
+        str(tmp_path),
+    )
+    reader._get_permissions_info({"id": "file-id"}, "user@example.com", "access-token")
+
+    assert len(calls) == 3
+    assert all(
+        call_kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT for _, call_kwargs in calls
+    )
+
+
+def test_onedrive_requests_use_custom_timeout(monkeypatch, tmp_path):
+    calls = []
+
+    class MockResponse:
+        status_code = 200
+        content = b"file contents"
+
+        def json(self):
+            return {"value": []}
+
+    def mock_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return MockResponse()
+
+    monkeypatch.setattr(
+        "llama_index.readers.microsoft_onedrive.base.requests.get", mock_get
+    )
+
+    request_timeout = (1.0, 5.0)
+    reader = OneDriveReader(
+        client_id=test_client_id,
+        tenant_id=test_tenant_id,
+        request_timeout=request_timeout,
+    )
+
+    reader._get_items_in_drive_with_maxretries("access-token")
+    reader._download_file_by_url(
+        {
+            "@microsoft.graph.downloadUrl": "https://download.example/file",
+            "name": "a.txt",
+        },
+        str(tmp_path),
+    )
+    reader._get_permissions_info({"id": "file-id"}, "user@example.com", "access-token")
+
+    assert len(calls) == 3
+    assert all(call_kwargs["timeout"] == request_timeout for _, call_kwargs in calls)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fixes #22140

This adds a bounded request timeout to the OneDrive reader's Microsoft Graph calls and file-download call so network stalls do not block indefinitely.

What changed:
- Added `request_timeout`, defaulting to `(3.0, 30.0)`.
- Passed the timeout to `_get_items_in_drive_with_maxretries`, `_download_file_by_url`, and `_get_permissions_info`.
- Added unit coverage for both default and custom timeout values without live Graph calls.

Validation:
- `uv run --python 3.12 --directory llama-index-integrations\readers\llama-index-readers-microsoft-onedrive pytest tests\test_readers_microsoft_onedrive.py -q`: 4 passed, 1 skipped
- `uv run --python 3.12 --directory llama-index-integrations\readers\llama-index-readers-microsoft-onedrive ruff check llama_index\readers\microsoft_onedrive\base.py tests\test_readers_microsoft_onedrive.py`: passed
- `uv run --python 3.12 --directory llama-index-integrations\readers\llama-index-readers-microsoft-onedrive ruff format llama_index\readers\microsoft_onedrive\base.py tests\test_readers_microsoft_onedrive.py --check`: passed
- `uv run --python 3.12 --directory llama-index-integrations\readers\llama-index-readers-microsoft-onedrive python -m py_compile llama_index\readers\microsoft_onedrive\base.py tests\test_readers_microsoft_onedrive.py`: passed
- `git diff --check`: passed

Note: running pytest without `--python 3.12` selected Python 3.14 locally and failed before collection because this package's pinned pytest version still uses deprecated AST aliases removed in Python 3.14. The supported Python 3.12 run passed.
