### PR TITLE
fix: require AG-UI tool call ids

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -60,13 +60,17 @@ def llama_index_message_to_ag_ui_message(
             tool_calls=tool_calls,
         )
     elif message.role.value == "tool" or "tool_call_id" in message.additional_kwargs:
+        tool_call_id = message.additional_kwargs.get("tool_call_id")
+        if not tool_call_id:
+            raise ValueError(
+                "Tool messages must include additional_kwargs['tool_call_id'] "
+                "to convert to an AG-UI ToolMessage."
+            )
         return ToolMessage(
             id=msg_id,
             content=message.content or "",
             role="tool",
-            tool_call_id=message.additional_kwargs.get(
-                "tool_call_id", str(uuid.uuid4())
-            ),
+            tool_call_id=tool_call_id,
         )
     else:
         raise ValueError(f"Unknown message role: {message.role}")

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+from ag_ui.core import ToolMessage
+
+from llama_index.core.llms import ChatMessage
+from llama_index.protocols.ag_ui.utils import llama_index_message_to_ag_ui_message
+
+
+def test_tool_message_requires_tool_call_id():
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1"},
+    )
+
+    with pytest.raises(ValueError, match="tool_call_id"):
+        llama_index_message_to_ag_ui_message(message)
+
+
+def test_tool_message_preserves_tool_call_id():
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={
+            "id": "tool_msg_1",
+            "tool_call_id": "call_get_weather_001",
+        },
+    )
+
+    ag_ui_message = llama_index_message_to_ag_ui_message(message)
+
+    assert isinstance(ag_ui_message, ToolMessage)
+    assert ag_ui_message.id == "tool_msg_1"
+    assert ag_ui_message.tool_call_id == "call_get_weather_001"


### PR DESCRIPTION
Fixes #22068

This stops `llama_index_message_to_ag_ui_message()` from silently fabricating a random `tool_call_id` when converting a tool-role `ChatMessage` to an AG-UI `ToolMessage`.

What changed:
- Require `additional_kwargs["tool_call_id"]` before emitting an AG-UI `ToolMessage`.
- Raise a clear `ValueError` when a tool message is missing the required ID.
- Preserve the provided `tool_call_id` for valid tool messages.
- Added focused regression tests for the missing-ID and valid-ID paths.

Validation:
- `uv run --frozen --python 3.12 --directory llama-index-integrations\protocols\llama-index-protocols-ag-ui pytest tests\test_utils.py tests\test_initial_state.py -q`: 5 passed
- `uv run --frozen --python 3.12 --directory llama-index-integrations\protocols\llama-index-protocols-ag-ui ruff check llama_index\protocols\ag_ui\utils.py tests\test_utils.py tests\test_initial_state.py`: passed
- `uv run --frozen --python 3.12 --directory llama-index-integrations\protocols\llama-index-protocols-ag-ui ruff format llama_index\protocols\ag_ui\utils.py tests\test_utils.py tests\test_initial_state.py --check`: passed
- `uv run --frozen --python 3.12 --directory llama-index-integrations\protocols\llama-index-protocols-ag-ui python -m py_compile llama_index\protocols\ag_ui\utils.py tests\test_utils.py tests\test_initial_state.py`: passed
- `git diff --check`: passed

No live AG-UI server or external API credentials are required for the regression tests.
