### PR TITLE
Add Pramagent tool guardrails example

### DIFF
--- a/docs/examples/agent/pramagent_tool_guardrails.ipynb
+++ b/docs/examples/agent/pramagent_tool_guardrails.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "pram-00-630d7b8b",
+   "metadata": {},
+   "source": [
+    "# External Tool Guardrails with Pramagent\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/agent/pramagent_tool_guardrails.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "This notebook shows how to place an external control layer in front of a LlamaIndex tool. LlamaIndex remains responsible for agent orchestration and tool selection; Pramagent validates the proposed tool call before the side effect runs.\n",
+    "\n",
+    "The example uses a refund tool because payments are a useful boundary case: the model may propose the right tool, but the application still needs deterministic policy, human approval, and an audit trail before execution.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-01-73a36078",
+   "metadata": {},
+   "source": [
+    "## Install dependencies\n",
+    "\n",
+    "This example does not require a model provider key. It exercises the tool boundary directly, which is the same boundary a LlamaIndex agent reaches after selecting a tool.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-02-f7897279",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U llama-index-core pramagent\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-03-9437fc11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.tools import FunctionTool\n",
+    "\n",
+    "from pramagent import Pramagent, Verdict\n",
+    "from pramagent.layers import ToolGuardLayer, ToolPolicy\n",
+    "from pramagent.layers.tool_guard import SideEffect\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-04-77104323",
+   "metadata": {},
+   "source": [
+    "## Define a side-effecting tool\n",
+    "\n",
+    "In a production agent this function would call a payment, ticketing, email, or database API. Here we keep the side effect visible by appending to an in-memory list. If Pramagent holds or blocks the action, the list should stay empty.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-05-9d5c0710",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "side_effects = []\n",
+    "\n",
+    "\n",
+    "def issue_refund(order_id: str, amount_usd: float, destination_account: str) -> dict:\n",
+    "    \"\"\"Issue a refund to a customer account.\"\"\"\n",
+    "    record = {\n",
+    "        \"order_id\": order_id,\n",
+    "        \"amount_usd\": amount_usd,\n",
+    "        \"destination_account\": destination_account,\n",
+    "    }\n",
+    "    side_effects.append(record)\n",
+    "    return {\"status\": \"executed\", **record}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-06-e98307f1",
+   "metadata": {},
+   "source": [
+    "## Add deterministic policy outside the model\n",
+    "\n",
+    "The policy below does three things before the refund function can execute:\n",
+    "\n",
+    "1. validates arguments with JSON Schema,\n",
+    "2. restricts execution to the `finance-demo` tenant and `refund` action label, and\n",
+    "3. escalates valid refund attempts for human approval instead of executing automatically.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-07-891e704f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "guard = ToolGuardLayer(\n",
+    "    policies=[\n",
+    "        ToolPolicy(\n",
+    "            name=\"issue_refund\",\n",
+    "            side_effect=SideEffect.PAYMENT,\n",
+    "            action=Verdict.ESCALATE,\n",
+    "            allowed_tenants={\"finance-demo\"},\n",
+    "            allowed_actions={\"refund\"},\n",
+    "            schema={\n",
+    "                \"type\": \"object\",\n",
+    "                \"required\": [\"order_id\", \"amount_usd\", \"destination_account\"],\n",
+    "                \"properties\": {\n",
+    "                    \"order_id\": {\"type\": \"string\", \"pattern\": \"^ord-[0-9]+$\"},\n",
+    "                    \"amount_usd\": {\"type\": \"number\", \"minimum\": 0.01, \"maximum\": 5000},\n",
+    "                    \"destination_account\": {\"type\": \"string\", \"pattern\": \"^acct-[0-9]{6,}$\"},\n",
+    "                },\n",
+    "                \"additionalProperties\": False,\n",
+    "            },\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "armor = Pramagent(tool_guard=guard)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-08-89c74646",
+   "metadata": {},
+   "source": [
+    "## Wrap the LlamaIndex tool\n",
+    "\n",
+    "The wrapper performs the Pramagent decision first. A block or escalation returns a structured tool result to the agent without running the side effect. Only an `ALLOW` decision calls the underlying function.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-09-64b9852d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def guarded_issue_refund(\n",
+    "    order_id: str,\n",
+    "    amount_usd: float,\n",
+    "    destination_account: str,\n",
+    "    tenant_id: str = \"finance-demo\",\n",
+    "    session_id: str = \"notebook-demo\",\n",
+    ") -> dict:\n",
+    "    proposed_args = {\n",
+    "        \"order_id\": order_id,\n",
+    "        \"amount_usd\": amount_usd,\n",
+    "        \"destination_account\": destination_account,\n",
+    "    }\n",
+    "    decision = armor.validate_tool(\n",
+    "        \"issue_refund\",\n",
+    "        proposed_args,\n",
+    "        tenant_id=tenant_id,\n",
+    "        session_id=session_id,\n",
+    "        action_label=\"refund\",\n",
+    "    )\n",
+    "\n",
+    "    if decision.verdict == Verdict.BLOCK:\n",
+    "        return {\n",
+    "            \"status\": \"blocked\",\n",
+    "            \"reason\": decision.reason,\n",
+    "            \"executed\": False,\n",
+    "        }\n",
+    "\n",
+    "    if decision.verdict == Verdict.ESCALATE:\n",
+    "        return {\n",
+    "            \"status\": \"held_for_human_approval\",\n",
+    "            \"reason\": decision.reason or \"policy requires approval\",\n",
+    "            \"executed\": False,\n",
+    "        }\n",
+    "\n",
+    "    result = issue_refund(order_id, amount_usd, destination_account)\n",
+    "    return {**result, \"executed\": True}\n",
+    "\n",
+    "\n",
+    "refund_tool = FunctionTool.from_defaults(\n",
+    "    fn=guarded_issue_refund,\n",
+    "    name=\"issue_refund\",\n",
+    "    description=\"Request a customer refund. Valid requests are held for human approval.\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-10-e885478f",
+   "metadata": {},
+   "source": [
+    "## Valid action: held, not executed\n",
+    "\n",
+    "The arguments are valid, but the payment side effect is configured to require human approval. The tool returns `held_for_human_approval`, and the underlying refund function never runs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-11-475411ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "held = refund_tool.call(\n",
+    "    order_id=\"ord-1001\",\n",
+    "    amount_usd=1200.00,\n",
+    "    destination_account=\"acct-123456\",\n",
+    ")\n",
+    "\n",
+    "print(held.raw_output)\n",
+    "print(\"side_effects:\", side_effects)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-12-24548c5d",
+   "metadata": {},
+   "source": [
+    "## Invalid action: blocked before execution\n",
+    "\n",
+    "This request exceeds the schema maximum. It is blocked deterministically before the side-effecting function can run.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-13-2933d22e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blocked = refund_tool.call(\n",
+    "    order_id=\"ord-1002\",\n",
+    "    amount_usd=9000.00,\n",
+    "    destination_account=\"acct-123456\",\n",
+    ")\n",
+    "\n",
+    "print(blocked.raw_output)\n",
+    "print(\"side_effects:\", side_effects)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-14-61074132",
+   "metadata": {},
+   "source": [
+    "## Use the guarded tool with an agent\n",
+    "\n",
+    "You can pass `refund_tool` to a LlamaIndex agent just like any other `FunctionTool`. LlamaIndex still handles the agent loop and tool selection; Pramagent handles the execution boundary.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pram-15-03ccd0de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=[refund_tool],\n",
+    "    system_prompt=(\n",
+    "        \"You help support teams process refund requests. \"\n",
+    "        \"Use the issue_refund tool when a refund is requested.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# After configuring your preferred LLM, run for example:\n",
+    "# response = await agent.run(\"Refund order ord-1001 to acct-123456 for $1200.\")\n",
+    "# print(response)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pram-16-58e2ddb1",
+   "metadata": {},
+   "source": [
+    "## Why this pattern is useful\n",
+    "\n",
+    "This keeps the trust boundary outside the model. The model may suggest a tool call, but deterministic policy decides whether the call executes, is held for approval, or is blocked. The same pattern can be applied to email, database writes, account changes, procurement actions, or any other tool with real side effects.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -12,6 +12,7 @@ Build powerful AI assistants with LlamaIndex's agent capabilities:
 - [React Agent](/python/examples/agent/react_agent) - Use the ReAct (Reasoning and Acting) pattern with agents
 - [Code Act Agent](/python/examples/agent/code_act_agent) - Agents that can write and execute code
 - [Multi-Agent Workflow](/python/examples/agent/agent_workflow_multi) - Build a multi-agent workflow with `AgentWorkflow`
+- [External Tool Guardrails with Pramagent](/python/examples/agent/pramagent_tool_guardrails) - Add deterministic policy checks before side-effecting tools execute
 
 You might also be interested in the [general introduction to agents](/python/framework/understanding/agent).
 


### PR DESCRIPTION
## What changed

Adds a documentation notebook showing how to put an external policy gate in front of a LlamaIndex `FunctionTool` using the open-source Pramagent package.

The example keeps LlamaIndex as the agent/tool abstraction and uses Pramagent only at the execution boundary:

- the agent/tool can still propose `issue_refund`
- Pramagent validates the proposed arguments with JSON Schema
- valid payment-like actions are held for human approval instead of executing automatically
- invalid actions are blocked before the underlying side-effect function runs

The notebook is linked from `docs/examples/index.md` under Agents.

## Why

Agent tools often touch side-effecting systems: refunds, emails, tickets, database writes, account changes, etc. This example demonstrates a small guardrails-as-code pattern for those boundaries: LlamaIndex handles orchestration and tool selection, while deterministic policy decides whether a selected tool call can actually execute.

## Validation

- Validated notebook JSON with `python -m json.tool`
- Validated notebook schema with `nbformat.validate`
- Smoke-tested the core notebook logic against the installed `llama-index-core` API and local Pramagent checkout:
  - valid refund request returns `held_for_human_approval`
  - over-limit refund request returns `blocked`
  - underlying side-effect function is not executed in either case