### PR TITLE
fix(sagemaker): stop corrupting streamed text via lstrip/rstrip (closes #22221)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/llama_index/llms/sagemaker_endpoint/utils.py
@@ -63,7 +63,9 @@ class IOHandler(BaseIOHandler):
 
     def deserialize_streaming_output(self, response: bytes) -> str:
         response_str = (
-            response.decode("utf-8").lstrip('[{"generated_text":"').rstrip('"}]')
+            response.decode("utf-8")
+            .removeprefix('[{"generated_text":"')
+            .removesuffix('"}]')
         )
         clean_response = '{"response":"' + response_str + '"}'
 

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-sagemaker-endpoint"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index llms sagemaker endpoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
+++ b/llama-index-integrations/llms/llama-index-llms-sagemaker-endpoint/tests/test_llms_sagemaker_endpoint.py
@@ -1,7 +1,34 @@
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.sagemaker_endpoint import SageMakerLLM
+from llama_index.llms.sagemaker_endpoint.utils import IOHandler
 
 
 def test_embedding_class():
     names_of_base_classes = [b.__name__ for b in SageMakerLLM.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_deserialize_streaming_output_preserves_text():
+    # Regression test: lstrip/rstrip were used as prefix/suffix removal, which
+    # ate leading/trailing characters from the generated text itself.
+    handler = IOHandler()
+    assert (
+        handler.deserialize_streaming_output(b'[{"generated_text":"the answer is 42"}]')
+        == "the answer is 42"
+    )
+    assert (
+        handler.deserialize_streaming_output(b'[{"generated_text":"great and neat"}]')
+        == "great and neat"
+    )
+    assert (
+        handler.deserialize_streaming_output(b'[{"generated_text":"data engineering"}]')
+        == "data engineering"
+    )
+
+
+def test_deserialize_streaming_output_handles_escaped_quotes():
+    handler = IOHandler()
+    assert (
+        handler.deserialize_streaming_output(b'[{"generated_text":"he said \\"hi\\""}]')
+        == 'he said "hi"'
+    )


### PR DESCRIPTION
Closes #22221.

`IOHandler.deserialize_streaming_output` in `llama-index-llms-sagemaker-endpoint` removed the `[{"generated_text":"` / `"}]` envelope with `str.lstrip` / `str.rstrip`:

```python
response_str = (
    response.decode("utf-8").lstrip('[{"generated_text":"').rstrip('"}]')
)
```

`lstrip`/`rstrip` treat their argument as a **set of characters**, not a literal prefix/suffix. Once the envelope is consumed, stripping continues into the generated text itself, silently eating any leading character in the set (`t`, `d`, `a`, `g`, `e`, `n`, `r`, `_`, `:`, ...) and trailing `"`/`}`/`]`. Since many responses begin with words like "the", "data", "great", streamed SageMaker output was routinely truncated with no error, and text ending in an escaped quote crashed the subsequent `json.loads`.

Fix: use `str.removeprefix` / `str.removesuffix`, which strip the literal envelope exactly once (`requires-python` is `>=3.10`, so both are available).

Added regression tests straight from the issue repro (pure bytes -> str, no AWS needed), including the escaped-quote case. `ruff check`/`ruff format` clean; bumped the package patch version.
