### PR TITLE
fix(elasticsearch): split sync and async store paths to avoid event-loop bridging in ASGI

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -4,7 +4,7 @@ import asyncio
 from logging import getLogger
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
-import nest_asyncio
+from elasticsearch import AsyncElasticsearch, Elasticsearch
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.vector_stores.types import (
@@ -17,8 +17,12 @@ from llama_index.core.vector_stores.types import (
 from llama_index.core.vector_stores.utils import (
     node_to_metadata_dict,
 )
-from elasticsearch.helpers.vectorstore import AsyncVectorStore
+from elasticsearch.helpers.vectorstore import AsyncVectorStore, VectorStore
 from elasticsearch.helpers.vectorstore import (
+    BM25Strategy,
+    DenseVectorStrategy,
+    RetrievalStrategy,
+    SparseVectorStrategy,
     AsyncBM25Strategy,
     AsyncSparseVectorStrategy,
     AsyncDenseVectorStrategy,
@@ -27,9 +31,11 @@ from elasticsearch.helpers.vectorstore import (
 )
 
 from llama_index.vector_stores.elasticsearch.utils import (
-    get_elasticsearch_client,
-    get_user_agent,
     convert_es_hit_to_node,
+    get_elasticsearch_client,
+    get_elasticsearch_clients,
+    get_sync_elasticsearch_client,
+    get_user_agent,
 )
 
 logger = getLogger(__name__)
@@ -39,6 +45,27 @@ DISTANCE_STRATEGIES = Literal[
     "DOT_PRODUCT",
     "EUCLIDEAN_DISTANCE",
 ]
+
+
+def _to_sync_retrieval_strategy(
+    retrieval_strategy: AsyncRetrievalStrategy,
+) -> RetrievalStrategy:
+    if isinstance(retrieval_strategy, AsyncDenseVectorStrategy):
+        return DenseVectorStrategy(
+            distance=retrieval_strategy.distance,
+            model_id=retrieval_strategy.model_id,
+            hybrid=retrieval_strategy.hybrid,
+            rrf=retrieval_strategy.rrf,
+            text_field=retrieval_strategy.text_field,
+        )
+    if isinstance(retrieval_strategy, AsyncSparseVectorStrategy):
+        return SparseVectorStrategy(model_id=retrieval_strategy.model_id)
+    if isinstance(retrieval_strategy, AsyncBM25Strategy):
+        return BM25Strategy(k1=retrieval_strategy.k1, b=retrieval_strategy.b)
+
+    raise TypeError(
+        f"Unsupported retrieval strategy type for sync operations: {type(retrieval_strategy)}"
+    )
 
 
 def _to_elasticsearch_filter(
@@ -127,7 +154,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
 
     Args:
         index_name: Name of the Elasticsearch index.
-        es_client: Optional. Pre-existing AsyncElasticsearch client.
+        es_client: Optional. Pre-existing Elasticsearch or AsyncElasticsearch client.
+        es_async_client: Optional. Pre-existing AsyncElasticsearch client.
         es_url: Optional. Elasticsearch URL.
         es_cloud_id: Optional. Elasticsearch cloud ID.
         es_api_key: Optional. Elasticsearch API key.
@@ -192,6 +220,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
     stores_text: bool = True
     index_name: str
     es_client: Optional[Any]
+    es_async_client: Optional[Any]
     es_url: Optional[str]
     es_cloud_id: Optional[str]
     es_api_key: Optional[str]
@@ -204,11 +233,15 @@ class ElasticsearchStore(BasePydanticVectorStore):
     retrieval_strategy: AsyncRetrievalStrategy
 
     _store = PrivateAttr()
+    _sync_store = PrivateAttr()
+    _owns_sync_client = PrivateAttr()
+    _owns_async_client = PrivateAttr()
 
     def __init__(
         self,
         index_name: str,
         es_client: Optional[Any] = None,
+        es_async_client: Optional[Any] = None,
         es_url: Optional[str] = None,
         es_cloud_id: Optional[str] = None,
         es_api_key: Optional[str] = None,
@@ -222,20 +255,76 @@ class ElasticsearchStore(BasePydanticVectorStore):
         metadata_mappings: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
-        nest_asyncio.apply()
+        if retrieval_strategy is None:
+            retrieval_strategy = AsyncDenseVectorStrategy(
+                distance=DistanceMetric[distance_strategy]
+            )
+        sync_retrieval_strategy = _to_sync_retrieval_strategy(retrieval_strategy)
 
-        if not es_client:
-            es_client = get_elasticsearch_client(
+        sync_client = None
+        async_client = es_async_client
+
+        if es_client is not None:
+            if isinstance(es_client, AsyncElasticsearch):
+                async_client = es_client
+            elif isinstance(es_client, Elasticsearch):
+                sync_client = es_client
+            else:
+                raise TypeError(
+                    f"`es_client` must be Elasticsearch or AsyncElasticsearch, got {type(es_client)}"
+                )
+
+        if es_async_client is not None and not isinstance(
+            es_async_client, AsyncElasticsearch
+        ):
+            raise TypeError(
+                f"`es_async_client` must be AsyncElasticsearch, got {type(es_async_client)}"
+            )
+
+        has_connection_settings = any(
+            [es_url, es_cloud_id, es_api_key, es_user, es_password]
+        )
+        if sync_client is None and async_client is None:
+            sync_client, async_client = get_elasticsearch_clients(
                 url=es_url,
                 cloud_id=es_cloud_id,
                 api_key=es_api_key,
                 username=es_user,
                 password=es_password,
             )
+            self._owns_sync_client = True
+            self._owns_async_client = True
+        else:
+            self._owns_sync_client = False
+            self._owns_async_client = False
+            if sync_client is None and has_connection_settings:
+                sync_client = get_sync_elasticsearch_client(
+                    url=es_url,
+                    cloud_id=es_cloud_id,
+                    api_key=es_api_key,
+                    username=es_user,
+                    password=es_password,
+                )
+                self._owns_sync_client = True
+            if async_client is None and has_connection_settings:
+                async_client = get_elasticsearch_client(
+                    url=es_url,
+                    cloud_id=es_cloud_id,
+                    api_key=es_api_key,
+                    username=es_user,
+                    password=es_password,
+                )
+                self._owns_async_client = True
 
-        if retrieval_strategy is None:
-            retrieval_strategy = AsyncDenseVectorStrategy(
-                distance=DistanceMetric[distance_strategy]
+        if sync_client is None:
+            raise ValueError(
+                "Synchronous Elasticsearch client is required for sync methods. "
+                "Provide `es_client` as `Elasticsearch` or connection settings."
+            )
+        if async_client is None:
+            raise ValueError(
+                "Asynchronous Elasticsearch client is required for async methods. "
+                "Provide `es_async_client`/`es_client` as `AsyncElasticsearch` or connection settings."
             )
 
         base_metadata_mappings = {
@@ -249,7 +338,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
 
         super().__init__(
             index_name=index_name,
-            es_client=es_client,
+            es_client=sync_client,
+            es_async_client=async_client,
             es_url=es_url,
             es_cloud_id=es_cloud_id,
             es_api_key=es_api_key,
@@ -262,9 +352,18 @@ class ElasticsearchStore(BasePydanticVectorStore):
             retrieval_strategy=retrieval_strategy,
         )
 
+        self._sync_store = VectorStore(
+            user_agent=get_user_agent(),
+            client=sync_client,
+            index=index_name,
+            retrieval_strategy=sync_retrieval_strategy,
+            text_field=text_field,
+            vector_field=vector_field,
+            metadata_mappings=metadata_mappings,
+        )
         self._store = AsyncVectorStore(
             user_agent=get_user_agent(),
-            client=es_client,
+            client=async_client,
             index=index_name,
             retrieval_strategy=retrieval_strategy,
             text_field=text_field,
@@ -283,7 +382,20 @@ class ElasticsearchStore(BasePydanticVectorStore):
         return self._store.client
 
     def close(self) -> None:
-        return asyncio.get_event_loop().run_until_complete(self._store.close())
+        if self._owns_sync_client:
+            self._sync_store.close()
+        if self._owns_async_client:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._store.close())
+            except RuntimeError:
+                asyncio.run(self._store.close())
+
+    async def aclose(self) -> None:
+        if self._owns_sync_client:
+            self._sync_store.close()
+        if self._owns_async_client:
+            await self._store.close()
 
     def add(
         self,
@@ -306,16 +418,37 @@ class ElasticsearchStore(BasePydanticVectorStore):
             List of node IDs that were added to the index.
 
         Raises:
-            ImportError: If elasticsearch['async'] python package is not installed.
-            BulkIndexError: If AsyncElasticsearch async_bulk indexing fails.
+            ImportError: If elasticsearch python package is not installed.
+            BulkIndexError: If Elasticsearch bulk indexing fails.
 
         """
-        return asyncio.get_event_loop().run_until_complete(
-            self.async_add(
-                nodes,
-                create_index_if_not_exists=create_index_if_not_exists,
-                **add_kwargs,
-            )
+        if len(nodes) == 0:
+            return []
+
+        embeddings: Optional[List[List[float]]] = None
+        texts: List[str] = []
+        metadatas: List[dict] = []
+        ids: List[str] = []
+        for node in nodes:
+            ids.append(node.node_id)
+            texts.append(node.get_content(metadata_mode=MetadataMode.NONE))
+            metadatas.append(node_to_metadata_dict(node, remove_text=True))
+
+        if isinstance(self.retrieval_strategy, AsyncDenseVectorStrategy):
+            embeddings = []
+            for node in nodes:
+                embeddings.append(node.get_embedding())
+
+            if not self._sync_store.num_dimensions:
+                self._sync_store.num_dimensions = len(embeddings[0])
+
+        return self._sync_store.add_texts(
+            texts=texts,
+            metadatas=metadatas,
+            vectors=embeddings,
+            ids=ids,
+            create_index_if_not_exists=create_index_if_not_exists,
+            bulk_kwargs=add_kwargs,
         )
 
     async def async_add(
@@ -387,8 +520,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Exception: If Elasticsearch delete_by_query fails.
 
         """
-        return asyncio.get_event_loop().run_until_complete(
-            self.adelete(ref_doc_id, **delete_kwargs)
+        self._sync_store.delete(
+            query={"term": {"metadata.ref_doc_id": ref_doc_id}}, **delete_kwargs
         )
 
     async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
@@ -423,9 +556,26 @@ class ElasticsearchStore(BasePydanticVectorStore):
             delete_kwargs: Optional additional arguments to pass to delete operation.
 
         """
-        return asyncio.get_event_loop().run_until_complete(
-            self.adelete_nodes(node_ids, filters, **delete_kwargs)
-        )
+        if not node_ids and not filters:
+            return
+
+        if node_ids and not filters:
+            self._sync_store.delete(ids=node_ids, **delete_kwargs)
+            return
+
+        query = {"bool": {"must": []}}
+
+        if node_ids:
+            query["bool"]["must"].append({"terms": {"_id": node_ids}})
+
+        if filters:
+            es_filter = _to_elasticsearch_filter(filters)
+            if "bool" in es_filter and "must" in es_filter["bool"]:
+                query["bool"]["must"].extend(es_filter["bool"]["must"])
+            else:
+                query["bool"]["must"].append(es_filter)
+
+        self._sync_store.delete(query=query, **delete_kwargs)
 
     async def adelete_nodes(
         self,
@@ -494,8 +644,36 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Exception: If Elasticsearch query fails.
 
         """
-        return asyncio.get_event_loop().run_until_complete(
-            self.aquery(query, custom_query, es_filter, **kwargs)
+        _mode_must_match_retrieval_strategy(query.mode, self.retrieval_strategy)
+
+        if query.filters is not None and len(query.filters.legacy_filters()) > 0:
+            filter = [_to_elasticsearch_filter(query.filters, metadata_keyword_suffix)]
+        else:
+            filter = es_filter or []
+
+        hits = self._sync_store.search(
+            query=query.query_str,
+            query_vector=query.query_embedding,
+            k=query.similarity_top_k,
+            num_candidates=query.similarity_top_k * 10,
+            filter=filter,
+            custom_query=custom_query,
+        )
+
+        top_k_nodes = []
+        top_k_ids = []
+        top_k_scores = []
+
+        for hit in hits:
+            node = convert_es_hit_to_node(hit, self.text_field)
+            top_k_nodes.append(node)
+            top_k_ids.append(hit["_id"])
+            top_k_scores.append(hit["_score"])
+
+        return VectorStoreQueryResult(
+            nodes=top_k_nodes,
+            ids=top_k_ids,
+            similarities=_to_llama_similarities(top_k_scores),
         )
 
     async def aquery(
@@ -577,9 +755,33 @@ class ElasticsearchStore(BasePydanticVectorStore):
             List[BaseNode]: List of nodes retrieved from the index.
 
         """
-        return asyncio.get_event_loop().run_until_complete(
-            self.aget_nodes(node_ids, filters)
+        if not node_ids and not filters:
+            raise ValueError("Either node_ids or filters must be provided.")
+
+        query = {"bool": {"must": []}}
+
+        if node_ids is not None:
+            query["bool"]["must"].append({"terms": {"_id": node_ids}})
+
+        if filters:
+            es_filter = _to_elasticsearch_filter(filters)
+            if "bool" in es_filter and "must" in es_filter["bool"]:
+                query["bool"]["must"].extend(es_filter["bool"]["must"])
+            else:
+                query["bool"]["must"].append(es_filter)
+
+        response = self._sync_store.client.search(
+            index=self.index_name,
+            body={"query": query, "size": 10000},
         )
+
+        hits = response.get("hits", {}).get("hits", [])
+        nodes = []
+
+        for hit in hits:
+            nodes.append(convert_es_hit_to_node(hit, self.text_field))
+
+        return nodes
 
     async def aget_nodes(
         self,
@@ -633,7 +835,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
         Clear all nodes from Elasticsearch index.
         This method deletes and recreates the index.
         """
-        return asyncio.get_event_loop().run_until_complete(self.aclear())
+        if self._sync_store.client.indices.exists(index=self.index_name):
+            self._sync_store.client.indices.delete(index=self.index_name)
 
     async def aclear(self) -> None:
         """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -1,6 +1,5 @@
 """Elasticsearch vector store."""
 
-import asyncio
 from logging import getLogger
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
@@ -384,12 +383,6 @@ class ElasticsearchStore(BasePydanticVectorStore):
     def close(self) -> None:
         if self._owns_sync_client:
             self._sync_store.close()
-        if self._owns_async_client:
-            try:
-                loop = asyncio.get_running_loop()
-                loop.create_task(self._store.close())
-            except RuntimeError:
-                asyncio.run(self._store.close())
 
     async def aclose(self) -> None:
         if self._owns_sync_client:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -231,8 +231,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
     distance_strategy: Optional[DISTANCE_STRATEGIES] = "COSINE"
     retrieval_strategy: AsyncRetrievalStrategy
 
-    _store = PrivateAttr()
-    _sync_store = PrivateAttr()
+    _store = PrivateAttr(default=None)
+    _sync_store = PrivateAttr(default=None)
     _owns_sync_client = PrivateAttr()
     _owns_async_client = PrivateAttr()
 
@@ -315,17 +315,6 @@ class ElasticsearchStore(BasePydanticVectorStore):
                 )
                 self._owns_async_client = True
 
-        if sync_client is None:
-            raise ValueError(
-                "Synchronous Elasticsearch client is required for sync methods. "
-                "Provide `es_client` as `Elasticsearch` or connection settings."
-            )
-        if async_client is None:
-            raise ValueError(
-                "Asynchronous Elasticsearch client is required for async methods. "
-                "Provide `es_async_client`/`es_client` as `AsyncElasticsearch` or connection settings."
-            )
-
         base_metadata_mappings = {
             "document_id": {"type": "keyword"},
             "doc_id": {"type": "keyword"},
@@ -351,24 +340,27 @@ class ElasticsearchStore(BasePydanticVectorStore):
             retrieval_strategy=retrieval_strategy,
         )
 
-        self._sync_store = VectorStore(
-            user_agent=get_user_agent(),
-            client=sync_client,
-            index=index_name,
-            retrieval_strategy=sync_retrieval_strategy,
-            text_field=text_field,
-            vector_field=vector_field,
-            metadata_mappings=metadata_mappings,
-        )
-        self._store = AsyncVectorStore(
-            user_agent=get_user_agent(),
-            client=async_client,
-            index=index_name,
-            retrieval_strategy=retrieval_strategy,
-            text_field=text_field,
-            vector_field=vector_field,
-            metadata_mappings=metadata_mappings,
-        )
+        if sync_client is not None:
+            self._sync_store = VectorStore(
+                user_agent=get_user_agent(),
+                client=sync_client,
+                index=index_name,
+                retrieval_strategy=sync_retrieval_strategy,
+                text_field=text_field,
+                vector_field=vector_field,
+                metadata_mappings=metadata_mappings,
+            )
+
+        if async_client is not None:
+            self._store = AsyncVectorStore(
+                user_agent=get_user_agent(),
+                client=async_client,
+                index=index_name,
+                retrieval_strategy=retrieval_strategy,
+                text_field=text_field,
+                vector_field=vector_field,
+                metadata_mappings=metadata_mappings,
+            )
 
         # Disable query embeddings when using Sparse vectors or BM25.
         # ELSER generates its own embeddings server-side
@@ -378,16 +370,33 @@ class ElasticsearchStore(BasePydanticVectorStore):
     @property
     def client(self) -> Any:
         """Get async elasticsearch client."""
-        return self._store.client
+        return self._require_async_store().client
+
+    def _require_sync_store(self) -> VectorStore:
+        if self._sync_store is None:
+            raise ValueError(
+                "Synchronous methods require a sync Elasticsearch client. "
+                "Provide `es_client` as `Elasticsearch` or connection settings (`es_url`/`es_cloud_id`)."
+            )
+        return self._sync_store
+
+    def _require_async_store(self) -> AsyncVectorStore:
+        if self._store is None:
+            raise ValueError(
+                "Asynchronous methods require an async Elasticsearch client. "
+                "Provide `es_async_client` or `es_client` as `AsyncElasticsearch`, "
+                "or connection settings (`es_url`/`es_cloud_id`)."
+            )
+        return self._store
 
     def close(self) -> None:
-        if self._owns_sync_client:
+        if self._owns_sync_client and self._sync_store is not None:
             self._sync_store.close()
 
     async def aclose(self) -> None:
-        if self._owns_sync_client:
+        if self._owns_sync_client and self._sync_store is not None:
             self._sync_store.close()
-        if self._owns_async_client:
+        if self._owns_async_client and self._store is not None:
             await self._store.close()
 
     def add(
@@ -415,6 +424,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
             BulkIndexError: If Elasticsearch bulk indexing fails.
 
         """
+        sync_store = self._require_sync_store()
+
         if len(nodes) == 0:
             return []
 
@@ -432,10 +443,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
             for node in nodes:
                 embeddings.append(node.get_embedding())
 
-            if not self._sync_store.num_dimensions:
-                self._sync_store.num_dimensions = len(embeddings[0])
+            if not sync_store.num_dimensions:
+                sync_store.num_dimensions = len(embeddings[0])
 
-        return self._sync_store.add_texts(
+        return sync_store.add_texts(
             texts=texts,
             metadatas=metadatas,
             vectors=embeddings,
@@ -469,6 +480,8 @@ class ElasticsearchStore(BasePydanticVectorStore):
             BulkIndexError: If AsyncElasticsearch async_bulk indexing fails.
 
         """
+        async_store = self._require_async_store()
+
         if len(nodes) == 0:
             return []
 
@@ -488,10 +501,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
             for node in nodes:
                 embeddings.append(node.get_embedding())
 
-            if not self._store.num_dimensions:
-                self._store.num_dimensions = len(embeddings[0])
+            if not async_store.num_dimensions:
+                async_store.num_dimensions = len(embeddings[0])
 
-        return await self._store.add_texts(
+        return await async_store.add_texts(
             texts=texts,
             metadatas=metadatas,
             vectors=embeddings,
@@ -513,7 +526,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Exception: If Elasticsearch delete_by_query fails.
 
         """
-        self._sync_store.delete(
+        self._require_sync_store().delete(
             query={"term": {"metadata.ref_doc_id": ref_doc_id}}, **delete_kwargs
         )
 
@@ -530,7 +543,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             Exception: If AsyncElasticsearch delete_by_query fails.
 
         """
-        await self._store.delete(
+        await self._require_async_store().delete(
             query={"term": {"metadata.ref_doc_id": ref_doc_id}}, **delete_kwargs
         )
 
@@ -552,8 +565,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if not node_ids and not filters:
             return
 
+        sync_store = self._require_sync_store()
+
         if node_ids and not filters:
-            self._sync_store.delete(ids=node_ids, **delete_kwargs)
+            sync_store.delete(ids=node_ids, **delete_kwargs)
             return
 
         query = {"bool": {"must": []}}
@@ -568,7 +583,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             else:
                 query["bool"]["must"].append(es_filter)
 
-        self._sync_store.delete(query=query, **delete_kwargs)
+        sync_store.delete(query=query, **delete_kwargs)
 
     async def adelete_nodes(
         self,
@@ -588,8 +603,10 @@ class ElasticsearchStore(BasePydanticVectorStore):
         if not node_ids and not filters:
             return
 
+        async_store = self._require_async_store()
+
         if node_ids and not filters:
-            await self._store.delete(ids=node_ids, **delete_kwargs)
+            await async_store.delete(ids=node_ids, **delete_kwargs)
             return
 
         query = {"bool": {"must": []}}
@@ -604,7 +621,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             else:
                 query["bool"]["must"].append(es_filter)
 
-        await self._store.delete(query=query, **delete_kwargs)
+        await async_store.delete(query=query, **delete_kwargs)
 
     def query(
         self,
@@ -644,7 +661,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         else:
             filter = es_filter or []
 
-        hits = self._sync_store.search(
+        hits = self._require_sync_store().search(
             query=query.query_str,
             query_vector=query.query_embedding,
             k=query.similarity_top_k,
@@ -707,7 +724,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
         else:
             filter = es_filter or []
 
-        hits = await self._store.search(
+        hits = await self._require_async_store().search(
             query=query.query_str,
             query_vector=query.query_embedding,
             k=query.similarity_top_k,
@@ -763,7 +780,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             else:
                 query["bool"]["must"].append(es_filter)
 
-        response = self._sync_store.client.search(
+        response = self._require_sync_store().client.search(
             index=self.index_name,
             body={"query": query, "size": 10000},
         )
@@ -810,7 +827,7 @@ class ElasticsearchStore(BasePydanticVectorStore):
             else:
                 query["bool"]["must"].append(es_filter)
 
-        response = await self._store.client.search(
+        response = await self._require_async_store().client.search(
             index=self.index_name,
             body={"query": query, "size": 10000},
         )
@@ -828,13 +845,15 @@ class ElasticsearchStore(BasePydanticVectorStore):
         Clear all nodes from Elasticsearch index.
         This method deletes and recreates the index.
         """
-        if self._sync_store.client.indices.exists(index=self.index_name):
-            self._sync_store.client.indices.delete(index=self.index_name)
+        sync_store = self._require_sync_store()
+        if sync_store.client.indices.exists(index=self.index_name):
+            sync_store.client.indices.delete(index=self.index_name)
 
     async def aclear(self) -> None:
         """
         Asynchronously clear all nodes from Elasticsearch index.
         This method deletes and recreates the index.
         """
-        if await self._store.client.indices.exists(index=self.index_name):
-            await self._store.client.indices.delete(index=self.index_name)
+        async_store = self._require_async_store()
+        if await async_store.client.indices.exists(index=self.index_name):
+            await async_store.client.indices.delete(index=self.index_name)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch
 from logging import getLogger
@@ -24,6 +24,42 @@ def get_elasticsearch_client(
     username: Optional[str] = None,
     password: Optional[str] = None,
 ) -> AsyncElasticsearch:
+    _, async_es_client = get_elasticsearch_clients(
+        url=url,
+        cloud_id=cloud_id,
+        api_key=api_key,
+        username=username,
+        password=password,
+    )
+
+    return async_es_client
+
+
+def get_sync_elasticsearch_client(
+    url: Optional[str] = None,
+    cloud_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> Elasticsearch:
+    sync_es_client, _ = get_elasticsearch_clients(
+        url=url,
+        cloud_id=cloud_id,
+        api_key=api_key,
+        username=username,
+        password=password,
+    )
+
+    return sync_es_client
+
+
+def get_elasticsearch_clients(
+    url: Optional[str] = None,
+    cloud_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> Tuple[Elasticsearch, AsyncElasticsearch]:
     if url and cloud_id:
         raise ValueError(
             "Both es_url and cloud_id are defined. Please provide only one."
@@ -52,7 +88,7 @@ def get_elasticsearch_client(
 
     sync_es_client.info()  # use sync client so don't have to 'await' to just get info
 
-    return async_es_client
+    return sync_es_client, async_es_client
 
 
 def convert_es_hit_to_node(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-elasticsearch"
-version = "0.6.0"
+version = "0.7.0"
 description = "llama-index vector_stores elasticsearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -1,4 +1,5 @@
 import aiohttp  # noqa
+import asyncio
 import logging
 import os
 import re
@@ -227,6 +228,11 @@ def es_store(
 ) -> Generator[ElasticsearchStore, None, None]:
     store = ElasticsearchStore(
         es_client=es_client,
+        es_url=os.environ.get("ES_URL", "http://localhost:9200"),
+        es_cloud_id=os.environ.get("ES_CLOUD_ID"),
+        es_api_key=os.environ.get("ES_API_KEY"),
+        es_user=os.environ.get("ES_USERNAME", "elastic"),
+        es_password=os.environ.get("ES_PASSWORD", "changeme"),
         index_name=index_name,
         distance_strategy="EUCLIDEAN_DISTANCE",
     )
@@ -242,6 +248,11 @@ def es_hybrid_store(
 ) -> Generator[ElasticsearchStore, None, None]:
     store = ElasticsearchStore(
         es_client=es_client,
+        es_url=os.environ.get("ES_URL", "http://localhost:9200"),
+        es_cloud_id=os.environ.get("ES_CLOUD_ID"),
+        es_api_key=os.environ.get("ES_API_KEY"),
+        es_user=os.environ.get("ES_USERNAME", "elastic"),
+        es_password=os.environ.get("ES_PASSWORD", "changeme"),
         index_name=index_name,
         distance_strategy="EUCLIDEAN_DISTANCE",
         retrieval_strategy=AsyncDenseVectorStrategy(hybrid=True),
@@ -258,6 +269,11 @@ def es_bm25_store(
 ) -> Generator[ElasticsearchStore, None, None]:
     store = ElasticsearchStore(
         es_client=es_client,
+        es_url=os.environ.get("ES_URL", "http://localhost:9200"),
+        es_cloud_id=os.environ.get("ES_CLOUD_ID"),
+        es_api_key=os.environ.get("ES_API_KEY"),
+        es_user=os.environ.get("ES_USERNAME", "elastic"),
+        es_password=os.environ.get("ES_PASSWORD", "changeme"),
         index_name=index_name,
         retrieval_strategy=AsyncBM25Strategy(),
     )
@@ -590,6 +606,52 @@ def test_metadata_filter_to_es_filter() -> None:
             ]
         }
     }
+
+
+def test_sync_methods_do_not_use_event_loop(mocker) -> None:
+    mocker.patch.object(
+        asyncio,
+        "get_event_loop",
+        side_effect=AssertionError("sync methods should not use get_event_loop"),
+    )
+    mocker.patch(
+        "llama_index.vector_stores.elasticsearch.base.convert_es_hit_to_node",
+        side_effect=lambda hit, _: TextNode(text="stub", id_=hit["_id"]),
+    )
+
+    sync_store = mocker.Mock()
+    sync_store.num_dimensions = None
+    sync_store.add_texts.return_value = ["node-1"]
+    sync_store.search.return_value = [{"_id": "node-1", "_score": 1.0, "_source": {}}]
+    sync_store.client.search.return_value = {
+        "hits": {"hits": [{"_id": "node-1", "_score": 1.0, "_source": {}}]}
+    }
+    sync_store.client.indices.exists.return_value = True
+
+    store = ElasticsearchStore.model_construct(
+        retrieval_strategy=AsyncDenseVectorStrategy(),
+        text_field="content",
+        index_name="test-index",
+    )
+    store._sync_store = sync_store
+
+    node = TextNode(text="stub", id_="node-1", embedding=[0.1, 0.2, 0.3])
+    assert store.add([node]) == ["node-1"]
+
+    query_result = store.query(
+        VectorStoreQuery(query_embedding=[0.1, 0.2, 0.3], similarity_top_k=1)
+    )
+    assert query_result.ids == ["node-1"]
+
+    store.delete("doc-1")
+    store.delete_nodes(node_ids=["node-1"])
+    _ = store.get_nodes(node_ids=["node-1"])
+    store.clear()
+
+    sync_store.delete.assert_any_call(query={"term": {"metadata.ref_doc_id": "doc-1"}})
+    sync_store.delete.assert_any_call(ids=["node-1"])
+    sync_store.client.search.assert_called_once()
+    sync_store.client.indices.delete.assert_called_once_with(index="test-index")
 
 
 @pytest.mark.asyncio

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -660,6 +660,18 @@ def test_sync_methods_do_not_use_event_loop(mocker) -> None:
     sync_store.client.indices.delete.assert_called_once_with(index="test-index")
 
 
+def test_async_only_client_does_not_require_sync_client() -> None:
+    async_client = AsyncElasticsearch("http://localhost:9200")
+    try:
+        store = ElasticsearchStore(index_name="test-index", es_client=async_client)
+        with pytest.raises(ValueError, match="Synchronous methods require"):
+            store.query(
+                VectorStoreQuery(query_embedding=[0.1, 0.2, 0.3], similarity_top_k=1)
+            )
+    finally:
+        asyncio.run(async_client.close())
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
 async def test_delete_nodes(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -634,6 +634,9 @@ def test_sync_methods_do_not_use_event_loop(mocker) -> None:
         index_name="test-index",
     )
     store._sync_store = sync_store
+    store._store = mocker.Mock()
+    store._owns_sync_client = True
+    store._owns_async_client = True
 
     node = TextNode(text="stub", id_="node-1", embedding=[0.1, 0.2, 0.3])
     assert store.add([node]) == ["node-1"]
@@ -646,11 +649,14 @@ def test_sync_methods_do_not_use_event_loop(mocker) -> None:
     store.delete("doc-1")
     store.delete_nodes(node_ids=["node-1"])
     _ = store.get_nodes(node_ids=["node-1"])
+    store.close()
     store.clear()
 
     sync_store.delete.assert_any_call(query={"term": {"metadata.ref_doc_id": "doc-1"}})
     sync_store.delete.assert_any_call(ids=["node-1"])
     sync_store.client.search.assert_called_once()
+    sync_store.close.assert_called_once()
+    store._store.close.assert_not_called()
     sync_store.client.indices.delete.assert_called_once_with(index="test-index")
 
 


### PR DESCRIPTION
## Description

`ElasticsearchStore` previously only accepted an `AsyncElasticsearch` client and wrapped every "sync" method (`query`, `add`, `delete`, `close`, etc.) with `asyncio.get_event_loop().run_until_complete(...)`, requiring `nest_asyncio.apply()`. In ASGI deployments (Gunicorn + Uvicorn) with a process-level pooled `AsyncElasticsearch` client, this breaks with `RuntimeError: Task got Future attached to a different loop`, and also breaks `close()` when called from a sync thread (e.g. Django's `sync_to_async`).

This PR splits the store into separate sync and async code paths, following the same pattern already used by `OpensearchVectorClient` in this repo:

- Accepts both `Elasticsearch` (sync) and `AsyncElasticsearch` (async) clients, via `es_client` (either type, auto-detected) or the new `es_async_client` param
- Sync methods (`query`, `add`, `delete`, `delete_nodes`, `get_nodes`, `clear`, `close`) now use the sync `Elasticsearch` client directly
- Async methods (`aquery`, `async_add`, `adelete`, etc.) continue using the async client, unchanged
- Removed `nest_asyncio` and all `run_until_complete` bridging
- `close()` only closes the sync client now; a new `aclose()` handles closing both — avoids the same loop-affinity crash inside `close()` itself
- Client/store creation is lazy per mode: constructing with only a sync (or only an async) client no longer raises at init; calling a sync method without a sync client (or vice versa) raises a clear `ValueError` at call time instead

This continues work started in #21336, which was reviewed and had its feedback addressed but was auto-closed for inactivity before merge. Rebased onto current `main` here.

Fixes #21325

**Known minor inefficiency (not fixed here, flagging for visibility):** `get_elasticsearch_client()` and `get_sync_elasticsearch_client()` in `utils.py` both internally call `get_elasticsearch_clients()`, which constructs *both* sync and async clients even when only one is requested. Not a correctness issue and out of scope for this fix, but worth cleaning up separately.

## New Package?
- [x] No

## Version Bump?
- [x] Yes (0.6.0 → 0.7.0, new public API surface: `es_async_client` param, `aclose()`)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change
