### PR TITLE
Add generic external memory retriever example

### DIFF
--- a/docs/examples/retrievers/external_memory_retriever.ipynb
+++ b/docs/examples/retrievers/external_memory_retriever.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# External Memory Retriever\n",
+    "\n",
+    "This example shows a small adapter pattern for using an external memory service as a LlamaIndex retriever. The service client is intentionally in-memory here, but the same shape can wrap an HTTP API, database query, or any other persistent memory backend.\n",
+    "\n",
+    "The key idea is to keep service-specific code inside the client and have the retriever return standard `NodeWithScore` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "from typing import Any, Dict, List, Protocol\n",
+    "\n",
+    "from llama_index.core.retrievers import BaseRetriever\n",
+    "from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the memory client boundary\n",
+    "\n",
+    "A real implementation could call `requests.get(...)`, `httpx.Client.post(...)`, or an SDK method inside `search`. Keeping that logic behind a tiny client interface makes the LlamaIndex retriever easy to test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass\n",
+    "class MemoryHit:\n",
+    "    text: str\n",
+    "    score: float\n",
+    "    metadata: Dict[str, Any]\n",
+    "\n",
+    "\n",
+    "class MemoryClient(Protocol):\n",
+    "    def search(self, query: str, limit: int) -> List[MemoryHit]: ...\n",
+    "\n",
+    "\n",
+    "class DemoMemoryClient:\n",
+    "    def __init__(self, memories: List[MemoryHit]) -> None:\n",
+    "        self.memories = memories\n",
+    "\n",
+    "    def search(self, query: str, limit: int) -> List[MemoryHit]:\n",
+    "        terms = query.lower().split()\n",
+    "        matches = [\n",
+    "            memory\n",
+    "            for memory in self.memories\n",
+    "            if any(term in memory.text.lower() for term in terms)\n",
+    "        ]\n",
+    "        return sorted(matches, key=lambda memory: memory.score, reverse=True)[:limit]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrap the client as a retriever\n",
+    "\n",
+    "Subclass `BaseRetriever` and implement `_retrieve`. Convert each service result into a `TextNode`, preserving metadata that may help downstream synthesis or citation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ExternalMemoryRetriever(BaseRetriever):\n",
+    "    def __init__(self, client: MemoryClient, similarity_top_k: int = 3) -> None:\n",
+    "        super().__init__()\n",
+    "        self.client = client\n",
+    "        self.similarity_top_k = similarity_top_k\n",
+    "\n",
+    "    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:\n",
+    "        hits = self.client.search(\n",
+    "            query=query_bundle.query_str,\n",
+    "            limit=self.similarity_top_k,\n",
+    "        )\n",
+    "        return [\n",
+    "            NodeWithScore(\n",
+    "                node=TextNode(text=hit.text, metadata=hit.metadata),\n",
+    "                score=hit.score,\n",
+    "            )\n",
+    "            for hit in hits\n",
+    "        ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve memory before generation\n",
+    "\n",
+    "The retriever can now be passed anywhere LlamaIndex expects a retriever, or called directly before merging memory snippets with regular RAG context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = DemoMemoryClient(\n",
+    "    memories=[\n",
+    "        MemoryHit(\n",
+    "            text=\"The user prefers concise answers with source links.\",\n",
+    "            score=0.92,\n",
+    "            metadata={\"memory_id\": \"pref-1\", \"kind\": \"preference\"},\n",
+    "        ),\n",
+    "        MemoryHit(\n",
+    "            text=\"The user is evaluating retriever patterns for a RAG app.\",\n",
+    "            score=0.87,\n",
+    "            metadata={\"memory_id\": \"proj-7\", \"kind\": \"project\"},\n",
+    "        ),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "retriever = ExternalMemoryRetriever(client, similarity_top_k=2)\n",
+    "nodes = retriever.retrieve(\"What retriever pattern should I use?\")\n",
+    "\n",
+    "for node in nodes:\n",
+    "    print(node.score, node.node.text, node.node.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the adapter returns normal `NodeWithScore` objects, the rest of the application does not need to know whether the context came from a vector index, a memory service, or both."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Small focused improvement for retriever examples.

## Changes
- Added a dependency-free notebook showing how to wrap an external memory service as a `BaseRetriever`.
- Included a tiny client boundary and in-memory demo client so the pattern is runnable without vendor credentials.

## Validation
- Parsed notebook JSON successfully.
- Executed all new notebook code cells successfully.

## Notes
Kept intentionally small to make review easy.