### PR TITLE
Fix indices folder reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pip install llama-index-llms-ollama
 pip install llama-index-embeddings-huggingface
 ```
 
-Examples are in the `docs/examples` folder. Indices are in the `indices` folder (see list of indices below).
+Examples are in the `docs/examples` folder. Indices are in the `llama-index-integrations/indices` folder (see list of indices below).
 
 To build a simple vector store index using OpenAI:
 


### PR DESCRIPTION
## Summary
Small focused improvement for README path accuracy.

## Changes
- Updated the indices folder reference from `indices` to `llama-index-integrations/indices`.

## Validation
- Confirmed `llama-index-integrations/indices` exists.
- Confirmed top-level `indices` is absent.

## Notes
Kept intentionally small to make review easy.