### PR TITLE
Fix router retriever tools docs example

### DIFF
--- a/docs/src/content/docs/framework/module_guides/querying/router/index.md
+++ b/docs/src/content/docs/framework/module_guides/querying/router/index.md
@@ -149,7 +149,7 @@ keyword_tool = RetrieverTool.from_defaults(
 retriever = RouterRetriever(
     selector=PydanticSingleSelector.from_defaults(llm=llm),
     retriever_tools=[
-        list_tool,
+        keyword_tool,
         vector_tool,
     ],
 )


### PR DESCRIPTION
## Summary
Small focused improvement for router retriever docs.

## Changes
- Replaced an undefined `list_tool` reference with the defined `keyword_tool` in the `RouterRetriever` example.

## Validation
- Checked the example references with `rg -n "vector_tool|keyword_tool|list_tool|retriever_tools" docs/src/content/docs/framework/module_guides/querying/router/index.md`.
- Confirmed the diff is a single docs-line change.

## Notes
Kept intentionally small to make review easy.