### PR TITLE
Fix RAG querying response mode default

### DIFF
--- a/docs/src/content/docs/framework/understanding/rag/querying/index.mdx
+++ b/docs/src/content/docs/framework/understanding/rag/querying/index.mdx
@@ -129,9 +129,9 @@ query_engine = RetrieverQueryEngine.from_args(
 
 Right now, we support the following options:
 
-- `default`: "create and refine" an answer by sequentially going through each retrieved `Node`;
+- `refine`: "create and refine" an answer by sequentially going through each retrieved `Node`;
   This makes a separate LLM call per Node. Good for more detailed answers.
-- `compact`: "compact" the prompt during each LLM call by stuffing as
+- `compact` (default): "compact" the prompt during each LLM call by stuffing as
   many `Node` text chunks that can fit within the maximum prompt size. If there are
   too many chunks to stuff in one prompt, "create and refine" an answer by going through
   multiple prompts.


### PR DESCRIPTION
## Summary
Small focused improvement for RAG querying docs.

## Changes
- Replaced the stale `default` response mode entry with `refine`.
- Marked `compact` as the default response mode to match the implementation and response modes guide.

## Validation
- Confirmed `RetrieverQueryEngine.from_args` and `get_response_synthesizer` default to `ResponseMode.COMPACT`.
- Checked the RAG querying guide now matches the response modes guide wording.

## Notes
Kept intentionally small to make review easy.