### PR TITLE
feat: support aws_bearer_token_bedrock authentication for Anthropic Bedrock

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -237,6 +237,7 @@ class Anthropic(FunctionCallingLLM):
         aws_region: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
+        aws_bearer_token_bedrock: Optional[str] = None,
         cache_idx: Optional[int] = None,
         thinking_dict: Optional[Dict[str, Any]] = None,
         tools: Optional[List[Dict[str, Any]]] = None,
@@ -289,21 +290,24 @@ class Anthropic(FunctionCallingLLM):
             )
         elif aws_region:
             self._client = anthropic.AnthropicBedrock(
-                aws_region=aws_region,
-                aws_access_key=aws_access_key_id,
-                aws_secret_key=aws_secret_access_key,
-                max_retries=max_retries,
-                default_headers=merged_headers,
-                timeout=timeout,
-            )
+    aws_region=aws_region,
+    aws_access_key=aws_access_key_id,
+    aws_secret_key=aws_secret_access_key,
+    aws_bearer_token_bedrock=aws_bearer_token_bedrock,
+    max_retries=max_retries,
+    default_headers=merged_headers,
+    timeout=timeout,
+)
+            
             self._aclient = anthropic.AsyncAnthropicBedrock(
-                aws_region=aws_region,
-                aws_access_key=aws_access_key_id,
-                aws_secret_key=aws_secret_access_key,
-                max_retries=max_retries,
-                default_headers=merged_headers,
-                timeout=timeout,
-            )
+    aws_region=aws_region,
+    aws_access_key=aws_access_key_id,
+    aws_secret_key=aws_secret_access_key,
+    aws_bearer_token_bedrock=aws_bearer_token_bedrock,
+    max_retries=max_retries,
+    default_headers=merged_headers,
+    timeout=timeout,
+)
         else:
             self._client = anthropic.Anthropic(
                 api_key=api_key,


### PR DESCRIPTION
## Summary

Adds support for the `aws_bearer_token_bedrock` authentication parameter for Anthropic Bedrock.

### Changes
- Added `aws_bearer_token_bedrock` as an optional parameter to the `Anthropic` constructor.
- Forwarded the parameter to both `anthropic.AnthropicBedrock` and `anthropic.AsyncAnthropicBedrock`.

### Testing
- Ran the Anthropic integration test suite.

Results:
- 46 passed
- 15 skipped

Fixes #22241