### PR TITLE
fix(google-genai): don't send default params in gemini genconfig

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -96,6 +96,7 @@ def llm_retry_decorator(f: Callable[..., Any]) -> Callable[..., Any]:
                 max_seconds=20,
             )
             return await retry(f)(self, *args, **kwargs)
+
     else:
 
         @functools.wraps(f)
@@ -133,7 +134,7 @@ class GoogleGenAI(FunctionCallingLLM):
     """
 
     model: str = Field(default=DEFAULT_MODEL, description="The Gemini model to use.")
-    temperature: float = Field(
+    temperature: Optional[float] = Field(
         default=DEFAULT_TEMPERATURE,
         description="The temperature to use during generation.",
         ge=0.0,
@@ -189,10 +190,10 @@ class GoogleGenAI(FunctionCallingLLM):
         **kwargs: Any,
     ):
         if temperature is None:
-            if "gemini-3" in model:
-                temperature = 1.0
-            else:
+            # Gemini 3-series models may error if temperature is set.
+            if "gemini-3" not in model:
                 temperature = DEFAULT_TEMPERATURE
+
         # API keys are optional. The API can be authorised via OAuth (detected
         # environmentally) or by the GOOGLE_API_KEY environment variable.
         api_key = api_key or os.getenv("GOOGLE_API_KEY", None)

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -287,10 +287,13 @@ async def create_file_part(
         file_buffer.seek(0)  # Reset to beginning
 
         if size < 20 * 1024 * 1024:  # 20MB is the Gemini inline data size limit
-            return types.Part.from_bytes(
-                data=file_buffer.read(),
-                mime_type=mime_type,
-            ), None
+            return (
+                types.Part.from_bytes(
+                    data=file_buffer.read(),
+                    mime_type=mime_type,
+                ),
+                None,
+            )
         elif file_mode == "inline":
             raise ValueError("Files in inline mode must be smaller than 20MB.")
         elif client is not None and client.vertexai:
@@ -315,10 +318,13 @@ async def create_file_part(
     if file.state.name == "FAILED":
         raise ValueError("Failed to upload the file with FileAPI")
 
-    return types.Part.from_uri(
-        file_uri=file.uri,
-        mime_type=mime_type,
-    ), file.name
+    return (
+        types.Part.from_uri(
+            file_uri=file.uri,
+            mime_type=mime_type,
+        ),
+        file.name,
+    )
 
 
 async def adelete_uploaded_files(file_api_names: list[str], client: Client) -> None:
@@ -444,14 +450,20 @@ async def chat_message_to_gemini(
             name=message.additional_kwargs.get("tool_call_id"),
             response={"result": message.content},
         )
-        return types.Content(
-            role=ROLES_TO_GEMINI[message.role], parts=[function_response_part]
-        ), file_api_names
+        return (
+            types.Content(
+                role=ROLES_TO_GEMINI[message.role], parts=[function_response_part]
+            ),
+            file_api_names,
+        )
 
-    return types.Content(
-        role=ROLES_TO_GEMINI[message.role],
-        parts=parts,
-    ), file_api_names
+    return (
+        types.Content(
+            role=ROLES_TO_GEMINI[message.role],
+            parts=parts,
+        ),
+        file_api_names,
+    )
 
 
 def convert_schema_to_function_declaration(
@@ -611,9 +623,12 @@ def handle_streaming_flexible_model(
             return output_cls.model_validate_json(current_json), current_json
         except ValidationError:
             try:
-                return flexible_model.model_validate_json(
-                    _repair_incomplete_json(current_json)
-                ), current_json
+                return (
+                    flexible_model.model_validate_json(
+                        _repair_incomplete_json(current_json)
+                    ),
+                    current_json,
+                )
             except ValidationError:
                 return None, current_json
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.5"
+version = "0.9.6"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -16,6 +16,7 @@ from llama_index.core.base.llms.types import (
     ToolCallBlock,
 )
 from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.constants import DEFAULT_TEMPERATURE
 from llama_index.core.program.function_program import get_function_tool
 from llama_index.core.prompts import ChatPromptTemplate, PromptTemplate
 from llama_index.core.tools import FunctionTool
@@ -934,6 +935,53 @@ def test_cached_content_initialization() -> None:
 
     # Verify cached_content is stored in generation config
     assert llm._generation_config["cached_content"] == cached_content_value
+
+
+def test_temperature_defaults() -> None:
+    """Test that GoogleGenAI initialization sets temperature defaults correctly based on model."""
+    with patch("google.genai.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.models.get.return_value = MagicMock(
+            input_token_limit=200000, output_token_limit=8192
+        )
+
+        # 1. Non-Gemini 3 models should get DEFAULT_TEMPERATURE (0.1)
+        llm_legacy = GoogleGenAI(
+            model="gemini-2.5-flash",
+            api_key="test-key",
+        )
+        assert llm_legacy.temperature == DEFAULT_TEMPERATURE
+        assert llm_legacy._generation_config["temperature"] == DEFAULT_TEMPERATURE
+
+        # 2. Gemini 3 models should leave temperature as None
+        llm_gemini3 = GoogleGenAI(
+            model="gemini-3-flash-preview",
+            api_key="test-key",
+        )
+        assert llm_gemini3.temperature is None
+        assert llm_gemini3._generation_config["temperature"] is None
+
+
+def test_temperature_explicitly_set() -> None:
+    """Test that GoogleGenAI initialization preserves custom temperature."""
+    with patch("google.genai.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.models.get.return_value = MagicMock(
+            input_token_limit=200000, output_token_limit=8192
+        )
+
+        llm = GoogleGenAI(
+            model="gemini-3-flash-preview",
+            api_key="test-key",
+            temperature=0.7,
+        )
+
+        # Verify temperature field is 0.7
+        assert llm.temperature == 0.7
+        # Verify temperature is correctly passed in the generation config dict
+        assert llm._generation_config["temperature"] == 0.7
 
 
 def test_cached_content_in_response() -> None:

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/uv.lock
@@ -1872,7 +1872,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-google-genai"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
# Description

Gemini 3-series models may throw errors if params like temperature are provided, so this change removes the defaults.

Note that 1.0 is the default if no temp is set, so the change should be backwards compatible.

## New Package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

0.9.6

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
