### PR TITLE
examples: HTTP-backed memory block

### DIFF
--- a/docs/examples/memory/http_backed_memory_block.ipynb
+++ b/docs/examples/memory/http_backed_memory_block.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/memory/http_backed_memory_block.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HTTP-Backed Memory Block\n",
+    "\n",
+    "This notebook shows how to build a custom `BaseMemoryBlock` that persists flushed chat history to an external HTTP service and retrieves relevant context on demand.\n",
+    "\n",
+    "The pattern is useful when memory must live outside the agent process — for example, a team-owned memory API, an existing user-profile service, or a shared session store.\n",
+    "\n",
+    "We use only the Python standard library (`urllib`, `http.server`) so no extra dependencies are required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-core"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mock HTTP memory service\n",
+    "\n",
+    "For demonstration, we spin up a tiny in-process HTTP server that stores memory batches in a dictionary. Replace this with your production endpoint in real deployments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import threading\n",
+    "from http.server import BaseHTTPRequestHandler, HTTPServer\n",
+    "from typing import Dict, List\n",
+    "\n",
+    "STORE: Dict[str, List[str]] = {}\n",
+    "\n",
+    "\n",
+    "class MemoryHandler(BaseHTTPRequestHandler):\n",
+    "    def log_message(self, format: str, *args) -> None:\n",
+    "        return  # keep notebook output clean\n",
+    "\n",
+    "    def do_GET(self) -> None:\n",
+    "        session_id = self.path.strip(\"/\").split(\"?\")[0]\n",
+    "        memory = \"\\n\".join(STORE.get(session_id, []))\n",
+    "        body = json.dumps({\"memory\": memory}).encode()\n",
+    "        self.send_response(200)\n",
+    "        self.send_header(\"Content-Type\", \"application/json\")\n",
+    "        self.end_headers()\n",
+    "        self.wfile.write(body)\n",
+    "\n",
+    "    def do_POST(self) -> None:\n",
+    "        length = int(self.headers.get(\"Content-Length\", 0))\n",
+    "        payload = json.loads(self.rfile.read(length).decode())\n",
+    "        session_id = payload[\"session_id\"]\n",
+    "        batch = \"\\n\".join(\n",
+    "            f\"<{m['role']}>{m['content']}</{m['role']}>\" for m in payload[\"messages\"]\n",
+    "        )\n",
+    "        STORE.setdefault(session_id, []).append(batch)\n",
+    "        self.send_response(201)\n",
+    "        self.end_headers()\n",
+    "\n",
+    "\n",
+    "server = HTTPServer((\"127.0.0.1\", 8765), MemoryHandler)\n",
+    "thread = threading.Thread(target=server.serve_forever, daemon=True)\n",
+    "thread.start()\n",
+    "print(\"Mock memory service listening on http://127.0.0.1:8765\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the HTTP-backed memory block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import json\n",
+    "from typing import Any, List, Optional\n",
+    "from urllib import request\n",
+    "\n",
+    "from llama_index.core.llms import ChatMessage\n",
+    "from llama_index.core.memory import BaseMemoryBlock, Memory\n",
+    "\n",
+    "\n",
+    "class HttpBackedMemoryBlock(BaseMemoryBlock[str]):\n",
+    "    endpoint_url: str = \"http://127.0.0.1:8765\"\n",
+    "    session_id: str = \"demo-session\"\n",
+    "    timeout_seconds: float = 5.0\n",
+    "\n",
+    "    async def _aget(\n",
+    "        self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any\n",
+    "    ) -> str:\n",
+    "        url = f\"{self.endpoint_url}/{self.session_id}\"\n",
+    "\n",
+    "        def _fetch() -> str:\n",
+    "            with request.urlopen(url, timeout=self.timeout_seconds) as resp:\n",
+    "                payload = json.loads(resp.read().decode())\n",
+    "                return payload.get(\"memory\", \"\")\n",
+    "\n",
+    "        return await asyncio.to_thread(_fetch)\n",
+    "\n",
+    "    async def _aput(self, messages: List[ChatMessage]) -> None:\n",
+    "        body = json.dumps(\n",
+    "            {\n",
+    "                \"session_id\": self.session_id,\n",
+    "                \"messages\": [\n",
+    "                    {\"role\": m.role, \"content\": m.content} for m in messages\n",
+    "                ],\n",
+    "            }\n",
+    "        ).encode()\n",
+    "\n",
+    "        def _post() -> None:\n",
+    "            req = request.Request(\n",
+    "                self.endpoint_url,\n",
+    "                data=body,\n",
+    "                headers={\"Content-Type\": \"application/json\"},\n",
+    "                method=\"POST\",\n",
+    "            )\n",
+    "            with request.urlopen(req, timeout=self.timeout_seconds):\n",
+    "                pass\n",
+    "\n",
+    "        await asyncio.to_thread(_post)\n",
+    "\n",
+    "    async def atruncate(\n",
+    "        self, content: str, tokens_to_truncate: int\n",
+    "    ) -> Optional[str]:\n",
+    "        lines = content.splitlines()\n",
+    "        drop = max(1, tokens_to_truncate // 4)\n",
+    "        return \"\\n\".join(lines[drop:]) if len(lines) > drop else \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wire memory block into `Memory`\n",
+    "\n",
+    "When short-term memory exceeds its token budget, flushed messages are sent to the HTTP service via `_aput()`. On retrieval, `_aget()` fetches the archived context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "memory = Memory.from_defaults(\n",
+    "    session_id=\"demo-session\",\n",
+    "    token_limit=80,\n",
+    "    token_flush_size=20,\n",
+    "    chat_history_token_ratio=0.5,\n",
+    "    memory_blocks=[HttpBackedMemoryBlock(session_id=\"demo-session\")],\n",
+    ")\n",
+    "\n",
+    "memory.put_messages(\n",
+    "    [\n",
+    "        ChatMessage(role=\"user\", content=\"I prefer responses in bullet points.\"),\n",
+    "        ChatMessage(role=\"assistant\", content=\"Got it — I'll use bullet points.\"),\n",
+    "        ChatMessage(role=\"user\", content=\"My project codename is Northstar.\"),\n",
+    "        ChatMessage(role=\"assistant\", content=\"Noted: project Northstar.\"),\n",
+    "        ChatMessage(role=\"user\", content=\"What format do I prefer?\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "chat_history = memory.get()\n",
+    "print(chat_history[0].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should see archived messages from the HTTP store merged into the retrieved memory. In production, point `endpoint_url` at your team's memory API and scope records with `session_id`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
﻿Adds a notebook demonstrating a custom HttpBackedMemoryBlock that persists flushed chat batches to an external HTTP service. Uses a local mock server so readers can run it without external infrastructure.
