### PR TITLE
examples: recall memory before RAG

### DIFF
--- a/docs/examples/memory/recall_memory_before_rag.ipynb
+++ b/docs/examples/memory/recall_memory_before_rag.ipynb
@@ -1,0 +1,169 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/memory/recall_memory_before_rag.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recall Memory Before a RAG Query\n",
+    "\n",
+    "Agent memory and document retrieval solve different problems. Memory stores conversation context (preferences, prior answers, extracted facts). A vector index stores external knowledge (policies, manuals, tickets).\n",
+    "\n",
+    "This notebook demonstrates a safe pattern: **recall user memory first**, then run RAG, and combine both contexts in the final answer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-core llama-index-llms-openai llama-index-embeddings-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a tiny document index (RAG corpus)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core import Document, VectorStoreIndex\n",
+    "from llama_index.core.retrievers import VectorIndexRetriever\n",
+    "\n",
+    "docs = [\n",
+    "    Document(\n",
+    "        text=\"Refund policy: annual plans are refundable within 30 days. Monthly plans are non-refundable.\"\n",
+    "    ),\n",
+    "    Document(\n",
+    "        text=\"Support hours: Monday-Friday 9am-5pm UTC. Emergency tickets are triaged within 4 hours.\"\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "index = VectorStoreIndex.from_documents(docs)\n",
+    "retriever = VectorIndexRetriever(index=index, similarity_top_k=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure agent memory with a static preference block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage\n",
+    "from llama_index.core.memory import Memory, StaticMemoryBlock\n",
+    "\n",
+    "memory = Memory.from_defaults(\n",
+    "    session_id=\"rag-demo\",\n",
+    "    token_limit=2000,\n",
+    "    memory_blocks=[\n",
+    "        StaticMemoryBlock(\n",
+    "            name=\"user_profile\",\n",
+    "            static_content=\"User is on the annual plan and prefers concise bullet-point answers.\",\n",
+    "            priority=0,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "memory.put_messages(\n",
+    "    [\n",
+    "        ChatMessage(role=\"user\", content=\"I am evaluating a refund for my annual subscription.\"),\n",
+    "        ChatMessage(role=\"assistant\", content=\"I can help — annual plans have a 30-day refund window.\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recall memory, then retrieve documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.llms import ChatMessage as CM\n",
+    "from llama_index.core.prompts import PromptTemplate\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "user_question = \"Can I get a refund and how fast will support respond?\"\n",
+    "\n",
+    "# Step 1: recall conversation memory BEFORE RAG\n",
+    "memory_messages = memory.get(messages=[CM(role=\"user\", content=user_question)])\n",
+    "memory_text = \"\\n\".join(m.content for m in memory_messages if m.content)\n",
+    "\n",
+    "# Step 2: retrieve knowledge-base context (separate from memory)\n",
+    "nodes = retriever.retrieve(user_question)\n",
+    "doc_context = \"\\n\\n\".join(n.node.get_content() for n in nodes)\n",
+    "\n",
+    "prompt = PromptTemplate(\n",
+    "    \"You are a helpful support agent.\\n\\n\"\n",
+    "    \"## User memory\\n{memory}\\n\\n\"\n",
+    "    \"## Retrieved policy docs\\n{docs}\\n\\n\"\n",
+    "    \"## Question\\n{question}\\n\\n\"\n",
+    "    \"Answer using both memory and docs. Respect the user's preferred format.\"\n",
+    ")\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "response = llm.complete(\n",
+    "    prompt.format(memory=memory_text, docs=doc_context, question=user_question)\n",
+    ")\n",
+    "print(response.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model sees (1) remembered preferences and prior turns, then (2) policy documents from the vector index. Keeping these steps separate prevents document retrieval from overwriting session context and makes debugging easier."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
﻿Adds a notebook showing how to recall Memory context before running document retrieval, then combine both in the final LLM prompt.
