### PR TITLE
examples: memory-aware retriever pattern

### DIFF
--- a/docs/examples/retrievers/memory_aware_retriever.ipynb
+++ b/docs/examples/retrievers/memory_aware_retriever.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/retrievers/memory_aware_retriever.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Memory-Aware Retriever (Mini Example)\n",
+    "\n",
+    "This minimal example shows how to wrap an existing retriever so each query is enriched with recalled agent memory.\n",
+    "\n",
+    "Use this when you want retrieval to reflect session context (for example, a remembered product tier or region) without storing that context inside the document index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-core"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List, Optional\n",
+    "\n",
+    "from llama_index.core import Document, VectorStoreIndex\n",
+    "from llama_index.core.base.base_retriever import BaseRetriever\n",
+    "from llama_index.core.llms import ChatMessage\n",
+    "from llama_index.core.memory import Memory, StaticMemoryBlock\n",
+    "from llama_index.core.schema import NodeWithScore, QueryBundle\n",
+    "\n",
+    "\n",
+    "class MemoryAwareRetriever(BaseRetriever):\n",
+    "    \"\"\"Prepends recalled memory to the query before delegating retrieval.\"\"\"\n",
+    "\n",
+    "    def __init__(self, base_retriever: BaseRetriever, memory: Memory) -> None:\n",
+    "        self._base_retriever = base_retriever\n",
+    "        self._memory = memory\n",
+    "        super().__init__()\n",
+    "\n",
+    "    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:\n",
+    "        memory_messages = self._memory.get(\n",
+    "            messages=[ChatMessage(role=\"user\", content=query_bundle.query_str)]\n",
+    "        )\n",
+    "        memory_text = \" \".join(m.content for m in memory_messages if m.content)\n",
+    "        enriched_query = (\n",
+    "            f\"{memory_text} {query_bundle.query_str}\".strip()\n",
+    "            if memory_text\n",
+    "            else query_bundle.query_str\n",
+    "        )\n",
+    "        return self._base_retriever.retrieve(enriched_query)\n",
+    "\n",
+    "    async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:\n",
+    "        memory_messages = await self._memory.aget(\n",
+    "            messages=[ChatMessage(role=\"user\", content=query_bundle.query_str)]\n",
+    "        )\n",
+    "        memory_text = \" \".join(m.content for m in memory_messages if m.content)\n",
+    "        enriched_query = (\n",
+    "            f\"{memory_text} {query_bundle.query_str}\".strip()\n",
+    "            if memory_text\n",
+    "            else query_bundle.query_str\n",
+    "        )\n",
+    "        return await self._base_retriever.aretrieve(enriched_query)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Try it on a tiny index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs = [\n",
+    "    Document(text=\"Enterprise SLA: 99.95% uptime with 1-hour response time.\"),\n",
+    "    Document(text=\"Starter SLA: best-effort support with 2-business-day response time.\"),\n",
+    "]\n",
+    "index = VectorStoreIndex.from_documents(docs)\n",
+    "base_retriever = index.as_retriever(similarity_top_k=1)\n",
+    "\n",
+    "memory = Memory.from_defaults(\n",
+    "    session_id=\"retriever-demo\",\n",
+    "    memory_blocks=[\n",
+    "        StaticMemoryBlock(\n",
+    "            name=\"plan\",\n",
+    "            static_content=\"The user is on the Enterprise plan.\",\n",
+    "            priority=0,\n",
+    "        )\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "retriever = MemoryAwareRetriever(base_retriever=base_retriever, memory=memory)\n",
+    "nodes = retriever.retrieve(\"What SLA response time applies to me?\")\n",
+    "print(nodes[0].node.get_content())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Without memory, the retriever might return the Starter SLA. After memory enrichment, the query is biased toward Enterprise context. For production systems, prefer explicit metadata filters when possible; use this wrapper for lightweight session-aware retrieval."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
﻿Adds a small retriever example that enriches each query with recalled Memory context before delegating to a base VectorIndexRetriever.
