### PR TITLE
docs: link new memory/retriever examples from memory guide

### DIFF
--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -316,6 +316,9 @@ You can find a few examples of memory in action below:
 - [Memory](/python/examples/memory/memory)
 - [Manipulating Memory at Runtime](/python/examples/memory/custom_memory)
 - [Limiting Multi-Turn Confusion with Custom Memory](/python/examples/memory/custom_multi_turn_memory)
+- [HTTP-Backed Memory Block](/python/examples/memory/http_backed_memory_block)
+- [Recall Memory Before RAG](/python/examples/memory/recall_memory_before_rag)
+- [Memory-Aware Retriever](/python/examples/retrievers/memory_aware_retriever)
 
 **NOTE:** Deprecated examples:
 


### PR DESCRIPTION
﻿Adds three links to the memory guide Examples section: HTTP-Backed Memory Block, Recall Memory Before RAG, and Memory-Aware Retriever.
