### PR TITLE
docs: add TokenLab OpenAILike example

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
@@ -21,3 +21,18 @@ llm = OpenAILike(
     is_function_calling_model=False,
 )
 ```
+
+For example, TokenLab provides an OpenAI-compatible `/v1` endpoint:
+
+```python
+from llama_index.llms.openai_like import OpenAILike
+
+llm = OpenAILike(
+    model="claude-sonnet-5",
+    api_base="https://api.tokenlab.sh/v1",
+    api_key="your-tokenlab-api-key",
+    context_window=200000,
+    is_chat_model=True,
+    is_function_calling_model=True,
+)
+```


### PR DESCRIPTION
## Summary
- Document TokenLab as an OpenAI-compatible endpoint for the LlamaIndex OpenAILike integration.
- Use TokenLab's OpenAI-compatible base URL: https://api.tokenlab.sh/v1
- No runtime behavior changes; documentation only.

## Verification
- git diff --check