### PR TITLE
feat(weaviate): tag client with LlamaIndex integration telemetry header

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -7,6 +7,7 @@ An index that is built on top of an existing vector store.
 
 import logging
 from contextlib import AbstractContextManager
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
@@ -38,6 +39,47 @@ import weaviate
 import weaviate.classes as wvc
 
 _logger = logging.getLogger(__name__)
+
+
+_INTEGRATION_HEADER = "X-Weaviate-Client-Integration"
+
+
+def _integration_header_value() -> str:
+    """Return the value for the Weaviate integration telemetry header."""
+    try:
+        return f"llama-index-python/{version('llama-index-vector-stores-weaviate')}"
+    except PackageNotFoundError:
+        return "llama-index-python"
+
+
+def _register_integration_header(client: Any) -> None:
+    """
+    Best-effort: tag the Weaviate client with the LlamaIndex integration header
+    so Weaviate telemetry can attribute traffic to LlamaIndex.
+
+    Mutates the connection's header objects by reference (mirrors the approach in
+    langchainjs#11088), covering REST and gRPC for both self-created and
+    user-supplied clients, whether or not they are already connected. Silently
+    skips if the client's internal shape changes so telemetry never breaks the
+    store.
+    """
+    if client is None:
+        return
+    try:
+        connection = client._connection
+        value = _integration_header_value()
+        # gRPC metadata source (live dict, mutated by reference)
+        connection.additional_headers[_INTEGRATION_HEADER] = value
+        # REST source dict (used when (re)building the httpx client)
+        connection._headers[_INTEGRATION_HEADER] = value
+        # Live httpx client, if already connected
+        live = getattr(connection, "_client", None)
+        if live is not None and hasattr(live, "headers"):
+            live.headers[_INTEGRATION_HEADER] = value
+        # Rebuild gRPC metadata so the new header is included
+        connection._prepare_grpc_headers()
+    except Exception as e:  # noqa: BLE001 - telemetry must never break the store
+        _logger.debug("Could not register Weaviate integration header: %s", e)
 
 
 _CUSTOM_BATCH_ERROR = (
@@ -319,6 +361,10 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             raise ValueError(_CUSTOM_BATCH_ERROR)
 
         self._property_types = None
+
+        # tag traffic so Weaviate telemetry can attribute it to LlamaIndex
+        _register_integration_header(getattr(self, "_client", None))
+        _register_integration_header(getattr(self, "_aclient", None))
 
         # create default schema if does not exist
         if self._client is not None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-weaviate"
-version = "1.6.1"
+version = "1.7.0"
 description = "llama-index vector_stores weaviate integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-weaviate"
-version = "1.7.0"
+version = "1.7.1"
 description = "llama-index vector_stores weaviate integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -7,7 +7,12 @@ from llama_index.core.schema import (
     RelatedNodeInfo,
 )
 from llama_index.core.schema import TextNode
-from llama_index.vector_stores.weaviate.base import _is_valid_batch_context_manager
+from llama_index.vector_stores.weaviate.base import (
+    _INTEGRATION_HEADER,
+    _integration_header_value,
+    _is_valid_batch_context_manager,
+    _register_integration_header,
+)
 from llama_index.vector_stores.weaviate import (
     WeaviateVectorStore,
     SyncClientNotProvidedError,
@@ -80,6 +85,43 @@ def test_no_weaviate_client_instance_provided():
     assert not weaviate_client.is_connected()  # As the Weaviate client was created within WeaviateVectorStore, it lies in its responsibility to close the connection when it is not longer needed
 
 
+def _grpc_header_value(connection, header_name):
+    grpc_headers = connection.grpc_headers() or ()
+    lowered = header_name.lower()
+    for key, value in grpc_headers:
+        if key.lower() == lowered:
+            return value
+    return None
+
+
+def test_integration_header_value_format():
+    value = _integration_header_value()
+    assert value.startswith("llama-index-python")
+
+
+def test_register_integration_header_is_best_effort():
+    # No client / wrong shape must never raise (telemetry must not break the store)
+    _register_integration_header(None)
+    _register_integration_header(object())
+
+
+def test_integration_header_registered_on_sync_client():
+    vector_store = WeaviateVectorStore(
+        client_kwargs={"embedded_options": weaviate.embedded.EmbeddedOptions()}
+    )
+    try:
+        expected = _integration_header_value()
+        connection = vector_store.client._connection
+        # REST: additional_headers (gRPC source), _headers, and the live httpx client
+        assert connection.additional_headers[_INTEGRATION_HEADER] == expected
+        assert connection._headers[_INTEGRATION_HEADER] == expected
+        assert connection._client.headers[_INTEGRATION_HEADER] == expected
+        # gRPC metadata (header keys are lowercased)
+        assert _grpc_header_value(connection, _INTEGRATION_HEADER) == expected
+    finally:
+        del vector_store
+
+
 @pytest.mark.asyncio
 class TestWeaviateAsync:
     @pytest_asyncio.fixture(scope="class")
@@ -130,6 +172,15 @@ class TestWeaviateAsync:
         assert results.similarities[0] == 1.0
 
         assert results.similarities[0] > results.similarities[1]
+
+    async def test_integration_header_registered_on_async_client(
+        self, async_vector_store
+    ):
+        expected = _integration_header_value()
+        connection = async_vector_store.async_client._connection
+        assert connection.additional_headers[_INTEGRATION_HEADER] == expected
+        assert connection._headers[_INTEGRATION_HEADER] == expected
+        assert _grpc_header_value(connection, _INTEGRATION_HEADER) == expected
 
     async def test_async_old_data_gone(self, async_vector_store):
         """Makes sure that no data stays in the database in between tests (otherwise more than one node would be found in the assertion)."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -7,7 +7,12 @@ from llama_index.core.schema import (
     RelatedNodeInfo,
 )
 from llama_index.core.schema import TextNode
-from llama_index.vector_stores.weaviate.base import _is_valid_batch_context_manager
+from llama_index.vector_stores.weaviate.base import (
+    _INTEGRATION_HEADER,
+    _integration_header_value,
+    _is_valid_batch_context_manager,
+    _register_integration_header,
+)
 from llama_index.vector_stores.weaviate import (
     WeaviateVectorStore,
     SyncClientNotProvidedError,
@@ -79,6 +84,43 @@ def test_no_weaviate_client_instance_provided():
     assert not weaviate_client.is_connected()  # As the Weaviate client was created within WeaviateVectorStore, it lies in its responsibility to close the connection when it is not longer needed
 
 
+def _grpc_header_value(connection, header_name):
+    grpc_headers = connection.grpc_headers() or ()
+    lowered = header_name.lower()
+    for key, value in grpc_headers:
+        if key.lower() == lowered:
+            return value
+    return None
+
+
+def test_integration_header_value_format():
+    value = _integration_header_value()
+    assert value.startswith("llama-index-python")
+
+
+def test_register_integration_header_is_best_effort():
+    # No client / wrong shape must never raise (telemetry must not break the store)
+    _register_integration_header(None)
+    _register_integration_header(object())
+
+
+def test_integration_header_registered_on_sync_client():
+    vector_store = WeaviateVectorStore(
+        client_kwargs={"embedded_options": weaviate.embedded.EmbeddedOptions()}
+    )
+    try:
+        expected = _integration_header_value()
+        connection = vector_store.client._connection
+        # REST: additional_headers (gRPC source), _headers, and the live httpx client
+        assert connection.additional_headers[_INTEGRATION_HEADER] == expected
+        assert connection._headers[_INTEGRATION_HEADER] == expected
+        assert connection._client.headers[_INTEGRATION_HEADER] == expected
+        # gRPC metadata (header keys are lowercased)
+        assert _grpc_header_value(connection, _INTEGRATION_HEADER) == expected
+    finally:
+        del vector_store
+
+
 @pytest.mark.asyncio(loop_scope="class")
 class TestWeaviateAsync:
     @pytest_asyncio.fixture(scope="class", loop_scope="class")
@@ -120,6 +162,15 @@ class TestWeaviateAsync:
         assert results.similarities[0] == 1.0
 
         assert results.similarities[0] > results.similarities[1]
+
+    async def test_integration_header_registered_on_async_client(
+        self, async_vector_store
+    ):
+        expected = _integration_header_value()
+        connection = async_vector_store.async_client._connection
+        assert connection.additional_headers[_INTEGRATION_HEADER] == expected
+        assert connection._headers[_INTEGRATION_HEADER] == expected
+        assert _grpc_header_value(connection, _INTEGRATION_HEADER) == expected
 
     async def test_async_old_data_gone(self, async_vector_store):
         """Makes sure that no data stays in the database in between tests (otherwise more than one node would be found in the assertion)."""

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/uv.lock
@@ -1910,7 +1910,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-weaviate"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
Register the X-Weaviate-Client-Integration header (value: llama-index-python/<version>) on both REST and gRPC transports for self-created and user-supplied Weaviate clients, best-effort so telemetry never breaks the store.

Bump package version to 1.7.0.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [X] Not a new package

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [X] Yes 1.6.1 → 1.7.0
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change

Added tests in tests/test_vector_stores_weaviate.py:
- test_integration_header_value_format — asserts the header value is llama-index-python...
- test_register_integration_header_is_best_effort — verifies None/malformed clients never raise
- plus coverage that the header is registered on the connection's REST and gRPC header sources.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran uv run make format; uv run make lint to appease the lint gods