### PR TITLE
fix(faiss): read id map json as utf-8

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/map_store.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/map_store.py
@@ -241,7 +241,7 @@ class FaissMapVectorStore(FaissVectorStore):
         id_map["faiss_id_to_node_id_map"] = self._faiss_id_to_node_id_map
         # save the id map as JSON for safe deserialization
         id_map_path = os.path.join(dirpath, DEFAULT_ID_MAP_NAME)
-        with open(id_map_path, "w") as f:
+        with open(id_map_path, "w", encoding="utf-8") as f:
             json.dump(id_map, f)
 
     @classmethod
@@ -281,7 +281,7 @@ class FaissMapVectorStore(FaissVectorStore):
             raise ValueError(f"No existing {__name__} found at {persist_path}.")
 
         faiss_index = faiss.read_index(persist_path)
-        with open(id_map_path, "r") as f:
+        with open(id_map_path, "r", encoding="utf-8") as f:
             raw = f.read()
         try:
             id_map = json.loads(raw)


### PR DESCRIPTION
## Problem
`FaissMapVectorStore` persists its ID map as `id_map.json`, but the text-mode reads/writes relied on Python's platform default encoding.

Most environments use UTF-8, but on non-UTF-8 locales this can make persistence behavior depend on the host instead of the JSON file format.

## Before / after
Before: `id_map.json` was opened with the platform default encoding for both write and read.

After: the FAISS map-store ID map is written and read explicitly as UTF-8, matching the JSON format and other text persistence code in the project.

## Verification
- `python -m py_compile llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/llama_index/vector_stores/faiss/map_store.py`
- `git diff --check`

I also attempted the focused FAISS test file:

`python -m pytest llama-index-integrations/vector_stores/llama-index-vector-stores-faiss/tests/test_vector_stores_faiss.py -q`

but this local checkout is not fully installed and collection stops on a missing `llama_index_instrumentation` dependency. I kept the patch limited to the encoding arguments only.