### PR TITLE
fix(mistralai): aggregate a single TextBlock per streamed message

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/llama_index/llms/mistralai/base.py
@@ -482,7 +482,7 @@ class MistralAI(FunctionCallingLLM):
 
         def gen() -> ChatResponseGen:
             content = ""
-            blocks: List[TextBlock | ThinkingBlock | ToolCallBlock] = []
+            tool_call_blocks: List[ToolCallBlock] = []
             for chunk in response:
                 delta = chunk.data.choices[0].delta
                 role = delta.role or MessageRole.ASSISTANT
@@ -491,7 +491,7 @@ class MistralAI(FunctionCallingLLM):
                 if delta.tool_calls:
                     for tool_call in delta.tool_calls:
                         if isinstance(tool_call, self._models.ToolCall):
-                            blocks.append(
+                            tool_call_blocks.append(
                                 ToolCallBlock(
                                     tool_call_id=tool_call.id,
                                     tool_name=tool_call.function.name,
@@ -517,18 +517,26 @@ class MistralAI(FunctionCallingLLM):
                 content += content_delta_str
 
                 # decide whether to include thinking in deltas/responses
+                thinking_txt = None
                 if self.model in MISTRAL_AI_REASONING_MODELS:
                     thinking_txt, response_txt = self._separate_thinking(content)
-
-                    if thinking_txt:
-                        blocks.append(ThinkingBlock(content=thinking_txt))
 
                     content = response_txt if not self.show_thinking else content
 
                     # If thinking hasn't ended, don't include it in the delta
                     if thinking_txt is None and not self.show_thinking:
                         content_delta = ""
+
+                # Rebuild the aggregated blocks from the running state each yield so
+                # the message carries a single cumulative TextBlock (and ThinkingBlock),
+                # mirroring the non-streaming `chat` path. Appending a new block per
+                # chunk would make ChatMessage.content the newline-joined concatenation
+                # of every growing prefix instead of the reply.
+                blocks: List[TextBlock | ThinkingBlock | ToolCallBlock] = []
+                if thinking_txt:
+                    blocks.append(ThinkingBlock(content=thinking_txt))
                 blocks.append(TextBlock(text=content))
+                blocks.extend(tool_call_blocks)
 
                 yield ChatResponse(
                     message=ChatMessage(
@@ -641,7 +649,7 @@ class MistralAI(FunctionCallingLLM):
 
         async def gen() -> ChatResponseAsyncGen:
             content = ""
-            blocks: List[ThinkingBlock | TextBlock | ToolCallBlock] = []
+            tool_call_blocks: List[ToolCallBlock] = []
             async for chunk in response:
                 delta = chunk.data.choices[0].delta
                 role = delta.role or MessageRole.ASSISTANT
@@ -649,7 +657,7 @@ class MistralAI(FunctionCallingLLM):
                 if delta.tool_calls:
                     for tool_call in delta.tool_calls:
                         if isinstance(tool_call, self._models.ToolCall):
-                            blocks.append(
+                            tool_call_blocks.append(
                                 ToolCallBlock(
                                     tool_call_id=tool_call.id,
                                     tool_name=tool_call.function.name,
@@ -675,10 +683,9 @@ class MistralAI(FunctionCallingLLM):
                 content += content_delta_str
 
                 # decide whether to include thinking in deltas/responses
+                thinking_txt = None
                 if self.model in MISTRAL_AI_REASONING_MODELS:
                     thinking_txt, response_txt = self._separate_thinking(content)
-                    if thinking_txt:
-                        blocks.append(ThinkingBlock(content=thinking_txt))
 
                     content = response_txt if not self.show_thinking else content
 
@@ -686,7 +693,16 @@ class MistralAI(FunctionCallingLLM):
                     if thinking_txt is None and not self.show_thinking:
                         content_delta = ""
 
+                # Rebuild the aggregated blocks from the running state each yield so
+                # the message carries a single cumulative TextBlock (and ThinkingBlock),
+                # mirroring the non-streaming `chat` path. Appending a new block per
+                # chunk would make ChatMessage.content the newline-joined concatenation
+                # of every growing prefix instead of the reply.
+                blocks: List[ThinkingBlock | TextBlock | ToolCallBlock] = []
+                if thinking_txt:
+                    blocks.append(ThinkingBlock(content=thinking_txt))
                 blocks.append(TextBlock(text=content))
+                blocks.extend(tool_call_blocks)
 
                 yield ChatResponse(
                     message=ChatMessage(

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-mistralai"
-version = "0.10.2"
+version = "0.10.3"
 description = "llama-index llms mistral ai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-mistralai/tests/test_mistralai.py
+++ b/llama-index-integrations/llms/llama-index-llms-mistralai/tests/test_mistralai.py
@@ -1,0 +1,75 @@
+import asyncio
+from types import SimpleNamespace
+
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import ChatMessage, MessageRole, TextBlock
+from llama_index.llms.mistralai import MistralAI
+
+
+def test_embedding_class():
+    names_of_base_classes = [b.__name__ for b in MistralAI.__mro__]
+    assert BaseLLM.__name__ in names_of_base_classes
+
+
+def _text_chunk(text: str) -> SimpleNamespace:
+    """Mimic a Mistral stream chunk carrying a plain-string content delta."""
+    delta = SimpleNamespace(role=None, tool_calls=None, content=text)
+    choice = SimpleNamespace(delta=delta)
+    return SimpleNamespace(data=SimpleNamespace(choices=[choice]))
+
+
+def test_stream_chat_aggregates_single_text_block(monkeypatch):
+    """The aggregated streamed message must carry one cumulative TextBlock.
+
+    Regression test: `stream_chat` used to append a new TextBlock holding the
+    whole accumulated text on every chunk, so `ChatMessage.content` (which joins
+    all TextBlock texts with "\n") became the newline-joined concatenation of
+    every growing prefix instead of the reply.
+    """
+    llm = MistralAI(api_key="fake", model="mistral-large-latest")
+
+    def fake_stream(**kwargs):
+        return iter([_text_chunk("Hello"), _text_chunk(" "), _text_chunk("world")])
+
+    monkeypatch.setattr(llm._client.chat, "stream", fake_stream)
+
+    responses = list(
+        llm.stream_chat([ChatMessage(role=MessageRole.USER, content="hi")])
+    )
+    final = responses[-1]
+
+    text_blocks = [b for b in final.message.blocks if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert final.message.content == "Hello world"
+    # the per-chunk delta stays correct throughout the stream
+    assert "".join(r.delta or "" for r in responses) == "Hello world"
+
+
+def test_astream_chat_aggregates_single_text_block(monkeypatch):
+    """Async counterpart of the aggregation regression test."""
+    llm = MistralAI(api_key="fake", model="mistral-large-latest")
+
+    async def fake_stream_async(**kwargs):
+        async def agen():
+            for chunk in [_text_chunk("Hello"), _text_chunk(" "), _text_chunk("world")]:
+                yield chunk
+
+        return agen()
+
+    monkeypatch.setattr(llm._client.chat, "stream_async", fake_stream_async)
+
+    async def collect():
+        return [
+            r
+            async for r in await llm.astream_chat(
+                [ChatMessage(role=MessageRole.USER, content="hi")]
+            )
+        ]
+
+    responses = asyncio.run(collect())
+    final = responses[-1]
+
+    text_blocks = [b for b in final.message.blocks if isinstance(b, TextBlock)]
+    assert len(text_blocks) == 1
+    assert final.message.content == "Hello world"
+    assert "".join(r.delta or "" for r in responses) == "Hello world"


### PR DESCRIPTION
# Description

`MistralAI.stream_chat` / `astream_chat` initialize `blocks` once outside the streaming loop, then append a fresh `TextBlock(text=content)` holding the **entire accumulated** text on every chunk. Because `ChatMessage.content` joins all `TextBlock` texts with `"\n"` (`llama-index-core/.../base/llms/types.py`), the final aggregated `message.content` becomes the newline-joined concatenation of every growing prefix instead of the reply.

Streaming three deltas `"Hello"`, `" "`, `"world"`:

- **before:** `message.blocks == [TextBlock("Hello"), TextBlock("Hello "), TextBlock("Hello world")]`, so `message.content == "Hello\nHello \nHello world"`
- **after:** `message.blocks == [TextBlock("Hello world")]`, `message.content == "Hello world"`

The per-chunk `.delta` was always correct; only the aggregated message was wrong, so any consumer that reads `resp.message.content` on the stream (agents, chat engines, memory writes) gets duplicated text. Reasoning models were worse, since `ThinkingBlock`s piled up per chunk too.

The fix rebuilds the aggregated `blocks` from running state on each yield — one cumulative `TextBlock`, an optional `ThinkingBlock`, then the accumulated tool-call blocks — mirroring the non-streaming `chat` path, which already builds a single correct `TextBlock`. Tool-call blocks are still accumulated across chunks (unchanged). No public API change; `.delta` is unchanged. Introduced in #19919.

Fixes # (no existing issue; self-reported with a reproduction).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.10.2 -> 0.10.3)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

The package had no `tests/` directory, so this adds one. `tests/test_mistralai.py` mocks the Mistral client (no network) and asserts the aggregated stream carries a single `TextBlock` and `message.content == "Hello world"` for both `stream_chat` and `astream_chat`. Both regression tests fail on `main` and pass on this branch.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] `ruff check` and `ruff format --check` are clean on the changed files

---

Disclosure: this fix was prepared with AI assistance. I reproduced the bug and verified the tests fail on `main` and pass on this branch in a clean container myself.
