### PR TITLE
Bugfix: Don't call unsupported `refresh` operation when using Opensearch serverless

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/CHANGELOG.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG — llama-index-vector-stores-opensearch
 
+## [1.2.1]
+
+- Bugfix: Don't call unsupported `refresh` operation when using Opensearch Serverless
+
 ## [1.0.0]
 
 - Changed engine default from deprecated `nmslib` (since version 3.0.0) to `faiss`

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -783,7 +783,7 @@ class OpensearchVectorClient:
             "query": {"term": {"metadata.doc_id.keyword": {"value": doc_id}}}
         }
         self._os_client.delete_by_query(
-            index=self._index, body=search_query, refresh=True
+            index=self._index, body=search_query, refresh=not self.is_aoss
         )
 
     async def adelete_by_doc_id(self, doc_id: str) -> None:
@@ -799,7 +799,7 @@ class OpensearchVectorClient:
             "query": {"term": {"metadata.doc_id.keyword": {"value": doc_id}}}
         }
         await self._os_async_client.delete_by_query(
-            index=self._index, body=search_query, refresh=True
+            index=self._index, body=search_query, refresh=not self.is_aoss
         )
 
     def delete_nodes(
@@ -827,7 +827,9 @@ class OpensearchVectorClient:
         if filters:
             query["query"]["bool"]["filter"].extend(self._parse_filters(filters))
 
-        self._os_client.delete_by_query(index=self._index, body=query, refresh=True)
+        self._os_client.delete_by_query(
+            index=self._index, body=query, refresh=not self.is_aoss
+        )
 
     async def adelete_nodes(
         self,
@@ -855,21 +857,23 @@ class OpensearchVectorClient:
             query["query"]["bool"]["filter"].extend(self._parse_filters(filters))
 
         await self._os_async_client.delete_by_query(
-            index=self._index, body=query, refresh=True
+            index=self._index, body=query, refresh=not self.is_aoss
         )
 
     def clear(self) -> None:
         """Clears index."""
         self._ensure_initialized()
         query = {"query": {"bool": {"filter": []}}}
-        self._os_client.delete_by_query(index=self._index, body=query, refresh=True)
+        self._os_client.delete_by_query(
+            index=self._index, body=query, refresh=not self.is_aoss
+        )
 
     async def aclear(self) -> None:
         """Clears index."""
         await self._async_ensure_initialized()
         query = {"query": {"bool": {"filter": []}}}
         await self._os_async_client.delete_by_query(
-            index=self._index, body=query, refresh=True
+            index=self._index, body=query, refresh=not self.is_aoss
         )
 
     def close(self) -> None:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -1,6 +1,5 @@
 """Elasticsearch/Opensearch vector store."""
 
-import asyncio
 import logging
 import uuid
 import warnings
@@ -23,6 +22,7 @@ from llama_index.core.vector_stores.utils import (
     metadata_dict_to_node,
     node_to_metadata_dict,
 )
+from llama_index.core.async_utils import asyncio_run
 from opensearchpy.client import Client as OSClient
 
 IMPORT_OPENSEARCH_PY_ERROR = (
@@ -886,12 +886,7 @@ class OpensearchVectorClient:
         if self._owns_os_client and self._os_client is not None:
             self._os_client.close()
         if self._owns_os_async_client and self._os_async_client is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                asyncio.run(self._os_async_client.close())
-            else:
-                loop.create_task(self._os_async_client.close())
+            asyncio_run(self._os_async_client.close())
 
     async def aclose(self) -> None:
         """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-opensearch"
-version = "1.2.0"
+version = "1.2.1"
 description = "llama-index vector_stores opensearch integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
@@ -108,7 +108,8 @@ def os_stores() -> Generator[List[OpensearchVectorStore], None, None]:
     for client in [client1, client2]:
         # teardown step
         # delete index
-        client._os_client.indices.delete(index=client._index)
+        if client._os_client.indices.exists(index=client._index):
+            client._os_client.indices.delete(index=client._index)
         # close client
         client.close()
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
@@ -1131,3 +1131,152 @@ def test_store_del_suppresses_exceptions() -> None:
 
     # Should not raise
     store.__del__()
+
+
+# ---------------------------------------------------------------------------
+# AOSS refresh-suppression tests
+#
+# On OpenSearch Serverless (AOSS), `refresh` on _delete_by_query and the
+# POST /{index}/_refresh endpoint are not supported. We hook into the
+# opensearch-py Transport.perform_request layer -- the last hop before the
+# HTTP request is serialized -- to prove the wire request never contains
+# `refresh=true` when is_aoss is set.
+# ---------------------------------------------------------------------------
+
+
+def _make_transport_recorded_client(is_aoss: bool):
+    """
+    Build an OpensearchVectorClient with real OpenSearch/AsyncOpenSearch clients
+    whose Transport.perform_request is stubbed to record calls without hitting
+    the network. Returns (client, sync_calls, async_calls).
+    """
+    sync_calls: list[dict] = []
+    async_calls: list[dict] = []
+
+    def _canned_response(url: str):
+        # A minimal response body that satisfies every endpoint we exercise.
+        if "_bulk" in url:
+            return {"errors": False, "items": []}
+        if "_delete_by_query" in url:
+            return {"deleted": 0, "failures": []}
+        if url.endswith("/_refresh"):
+            return {"_shards": {"total": 0, "successful": 0, "failed": 0}}
+        return {}
+
+    def _sync_perform(method, url, params=None, body=None, headers=None):
+        sync_calls.append(
+            {"method": method, "url": url, "params": dict(params or {}), "body": body}
+        )
+        return _canned_response(url)
+
+    async def _async_perform(method, url, params=None, body=None, headers=None):
+        async_calls.append(
+            {"method": method, "url": url, "params": dict(params or {}), "body": body}
+        )
+        return _canned_response(url)
+
+    client = OpensearchVectorClient(
+        endpoint="http://localhost:9200",
+        index="test_refresh_idx",
+        dim=3,
+    )
+    client._os_client.transport.perform_request = _sync_perform
+    client._os_async_client.transport.perform_request = _async_perform
+    # Override AOSS detection (normally driven by AWS4Auth service attribute).
+    client.is_aoss = is_aoss
+    # Skip lazy index initialization -- we don't want its perform_request calls
+    # cluttering our recorded calls, and we don't have a real cluster.
+    client._initialized = True
+    client._efficient_filtering_enabled = False
+
+    return client, sync_calls, async_calls
+
+
+@pytest.mark.parametrize("is_aoss", [True, False])
+def test_delete_operations_refresh_param_respects_aoss(is_aoss: bool) -> None:
+    """
+    delete_by_doc_id / delete_nodes / clear must not send `refresh=true`
+    on AOSS, but must send it otherwise.
+    """
+    client, calls, _ = _make_transport_recorded_client(is_aoss=is_aoss)
+
+    client.delete_by_doc_id("doc-1")
+    client.delete_nodes(node_ids=["a", "b"])
+    client.clear()
+
+    dbq_calls = [c for c in calls if "_delete_by_query" in c["url"]]
+    assert len(dbq_calls) == 3, f"expected 3 _delete_by_query calls, got {dbq_calls}"
+
+    for c in dbq_calls:
+        refresh_true = c["params"].get("refresh") == b"true"
+        if is_aoss:
+            assert not refresh_true, (
+                f"refresh=true leaked into AOSS request params: {c['params']}"
+            )
+        else:
+            assert refresh_true, (
+                f"refresh=true missing from non-AOSS request params: {c['params']}"
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_aoss", [True, False])
+async def test_adelete_operations_refresh_param_respects_aoss(is_aoss: bool) -> None:
+    """Async variant of :func:`test_delete_operations_refresh_param_respects_aoss`."""
+    client, _, calls = _make_transport_recorded_client(is_aoss=is_aoss)
+
+    await client.adelete_by_doc_id("doc-1")
+    await client.adelete_nodes(node_ids=["a", "b"])
+    await client.aclear()
+
+    dbq_calls = [c for c in calls if "_delete_by_query" in c["url"]]
+    assert len(dbq_calls) == 3, f"expected 3 _delete_by_query calls, got {dbq_calls}"
+
+    for c in dbq_calls:
+        refresh_true = c["params"].get("refresh") == b"true"
+        if is_aoss:
+            assert not refresh_true, (
+                f"refresh=true leaked into AOSS request params: {c['params']}"
+            )
+        else:
+            assert refresh_true, (
+                f"refresh=true missing from non-AOSS request params: {c['params']}"
+            )
+
+
+@pytest.mark.parametrize("is_aoss", [True, False])
+def test_index_results_skips_indices_refresh_on_aoss(is_aoss: bool) -> None:
+    """
+    After bulk ingest the `POST /{index}/_refresh` endpoint should be hit only
+    when NOT running against AOSS.
+    """
+    client, calls, _ = _make_transport_recorded_client(is_aoss=is_aoss)
+
+    node = TextNode(text="hi", id_="n1", embedding=[0.1, 0.2, 0.3])
+    client.index_results([node])
+
+    refresh_calls = [c for c in calls if c["url"].endswith("/_refresh")]
+    if is_aoss:
+        assert refresh_calls == [], f"unexpected _refresh call on AOSS: {refresh_calls}"
+    else:
+        assert len(refresh_calls) == 1, (
+            f"expected exactly one _refresh call, got {refresh_calls}"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_aoss", [True, False])
+async def test_aindex_results_skips_indices_refresh_on_aoss(is_aoss: bool) -> None:
+    """Async variant of :func:`test_index_results_skips_indices_refresh_on_aoss`."""
+    client, _, calls = _make_transport_recorded_client(is_aoss=is_aoss)
+
+    node = TextNode(text="hi", id_="n1", embedding=[0.1, 0.2, 0.3])
+    await client.aindex_results([node])
+
+    refresh_calls = [c for c in calls if c["url"].endswith("/_refresh")]
+    if is_aoss:
+        assert refresh_calls == [], f"unexpected _refresh call on AOSS: {refresh_calls}"
+    else:
+        assert len(refresh_calls) == 1, (
+            f"expected exactly one _refresh call, got {refresh_calls}"
+        )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_vector_stores_opensearch.py
@@ -278,7 +278,7 @@ def test_close_does_not_raise_in_running_event_loop():
     client._owns_os_async_client = True
 
     with patch(
-        "llama_index.vector_stores.opensearch.base.asyncio.get_running_loop",
+        "llama_index.core.async_utils.asyncio.get_running_loop",
         return_value=MagicMock(),
     ):
         client.close()

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/uv.lock
@@ -1893,7 +1893,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-opensearch"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1931,7 +1931,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },


### PR DESCRIPTION
# Description

In multiple operations in the `llama-index-vector-stores-opensearch` integration, the already implemented flag `is_aoss` is not used to suppress the `refresh` operation, which is not supported on OpenSearch serverless. In other operations, this has already been done, but currently is inconsistent.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
