### PR TITLE
fix: limit HWP section decompression

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
 
+DEFAULT_MAX_DECOMPRESSED_SECTION_SIZE = 100 * 1024 * 1024
+
 
 class HWPReader(BaseReader):
     """
@@ -13,8 +15,17 @@ class HWPReader(BaseReader):
     Args: None.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        max_decompressed_size: int = DEFAULT_MAX_DECOMPRESSED_SECTION_SIZE,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
+        if max_decompressed_size <= 0:
+            raise ValueError("max_decompressed_size must be greater than 0")
+
+        self.max_decompressed_size = max_decompressed_size
         self.FILE_HEADER_SECTION = "FileHeader"
         self.HWP_SUMMARY_SECTION = "\x05HwpSummaryInformation"
         self.SECTION_NAME_LENGTH = len("Section")
@@ -86,12 +97,43 @@ class HWPReader(BaseReader):
         header_data = header.read()
         return (header_data[36] & 1) == 1
 
+    def _decompress_section(self, data: bytes) -> bytes:
+        decompressor = zlib.decompressobj(-15)
+        chunks: List[bytes] = []
+        total_size = 0
+
+        for index in range(0, len(data), 64 * 1024):
+            remaining_size = self.max_decompressed_size + 1 - total_size
+            chunk = decompressor.decompress(
+                data[index : index + 64 * 1024], remaining_size
+            )
+            chunks.append(chunk)
+            total_size += len(chunk)
+
+            if total_size > self.max_decompressed_size or decompressor.unconsumed_tail:
+                raise ValueError(
+                    "decompressed HWP section exceeds configured maximum size"
+                )
+
+        remaining_size = self.max_decompressed_size + 1 - total_size
+        chunk = decompressor.flush(remaining_size)
+        chunks.append(chunk)
+        total_size += len(chunk)
+
+        if total_size > self.max_decompressed_size:
+            raise ValueError("decompressed HWP section exceeds configured maximum size")
+
+        if not decompressor.eof:
+            raise zlib.error("incomplete or truncated HWP section")
+
+        return b"".join(chunks)
+
     def get_text_from_section(self, load_file, section):
         bodytext = load_file.openstream(section)
         data = bodytext.read()
 
         unpacked_data = (
-            zlib.decompress(data, -15) if self.is_compressed(load_file) else data
+            self._decompress_section(data) if self.is_compressed(load_file) else data
         )
         size = len(unpacked_data)
 

--- a/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
+++ b/llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
@@ -1,3 +1,7 @@
+import zlib
+
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.hwp import HWPReader
 
@@ -5,3 +9,28 @@ from llama_index.readers.hwp import HWPReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HWPReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def _raw_deflate(data: bytes) -> bytes:
+    compressor = zlib.compressobj(wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+def test_decompress_section_round_trips_raw_deflate():
+    payload = b"hello hwp" * 128
+    reader = HWPReader(max_decompressed_size=len(payload))
+
+    assert reader._decompress_section(_raw_deflate(payload)) == payload
+
+
+def test_decompress_section_rejects_oversized_output():
+    payload = b"x" * 4096
+    reader = HWPReader(max_decompressed_size=len(payload) - 1)
+
+    with pytest.raises(ValueError, match="exceeds configured maximum size"):
+        reader._decompress_section(_raw_deflate(payload))
+
+
+def test_max_decompressed_size_must_be_positive():
+    with pytest.raises(ValueError, match="greater than 0"):
+        HWPReader(max_decompressed_size=0)


### PR DESCRIPTION
## Summary
- replace unbounded HWP section decompression with a bounded raw-deflate decompressor
- add a configurable max decompressed section size with validation
- cover raw-deflate round trip, oversized output rejection, and invalid limit handling

Fixes #22101

## Tests
- uv run --no-project --python C:\\Users\\rdpadmin\\.cache\\codex-runtimes\\codex-primary-runtime\\dependencies\\python\\python.exe --with pytest==7.2.1 --with-editable ./llama-index-core --with-editable ./llama-index-integrations/readers/llama-index-readers-hwp pytest llama-index-integrations/readers/llama-index-readers-hwp/tests -q
- uvx --from ruff==0.11.11 ruff format --check llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
- uvx --from ruff==0.11.11 ruff check llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py
- python -m py_compile llama-index-integrations/readers/llama-index-readers-hwp/llama_index/readers/hwp/base.py llama-index-integrations/readers/llama-index-readers-hwp/tests/test_readers_hwp.py