### PR TITLE
Fix RedisKVStore.get_all/aget_all crash when decode_responses=True

### DIFF
--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/llama_index/storage/kvstore/redis/base.py
@@ -158,7 +158,10 @@ class RedisKVStore(BaseKVStore):
         collection_kv_dict = {}
         for key, val_str in self._redis_client.hscan_iter(name=collection):
             value = dict(json.loads(val_str))
-            collection_kv_dict[key.decode()] = value
+            # `key` is `bytes` unless the client was configured with
+            # `decode_responses=True`, in which case it's already a `str`.
+            key_str = key.decode() if isinstance(key, bytes) else key
+            collection_kv_dict[key_str] = value
         return collection_kv_dict
 
     async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
@@ -166,7 +169,10 @@ class RedisKVStore(BaseKVStore):
         collection_kv_dict = {}
         async for key, val_str in self._async_redis_client.hscan_iter(name=collection):
             value = dict(json.loads(val_str))
-            collection_kv_dict[key.decode()] = value
+            # `key` is `bytes` unless the client was configured with
+            # `decode_responses=True`, in which case it's already a `str`.
+            key_str = key.decode() if isinstance(key, bytes) else key
+            collection_kv_dict[key_str] = value
         return collection_kv_dict
 
     def delete(self, key: str, collection: str = DEFAULT_COLLECTION) -> bool:

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/pyproject.toml
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-kvstore-redis"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index kvstore redis integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/tests/test_storage_kvstore_redis.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from llama_index.core.storage.kvstore.types import BaseKVStore
 from llama_index.storage.kvstore.redis import RedisKVStore
 
@@ -5,3 +7,82 @@ from llama_index.storage.kvstore.redis import RedisKVStore
 def test_class():
     names_of_base_classes = [b.__name__ for b in RedisKVStore.__mro__]
     assert BaseKVStore.__name__ in names_of_base_classes
+
+
+class _SyncHScanIter:
+    """Minimal stand-in for redis-py's sync hscan_iter, yielding fixed (key, value) pairs."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def __call__(self, name):
+        return iter(self._items)
+
+
+class _AsyncHScanIter:
+    """Minimal stand-in for redis-py's async hscan_iter, yielding fixed (key, value) pairs."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def __call__(self, name):
+        return self._aiter(self._items)
+
+    @staticmethod
+    async def _aiter(items):
+        for item in items:
+            yield item
+
+
+def _make_kvstore(items):
+    """
+    Build a RedisKVStore backed by fake sync/async clients that both yield `items`
+    from hscan_iter, without touching a real Redis server.
+    """
+    from unittest.mock import MagicMock
+
+    redis_client = MagicMock()
+    redis_client.hscan_iter = _SyncHScanIter(items)
+    async_redis_client = MagicMock()
+    async_redis_client.hscan_iter = _AsyncHScanIter(items)
+    return RedisKVStore(redis_client=redis_client, async_redis_client=async_redis_client)
+
+
+def test_get_all_with_bytes_keys():
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22115.
+
+    With the redis-py default (decode_responses=False), hscan_iter yields keys as
+    bytes, and get_all must decode them.
+    """
+    items = [(b"doc-1", b'{"a": 1}'), (b"doc-2", b'{"b": 2}')]
+    store = _make_kvstore(items)
+    assert store.get_all() == {"doc-1": {"a": 1}, "doc-2": {"b": 2}}
+
+
+def test_get_all_with_str_keys():
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22115.
+
+    With decode_responses=True, hscan_iter yields keys already decoded as str;
+    get_all must not call .decode() on them.
+    """
+    items = [("doc-1", '{"a": 1}'), ("doc-2", '{"b": 2}')]
+    store = _make_kvstore(items)
+    assert store.get_all() == {"doc-1": {"a": 1}, "doc-2": {"b": 2}}
+
+
+def test_aget_all_with_bytes_keys():
+    """Async counterpart of test_get_all_with_bytes_keys."""
+    items = [(b"doc-1", b'{"a": 1}'), (b"doc-2", b'{"b": 2}')]
+    store = _make_kvstore(items)
+    result = asyncio.run(store.aget_all())
+    assert result == {"doc-1": {"a": 1}, "doc-2": {"b": 2}}
+
+
+def test_aget_all_with_str_keys():
+    """Async counterpart of test_get_all_with_str_keys."""
+    items = [("doc-1", '{"a": 1}'), ("doc-2", '{"b": 2}')]
+    store = _make_kvstore(items)
+    result = asyncio.run(store.aget_all())
+    assert result == {"doc-1": {"a": 1}, "doc-2": {"b": 2}}

--- a/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/uv.lock
+++ b/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-redis/uv.lock
@@ -1824,7 +1824,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-storage-kvstore-redis"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`RedisKVStore.get_all` and `aget_all` call `key.decode()` unconditionally on every key returned by `hscan_iter`. That only works when the underlying `redis-py` client uses the default `decode_responses=False` (keys come back as `bytes`). When the client is configured with `decode_responses=True`, `hscan_iter` yields keys already as `str`, and `key.decode()` raises:

```
AttributeError: 'str' object has no attribute 'decode'
```

Fixes #22115.

## History

This is a regression that has flipped back and forth once already:

- #12324 removed the `.decode()` call to fix `decode_responses=True` (issue #12319).
- #13201 unconditionally re-added `.decode()` about a month later to fix the (still real) `decode_responses=False` case, which reintroduced this exact bug for `decode_responses=True`.

Neither version actually supports both client configurations at the same time, since each one hardcodes an assumption about the key type instead of checking it.

## Fix

```python
key_str = key.decode() if isinstance(key, bytes) else key
```

applied in both `get_all` and `aget_all`. This works for both configurations without needing to know how the client was constructed.

## Testing

Added `test_get_all_with_bytes_keys`, `test_get_all_with_str_keys`, `test_aget_all_with_bytes_keys`, and `test_aget_all_with_str_keys` to `tests/test_storage_kvstore_redis.py`. These use minimal fake sync/async `hscan_iter` implementations (no real Redis server needed) that yield fixed `(key, value)` pairs with either `bytes` or `str` keys, matching what `redis-py` actually returns under each `decode_responses` setting.

Verified:
- The two `str`-key tests fail against the current code with the exact reported `AttributeError: 'str' object has no attribute 'decode'`, confirming they reproduce the issue.
- All four tests pass against this fix.
- The two `bytes`-key tests pass against both the current code and this fix, confirming no regression for the default (`decode_responses=False`) configuration -- the one #13201 was protecting.

```
tests/test_storage_kvstore_redis.py::test_class PASSED
tests/test_storage_kvstore_redis.py::test_get_all_with_bytes_keys PASSED
tests/test_storage_kvstore_redis.py::test_get_all_with_str_keys PASSED
tests/test_storage_kvstore_redis.py::test_aget_all_with_bytes_keys PASSED
tests/test_storage_kvstore_redis.py::test_aget_all_with_str_keys PASSED
```

Bumped the package version (`0.5.0` -> `0.5.1`) and its self-reference in `uv.lock` per the contribution checklist.

## Version Bump?

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes