### PR TITLE
fix(llms-siliconflow): correctly parse SSE stream in astream_chat

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py
@@ -519,27 +519,27 @@ class SiliconFlow(FunctionCallingLLM):
                     response.raise_for_status()
                     response_txt = ""
                     response_role = "assistant"
-                    async for line in response.content.iter_any():
-                        line = cast(bytes, line).decode("utf-8")
-                        chunks = list(filter(None, line.split("data: ")))
-                        for chunk in chunks:
-                            if chunk.strip() == "[DONE]":
-                                break
-                            chunk_json = json.loads(chunk)
-                            delta: dict = chunk_json["choices"][0]["delta"]
-                            response_role = delta.get("role") or response_role
-                            delta_txt = delta["content"] or ""
-                            response_txt += delta_txt
-                            tool_calls = delta.get("tool_calls")
-                            yield ChatResponse(
-                                message=ChatMessage(
-                                    content=response_txt,
-                                    role=response_role,
-                                    additional_kwargs={"tool_calls": tool_calls},
-                                ),
-                                delta=delta_txt,
-                                raw=line,
-                            )
+                    async for line in response.content:
+                        line = cast(bytes, line).decode("utf-8").rstrip("\r\n")
+                        if not line.startswith("data:"):
+                            continue
+                        if line.strip() == "data: [DONE]":
+                            break
+                        chunk_json = json.loads(line[5:])
+                        delta: dict = chunk_json["choices"][0]["delta"]
+                        response_role = delta.get("role") or response_role
+                        delta_txt = delta["content"] or ""
+                        response_txt += delta_txt
+                        tool_calls = delta.get("tool_calls")
+                        yield ChatResponse(
+                            message=ChatMessage(
+                                content=response_txt,
+                                role=response_role,
+                                additional_kwargs={"tool_calls": tool_calls},
+                            ),
+                            delta=delta_txt,
+                            raw=chunk_json,
+                        )
 
         return gen()
 

--- a/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
+++ b/llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py
@@ -53,6 +53,32 @@ class MockAsyncResponse:
         return self._json_data
 
 
+class MockStreamContent:
+    """Mimics aiohttp's StreamReader, yielding one complete line at a time."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class MockAsyncStreamResponse:
+    def __init__(self, chunks):
+        self.status = 200
+        self.content = MockStreamContent(chunks)
+
+    def raise_for_status(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
 def test_llm_class():
     names_of_base_classes = [b.__name__ for b in SiliconFlow.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
@@ -206,29 +232,6 @@ async def test_astream_chat():
         b"data: [DONE]\n",
     ]
 
-    # Create a mock async response with iter_any method
-    class MockStreamContent:
-        def __init__(self, chunks):
-            self._chunks = chunks
-
-        async def iter_any(self):
-            for chunk in self._chunks:
-                yield chunk
-
-    class MockAsyncStreamResponse:
-        def __init__(self, chunks):
-            self.status = 200
-            self.content = MockStreamContent(chunks)
-
-        def raise_for_status(self):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            pass
-
     mock_response = MockAsyncStreamResponse(stream_chunks)
 
     llm = SiliconFlow(api_key="test_api_key")
@@ -278,3 +281,36 @@ async def test_astream_chat():
             headers=llm._headers,
             timeout=llm.timeout,
         )
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_content_containing_data_prefix():
+    """
+    Regression test: model output containing the literal substring
+    "data: " must not be mangled by the SSE parser (see GH issue #22223).
+    """
+    messages = [ChatMessage(role=MessageRole.USER, content="Hello")]
+
+    stream_chunks = [
+        b'data: {"id": "1", "choices": [{"delta": {"role": "assistant", '
+        b'"content": "the log shows data: 42 here"}}]}\n',
+        b"\n",  # blank keep-alive line between SSE events must be skipped
+        b'data: {"id": "2", "choices": [{"delta": {"content": " and more"}}]}\n',
+        b"data: [DONE]\n",
+    ]
+
+    mock_response = MockAsyncStreamResponse(stream_chunks)
+    llm = SiliconFlow(api_key="test_api_key")
+
+    with mock.patch("aiohttp.ClientSession.post", return_value=mock_response):
+        stream = await llm.astream_chat(messages)
+
+        responses = []
+        async for response in stream:
+            responses.append(response)
+
+        assert len(responses) == 2
+        assert responses[0].delta == "the log shows data: 42 here"
+        assert responses[0].message.content == "the log shows data: 42 here"
+        assert responses[1].delta == " and more"
+        assert responses[1].message.content == "the log shows data: 42 here and more"


### PR DESCRIPTION
## Summary
- Fixes `SiliconFlow.astream_chat` (and `astream_complete`, which delegates to it) so it no longer corrupts streamed responses when the model's own output contains the literal substring `"data: "`.
- The async SSE parser previously called `response.content.iter_any()` and split each chunk on the string `"data: "`. This breaks in two ways: (1) it tears apart valid JSON whenever the delta text itself contains `"data: "` (e.g. logs, code snippets), and (2) `iter_any()` yields arbitrary byte boundaries, so a single SSE event can be split across two reads.
- Replaced this with line-based async iteration over `response.content` (mirroring the existing, correct sync `stream_chat` implementation), which only treats a leading `"data:"` prefix as the event marker and leaves the rest of the line untouched.

## Why this helps
Any assistant response that happens to mention `data: ` (a common substring in logs, HTTP examples, or code) currently corrupts or crashes `astream_chat`, while the sync `stream_chat` path handles the same input correctly. This fixes the divergence and brings async streaming behavior in line with sync.

## Changes made
- `llama-index-integrations/llms/llama-index-llms-siliconflow/llama_index/llms/siliconflow/base.py`: rewrote the SSE parsing loop in `astream_chat` to iterate line-by-line over `response.content` and only strip the leading `data:` prefix, instead of splitting the whole chunk on the substring `"data: "`.
- `llama-index-integrations/llms/llama-index-llms-siliconflow/tests/test_llms_siliconflow.py`: updated the `MockStreamContent` test double to match aiohttp's line-based async iteration, and added a regression test covering model output that contains the literal substring `"data: "` plus a blank keep-alive line between events.

## Testing
- `uv run -- pytest tests` — 7 passed (including the new regression test)
- `uv run ruff check` — no issues
- `uv run ruff format --check` — no issues

## Related issue
Closes #22223
