### PR TITLE
Fix verdict-injection in _marshal_llm_to_json (prompt-injection-into-judge)

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -23,6 +23,16 @@ def _marshal_llm_to_json(output: str) -> str:
     """
     output = output.strip()
 
+    # Security: find ALL balanced JSON objects/arrays and return the LAST one.
+    # The LLM's own authoritative output appears last; earlier JSON may have
+    # originated from model-under-test output referenced in the LLM's reasoning
+    # (verdict injection). Using find("{")..rfind("}") spans both, allowing
+    # injected JSON to be parsed instead of the real output.
+    all_json = _find_all_balanced_json(output)
+    if all_json:
+        return all_json[-1]
+
+    # Fallback: original behavior for backward compatibility (incomplete JSON)
     left_square = output.find("[")
     left_brace = output.find("{")
 
@@ -34,6 +44,50 @@ def _marshal_llm_to_json(output: str) -> str:
         right = output.rfind("}")
 
     return output[left : right + 1]
+
+
+def _find_all_balanced_json(text: str) -> list[str]:
+    """Find all complete balanced JSON objects or arrays in text."""
+    results: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] in "{[":
+            open_char = text[i]
+            close_char = "]" if open_char == "[" else "}"
+            depth = 0
+            in_string = False
+            escape = False
+            for j in range(i, len(text)):
+                ch = text[j]
+                if escape:
+                    escape = False
+                    continue
+                if ch == "\\":
+                    escape = True
+                    continue
+                if ch == '"':
+                    in_string = not in_string
+                    continue
+                if in_string:
+                    continue
+                if ch == open_char:
+                    depth += 1
+                elif ch == close_char:
+                    depth -= 1
+                    if depth == 0:
+                        candidate = text[i : j + 1]
+                        try:
+                            json.loads(candidate)
+                            results.append(candidate)
+                        except json.JSONDecodeError:
+                            pass
+                        i = j + 1
+                        break
+            else:
+                break
+        else:
+            i += 1
+    return results
 
 
 def parse_json_markdown(text: str) -> Any:


### PR DESCRIPTION
## Summary

`_marshal_llm_to_json` in `output_parsers/utils.py` extracts JSON using `find("{")` to `rfind("}")` — a first-to-last span that includes JSON from model-under-test output referenced in the LLM's reasoning. A model that embeds `{"answer": "safe"}` in its output can hijack the parsed result when the LLM references that output.

**Severity:** HIGH
**Class:** Prompt-injection-into-judge → verdict manipulation

## Root cause

`output_parsers/utils.py:26-34`:
```python
left_brace = output.find("{")
right = output.rfind("}")
return output[left : right + 1]
```

The span from the first `{` to the last `}` may include JSON originating from model-under-test output.

## Fix

`_find_all_balanced_json()` collects ALL complete balanced JSON objects (with string/escape tracking) and returns the last one. The original `find`/`rfind` approach is retained as a fallback for incomplete JSON.

## Cross-framework pattern

Same vulnerability class found in 7 frameworks:

| Framework | PR |
|---|---|
| deepeval | [#2868](https://github.com/confident-ai/deepeval/pull/2868) |
| ragas | [#2829](https://github.com/vibrantlabsai/ragas/pull/2829) |
| guardrails-ai | [#1566](https://github.com/guardrails-ai/guardrails/pull/1566) |
| promptfoo | [#10036](https://github.com/promptfoo/promptfoo/pull/10036) |
| instructor | [#2424](https://github.com/567-labs/instructor/pull/2424) |
| CrewAI | [#6502](https://github.com/crewAIInc/crewAI/pull/6502) |
| **LlamaIndex** | **this PR** |

## Verification

- ruff: clean
- PoC regression: passes
- Single-file change

## Dedup

Searched issues for "JSON injection", "verdict injection", "parse_json_markdown". All existing issues are crash/format bugs. Novel.

