### PR TITLE
fix(anthropic): add latest Claude models to structured output and pro…

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/utils.py
@@ -581,6 +581,17 @@ def force_single_tool_call(response: ChatResponse) -> None:
 # Anthropic models that support prompt caching
 # Based on: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
 ANTHROPIC_PROMPT_CACHING_SUPPORTED_MODELS: Tuple[str, ...] = (
+    # Claude Fable 5
+    "claude-fable-5",
+    # Claude Sonnet 5
+    "claude-sonnet-5",
+    # Claude 4.8 Opus
+    "claude-opus-4-8",
+    # Claude 4.7 Opus
+    "claude-opus-4-7",
+    # Claude 4.6 Sonnet / Opus
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
     # Claude 4.5 Opus
     "claude-opus-4-5-20251101",
     "claude-opus-4-5",
@@ -630,6 +641,10 @@ STRUCTURED_OUTPUT_SUPPORT: Tuple[str, ...] = (
     "claude-opus-4-5",
     "claude-sonnet-4-6",
     "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-fable-5",
 )
 
 

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.11.8"
+version = "0.11.9"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
Title: fix(anthropic): support latest Claude models for structured output & prompt caching

Body:
Adds claude-opus-4-7, claude-opus-4-8, claude-sonnet-5, and claude-fable-5 to STRUCTURED_OUTPUT_SUPPORT, and adds those plus claude-sonnet-4-6 / claude-opus-4-6 to ANTHROPIC_PROMPT_CACHING_SUPPORTED_MODELS. 
Bumps version to 0.11.9.