### PR TITLE
fix(tools-mcp): support audio, embedded resource, and resource-link content in get_prompt

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -1,6 +1,7 @@
 import warnings
 import logging
 import io
+import mimetypes
 
 from contextlib import asynccontextmanager
 from datetime import timedelta
@@ -27,7 +28,68 @@ from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthClientInformat
 from mcp import types
 from pydantic import AnyUrl
 
-from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.llms import (
+    ChatMessage,
+    TextBlock,
+    ImageBlock,
+    AudioBlock,
+    DocumentBlock,
+)
+
+
+def _audio_format_from_mimetype(mime_type: str) -> Optional[str]:
+    """Turn a MIME type like ``audio/mpeg`` into a bare extension like ``mp3``."""
+    ext = mimetypes.guess_extension(mime_type)
+    if ext:
+        return ext.lstrip(".")
+    # Fall back to the subtype (e.g. "audio/wav" -> "wav") when the stdlib
+    # table doesn't recognize the MIME type.
+    return mime_type.split("/")[-1] or None
+
+
+def _mcp_prompt_message_to_chat_message(message: "types.PromptMessage") -> ChatMessage:
+    """
+    Convert a single MCP ``PromptMessage`` into a llama-index ``ChatMessage``.
+
+    Split out from ``get_prompt`` so each MCP content type (text, image, audio,
+    embedded resource, resource link) can be unit tested without needing a live
+    MCP session.
+    """
+    content = message.content
+    if isinstance(content, types.TextContent):
+        block = TextBlock(text=content.text)
+    elif isinstance(content, types.ImageContent):
+        block = ImageBlock(
+            image=content.data,
+            image_mimetype=content.mimeType,
+        )
+    elif isinstance(content, types.AudioContent):
+        block = AudioBlock(
+            audio=content.data,
+            format=_audio_format_from_mimetype(content.mimeType),
+        )
+    elif isinstance(content, types.EmbeddedResource):
+        resource = content.resource
+        if isinstance(resource, types.TextResourceContents):
+            block = TextBlock(text=resource.text)
+        else:
+            # BlobResourceContents: base64-encoded binary payload.
+            block = DocumentBlock(
+                data=resource.blob.encode("utf-8"),
+                document_mimetype=resource.mimeType,
+                title=str(resource.uri),
+            )
+    elif isinstance(content, types.ResourceLink):
+        # A resource link only carries a reference (uri/name), not the actual
+        # content, so there is nothing to download here without an extra
+        # server round trip. Surface it as text so callers at least see it
+        # instead of the request failing outright.
+        label = content.title or content.name
+        block = TextBlock(text=f"[{label}]({content.uri})")
+    else:
+        raise ValueError(f"Unsupported content type: {type(content)}")
+
+    return ChatMessage(role=message.role, blocks=[block])
 
 
 class StreamingHandler(logging.Handler):
@@ -377,34 +439,7 @@ class BasicMCPClient(ClientSession):
         """
         async with self._run_session() as session:
             prompt = await session.get_prompt(prompt_name, arguments)
-            llama_messages = []
-            for message in prompt.messages:
-                if isinstance(message.content, types.TextContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[TextBlock(text=message.content.text)],
-                        )
-                    )
-                elif isinstance(message.content, types.ImageContent):
-                    llama_messages.append(
-                        ChatMessage(
-                            role=message.role,
-                            blocks=[
-                                ImageBlock(
-                                    image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
-                                )
-                            ],
-                        )
-                    )
-                elif isinstance(message.content, types.EmbeddedResource):
-                    raise NotImplementedError(
-                        "Embedded resources are not supported yet"
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported content type: {type(message.content)}"
-                    )
-
-            return llama_messages
+            return [
+                _mcp_prompt_message_to_chat_message(message)
+                for message in prompt.messages
+            ]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 import pytest
 
 from llama_index.tools.mcp import BasicMCPClient
-from llama_index.tools.mcp.client import enable_sse
+from llama_index.tools.mcp.client import enable_sse, _mcp_prompt_message_to_chat_message
 from mcp import types
 
 
@@ -259,3 +259,76 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+
+def test_prompt_message_text_content():
+    """Text content should map to a TextBlock, unchanged from before."""
+    message = types.PromptMessage(
+        role="user", content=types.TextContent(type="text", text="hello")
+    )
+    chat_message = _mcp_prompt_message_to_chat_message(message)
+    assert chat_message.blocks[0].block_type == "text"
+    assert chat_message.blocks[0].text == "hello"
+
+
+def test_prompt_message_audio_content():
+    """AudioContent used to raise ValueError; it should now map to AudioBlock."""
+    message = types.PromptMessage(
+        role="user",
+        content=types.AudioContent(type="audio", data="ZmFrZQ==", mimeType="audio/mpeg"),
+    )
+    chat_message = _mcp_prompt_message_to_chat_message(message)
+    assert chat_message.blocks[0].block_type == "audio"
+    assert chat_message.blocks[0].format == "mp3"
+
+
+def test_prompt_message_embedded_text_resource():
+    """EmbeddedResource wrapping text content used to raise NotImplementedError."""
+    message = types.PromptMessage(
+        role="user",
+        content=types.EmbeddedResource(
+            type="resource",
+            resource=types.TextResourceContents(
+                uri="file:///notes.txt", mimeType="text/plain", text="resource body"
+            ),
+        ),
+    )
+    chat_message = _mcp_prompt_message_to_chat_message(message)
+    assert chat_message.blocks[0].block_type == "text"
+    assert chat_message.blocks[0].text == "resource body"
+
+
+def test_prompt_message_embedded_blob_resource():
+    """EmbeddedResource wrapping binary content should map to a DocumentBlock."""
+    import base64
+
+    message = types.PromptMessage(
+        role="user",
+        content=types.EmbeddedResource(
+            type="resource",
+            resource=types.BlobResourceContents(
+                uri="file:///data.bin",
+                mimeType="application/octet-stream",
+                blob=base64.b64encode(b"binary-data").decode(),
+            ),
+        ),
+    )
+    chat_message = _mcp_prompt_message_to_chat_message(message)
+    assert chat_message.blocks[0].block_type == "document"
+    assert chat_message.blocks[0].document_mimetype == "application/octet-stream"
+
+
+def test_prompt_message_resource_link():
+    """ResourceLink used to raise ValueError; it has no content to fetch, so it
+    should degrade to a text reference instead of failing outright."""
+    message = types.PromptMessage(
+        role="user",
+        content=types.ResourceLink(
+            type="resource_link", uri="https://example.com/doc", name="doc-name"
+        ),
+    )
+    chat_message = _mcp_prompt_message_to_chat_message(message)
+    assert chat_message.blocks[0].block_type == "text"
+    assert "doc-name" in chat_message.blocks[0].text
+    assert "https://example.com/doc" in chat_message.blocks[0].text


### PR DESCRIPTION
## What

`BasicMCPClient.get_prompt()` only handled `TextContent` and `ImageContent`. Any MCP server whose prompt messages included `AudioContent`, `EmbeddedResource`, or `ResourceLink` (all valid `PromptMessage.content` types per the MCP spec) made `get_prompt()` fail:

- `AudioContent` -> bare `ValueError: Unsupported content type`
- `EmbeddedResource` -> `NotImplementedError: Embedded resources are not supported yet`
- `ResourceLink` -> bare `ValueError: Unsupported content type`

## Fix

Added the three missing branches:
- `AudioContent` -> `AudioBlock`, deriving the `format` from the MIME type (`mimetypes.guess_extension`, falling back to the subtype)
- `EmbeddedResource` -> `TextBlock` when the wrapped resource is `TextResourceContents`, `DocumentBlock` when it's `BlobResourceContents`
- `ResourceLink` -> `TextBlock`, since a link only carries a `uri`/`name` reference and there's no content to fetch without an extra server round trip

Also extracted the per-message conversion out of `get_prompt()` into a standalone `_mcp_prompt_message_to_chat_message()` helper, so each content type can be unit tested directly without spinning up a live MCP session (the existing tests in this file all go through a real subprocess test server).

## Testing

Added `test_prompt_message_text_content`, `test_prompt_message_audio_content`, `test_prompt_message_embedded_text_resource`, `test_prompt_message_embedded_blob_resource`, and `test_prompt_message_resource_link` in `test_client.py`, exercising the helper directly with constructed `types.PromptMessage` objects for each content type.

Ran the four new regression tests against the old code first to confirm they reproduce the exact reported failures (`ValueError`/`NotImplementedError`), then against the fix to confirm they pass. Also ran `ruff check --select F,E9` on both changed files with no findings.
