### PR TITLE
fix(core): stop asyncio.gather from leaking orphaned tool tasks in apredict_and_call

### DIFF
--- a/llama-index-core/llama_index/core/llms/function_calling.py
+++ b/llama-index-core/llama_index/core/llms/function_calling.py
@@ -281,6 +281,7 @@ class FunctionCallingLLM(LLM):
         from llama_index.core.tools.calling import (
             acall_tool_with_selection,
         )
+        from llama_index.core.tools.types import ToolOutput
 
         if not self.metadata.is_function_calling_model:
             return await super().apredict_and_call(
@@ -307,7 +308,36 @@ class FunctionCallingLLM(LLM):
             acall_tool_with_selection(tool_call, tools, verbose=verbose)
             for tool_call in tool_calls
         ]
-        tool_outputs = await asyncio.gather(*tool_tasks)
+        # `acall_tool_with_selection` already wraps tool-execution errors into
+        # an errored `ToolOutput`, but it looks up the tool by name with a
+        # plain dict index before that try/except, so a hallucinated or
+        # otherwise unknown tool name still raises `KeyError` straight out of
+        # the task. With the default `asyncio.gather(*tool_tasks)`, that
+        # exception is propagated to the caller immediately while the other
+        # in-flight tool calls are left running unawaited and uncancelled --
+        # under load, those orphaned tasks accumulate open sockets/file
+        # descriptors. `return_exceptions=True` waits for every task to
+        # finish (success or failure) before this line returns, so nothing is
+        # left running in the background, and we convert any exception into
+        # the same errored `ToolOutput` shape callers already handle below.
+        raw_results = await asyncio.gather(*tool_tasks, return_exceptions=True)
+        tool_outputs = []
+        for tool_call, result in zip(tool_calls, raw_results):
+            if isinstance(result, BaseException):
+                tool_outputs.append(
+                    ToolOutput(
+                        content=f"Encountered error: {result}",
+                        tool_name=tool_call.tool_name,
+                        raw_input=tool_call.tool_kwargs,
+                        raw_output=str(result),
+                        is_error=True,
+                        exception=(
+                            result if isinstance(result, Exception) else None
+                        ),
+                    )
+                )
+            else:
+                tool_outputs.append(result)
         tool_outputs_with_error = [
             tool_output for tool_output in tool_outputs if tool_output.is_error
         ]

--- a/llama-index-core/tests/llms/test_function_calling.py
+++ b/llama-index-core/tests/llms/test_function_calling.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, AsyncGenerator, Coroutine, Dict, List, Optional, Sequence, Union
 from unittest.mock import patch
 
@@ -103,6 +104,15 @@ class Person(BaseModel):
 
 
 @pytest.fixture()
+def person_tool_selection_success(person_tool: FunctionTool) -> ToolSelection:
+    return ToolSelection(
+        tool_id="",
+        tool_name=person_tool.metadata.name,
+        tool_kwargs={"name": "Alice"},
+    )
+
+
+@pytest.fixture()
 def person_tool() -> FunctionTool:
     return get_function_tool(Person)
 
@@ -187,3 +197,35 @@ def test_tool_required_compatibility_with_support(
         args, kwargs = mock_prepare.call_args
         assert "tool_required" in kwargs
         assert kwargs["tool_required"] is True
+
+
+
+@pytest.mark.asyncio
+async def test_apredict_and_call_unknown_tool_name_does_not_leak_task(
+    person_tool: FunctionTool, person_tool_selection_success: ToolSelection
+) -> None:
+    """
+    A tool_call referencing a name that isn't in `tools` (e.g. a hallucinated
+    tool name) used to raise KeyError straight out of asyncio.gather(), which
+    left any other in-flight tool call running as an orphaned, uncancelled
+    task in the background. It should now surface as an errored ToolOutput
+    like any other tool failure, with no task left running afterwards.
+    """
+    unknown_tool_selection = ToolSelection(
+        tool_id="", tool_name="does_not_exist", tool_kwargs={}
+    )
+    llm = MockFunctionCallingLLM([unknown_tool_selection, person_tool_selection_success])
+
+    tasks_before = asyncio.all_tasks()
+    response = await llm.apredict_and_call(tools=[person_tool], allow_parallel_tool_calls=True)
+    await asyncio.sleep(0)
+    tasks_after = asyncio.all_tasks()
+
+    assert not (tasks_after - tasks_before), (
+        "no task should be left running in the background after apredict_and_call returns"
+    )
+    assert len(response.sources) == 2
+    unknown_output, good_output = response.sources
+    assert unknown_output.is_error
+    assert "does_not_exist" in unknown_output.content
+    assert not good_output.is_error


### PR DESCRIPTION
## What

`apredict_and_call()` runs all tool calls concurrently via `asyncio.gather(*tool_tasks)` (default `return_exceptions=False`). `acall_tool_with_selection()` looks up the target tool with a plain dict index (`tools_by_name[name]`) *before* its try/except, so a `tool_call` referencing a name that isn't in the `tools` list (e.g. a hallucinated tool name from the model) raises a bare `KeyError` instead of the usual errored `ToolOutput`.

Because `return_exceptions` defaults to `False`, that `KeyError` propagates to the caller as soon as it happens, but the other in-flight tool tasks are left running -- `asyncio.gather` does not cancel siblings when one task raises. Under concurrent load, or any time a model mixes a hallucinated tool name in among otherwise-valid parallel tool calls, those orphaned tasks keep running in the background and hold onto whatever sockets/file descriptors their tool implementations were using.

## Fix

Switched to `asyncio.gather(*tool_tasks, return_exceptions=True)`, which waits for every task to finish (success or failure) before the call returns, and converts any raised exception into the same errored `ToolOutput` shape callers already handle for ordinary tool-execution failures (`acall_tool` already does this internally for exceptions raised *inside* the tool call -- this just extends the same handling to the lookup step).

## Testing

Verified the failure mode with a standalone simulation replicating the exact dict-lookup + gather structure: with `return_exceptions=False`, the exception surfaces to the caller while the other task is still pending, and that task only finishes in the background afterwards (i.e. after the caller already moved on with an unhandled exception). With `return_exceptions=True`, nothing is left pending when the call returns.

Added `test_apredict_and_call_unknown_tool_name_does_not_leak_task` in `tests/llms/test_function_calling.py`, which asserts `asyncio.all_tasks()` has no new entries after `apredict_and_call` returns. Ran it against the old code first to confirm it reproduces the exact reported `KeyError`, then against the fix to confirm it passes. All 6 pre-existing tests in the file still pass unchanged.
