### PR TITLE
fix(core): refresh state_prompt on the next LLM step after a tool mutates state

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -722,6 +722,13 @@ class BaseWorkflowAgent(
         user_msg_str = await ctx.store.get("user_msg_str")
         input_messages = await memory.aget(input=user_msg_str)
 
+        # A tool may have just mutated ctx.store["state"] (see
+        # handle_tool_call_results above). setup_agent only re-applies the
+        # state_prompt while this flag is False, so it must be reset here;
+        # otherwise the next LLM step reuses the raw user message instead of
+        # being reformatted with whatever the tool changed.
+        await ctx.store.set("formatted_input_with_state", False)
+
         return AgentInput(input=input_messages, current_agent_name=self.name)
 
     # TODO: Remove the deprecated agent-specific overload. The agent params

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -756,6 +756,13 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
         agent_name = await ctx.store.get("current_agent_name")
         agent = self.agents[agent_name]
 
+        # A tool may have just mutated ctx.store["state"] (see
+        # handle_tool_call_results above). setup_agent only re-applies the
+        # state_prompt while this flag is False, so it must be reset here;
+        # otherwise the next LLM step reuses the raw user message instead of
+        # being reformatted with whatever the tool changed.
+        await ctx.store.set("formatted_input_with_state", False)
+
         return AgentInput(input=input_messages, current_agent_name=agent.name)
 
     # TODO: Remove the deprecated agent-specific overload. The agent params

--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -431,6 +431,61 @@ async def test_function_agent_with_mock_function_calling_llm():
 
 
 @pytest.mark.asyncio
+async def test_function_agent_state_refreshed_after_tool_call():
+    """
+    A tool that mutates ctx.store["state"] should have that change reflected
+    in the state_prompt on the *next* LLM step.
+
+    Regression test for GH #22248: setup_agent only reformats the last
+    message with state_prompt while ctx.store["formatted_input_with_state"]
+    is False, and that flag was never reset after a tool call, so the second
+    LLM step saw the raw user message instead of the refreshed state.
+    """
+    from llama_index.core.workflow import Context
+
+    captured_inputs = []
+
+    async def update_state(ctx: Context) -> str:
+        state = await ctx.store.get("state")
+        state["counter"] = 1
+        await ctx.store.set("state", state)
+        return "state updated"
+
+    def response_generator(messages, **kwargs):
+        captured_inputs.append(messages)
+        if len(captured_inputs) == 1:
+            return ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="updating state",
+                additional_kwargs={
+                    "tool_calls": [
+                        ToolSelection(
+                            tool_id="update-state",
+                            tool_name="update_state",
+                            tool_kwargs={},
+                        )
+                    ]
+                },
+            )
+        return ChatMessage(role=MessageRole.ASSISTANT, content="done")
+
+    agent = FunctionAgent(
+        name="agent",
+        description="test",
+        tools=[update_state],
+        llm=MockFunctionCallingLLM(response_generator=response_generator),
+        initial_state={"counter": 0},
+        state_prompt="Current state: {state}. User message: {msg}",
+    )
+
+    memory = ChatMemoryBuffer.from_defaults(tokenizer_fn=lambda text: text.split())
+    await agent.run(user_msg="test", memory=memory)
+
+    assert "'counter': 0" in str(captured_inputs[0][0].content)
+    assert "'counter': 1" in str(captured_inputs[1][0].content)
+
+
+@pytest.mark.asyncio
 async def test_function_agent_with_context_and_chat_message():
     """Test FunctionAgent with explicit Context and ChatMessage input following the full adoption pattern."""
     from llama_index.core.llms import TextBlock


### PR DESCRIPTION
## What

When an agent or `AgentWorkflow` uses `initial_state` with a `state_prompt`, the first LLM step gets the formatted state prompt as expected, but if a tool mutates `ctx.store["state"]`, every LLM step *after* that keeps seeing the raw, unformatted user message instead of the refreshed state.

## Root cause

`setup_agent()` only reformats the last message with `state_prompt` while `ctx.store["formatted_input_with_state"]` is `False`, and immediately sets it to `True` after doing so. That flag only gets reset back to `False` once, in `_init_context()`, which runs at the very start of a `.run()` call. On the tool-call loop-back path (`aggregate_tool_results()` returning the next `AgentInput`), the flag is never reset, so `setup_agent()` skips reformatting on every subsequent step, no matter what a tool changed in `state`.

This is distinct from the double-formatting bug fixed in #18417 (which is about the flag *not* being set when it should be); this is about the flag never being *unset* again after the first LLM step.

## Fix

Reset `formatted_input_with_state` to `False` right before `aggregate_tool_results()` returns the next `AgentInput`, in both `base_agent.py` (single-agent path) and `multi_agent_workflow.py` (multi-agent path), so `setup_agent()` reformats the next message with the current state.

## Testing

Reproduced with the exact scenario from the bug report (`FunctionAgent` + a tool that sets `state["counter"] = 1`): on current `main`, the second LLM call receives the raw `"test"` message; with the fix, it receives `"Current state: {'counter': 1}. User message: test"`. Confirmed the same behavior for the `AgentWorkflow` (multi-agent) path with an equivalent repro.

Added `test_function_agent_state_refreshed_after_tool_call` to `test_single_agent_workflow.py`. Ran it against the old code first to confirm it reproduces the exact reported failure, then against the fix to confirm it passes. Also re-ran the existing `test_workflow_with_state` in `test_multi_agent_workflow.py` (which guards against the #18417 double-formatting regression) to confirm this change doesn't reintroduce that bug.
