### PR TITLE
feat: add llama-index-llms-edenai integration

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-edenai/.gitignore
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+dist/
+build/
+.venv/
+venv/
+.env
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/

--- a/llama-index-integrations/llms/llama-index-llms-edenai/LICENSE
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eden AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/llms/llama-index-llms-edenai/Makefile
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/llms/llama-index-llms-edenai/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/README.md
@@ -1,0 +1,72 @@
+# LlamaIndex Llms Integration: Eden AI
+
+[Eden AI](https://www.edenai.co) gives you access to 500+ models from every major provider
+(OpenAI, Anthropic, Google, Mistral, and more) through a single, OpenAI-compatible API and one
+API key. Models are addressed in `provider/model` format, and an EU endpoint is available for
+GDPR data residency.
+
+## Installation
+
+```bash
+%pip install llama-index-llms-edenai
+!pip install llama-index
+```
+
+## Setup
+
+### Initialize Eden AI
+
+Set your API key with the `EDENAI_API_KEY` environment variable or pass it directly. You can
+create a key at [app.edenai.run](https://app.edenai.run).
+
+```python
+from llama_index.llms.edenai import EdenAI
+
+llm = EdenAI(
+    model="openai/gpt-4o-mini",
+    api_key="<your-api-key>",  # or set EDENAI_API_KEY
+)
+```
+
+Models use `provider/model` format, e.g. `openai/gpt-4o-mini`,
+`anthropic/claude-sonnet-4-5`, `mistral/mistral-large-latest`. See the full list at
+[app.edenai.run/models](https://app.edenai.run/models).
+
+### EU data residency (GDPR)
+
+To keep requests and data within the EU, use Eden AI's EU endpoint:
+
+```python
+llm = EdenAI(
+    model="mistral/mistral-large-latest",
+    api_base="https://api.eu.edenai.run/v3",  # or set EDENAI_API_BASE
+)
+```
+
+## Usage
+
+### Complete
+
+```python
+response = llm.complete("Hello World!")
+print(str(response))
+```
+
+### Chat
+
+```python
+from llama_index.core.llms import ChatMessage
+
+messages = [
+    ChatMessage(role="system", content="You are a helpful assistant."),
+    ChatMessage(role="user", content="Tell me a joke."),
+]
+print(llm.chat(messages))
+```
+
+### Stream
+
+```python
+for chunk in llm.stream_complete("Tell me a story in 200 words"):
+    print(chunk.delta, end="")
+```

--- a/llama-index-integrations/llms/llama-index-llms-edenai/llama_index/llms/edenai/__init__.py
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/llama_index/llms/edenai/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.llms.edenai.base import EdenAI
+
+__all__ = ["EdenAI"]

--- a/llama-index-integrations/llms/llama-index-llms-edenai/llama_index/llms/edenai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/llama_index/llms/edenai/base.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict, Optional
+
+from llama_index.core.base.llms.types import LLMMetadata
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.constants import (
+    DEFAULT_CONTEXT_WINDOW,
+    DEFAULT_NUM_OUTPUTS,
+    DEFAULT_TEMPERATURE,
+)
+from llama_index.core.base.llms.generic_utils import get_from_param_or_env
+from llama_index.llms.openai_like import OpenAILike
+
+DEFAULT_API_BASE = "https://api.edenai.run/v3"
+# Eden AI's EU endpoint keeps requests and data within the EU (GDPR data
+# residency). Point ``api_base`` here (or set EDENAI_API_BASE) to stay in the EU.
+EU_API_BASE = "https://api.eu.edenai.run/v3"
+DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+
+class EdenAI(OpenAILike):
+    """
+    Eden AI LLM.
+
+    Eden AI gives you access to 500+ models from every major provider (OpenAI,
+    Anthropic, Google, Mistral, and more) behind a single, OpenAI-compatible
+    API and one API key. Models are addressed in ``provider/model`` format, for
+    example ``openai/gpt-4o-mini``, ``anthropic/claude-sonnet-4-5`` or
+    ``mistral/mistral-large-latest``.
+
+    Set your key with the ``EDENAI_API_KEY`` environment variable or the
+    ``api_key`` argument. You can create one at https://app.edenai.run.
+
+    For GDPR data residency, use Eden AI's EU endpoint by setting
+    ``api_base="https://api.eu.edenai.run/v3"`` (or the ``EDENAI_API_BASE``
+    environment variable), so requests and data stay within the EU.
+
+    Examples:
+        `pip install llama-index-llms-edenai`
+
+        ```python
+        from llama_index.llms.edenai import EdenAI
+
+        llm = EdenAI(
+            model="openai/gpt-4o-mini",
+            api_key="<your-api-key>",
+        )
+
+        response = llm.complete("Hello World!")
+        print(str(response))
+        ```
+
+    """
+
+    model: str = Field(
+        description=(
+            "The Eden AI model to use, in 'provider/model' format. "
+            "See https://app.edenai.run/models for the available options."
+        )
+    )
+    context_window: int = Field(
+        default=DEFAULT_CONTEXT_WINDOW,
+        description="The maximum number of context tokens for the model.",
+        gt=0,
+    )
+    is_chat_model: bool = Field(
+        default=True,
+        description=LLMMetadata.model_fields["is_chat_model"].description,
+    )
+    is_function_calling_model: bool = Field(
+        default=True,
+        description=LLMMetadata.model_fields["is_function_calling_model"].description,
+    )
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        temperature: float = DEFAULT_TEMPERATURE,
+        max_tokens: int = DEFAULT_NUM_OUTPUTS,
+        additional_kwargs: Optional[Dict[str, Any]] = None,
+        max_retries: int = 5,
+        api_base: Optional[str] = DEFAULT_API_BASE,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        additional_kwargs = additional_kwargs or {}
+
+        api_base = get_from_param_or_env(
+            "api_base", api_base, "EDENAI_API_BASE", DEFAULT_API_BASE
+        )
+        api_key = get_from_param_or_env("api_key", api_key, "EDENAI_API_KEY", "")
+
+        super().__init__(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            api_base=api_base,
+            api_key=api_key,
+            additional_kwargs=additional_kwargs,
+            max_retries=max_retries,
+            **kwargs,
+        )
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "EdenAI_LLM"

--- a/llama-index-integrations/llms/llama-index-llms-edenai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-llms-edenai"
+version = "0.1.0"
+description = "llama-index llms edenai integration"
+authors = [{name = "Eden AI", email = "support@edenai.co"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "llama-index-llms-openai-like>=0.7.0,<0.8",
+    "llama-index-core>=0.14.3,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.llms.edenai"
+
+[tool.llamahub.class_authors]
+EdenAI = "MVS-source"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/llms/llama-index-llms-edenai/tests/test_llms_edenai.py
+++ b/llama-index-integrations/llms/llama-index-llms-edenai/tests/test_llms_edenai.py
@@ -1,0 +1,31 @@
+from llama_index.core.base.llms.base import BaseLLM
+from llama_index.llms.edenai import EdenAI
+from llama_index.llms.edenai.base import (
+    DEFAULT_API_BASE,
+    DEFAULT_MODEL,
+    EU_API_BASE,
+)
+
+
+def test_llm_class():
+    names_of_base_classes = [b.__name__ for b in EdenAI.__mro__]
+    assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_defaults():
+    llm = EdenAI(api_key="dummy_key")
+    assert llm.model == DEFAULT_MODEL
+    assert llm.api_base == DEFAULT_API_BASE
+    assert llm.is_chat_model is True
+    assert llm.is_function_calling_model is True
+
+
+def test_eu_endpoint_override():
+    llm = EdenAI(api_key="dummy_key", api_base=EU_API_BASE)
+    assert llm.api_base == EU_API_BASE
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("EDENAI_API_KEY", "env_key_123")
+    llm = EdenAI()
+    assert llm.api_key == "env_key_123"


### PR DESCRIPTION
## Summary
Adds an Eden AI LLM integration: `llama-index-llms-edenai`.

[Eden AI](https://www.edenai.co) exposes 500+ models from every major provider (OpenAI, Anthropic, Google, Mistral, and more) behind a single OpenAI-compatible API and one API key, addressed as `provider/model`. The integration therefore subclasses `OpenAILike`, mirroring the existing `llama-index-llms-openrouter` package.

## Details
- Default endpoint `https://api.edenai.run/v3`, default model `openai/gpt-4o-mini`.
- API key via the `EDENAI_API_KEY` env var or the `api_key` argument.
- **EU endpoint** (`https://api.eu.edenai.run/v3`) documented for GDPR data residency (set `api_base` or `EDENAI_API_BASE`).
- Chat + function-calling enabled by default.
- README with usage, and tests.

## Testing
Package installs and unit tests pass locally (4/4): base-class check, defaults, EU endpoint override, and API key from env.