### PR TITLE
Add tests for ag-ui tool_call_id handling

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_utils.py
@@ -1,0 +1,71 @@
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.protocols.ag_ui.utils import (
+    ag_ui_message_to_llama_index_message,
+    llama_index_message_to_ag_ui_message,
+)
+
+
+def test_tool_message_missing_tool_call_id_raises():
+    """
+    Regression test for GH #22068, fixed in #22103: a 'tool' role ChatMessage
+    without 'tool_call_id' in additional_kwargs used to silently fabricate a
+    random uuid4 as ToolMessage.tool_call_id. That id pairs with no
+    AssistantMessage.tool_calls[*].id, which providers like OpenAI and
+    Anthropic reject as an invalid message history. It has to raise rather
+    than hand back a message that only fails much later.
+    """
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1"},  # no tool_call_id
+    )
+    with pytest.raises(ValueError, match="tool_call_id"):
+        llama_index_message_to_ag_ui_message(message)
+
+
+def test_tool_message_with_tool_call_id_round_trips():
+    """A tool message that does carry tool_call_id must convert cleanly and
+    round-trip back with the same id, matching the AssistantMessage that
+    issued the call."""
+    message = ChatMessage(
+        role="tool",
+        content="22 C, sunny",
+        additional_kwargs={"id": "tool_msg_1", "tool_call_id": "call_get_weather_001"},
+    )
+
+    ag_ui_message = llama_index_message_to_ag_ui_message(message)
+    assert ag_ui_message.tool_call_id == "call_get_weather_001"
+
+    back = ag_ui_message_to_llama_index_message(ag_ui_message)
+    assert back.additional_kwargs.get("tool_call_id") == "call_get_weather_001"
+
+
+def test_full_history_missing_tool_call_id_raises_not_silently_orphaned():
+    """End-to-end shape from the bug report: an assistant message with a real
+    tool call id, followed by a tool message that lost its tool_call_id
+    (e.g. dropped by a memory backend on serialize/restore). Converting the
+    full history must fail loudly instead of producing a ToolMessage whose
+    tool_call_id doesn't match the AssistantMessage's tool call id."""
+    history = [
+        ChatMessage(
+            role="assistant",
+            content="",
+            additional_kwargs={
+                "id": "asst_msg_1",
+                "ag_ui_tool_calls": [
+                    {"id": "call_get_weather_001", "name": "get_weather", "arguments": '{"city": "Paris"}'}
+                ],
+            },
+        ),
+        ChatMessage(
+            role="tool",
+            content="22 C, sunny",
+            additional_kwargs={"id": "tool_msg_1"},  # tool_call_id dropped
+        ),
+    ]
+
+    llama_index_message_to_ag_ui_message(history[0])  # assistant message converts fine
+    with pytest.raises(ValueError, match="tool_call_id"):
+        llama_index_message_to_ag_ui_message(history[1])


### PR DESCRIPTION
## What

`llama_index_message_to_ag_ui_message()`'s tool-message branch reads `tool_call_id` from `additional_kwargs` with a `str(uuid.uuid4())` default:

```python
tool_call_id=message.additional_kwargs.get("tool_call_id", str(uuid.uuid4())),
```

A `role="tool"` `ChatMessage` that lacks `tool_call_id` (a `BaseMemory` backend dropping `additional_kwargs` on serialize/restore, custom step synthesis re-creating `ChatMessage`s without copying it, user-supplied initial history, etc.) silently gets a random id substituted in instead. That id has no relationship to any prior `AssistantMessage.tool_calls[*].id`, so the resulting `ToolMessage` in the AG-UI snapshot pairs with nothing. Providers like OpenAI/Anthropic reject that message history shape outright (`tool_use_id ... has no matching tool_use_id`), and since `ag_ui_message_to_llama_index_message` reads the fabricated id straight back into `chat_history` on the next turn, the orphan persists across turns instead of surfacing once and getting noticed.

## Fix

Raise a clear `ValueError` when `tool_call_id` is missing, the same way this function already raises for an unrecognized message role, instead of silently constructing a `ToolMessage` that's guaranteed to break the next LLM call.

## Testing

Verified against the exact repro in #22068: on the old code, converting a tool message without `tool_call_id` produces a `uuid4` that doesn't match the assistant's real tool call id (no error, no log); with the fix, it raises immediately at the point where the bad shape is introduced, rather than downstream at the LLM API call.

Added three tests to `tests/test_utils.py`:
- `test_tool_message_missing_tool_call_id_raises` -- the direct regression case
- `test_tool_message_with_tool_call_id_round_trips` -- confirms the normal (valid) path still works and round-trips through `ag_ui_message_to_llama_index_message` correctly
- `test_full_history_missing_tool_call_id_raises_not_silently_orphaned` -- the full history shape from the bug report (assistant message with a real tool call id, followed by a tool message that lost its `tool_call_id`)

Ran all three against the pre-fix code first to confirm they reproduce the exact silent-fabrication behavior described in #22068, then against the fix to confirm they pass.

Fixes #22068
