### PR TITLE
fix(google-genai): reset part per block so empty blocks don't duplicate the previous Part

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -349,8 +349,8 @@ async def chat_message_to_gemini(
     unique_tool_calls = []
     parts = []
     file_api_names = []
-    part = None
     for index, block in enumerate(message.blocks):
+        part = None
         file_api_name = None
 
         if isinstance(block, TextBlock):

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.6"
+version = "0.9.7"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -28,6 +28,7 @@ from llama_index.llms.google_genai.utils import (
     create_file_part,
     prepare_chat_params,
     chat_from_gemini_response,
+    chat_message_to_gemini,
 )
 
 
@@ -2096,3 +2097,47 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_chat_message_to_gemini_empty_text_block_not_duplicated() -> None:
+    """An empty TextBlock must not re-emit the previous block's Part.
+
+    `part` was initialized once before the block loop, so a block that produces
+    no Part (empty TextBlock / empty ThinkingBlock) left the previous Part in
+    place and the unconditional append duplicated it.
+    """
+    message = ChatMessage(
+        role=MessageRole.USER,
+        blocks=[TextBlock(text="hello"), TextBlock(text="")],
+    )
+
+    content, _ = await chat_message_to_gemini(message)
+
+    assert [part.text for part in content.parts] == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_chat_message_to_gemini_empty_block_between_content_not_duplicated() -> (
+    None
+):
+    """A reasoning + empty-text + tool-call turn (the exact shape streaming
+    providers emit for a reasoning+tool-call response) must yield one Part per
+    non-empty block, not a duplicated thought.
+    """
+    message = ChatMessage(
+        role=MessageRole.MODEL,
+        blocks=[
+            ThinkingBlock(content="let me think"),
+            TextBlock(text=""),
+            ToolCallBlock(tool_name="get_weather", tool_kwargs={"city": "SF"}),
+        ],
+    )
+
+    content, _ = await chat_message_to_gemini(message)
+
+    assert len(content.parts) == 2
+    assert content.parts[0].text == "let me think"
+    assert content.parts[0].thought is True
+    assert content.parts[1].function_call is not None
+    assert content.parts[1].function_call.name == "get_weather"


### PR DESCRIPTION
### Root cause

`chat_message_to_gemini` (`llama-index-llms-google-genai/.../utils.py`) initialized `part = None` **once before** the block loop. A block that produces no Part — an empty `TextBlock`, or a `ThinkingBlock` with empty content — skips every branch that reassigns `part`, so the unconditional `if part is not None: parts.append(part)` at the bottom of the loop **re-appends the previous block's Part**. On a `MessageRole.MODEL` message it also overwrites that stale Part's `thought_signature` by index, so both appended references end up corrupted.

This fires on the exact shape streaming providers emit for a reasoning + tool-call turn — a `ThinkingBlock`, an empty `TextBlock` (providers append `TextBlock(text="")` even when content is empty), then a `ToolCallBlock`. Feeding that assistant message back into a Gemini turn duplicates the thought Part in the request sent to the API.

### Fix

Move `part = None` to the top of each loop iteration so a block that yields nothing appends nothing. One line.

### Verified (clean Docker container, python:3.12-slim; llama-index-core + google-genai SDK, integration selected via PYTHONPATH, `__file__` provenance-checked)

- On `main` (67514f63): `[Thinking("let me think"), TextBlock(""), ToolCall("get_weather")]` -> **3 parts** (`let me think` duplicated); `[TextBlock("hello"), TextBlock("")]` -> **2 parts** (`hello` duplicated).
- On the branch: **2 parts** and **1 part** respectively; the empty block contributes nothing.

Two regression tests on `chat_message_to_gemini` fail on main and pass on the branch. Full `test_llms_google_genai.py` stays green (29 passed / 42 skipped, skips need live API); ruff check + format clean on the changed lines. Package version bumped 0.9.6 -> 0.9.7.

### Note

A maintainer could argue empty `TextBlock`s "shouldn't happen," but they demonstrably do in cross-provider agent histories (streaming reasoning+tool-call turns produce them), which is the trigger here.
