### PR TITLE
fix(docs): read group conversation JSON as utf-8

### DIFF
--- a/docs/examples/discover_llamaindex/document_management/group_conversations.py
+++ b/docs/examples/discover_llamaindex/document_management/group_conversations.py
@@ -27,7 +27,7 @@ class Message:
 
 
 data_file = sys.argv[1]
-with open(data_file, "r") as f:
+with open(data_file, "r", encoding="utf-8") as f:
     data = json.load(f)
 
 messages = {}
@@ -74,7 +74,7 @@ for msg in messages.values():
         if is_thread:
             convo_docs.append({"thread": convo, "metadata": metadata})
 
-with open("conversation_docs.json", "w") as f:
+with open("conversation_docs.json", "w", encoding="utf-8") as f:
     json.dump(convo_docs, f)
 
 print("Done! Written to conversation_docs.json")


### PR DESCRIPTION
## Summary
- Adds explicit UTF-8 encoding when the `group_conversations.py` docs example reads exported message JSON and writes `conversation_docs.json`.

## Problem
The example processes conversation exports, which can contain multilingual author names and message text. Without an explicit encoding, Python falls back to the host locale, so the example can fail or decode text incorrectly on non-UTF-8 Windows/locales.

## Before / after
Before: `open(data_file, "r")` and `open("conversation_docs.json", "w")` used the platform default encoding.

After: both text-mode file operations use `encoding="utf-8"`, making the example deterministic across platforms.

## Verification
- `python -m py_compile docs/examples/discover_llamaindex/document_management/group_conversations.py`
- Ran the script against a small UTF-8 conversation export containing Japanese text and verified that `conversation_docs.json` was produced successfully.
- `git diff --check`