### PR TITLE
fix(tools-mcp): preserve inline nested object properties in create_model_from_json_schema

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -93,6 +93,13 @@ class TypeResolutionMixin:
             return self._create_list_type(schema, defs)
         if self._is_simple_object(schema):
             return self._create_dict_type(schema, defs)
+        # Handle inline nested objects: type=object with named properties but no
+        # additionalProperties. Without this branch, such schemas fell through to
+        # json_type_mapping["object"] (bare Dict), silently dropping all nested
+        # field definitions. See: https://github.com/run-llama/llama_index/issues/22141
+        if json_type == "object" and "properties" in schema:
+            model_name = schema.get("title") or f"InlineModel_{id(schema)}"
+            return self._create_model(schema, model_name, defs)
         return json_type_mapping.get(json_type, str)
 
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -777,3 +777,102 @@ async def test_aget_tools_from_mcp_url_propagates_combined_params(
     # Verify merged params
     assert add_tool.partial_params == {"a": 1.0, "user_id": "global", "b": 2.0}
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+# --- Regression tests for GH-22141 ---
+
+
+def test_create_model_from_json_schema_preserves_inline_nested_object(
+    client: BasicMCPClient,
+):
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22141
+
+    create_model_from_json_schema must build a structured Pydantic model for inline
+    nested objects (type: object with properties, but no $ref/$defs entry).
+    Previously, such schemas fell through to json_type_mapping["object"] (bare Dict),
+    silently stripping all nested field definitions.
+    """
+    from pydantic import BaseModel
+
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+    schema = {
+        "properties": {
+            "nested": {
+                "properties": {"value": {"title": "Value", "type": "string"}},
+                "required": ["value"],
+                "type": "object",
+            },
+        },
+        "required": ["nested"],
+        "type": "object",
+    }
+    model = tool_spec.create_model_from_json_schema(schema)
+
+    assert "nested" in model.model_fields, "Expected 'nested' field in model"
+    nested_annotation = model.model_fields["nested"].annotation
+
+    # The nested field must be a Pydantic BaseModel, NOT a bare Dict
+    assert issubclass(nested_annotation, BaseModel), (
+        f"Expected a Pydantic BaseModel for inline nested object, got {nested_annotation}. "
+        "This means inline nested object properties were dropped (GH-22141)."
+    )
+
+    # The nested model must expose the inner fields
+    assert "value" in nested_annotation.model_fields, (
+        "Expected 'value' field preserved in nested Pydantic model"
+    )
+
+
+def test_create_model_from_json_schema_inline_and_ref_both_structured(
+    client: BasicMCPClient,
+):
+    """
+    Verify that an inline nested object and a $ref-based nested object both produce
+    a structured Pydantic BaseModel field, ensuring parity between the two approaches.
+    """
+    from pydantic import BaseModel
+
+    tool_spec = McpToolSpec(client, allowed_tools=[])
+
+    # Case 1: inline nested object (the previously-broken path)
+    inline_schema = {
+        "properties": {
+            "nested": {
+                "properties": {"value": {"title": "Value", "type": "string"}},
+                "required": ["value"],
+                "type": "object",
+            },
+        },
+        "required": ["nested"],
+        "type": "object",
+    }
+    inline_model = tool_spec.create_model_from_json_schema(inline_schema)
+    inline_nested_type = inline_model.model_fields["nested"].annotation
+    assert issubclass(inline_nested_type, BaseModel), (
+        f"Inline nested object should produce a BaseModel, got {inline_nested_type}"
+    )
+
+    # Case 2: $ref-based nested object (the previously-working path)
+    tool_spec2 = McpToolSpec(client, allowed_tools=[])
+    ref_schema = {
+        "$defs": {
+            "Inner": {
+                "properties": {"value": {"title": "Value", "type": "string"}},
+                "required": ["value"],
+                "title": "Inner",
+                "type": "object",
+            },
+        },
+        "properties": {
+            "nested": {"$ref": "#/$defs/Inner"},
+        },
+        "required": ["nested"],
+        "type": "object",
+    }
+    ref_model = tool_spec2.create_model_from_json_schema(ref_schema)
+    ref_nested_type = ref_model.model_fields["nested"].annotation
+    assert issubclass(ref_nested_type, BaseModel), (
+        f"$ref-based nested object should produce a BaseModel, got {ref_nested_type}"
+    )
+


### PR DESCRIPTION
## Summary

Fixes **#22141**: `McpToolSpec.create_model_from_json_schema` silently collapses inline nested objects (schemas with `type: object` + `properties` but no `$ref`/`$defs` entry) into a bare `Dict`, discarding all inner field definitions.

> **Note:** This is a focused re-submission of the fix from #22289. Per the reviewer's feedback in that PR, the unrelated `timeout=60.0` changes across other integrations have been split out so this PR contains only the two files directly related to the bug fix.

---

## Root Cause

`_resolve_basic_type` has two guards for object schemas:

1. `_is_simple_object(schema)` — fires when `additionalProperties` is present and is a dict → `_create_dict_type`
2. Final fallback: `json_type_mapping.get("object")` → bare `Dict`

An inline nested object like:

```json
{
  "type": "object",
  "properties": {"value": {"type": "string"}},
  "required": ["value"]
}
```

has `properties` but neither `$ref` nor `additionalProperties`, so it falls all the way through to `json_type_mapping["object"]` → `Dict` — silently dropping all nested field definitions.

---

## Fix

Add an explicit guard in `_resolve_basic_type` between the `_is_simple_object` check and the final type-mapping fallback (7 lines added, 0 deleted):

```python
# Handle inline nested objects: type=object with named properties but no
# additionalProperties. Without this branch, such schemas fell through to
# json_type_mapping["object"] (bare Dict), silently dropping all nested
# field definitions. See: https://github.com/run-llama/llama_index/issues/22141
if json_type == "object" and "properties" in schema:
    model_name = schema.get("title") or f"InlineModel_{id(schema)}"
    return self._create_model(schema, model_name, defs)
```

This delegates to `_create_model` — the same recursive code path already used for `$ref`-resolved models — ensuring inline and `$ref`-based nested objects produce equivalent typed Pydantic `BaseModel` subclasses.

---

## Verification

**Before:**
```python
model = tool_spec.create_model_from_json_schema(schema)
print(model.model_fields["nested"].annotation)  # typing.Dict  ❌
```

**After:**
```python
nested_type = model.model_fields["nested"].annotation
assert issubclass(nested_type, BaseModel)    # ✅
assert "value" in nested_type.model_fields   # ✅ field preserved
```

---

## Tests Added

Two regression tests in `tests/test_tools_mcp.py`:

- `test_create_model_from_json_schema_preserves_inline_nested_object` — directly verifies the broken path: inline nested object field annotation is a `BaseModel` subclass (not `Dict`) and exposes the inner fields.
- `test_create_model_from_json_schema_inline_and_ref_both_structured` — cross-validates that inline nested objects and `$ref`-based nested objects produce equivalent structured results, ensuring parity between the two resolution paths.
