### PR TITLE
fix(anthropic): preserve cache_creation/cache_read tokens in streamed usage metadata

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -504,6 +504,8 @@ class Anthropic(FunctionCallingLLM):
             # Track usage metadata and stop_reason from RawMessage events
             usage_metadata: Dict[str, Any] = {}
             input_tokens: Optional[int] = None
+            cache_creation_input_tokens: Optional[int] = None
+            cache_read_input_tokens: Optional[int] = None
             stop_reason: Optional[str] = None
             for r in response:
                 thinking_delta = ""
@@ -647,11 +649,21 @@ class Anthropic(FunctionCallingLLM):
                 elif isinstance(r, RawMessageStartEvent):
                     # Capture initial usage metadata from message_start
                     if hasattr(r.message, "usage") and r.message.usage:
-                        # Save input tokens for later
+                        # Save input and cache tokens for later. Anthropic only
+                        # reports the cache token counts on message_start, so we
+                        # carry them forward onto the message_delta usage below.
                         input_tokens = r.message.usage.input_tokens
+                        cache_creation_input_tokens = getattr(
+                            r.message.usage, "cache_creation_input_tokens", None
+                        )
+                        cache_read_input_tokens = getattr(
+                            r.message.usage, "cache_read_input_tokens", None
+                        )
                         usage_metadata = {
                             "input_tokens": r.message.usage.input_tokens,
                             "output_tokens": r.message.usage.output_tokens,
+                            "cache_creation_input_tokens": cache_creation_input_tokens,
+                            "cache_read_input_tokens": cache_read_input_tokens,
                         }
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
@@ -661,6 +673,14 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.usage.input_tokens,
                             "output_tokens": r.usage.output_tokens,
+                            "cache_creation_input_tokens": getattr(
+                                r.usage, "cache_creation_input_tokens", None
+                            )
+                            or cache_creation_input_tokens,
+                            "cache_read_input_tokens": getattr(
+                                r.usage, "cache_read_input_tokens", None
+                            )
+                            or cache_read_input_tokens,
                         }
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason
@@ -761,6 +781,8 @@ class Anthropic(FunctionCallingLLM):
             # Track usage metadata and stop_reason from RawMessage events
             usage_metadata: Dict[str, Any] = {}
             input_tokens: Optional[int] = None
+            cache_creation_input_tokens: Optional[int] = None
+            cache_read_input_tokens: Optional[int] = None
             stop_reason: Optional[str] = None
             async for r in response:
                 thinking_delta = ""
@@ -904,11 +926,21 @@ class Anthropic(FunctionCallingLLM):
                 elif isinstance(r, RawMessageStartEvent):
                     # Capture initial usage metadata from message_start
                     if hasattr(r.message, "usage") and r.message.usage:
-                        # Save input tokens for later
+                        # Save input and cache tokens for later. Anthropic only
+                        # reports the cache token counts on message_start, so we
+                        # carry them forward onto the message_delta usage below.
                         input_tokens = r.message.usage.input_tokens
+                        cache_creation_input_tokens = getattr(
+                            r.message.usage, "cache_creation_input_tokens", None
+                        )
+                        cache_read_input_tokens = getattr(
+                            r.message.usage, "cache_read_input_tokens", None
+                        )
                         usage_metadata = {
                             "input_tokens": r.message.usage.input_tokens,
                             "output_tokens": r.message.usage.output_tokens,
+                            "cache_creation_input_tokens": cache_creation_input_tokens,
+                            "cache_read_input_tokens": cache_read_input_tokens,
                         }
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
@@ -918,6 +950,14 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.usage.input_tokens,
                             "output_tokens": r.usage.output_tokens,
+                            "cache_creation_input_tokens": getattr(
+                                r.usage, "cache_creation_input_tokens", None
+                            )
+                            or cache_creation_input_tokens,
+                            "cache_read_input_tokens": getattr(
+                                r.usage, "cache_read_input_tokens", None
+                            )
+                            or cache_read_input_tokens,
                         }
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -860,6 +860,150 @@ async def test_astream_chat_usage_and_stop_reason_mock():
     assert stop_reason == "max_tokens"
 
 
+def test_stream_chat_usage_includes_cache_tokens_mock():
+    """
+    Mock test for streaming cache-token usage metadata - no API key required.
+
+    Anthropic reports cache_creation_input_tokens and cache_read_input_tokens on
+    the message_start event; the message_delta usage does not repeat them. So
+    stream_chat must carry these token classes forward, the same way it already
+    carries input_tokens forward, otherwise the final usage metadata drops them
+    and only reports input_tokens/output_tokens.
+    """
+    from unittest.mock import MagicMock
+    from anthropic.types import TextDelta, Usage
+
+    mock_text_delta = MagicMock(spec=TextDelta)
+    mock_text_delta.text = "Hi"
+    mock_text_delta.type = "text_delta"
+
+    # message_start carries input, output and the cache token counts
+    mock_first_usage = MagicMock(spec=Usage)
+    mock_first_usage.input_tokens = 15
+    mock_first_usage.output_tokens = 1
+    mock_first_usage.cache_creation_input_tokens = 100
+    mock_first_usage.cache_read_input_tokens = 50
+
+    # message_delta only updates output_tokens; the cache counts are not repeated
+    mock_last_usage = MagicMock(spec=Usage)
+    mock_last_usage.input_tokens = None
+    mock_last_usage.output_tokens = 8
+    mock_last_usage.cache_creation_input_tokens = None
+    mock_last_usage.cache_read_input_tokens = None
+
+    mock_delta = MagicMock()
+    mock_delta.stop_reason = "end_turn"
+
+    def mock_stream_generator():
+        from anthropic.types import (
+            RawContentBlockDeltaEvent,
+            ContentBlockStopEvent,
+            RawMessageDeltaEvent,
+            RawMessageStartEvent,
+            Message,
+        )
+
+        yield MagicMock(
+            spec=RawMessageStartEvent,
+            message=MagicMock(spec=Message, usage=mock_first_usage),
+        )
+        yield MagicMock(spec=RawContentBlockDeltaEvent, delta=mock_text_delta, index=0)
+        yield MagicMock(spec=ContentBlockStopEvent, index=0)
+        yield MagicMock(
+            spec=RawMessageDeltaEvent,
+            usage=mock_last_usage,
+            delta=mock_delta,
+        )
+
+    llm = Anthropic(model="claude-sonnet-4-5")
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_stream_generator()
+    llm._client = mock_client
+
+    messages = [ChatMessage(role="user", content="Test message")]
+    chunks = list(llm.stream_chat(messages))
+
+    assert len(chunks) > 0, "Should yield at least one chunk"
+    usage = chunks[-1].message.additional_kwargs.get("usage")
+    assert usage is not None, "Usage metadata should be captured"
+    assert usage["input_tokens"] == 15
+    assert usage["output_tokens"] == 8
+    # Cache token counts from message_start survive into the final usage metadata
+    assert usage["cache_creation_input_tokens"] == 100
+    assert usage["cache_read_input_tokens"] == 50
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_usage_includes_cache_tokens_mock():
+    """
+    Async version of test_stream_chat_usage_includes_cache_tokens_mock.
+    """
+    from unittest.mock import MagicMock, AsyncMock
+    from anthropic.types import TextDelta, Usage
+
+    mock_text_delta = MagicMock(spec=TextDelta)
+    mock_text_delta.text = "Hi async"
+    mock_text_delta.type = "text_delta"
+
+    mock_first_usage = MagicMock(spec=Usage)
+    mock_first_usage.input_tokens = 20
+    mock_first_usage.output_tokens = 1
+    mock_first_usage.cache_creation_input_tokens = 200
+    mock_first_usage.cache_read_input_tokens = 75
+
+    mock_last_usage = MagicMock(spec=Usage)
+    mock_last_usage.input_tokens = None
+    mock_last_usage.output_tokens = 12
+    mock_last_usage.cache_creation_input_tokens = None
+    mock_last_usage.cache_read_input_tokens = None
+
+    mock_delta = MagicMock()
+    mock_delta.stop_reason = "end_turn"
+
+    async def mock_async_stream_generator():
+        from anthropic.types import (
+            RawContentBlockDeltaEvent,
+            ContentBlockStopEvent,
+            RawMessageDeltaEvent,
+            RawMessageStartEvent,
+            Message,
+        )
+
+        yield MagicMock(
+            spec=RawMessageStartEvent,
+            message=MagicMock(spec=Message, usage=mock_first_usage),
+        )
+        yield MagicMock(spec=RawContentBlockDeltaEvent, delta=mock_text_delta, index=0)
+        yield MagicMock(spec=ContentBlockStopEvent, index=0)
+        yield MagicMock(
+            spec=RawMessageDeltaEvent,
+            usage=mock_last_usage,
+            delta=mock_delta,
+        )
+
+    llm = Anthropic(model="claude-sonnet-4-5")
+    mock_async_client = AsyncMock()
+    mock_async_client.messages.create = AsyncMock(
+        return_value=mock_async_stream_generator()
+    )
+    llm._aclient = mock_async_client
+
+    messages = [ChatMessage(role="user", content="Test async message")]
+    stream_resp = await llm.astream_chat(messages)
+
+    chunks = []
+    async for chunk in stream_resp:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0, "Should yield at least one chunk"
+    usage = chunks[-1].message.additional_kwargs.get("usage")
+    assert usage is not None, "Usage metadata should be captured in async streaming"
+    assert usage["input_tokens"] == 20
+    assert usage["output_tokens"] == 12
+    assert usage["cache_creation_input_tokens"] == 200
+    assert usage["cache_read_input_tokens"] == 75
+
+
 @pytest.mark.skipif(
     os.getenv("ANTHROPIC_API_KEY") is None,
     reason="Anthropic API key not available to test streaming metadata",


### PR DESCRIPTION
# Description

`Anthropic.stream_chat` and `astream_chat` report token usage on each streamed
chunk via `message.additional_kwargs["usage"]`. That dict was built with only
`input_tokens` and `output_tokens`, so the two cache token classes this adapter's
own prompt caching produces, `cache_creation_input_tokens` and
`cache_read_input_tokens`, never reached callers. Anthropic reports those counts
on the `message_start` event and does not repeat them on `message_delta`; the
delta handler rebuilds `usage_metadata` from scratch, so even the value seen at
start was discarded by the final chunk.

Invariant: reported usage metadata must reflect every token class the API
returned. (The non-streaming `chat`/`achat` path is a separate gap, it attaches
no usage at all, and is intentionally left out to keep this to one concern.)

Fix: capture the two cache token counts at `message_start` and carry them
forward onto the `message_delta` usage, mirroring the existing `input_tokens`
carry-forward. `getattr(..., None)` keeps it safe if an SDK event omits a field.
Applied symmetrically to the sync and async generators.

Fixes # (no tracked issue; self-reported)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (llama-index-llms-anthropic 0.11.8 to 0.11.9)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_stream_chat_usage_includes_cache_tokens_mock` and its async twin.
Each drives a mocked stream where `message_start` carries the cache tokens and
`message_delta` does not, then asserts the final chunk's usage still reports
them. Verified in a clean Docker container (python:3.11-slim, anthropic 0.116.0):
the new tests fail on current main with `KeyError: 'cache_creation_input_tokens'`
and pass on this branch; the full package suite is green (48 passed, 15 skipped
where a live API key is required). `ruff format` reports no changes and the new
code adds no new `ruff check` findings.

Not verified: I did not exercise this against the live Anthropic API. The mocked
stream matches the SDK event and usage types (anthropic>=0.75.0) the code already
relies on.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran ruff format and ruff check on the changed files

This change was written with AI assistance and verified by me before opening.
