### PR TITLE
fix: prevent orphaned embedding API calls in aget_text_embedding_batch

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import contextvars
 import concurrent.futures
 from itertools import zip_longest
-from typing import Any, Coroutine, Iterable, List, Optional, TypeVar
+from typing import Any, Callable, Coroutine, Iterable, List, Optional, TypeVar
 
 import llama_index.core.instrumentation as instrument
 
@@ -133,6 +133,70 @@ async def batch_gather(
 DEFAULT_NUM_WORKERS = 4
 
 T = TypeVar("T")
+
+
+async def _await_or_return_exception(coro: Coroutine[Any, Any, T]) -> Any:
+    """
+    Await a coroutine, returning any raised exception instead of propagating it.
+
+    Used by ``gather_with_bounded_lifetime`` to ensure that when several
+    coroutines are run concurrently, a single failure does not leave sibling
+    coroutines running unsupervised in the background. ``asyncio.CancelledError``
+    is re-raised immediately rather than captured, to preserve cooperative
+    cancellation semantics.
+    """
+    try:
+        return await coro
+    except asyncio.CancelledError:
+        raise
+    except BaseException as e:
+        return e
+
+
+async def gather_with_bounded_lifetime(
+    coros: List[Coroutine[Any, Any, T]],
+    gather_fn: Callable[..., Coroutine[Any, Any, List[Any]]] = asyncio.gather,
+    **gather_kwargs: Any,
+) -> List[T]:
+    """
+    Run coroutines concurrently via ``gather_fn`` without orphaning siblings on failure.
+
+    A bare ``asyncio.gather(*coros)`` raises as soon as one coroutine fails,
+    while any other coroutines that were already scheduled keep running
+    detached in the background with nothing left to await or cancel them. This
+    function instead waits for every coroutine to actually finish before
+    raising, so the lifetime of the whole batch stays bounded to the call that
+    spawned it: by the time this function returns (or raises), nothing it
+    started is still running.
+
+    Args:
+        coros: List of coroutines to run concurrently.
+        gather_fn: The gather implementation to use, e.g. ``asyncio.gather``
+            (the default) or ``tqdm.asyncio.tqdm_asyncio.gather``. Must accept
+            the wrapped coroutines as positional arguments plus arbitrary
+            keyword arguments, and return results in call order.
+        **gather_kwargs: Additional keyword arguments forwarded to
+            ``gather_fn`` (e.g. ``desc``/``total`` for a tqdm-based gather).
+
+    Returns:
+        List of results, in the same order as ``coros``.
+
+    Raises:
+        The first exception raised by any coroutine in ``coros``, once all
+        coroutines have completed.
+
+    """
+    if not coros:
+        return []
+
+    wrapped = [_await_or_return_exception(c) for c in coros]
+    results = await gather_fn(*wrapped, **gather_kwargs)
+
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+
+    return results
 
 
 @dispatcher.span

--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -1,6 +1,5 @@
 """Base embeddings file."""
 
-import asyncio
 import uuid
 from abc import abstractmethod
 from enum import Enum
@@ -21,7 +20,7 @@ from llama_index.core.constants import (
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.schema import BaseNode, MetadataMode, TransformComponent
 from llama_index.core.utils import get_tqdm_iterable
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import gather_with_bounded_lifetime, run_jobs
 
 # TODO: change to numpy array
 Embedding = List[float]
@@ -303,8 +302,8 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
 
         Subclasses can implement this method if batch queries are supported.
         """
-        return await asyncio.gather(
-            *[self._aget_text_embedding(text) for text in texts]
+        return await gather_with_bounded_lifetime(
+            [self._aget_text_embedding(text) for text in texts]
         )
 
     async def _aget_text_embeddings_rate_limited(
@@ -577,7 +576,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
 
                 cur_batch = []
 
-        # flatten the results of asyncio.gather, which is a list of embeddings lists
+        # flatten the results of gather_with_bounded_lifetime, which is a list of embeddings lists
         if len(embeddings_coroutines) > 0:
             if num_workers and num_workers > 1:
                 nested_embeddings = await run_jobs(
@@ -590,15 +589,20 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 try:
                     from tqdm.asyncio import tqdm_asyncio
 
-                    nested_embeddings = await tqdm_asyncio.gather(
-                        *embeddings_coroutines,
+                    nested_embeddings = await gather_with_bounded_lifetime(
+                        embeddings_coroutines,
+                        gather_fn=tqdm_asyncio.gather,
                         total=len(embeddings_coroutines),
                         desc="Generating embeddings",
                     )
                 except ImportError:
-                    nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+                    nested_embeddings = await gather_with_bounded_lifetime(
+                        embeddings_coroutines
+                    )
             else:
-                nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+                nested_embeddings = await gather_with_bounded_lifetime(
+                    embeddings_coroutines
+                )
         else:
             nested_embeddings = []
 

--- a/llama-index-core/llama_index/core/base/embeddings/base_sparse.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base_sparse.py
@@ -1,6 +1,5 @@
 """Base sparse embeddings file."""
 
-import asyncio
 import math
 from abc import abstractmethod
 from collections import defaultdict
@@ -20,7 +19,7 @@ from llama_index.core.instrumentation.events.embedding import (
 )
 import llama_index.core.instrumentation as instrument
 from llama_index.core.utils import get_tqdm_iterable
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import gather_with_bounded_lifetime, run_jobs
 
 
 dispatcher = instrument.get_dispatcher(__name__)
@@ -209,8 +208,8 @@ class BaseSparseEmbedding(BaseModel, DispatcherSpanMixin):
 
         Subclasses can implement this method if batch queries are supported.
         """
-        return await asyncio.gather(
-            *[self._aget_text_embedding(text) for text in texts]
+        return await gather_with_bounded_lifetime(
+            [self._aget_text_embedding(text) for text in texts]
         )
 
     @dispatcher.span
@@ -319,7 +318,7 @@ class BaseSparseEmbedding(BaseModel, DispatcherSpanMixin):
                 embeddings_coroutines.append(self._aget_text_embeddings(cur_batch))
                 cur_batch = []
 
-        # flatten the results of asyncio.gather, which is a list of embeddings lists
+        # flatten the results of gather_with_bounded_lifetime, which is a list of embeddings lists
         nested_embeddings = []
 
         if num_workers and num_workers > 1:
@@ -334,15 +333,20 @@ class BaseSparseEmbedding(BaseModel, DispatcherSpanMixin):
                 try:
                     from tqdm.asyncio import tqdm_asyncio
 
-                    nested_embeddings = await tqdm_asyncio.gather(
-                        *embeddings_coroutines,
+                    nested_embeddings = await gather_with_bounded_lifetime(
+                        embeddings_coroutines,
+                        gather_fn=tqdm_asyncio.gather,
                         total=len(embeddings_coroutines),
                         desc="Generating embeddings",
                     )
                 except ImportError:
-                    nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+                    nested_embeddings = await gather_with_bounded_lifetime(
+                        embeddings_coroutines
+                    )
             else:
-                nested_embeddings = await asyncio.gather(*embeddings_coroutines)
+                nested_embeddings = await gather_with_bounded_lifetime(
+                    embeddings_coroutines
+                )
 
         result_embeddings = [
             embedding for embeddings in nested_embeddings for embedding in embeddings

--- a/llama-index-core/tests/embeddings/test_base.py
+++ b/llama-index-core/tests/embeddings/test_base.py
@@ -1,11 +1,51 @@
 """Embeddings."""
 
-from typing import Any, List
+import asyncio
+from typing import Any, List, Set
 from unittest.mock import patch
 import pytest
 
-from llama_index.core.base.embeddings.base import SimilarityMode, mean_agg
+from llama_index.core.base.embeddings.base import (
+    BaseEmbedding,
+    SimilarityMode,
+    mean_agg,
+)
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+
+
+class FlakyEmbedding(BaseEmbedding):
+    """
+    Embedding model whose async text-embedding calls can be made to fail for
+    specific texts, and which records which texts actually finished. Used to
+    verify that a failure in one text embedding doesn't leave sibling
+    in-flight embedding calls orphaned (see #22312).
+    """
+
+    _fail_texts: Set[str] = PrivateAttr(default_factory=set)
+    _completed: List[str] = PrivateAttr(default_factory=list)
+    _delay: float = PrivateAttr(default=0.2)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "FlakyEmbedding"
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return [0.0]
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return [0.0]
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return [0.0]
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        if text in self._fail_texts:
+            await asyncio.sleep(0.01)
+            raise ValueError(f"embedding API rejected: {text}")
+        await asyncio.sleep(self._delay)
+        self._completed.append(text)
+        return [0.1, 0.2, 0.3]
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -100,3 +140,62 @@ def test_mean_agg_empty_list() -> None:
     """Test mean aggregation raises ValueError for empty list."""
     with pytest.raises(ValueError, match="No embeddings to aggregate"):
         mean_agg([])
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embeddings_no_orphaned_siblings_on_failure() -> None:
+    """
+    Regression test for #22312 (Level 1: _aget_text_embeddings).
+
+    A single failing text embedding must not leave sibling in-flight
+    embedding calls orphaned. By the time the exception propagates, every
+    other text in the same sub-batch must have already finished.
+    """
+    embed_model = FlakyEmbedding()
+    embed_model._fail_texts = {"doc chunk 2 with policy-violating content"}
+    batch = [
+        "doc chunk 1",
+        "doc chunk 2 with policy-violating content",
+        "doc chunk 3",
+    ]
+
+    with pytest.raises(ValueError, match="doc chunk 2"):
+        await embed_model._aget_text_embeddings(batch)
+
+    assert sorted(embed_model._completed) == ["doc chunk 1", "doc chunk 3"]
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embedding_batch_no_orphaned_siblings_on_failure() -> None:
+    """
+    Regression test for #22312 (Level 2: aget_text_embedding_batch, plain
+    asyncio.gather branch, i.e. show_progress=False and num_workers<=1).
+
+    A failure in one sub-batch must not leave sibling sub-batches (and the
+    in-flight embedding calls within them) orphaned.
+    """
+    embed_model = FlakyEmbedding(embed_batch_size=2)
+    embed_model._fail_texts = {"bad text"}
+    texts = ["ok 1", "bad text", "ok 2", "ok 3"]
+
+    with pytest.raises(ValueError, match="bad text"):
+        await embed_model.aget_text_embedding_batch(texts, show_progress=False)
+
+    assert sorted(embed_model._completed) == ["ok 1", "ok 2", "ok 3"]
+
+
+@pytest.mark.asyncio
+async def test_aget_text_embedding_batch_show_progress_no_orphaned_siblings() -> None:
+    """
+    Regression test for #22312 (Level 2: aget_text_embedding_batch,
+    show_progress=True branch, which uses tqdm_asyncio.gather or its
+    ImportError fallback).
+    """
+    embed_model = FlakyEmbedding(embed_batch_size=2)
+    embed_model._fail_texts = {"bad text"}
+    texts = ["ok 1", "bad text", "ok 2", "ok 3"]
+
+    with pytest.raises(ValueError, match="bad text"):
+        await embed_model.aget_text_embedding_batch(texts, show_progress=True)
+
+    assert sorted(embed_model._completed) == ["ok 1", "ok 2", "ok 3"]

--- a/llama-index-core/tests/sparse_embeddings/test_mock_sparse_embeddings.py
+++ b/llama-index-core/tests/sparse_embeddings/test_mock_sparse_embeddings.py
@@ -1,6 +1,46 @@
+import asyncio
+from typing import List, Set
+
 import pytest
 
+from llama_index.core.base.embeddings.base_sparse import BaseSparseEmbedding
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.sparse_embeddings.mock_sparse_embedding import MockSparseEmbedding
+
+
+class FlakySparseEmbedding(BaseSparseEmbedding):
+    """
+    Sparse embedding model whose async text-embedding calls can be made to
+    fail for specific texts, and which records which texts actually
+    finished. Used to verify that a failure in one text embedding doesn't
+    leave sibling in-flight embedding calls orphaned (see #22312).
+    """
+
+    _fail_texts: Set[str] = PrivateAttr(default_factory=set)
+    _completed: List[str] = PrivateAttr(default_factory=list)
+    _delay: float = PrivateAttr(default=0.2)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "FlakySparseEmbedding"
+
+    def _get_query_embedding(self, query: str):
+        return {0: 0.0}
+
+    async def _aget_query_embedding(self, query: str):
+        return {0: 0.0}
+
+    def _get_text_embedding(self, text: str):
+        return {0: 0.0}
+
+    async def _aget_text_embedding(self, text: str):
+        if text in self._fail_texts:
+            await asyncio.sleep(0.01)
+            raise ValueError(f"embedding API rejected: {text}")
+        await asyncio.sleep(self._delay)
+        self._completed.append(text)
+        return {0: 0.1}
+
 
 text_embedding_map = {
     "hello": {0: 0.25},
@@ -77,3 +117,36 @@ async def test_aggregate_embeddings_async(mock_sparse_embedding: MockSparseEmbed
     queries = ["hello", "world"]
     embedding = await mock_sparse_embedding.aget_agg_embedding_from_queries(queries)
     assert embedding == {0: 0.125, 1: 0.25}
+
+
+@pytest.mark.asyncio
+async def test_sparse_aget_text_embeddings_no_orphaned_siblings_on_failure() -> None:
+    """
+    Regression test for #22312 (Level 1: _aget_text_embeddings, sparse variant).
+    """
+    embed_model = FlakySparseEmbedding()
+    embed_model._fail_texts = {"bad text"}
+    batch = ["ok 1", "bad text", "ok 2"]
+
+    with pytest.raises(ValueError, match="bad text"):
+        await embed_model._aget_text_embeddings(batch)
+
+    assert sorted(embed_model._completed) == ["ok 1", "ok 2"]
+
+
+@pytest.mark.asyncio
+async def test_sparse_aget_text_embedding_batch_no_orphaned_siblings_on_failure() -> (
+    None
+):
+    """
+    Regression test for #22312 (Level 2: aget_text_embedding_batch, sparse
+    variant, plain asyncio.gather branch).
+    """
+    embed_model = FlakySparseEmbedding(embed_batch_size=2)
+    embed_model._fail_texts = {"bad text"}
+    texts = ["ok 1", "bad text", "ok 2", "ok 3"]
+
+    with pytest.raises(ValueError, match="bad text"):
+        await embed_model.aget_text_embedding_batch(texts, show_progress=False)
+
+    assert sorted(embed_model._completed) == ["ok 1", "ok 2", "ok 3"]

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,11 @@
 import asyncio
 import contextvars
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+from llama_index.core.async_utils import (
+    batch_gather,
+    asyncio_run,
+    gather_with_bounded_lifetime,
+)
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +41,104 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_all_succeed() -> None:
+    """All coroutines succeed: results are returned in call order."""
+
+    async def async_method(n: int) -> int:
+        return n
+
+    coros = [async_method(n) for n in range(5)]
+    results = await gather_with_bounded_lifetime(coros)
+    assert results == list(range(5))
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_empty_list() -> None:
+    """An empty coroutine list returns an empty list without calling gather_fn."""
+    results = await gather_with_bounded_lifetime([])
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_waits_for_siblings_before_raising() -> None:
+    """
+    Regression test for #22312: a single failing coroutine must not leave
+    sibling coroutines orphaned in the background. By the time this function
+    raises, every coroutine it started must have already finished.
+    """
+    completed: list[str] = []
+
+    async def worker(name: str, should_fail: bool, delay: float) -> str:
+        if should_fail:
+            await asyncio.sleep(0.01)
+            raise ValueError(f"failed: {name}")
+        await asyncio.sleep(delay)
+        completed.append(name)
+        return name
+
+    coros = [
+        worker("a", False, 0.2),
+        worker("b", True, 0),
+        worker("c", False, 0.2),
+    ]
+
+    with pytest.raises(ValueError, match="failed: b"):
+        await gather_with_bounded_lifetime(coros)
+
+    # If this were a bare asyncio.gather, the ValueError would propagate
+    # almost immediately (after ~0.01s), well before "a" and "c" (0.2s
+    # delay) finish - leaving them orphaned. Asserting they're already in
+    # `completed` proves gather_with_bounded_lifetime waited for them.
+    assert sorted(completed) == ["a", "c"]
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_raises_first_exception() -> None:
+    """When multiple coroutines fail, the first one (by position) is raised."""
+
+    async def fail(msg: str, delay: float) -> None:
+        await asyncio.sleep(delay)
+        raise ValueError(msg)
+
+    coros = [fail("first", 0), fail("second", 0.05)]
+
+    with pytest.raises(ValueError, match="first"):
+        await gather_with_bounded_lifetime(coros)
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_custom_gather_fn() -> None:
+    """A custom gather_fn (e.g. tqdm_asyncio.gather) is used and receives kwargs."""
+    received_kwargs = {}
+
+    async def custom_gather(*coros, **kwargs):
+        received_kwargs.update(kwargs)
+        return await asyncio.gather(*coros)
+
+    async def async_method(n: int) -> int:
+        return n
+
+    coros = [async_method(n) for n in range(3)]
+    results = await gather_with_bounded_lifetime(
+        coros, gather_fn=custom_gather, desc="test", total=3
+    )
+    assert results == [0, 1, 2]
+    assert received_kwargs == {"desc": "test", "total": 3}
+
+
+@pytest.mark.asyncio
+async def test_gather_with_bounded_lifetime_reraises_cancelled_error() -> None:
+    """CancelledError must propagate immediately, not be captured as a result."""
+
+    async def cancels_self() -> None:
+        raise asyncio.CancelledError
+
+    async def normal() -> int:
+        await asyncio.sleep(0.05)
+        return 1
+
+    with pytest.raises(asyncio.CancelledError):
+        await gather_with_bounded_lifetime([cancels_self(), normal()])


### PR DESCRIPTION
## Summary

Addresses #22312

`BaseEmbedding._aget_text_embeddings` and `aget_text_embedding_batch` (and
the equivalent `BaseSparseEmbedding` methods) fan out embedding calls with
bare `asyncio.gather` / `tqdm_asyncio.gather` at two nested levels. When one
text in a batch fails, sibling in-flight embedding API calls are left
running detached, with nothing left to await or cancel them.

## Approach

The issue and the bot analysis on it flagged two possible strategies:
`return_exceptions=True` + collect/re-raise, or a `TaskGroup`-based
cancel-on-first-failure. `TaskGroup` requires Python 3.11+, and
`llama-index-core` supports `>=3.10`, so this PR goes with the former for
default/backward compatibility.

One wrinkle: `tqdm_asyncio.gather` doesn't accept `return_exceptions` — it
uses `as_completed` internally rather than wrapping `asyncio.gather`, so the
flag has no effect there. To get consistent behavior across both, this adds
a shared `gather_with_bounded_lifetime()` helper in `async_utils.py` that
wraps each individual coroutine to capture its own exception as a return
value (instead of relying on a gather-level flag), waits for every sibling
to finish, then raises the first exception encountered.
`asyncio.CancelledError` is re-raised immediately rather than captured, to
preserve cooperative cancellation semantics.

## Changes

- **`async_utils.py`**: new `gather_with_bounded_lifetime()` +
  `_await_or_return_exception()` helper.
- **`base.py`** / **`base_sparse.py`**: replaced all three affected gather
  sites — `_aget_text_embeddings` (Level 1), and the plain-gather,
  tqdm-progress-gather, and ImportError-fallback branches of
  `aget_text_embedding_batch` (Level 2) — with the new helper. Removed the
  now-unused top-level `asyncio` import from both files.

## Out of scope

`run_jobs()` in `async_utils.py` has the same underlying gather pattern, but
it's shared by 12 other call sites outside the embeddings module (readers,
retrievers, node parsers, property-graph transformations, extractors).
Changing its exception semantics has a much wider blast radius, so it's left
as a separate follow-up rather than bundled into this fix.

## Testing

- New unit tests for `gather_with_bounded_lifetime` itself: success path,
  empty list, waits-for-siblings-before-raising (the core regression), first
  exception wins, custom `gather_fn` with kwargs, `CancelledError`
  re-raising.
- New regression tests on real `BaseEmbedding`/`BaseSparseEmbedding`
  subclasses at both levels (including the `show_progress=True` branch),
  asserting sibling texts actually complete before the exception
  propagates — not just that the call doesn't crash.
- `ruff check` / `ruff format` clean.
- `tests/embeddings/`, `tests/sparse_embeddings/`, `tests/test_async_utils.py`:
  34/34 passed.
- Broader sweep (`tests/indices/`, `tests/node_parser/`, `tests/retrievers/`):
  376 passed, 7 skipped, 6 xfailed, 0 failed.