### PR TITLE
fix(couchbase): parameterize SQL++ metadata filters in CouchbaseQueryVectorStore.query()

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/llama_index/vector_stores/couchbase/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/llama_index/vector_stores/couchbase/base.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
@@ -146,57 +146,65 @@ def _to_couchbase_filter(standard_filters: MetadataFilters) -> Dict[str, Any]:
 
 
 def _convert_llamaindex_filters_to_sql(
-    filters: MetadataFilters, metadata_key: str
-) -> str:
+    filters: MetadataFilters,
+    metadata_key: str,
+    named_parameters: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, Dict[str, Any]]:
     """
-    Convert LlamaIndex MetadataFilters to SQL++ WHERE clause.
+    Convert LlamaIndex MetadataFilters to a parameterized SQL++ WHERE clause.
+
+    Filter values are never interpolated into the query string. Each value is
+    bound to a named parameter (e.g. $metadata_filter_0) and returned
+    alongside the SQL++ fragment so the caller can pass it to the Couchbase
+    SDK via `named_parameters`, mirroring the pattern already used by
+    `delete()` on this class. This avoids SQL++ injection via filter values.
 
     Args:
         filters: LlamaIndex MetadataFilters object
         metadata_key: The metadata field prefix for the document
+        named_parameters: Optional dict of already-collected named
+            parameters. Used internally to keep parameter names unique
+            across recursive calls for nested MetadataFilters. Callers
+            should normally omit this and use the dict in the return value.
 
     Returns:
-        SQL++ WHERE clause string
+        A tuple of (SQL++ WHERE clause fragment, named_parameters dict).
 
     """
+    if named_parameters is None:
+        named_parameters = {}
+
     if not filters or not filters.filters:
-        return ""
+        return "", named_parameters
+
+    def _next_param_name() -> str:
+        return f"metadata_filter_{len(named_parameters)}"
+
+    _COMPARISON_OPERATORS = {
+        FilterOperator.EQ: "=",
+        FilterOperator.NE: "!=",
+        FilterOperator.GT: ">",
+        FilterOperator.GTE: ">=",
+        FilterOperator.LT: "<",
+        FilterOperator.LTE: "<=",
+    }
 
     def _build_condition(filter_item: Any) -> str:
-        """Build a single SQL++ condition from a MetadataFilter."""
+        """Build a single parameterized SQL++ condition from a MetadataFilter."""
         field_name = f"d.{metadata_key}.{filter_item.key}"
 
-        if filter_item.operator == FilterOperator.EQ:
-            if isinstance(filter_item.value, str):
-                return f"{field_name} = '{filter_item.value}'"
-            else:
-                return f"{field_name} = {filter_item.value}"
-        elif filter_item.operator == FilterOperator.NE:
-            if isinstance(filter_item.value, str):
-                return f"{field_name} != '{filter_item.value}'"
-            else:
-                return f"{field_name} != {filter_item.value}"
-        elif filter_item.operator == FilterOperator.GT:
-            return f"{field_name} > {filter_item.value}"
-        elif filter_item.operator == FilterOperator.GTE:
-            return f"{field_name} >= {filter_item.value}"
-        elif filter_item.operator == FilterOperator.LT:
-            return f"{field_name} < {filter_item.value}"
-        elif filter_item.operator == FilterOperator.LTE:
-            return f"{field_name} <= {filter_item.value}"
+        if filter_item.operator in _COMPARISON_OPERATORS:
+            param_name = _next_param_name()
+            named_parameters[param_name] = filter_item.value
+            return f"{field_name} {_COMPARISON_OPERATORS[filter_item.operator]} ${param_name}"
         elif filter_item.operator == FilterOperator.IN:
-            if isinstance(filter_item.value, list):
-                values = ", ".join(
-                    [
-                        f"'{v}'" if isinstance(v, str) else str(v)
-                        for v in filter_item.value
-                    ]
-                )
-                return f"{field_name} IN [{values}]"
-            else:
+            if not isinstance(filter_item.value, list):
                 raise ValueError(
                     f"'in' operator expects a list value, got {type(filter_item.value)}"
                 )
+            param_name = _next_param_name()
+            named_parameters[param_name] = filter_item.value
+            return f"{field_name} IN ${param_name}"
         else:
             raise ValueError(f"Unsupported filter operator: {filter_item.operator}")
 
@@ -207,22 +215,20 @@ def _convert_llamaindex_filters_to_sql(
             condition = _build_condition(filter_item)
             filter_conditions.append(condition)
         elif isinstance(filter_item, MetadataFilters):
-            condition = (
-                "("
-                + _convert_llamaindex_filters_to_sql(filter_item, metadata_key)
-                + ")"
+            nested_sql, _ = _convert_llamaindex_filters_to_sql(
+                filter_item, metadata_key, named_parameters
             )
-            filter_conditions.append(condition)
+            filter_conditions.append(f"({nested_sql})")
         else:
             logger.warning(f"Unsupported filter type: {type(filter_item)}")
             continue
 
     if not filter_conditions:
-        return ""
+        return "", named_parameters
 
     # Join conditions based on the filter condition (AND/OR)
     condition_connector = " AND " if filters.condition == "and" else " OR "
-    return condition_connector.join(filter_conditions)
+    return condition_connector.join(filter_conditions), named_parameters
 
 
 class CouchbaseVectorStoreBase(BasePydanticVectorStore):
@@ -856,16 +862,23 @@ class CouchbaseQueryVectorStore(CouchbaseVectorStoreBase):
 
         # Handle filters if provided
         where_clause = ""
+        filter_named_parameters: Dict[str, Any] = {}
         if query.filters:
             try:
-                # Convert LlamaIndex filters to SQL++ conditions
-                filter_sql = _convert_llamaindex_filters_to_sql(
-                    query.filters, self._metadata_key
+                # Convert LlamaIndex filters to a parameterized SQL++ WHERE
+                # clause. Filter values are bound via named parameters rather
+                # than interpolated into the query string, to avoid SQL++
+                # injection through filter values (see #22314).
+                filter_sql, filter_named_parameters = (
+                    _convert_llamaindex_filters_to_sql(
+                        query.filters, self._metadata_key
+                    )
                 )
                 if filter_sql:
                     where_clause = f"WHERE {filter_sql}"
             except Exception as e:
                 logger.warning(f"Failed to process filters: {e}")
+                filter_named_parameters = {}
 
         if query.output_fields:
             fields = query.output_fields.join(",")
@@ -893,8 +906,18 @@ class CouchbaseQueryVectorStore(CouchbaseVectorStoreBase):
         """
 
         try:
-            # Execute the query
-            result = self._cluster.query(query_str, self._query_options)
+            # Execute the query, binding any filter values as named
+            # parameters rather than interpolating them into query_str.
+            query_options = (
+                self._query_options.copy() if self._query_options else QueryOptions()
+            )
+            if filter_named_parameters:
+                merged_named_parameters = dict(
+                    query_options.get("named_parameters") or {}
+                )
+                merged_named_parameters.update(filter_named_parameters)
+                query_options["named_parameters"] = merged_named_parameters
+            result = self._cluster.query(query_str, query_options)
 
             top_k_nodes = []
             top_k_scores = []

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-couchbase"
-version = "0.7.1"
+version = "0.7.2"
 description = "llama-index vector_stores couchbase integration"
 authors = [{name = "Couchbase", email = "devadvocates@couchbase.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/tests/test_sql_injection_filters.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/tests/test_sql_injection_filters.py
@@ -5,12 +5,22 @@ Regression tests for SQL++ injection in
 These are pure unit tests against a module-level function and require no
 live Couchbase connection.
 """
+
+from unittest.mock import MagicMock, patch
+
+from couchbase.cluster import Cluster
+from couchbase.options import QueryOptions
+
 from llama_index.core.vector_stores.types import (
     FilterOperator,
     MetadataFilter,
     MetadataFilters,
+    VectorStoreQuery,
 )
 from llama_index.vector_stores.couchbase.base import (
+    CouchbaseQueryVectorStore,
+    QueryVectorSearchType,
+    QueryVectorSearchSimilarity,
     _convert_llamaindex_filters_to_sql,
 )
 
@@ -84,9 +94,7 @@ def test_in_filter_requires_list_value() -> None:
 
     filters = MetadataFilters(
         filters=[
-            MetadataFilter(
-                key="tag", value="not-a-list", operator=FilterOperator.IN
-            )
+            MetadataFilter(key="tag", value="not-a-list", operator=FilterOperator.IN)
         ]
     )
 
@@ -125,3 +133,138 @@ def test_empty_filters_return_empty_sql_and_params() -> None:
     sql, params = _convert_llamaindex_filters_to_sql(None, "metadata")
     assert sql == ""
     assert params == {}
+
+
+# ---------------------------------------------------------------------------
+# query()-level tests: exercise the full path, including the named_parameters
+# merge in CouchbaseQueryVectorStore.query(), which the unit tests above
+# (against _convert_llamaindex_filters_to_sql directly) don't cover. These use
+# a mocked Couchbase cluster - no live connection needed.
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_cluster() -> MagicMock:
+    """
+    A Mock cluster that satisfies isinstance(cluster, Cluster) (via spec) and
+    returns an empty result set from .query(), so CouchbaseQueryVectorStore
+    construction and query() execution succeed without a real connection.
+    """
+    cluster = MagicMock(spec=Cluster)
+    mock_result = MagicMock()
+    mock_result.rows.return_value = []
+    cluster.query.return_value = mock_result
+    return cluster
+
+
+def _make_vector_store(cluster: MagicMock, **kwargs) -> CouchbaseQueryVectorStore:
+    """
+    Construct a CouchbaseQueryVectorStore against a mocked cluster.
+
+    The bucket/scope/collection-existence checks in __init__ walk the real
+    Couchbase SDK's bucket.collections().get_all_scopes() shape, which isn't
+    meaningful to fake for a mocked cluster and isn't what these tests are
+    verifying - so they're patched out directly, isolating the tests to the
+    filter/query-building logic under test.
+    """
+    with (
+        patch.object(
+            CouchbaseQueryVectorStore, "_check_bucket_exists", return_value=True
+        ),
+        patch.object(
+            CouchbaseQueryVectorStore,
+            "_check_scope_and_collection_exists",
+            return_value=True,
+        ),
+    ):
+        return CouchbaseQueryVectorStore(
+            cluster=cluster,
+            bucket_name="test_bucket",
+            scope_name="test_scope",
+            collection_name="test_collection",
+            search_type=QueryVectorSearchType.ANN,
+            similarity=QueryVectorSearchSimilarity.COSINE,
+            **kwargs,
+        )
+
+
+def test_query_with_malicious_filter_does_not_interpolate_into_sql() -> None:
+    """
+    End-to-end regression test for #22314: the malicious payload from the
+    issue must never appear in the SQL string actually sent to the cluster,
+    and must instead be bound as a named parameter.
+    """
+    cluster = _make_mock_cluster()
+    store = _make_vector_store(cluster)
+
+    q = VectorStoreQuery(
+        query_embedding=[0.1, 0.2, 0.3],
+        similarity_top_k=3,
+        filters=MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="category", value=MALICIOUS_VALUE, operator=FilterOperator.EQ
+                )
+            ]
+        ),
+    )
+
+    store.query(q)
+
+    assert cluster.query.call_count == 1
+    query_str, query_options_arg = cluster.query.call_args.args
+
+    assert MALICIOUS_VALUE not in query_str
+    assert query_options_arg["named_parameters"] == {
+        "metadata_filter_0": MALICIOUS_VALUE
+    }
+
+
+def test_query_merges_filter_params_without_clobbering_existing_named_parameters() -> (
+    None
+):
+    """
+    Verifies the claim in the fix: pre-existing named_parameters set on
+    self._query_options must survive being merged with filter-derived ones,
+    not be overwritten by them.
+    """
+    cluster = _make_mock_cluster()
+    store = _make_vector_store(
+        cluster,
+        query_options=QueryOptions(
+            named_parameters={"existing_param": "existing_value"}
+        ),
+    )
+
+    q = VectorStoreQuery(
+        query_embedding=[0.1, 0.2, 0.3],
+        similarity_top_k=1,
+        filters=MetadataFilters(
+            filters=[
+                MetadataFilter(
+                    key="genre", value="Thriller", operator=FilterOperator.EQ
+                )
+            ]
+        ),
+    )
+
+    store.query(q)
+
+    _, query_options_arg = cluster.query.call_args.args
+    merged = query_options_arg["named_parameters"]
+    assert merged["existing_param"] == "existing_value"
+    assert merged["metadata_filter_0"] == "Thriller"
+
+
+def test_query_without_filters_does_not_set_named_parameters() -> None:
+    """
+    A query with no filters shouldn't fabricate an empty named_parameters
+    entry or otherwise disturb query_options.
+    """
+    cluster = _make_mock_cluster()
+    store = _make_vector_store(cluster)
+
+    q = VectorStoreQuery(query_embedding=[0.1, 0.2, 0.3], similarity_top_k=1)
+    store.query(q)
+
+    _, query_options_arg = cluster.query.call_args.args
+    assert not query_options_arg.get("named_parameters")

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/tests/test_sql_injection_filters.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-couchbase/tests/test_sql_injection_filters.py
@@ -1,0 +1,127 @@
+"""
+Regression tests for SQL++ injection in
+`_convert_llamaindex_filters_to_sql` (see issue #22314).
+
+These are pure unit tests against a module-level function and require no
+live Couchbase connection.
+"""
+from llama_index.core.vector_stores.types import (
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+)
+from llama_index.vector_stores.couchbase.base import (
+    _convert_llamaindex_filters_to_sql,
+)
+
+MALICIOUS_VALUE = "' OR 1=1 UNION SELECT d.* FROM sensitive_bucket d --"
+
+
+def test_eq_filter_does_not_interpolate_value_into_sql() -> None:
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="category", value=MALICIOUS_VALUE, operator=FilterOperator.EQ
+            )
+        ]
+    )
+
+    sql, params = _convert_llamaindex_filters_to_sql(filters, "metadata")
+
+    # The malicious payload must never appear in the generated SQL string.
+    assert MALICIOUS_VALUE not in sql
+    assert "'" not in sql
+    # It must instead be carried as a bound named parameter.
+    assert sql == "d.metadata.category = $metadata_filter_0"
+    assert params == {"metadata_filter_0": MALICIOUS_VALUE}
+
+
+def test_ne_gt_lt_filters_use_named_parameters() -> None:
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="status", value="banned", operator=FilterOperator.NE),
+            MetadataFilter(key="score", value=10, operator=FilterOperator.GT),
+            MetadataFilter(key="score", value=100, operator=FilterOperator.LTE),
+        ],
+        condition="and",
+    )
+
+    sql, params = _convert_llamaindex_filters_to_sql(filters, "metadata")
+
+    assert sql == (
+        "d.metadata.status != $metadata_filter_0 AND "
+        "d.metadata.score > $metadata_filter_1 AND "
+        "d.metadata.score <= $metadata_filter_2"
+    )
+    assert params == {
+        "metadata_filter_0": "banned",
+        "metadata_filter_1": 10,
+        "metadata_filter_2": 100,
+    }
+
+
+def test_in_filter_binds_list_as_single_named_parameter() -> None:
+    malicious_list_item = "a', 'b') OR 1=1 --"
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tag",
+                value=["safe", malicious_list_item],
+                operator=FilterOperator.IN,
+            )
+        ]
+    )
+
+    sql, params = _convert_llamaindex_filters_to_sql(filters, "metadata")
+
+    assert malicious_list_item not in sql
+    assert sql == "d.metadata.tag IN $metadata_filter_0"
+    assert params == {"metadata_filter_0": ["safe", malicious_list_item]}
+
+
+def test_in_filter_requires_list_value() -> None:
+    import pytest
+
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(
+                key="tag", value="not-a-list", operator=FilterOperator.IN
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="expects a list value"):
+        _convert_llamaindex_filters_to_sql(filters, "metadata")
+
+
+def test_nested_filters_produce_unique_parameter_names() -> None:
+    inner = MetadataFilters(
+        filters=[
+            MetadataFilter(key="a", value=MALICIOUS_VALUE, operator=FilterOperator.EQ),
+            MetadataFilter(key="b", value="x", operator=FilterOperator.EQ),
+        ],
+        condition="or",
+    )
+    outer = MetadataFilters(
+        filters=[
+            MetadataFilter(key="c", value=1, operator=FilterOperator.GTE),
+            inner,
+        ],
+        condition="and",
+    )
+
+    sql, params = _convert_llamaindex_filters_to_sql(outer, "metadata")
+
+    # Three total leaf filters -> three unique parameter names, no reuse.
+    assert len(params) == 3
+    assert MALICIOUS_VALUE not in sql
+    assert sql == (
+        "d.metadata.c >= $metadata_filter_0 AND "
+        "(d.metadata.a = $metadata_filter_1 OR d.metadata.b = $metadata_filter_2)"
+    )
+
+
+def test_empty_filters_return_empty_sql_and_params() -> None:
+    sql, params = _convert_llamaindex_filters_to_sql(None, "metadata")
+    assert sql == ""
+    assert params == {}


### PR DESCRIPTION
## Summary

Fixes #22314

`_convert_llamaindex_filters_to_sql()` built its SQL++ WHERE clause by
interpolating filter values directly into the query string, with only
naive single-quote wrapping for strings and no escaping at all for
GT/GTE/LT/LTE. An attacker-controlled metadata filter value could break
out of the intended clause and alter query structure (SQL++ injection).

This mirrors the pattern already used by `delete()` on the same class
(fixed in #18316): values are now bound via Couchbase named parameters
(`$metadata_filter_N`) instead of being spliced into the query text.

## Changes

- `_convert_llamaindex_filters_to_sql()` now returns `(sql, named_parameters)`
  instead of a raw SQL string. All six operators (EQ, NE, GT, GTE, LT, LTE,
  IN) are parameterized, including the previously-unquoted numeric
  comparison operators.
- `CouchbaseQueryVectorStore.query()` merges the returned `named_parameters`
  into `query_options` before executing, without clobbering any
  `named_parameters` already set on `self._query_options`.
- `tests/test_sql_injection_filters.py`:
  - Unit tests against `_convert_llamaindex_filters_to_sql` directly,
    proving the injection payload from the issue never reaches the
    generated SQL string, plus coverage for nested filters, `IN`, and
    non-list `IN` value validation.
  - Mocked-cluster tests exercising the full `query()` path: the malicious
    payload never reaching the SQL string sent to `cluster.query()`, and
    the named-parameter merge correctly preserving pre-existing values
    instead of overwriting them. Verified these catch a real regression by
    running them against the pre-fix code and confirming they fail.

## A note on the `IN` operator

`IN` filters bind a Python list as a single named parameter
(`field IN $param`). I don't have access to a live Couchbase cluster to
execute this directly, so this is verified via Couchbase's SQL++
documentation rather than live execution: membership tests (`IN`/`NOT IN`)
accept any expression evaluating to an array on the right-hand side, and
named parameters substitute as a value wherever they appear — composing
the two is standard, documented behavior, but it hasn't been run against
a real cluster. Flagging this explicitly rather than claiming full
certainty.

## Version bump

Bumped `pyproject.toml` `0.7.1` → `0.7.2` per the PR template checklist
for non-core package changes.

## AI assistance disclosure

Portions of this fix and its tests were developed with AI assistance,
which CONTRIBUTING.md asks contributors to flag for security-related
code. Extra verification was done accordingly: `QueryOptions`'s
dict-subclass behavior was checked against the actual installed Couchbase
SDK, the regression tests were confirmed to fail against the pre-fix
vulnerable code (not just pass against the fix), and the `IN`-operator
reasoning above was cross-checked against Couchbase's own docs rather
than assumed.

## Testing
uv run ruff check llama_index/ tests/
uv run pytest tests/ -v

9 passed (all non-live-cluster tests), 30 skipped (existing tests
requiring live Couchbase credentials — pre-existing, unrelated to this
change), 0 failed.

## New Package?
No

## Version Bump?
Yes (0.7.1 → 0.7.2, internal bug fix, no public API change)

## Type of Change
Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I added new unit tests to cover this change (see Testing section above).