### PR TITLE
fix(sharepoint): honor recursive flag during file discovery

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -389,6 +389,7 @@ class SharePointReader(
             sharepoint_site_name=self.sharepoint_site_name,
             sharepoint_site_id=self.sharepoint_site_id,
             sharepoint_folder_id=folder_id,
+            recursive=include_subfolders,
         )
 
         metadata = {}
@@ -748,9 +749,12 @@ class SharePointReader(
 
         return file_paths
 
-    def _list_drive_contents(self) -> List[Path]:
+    def _list_drive_contents(self, recursive: bool = True) -> List[Path]:
         """
         Helper method to fetch the contents of the drive.
+
+        Args:
+            recursive (bool): Whether to include files from subfolders recursively.
 
         Returns:
             List[Path]: List of file paths.
@@ -765,10 +769,10 @@ class SharePointReader(
         items = self._get_all_items_with_pagination(drive_contents_endpoint)
 
         for item in items:
-            if "folder" in item:
+            if "folder" in item and recursive:
                 # Append folder path
                 folder_paths = self._list_folder_contents(
-                    item["id"], recursive=True, current_path=item["name"]
+                    item["id"], recursive=recursive, current_path=item["name"]
                 )
                 file_paths.extend(folder_paths)
             elif "file" in item:
@@ -839,7 +843,7 @@ class SharePointReader(
                 file_paths.extend(folder_contents)
             else:
                 # Fetch drive contents
-                drive_contents = self._list_drive_contents()
+                drive_contents = self._list_drive_contents(recursive=recursive)
                 file_paths.extend(drive_contents)
         except Exception as exp:
             logger.error("An error occurred while listing files in SharePoint: %s", exp)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -172,6 +172,67 @@ def test_list_resources(sharepoint_reader):
     assert file_paths[1] == Path("dummy_site_name/dummy_folder_path/file2.txt")
 
 
+@pytest.mark.parametrize("include_subfolders", [False, True])
+def test_download_files_forwards_recursive_flag(sharepoint_reader, include_subfolders):
+    with patch.object(
+        SharePointReader, "list_resources", return_value=[]
+    ) as list_resources:
+        sharepoint_reader._download_files_and_extract_metadata(
+            "dummy_folder_id",
+            "unused",
+            include_subfolders=include_subfolders,
+        )
+
+    list_resources.assert_called_once_with(
+        sharepoint_site_name="dummy_site_name",
+        sharepoint_site_id=None,
+        sharepoint_folder_id="dummy_folder_id",
+        recursive=include_subfolders,
+    )
+
+
+@pytest.mark.parametrize(
+    ("recursive", "expected_paths", "lists_subfolder"),
+    [
+        (False, [Path("root.txt")], False),
+        (True, [Path("folder/nested.txt"), Path("root.txt")], True),
+    ],
+)
+def test_list_resources_from_drive_root_honors_recursive(
+    sharepoint_reader, recursive, expected_paths, lists_subfolder
+):
+    sharepoint_reader.sharepoint_folder_path = None
+    root_items = [
+        {"id": "folder_id", "name": "folder", "folder": {}},
+        {"id": "root_file_id", "name": "root.txt", "file": {}},
+    ]
+
+    with (
+        patch.object(
+            sharepoint_reader,
+            "_get_all_items_with_pagination",
+            return_value=root_items,
+        ),
+        patch.object(
+            sharepoint_reader,
+            "_list_folder_contents",
+            return_value=[Path("folder/nested.txt")],
+        ) as list_folder_contents,
+    ):
+        paths = sharepoint_reader.list_resources(
+            sharepoint_site_name="dummy_site_name",
+            recursive=recursive,
+        )
+
+    assert paths == expected_paths
+    if lists_subfolder:
+        list_folder_contents.assert_called_once_with(
+            "folder_id", recursive=True, current_path="folder"
+        )
+    else:
+        list_folder_contents.assert_not_called()
+
+
 def test_load_documents_with_metadata(sharepoint_reader):
     # Setting the _drive_id_endpoint manually to avoid the AttributeError
     sharepoint_reader._drive_id_endpoint = (

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
@@ -1949,7 +1949,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1988,7 +1988,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },


### PR DESCRIPTION
# Description

Fix `SharePointReader` ignoring `recursive=False` during remote file discovery.

The recursive flag was passed to `_download_files_and_extract_metadata` as
`include_subfolders`, but was not forwarded to `list_resources`. As a result,
`list_resources` used its default `recursive=True`.

Drive-root discovery also hardcoded recursive traversal for every root folder.

This change:

- forwards `include_subfolders` to `list_resources`;
- makes `_list_drive_contents` honor the recursive flag;
- preserves the existing recursive behavior when `recursive=True`;
- adds regression tests for folder-scoped and drive-root discovery;

No new dependencies are introduced.

Fixes #22320

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Tests cover:

- forwarding `include_subfolders=False`;
- forwarding `include_subfolders=True`;
- skipping root subfolders when `recursive=False`;
- preserving root subfolder traversal when `recursive=True`.

Validation:

```text
22 passed
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing package unit tests pass locally
- [x] I ran `uv run make format; uv run make lint`

Targeted Ruff checks were run successfully for both modified Python files.

Disclosure: this change was AI-assisted. I manually reviewed the implementation
and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
