### PR TITLE
fix(sharepoint): prevent duplicate filename overwrites

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -1,5 +1,6 @@
 """SharePoint files reader."""
 
+import hashlib
 import html
 import logging
 import os
@@ -435,8 +436,10 @@ class SharePointReader(
             str: The path of the downloaded file in the temporary directory.
 
         """
-        # Get the download URL for the file.
-        file_name = item["name"]
+        # Use the item ID to avoid collisions between files with the same name.
+        file_suffix = Path(item["name"]).suffix
+        item_digest = hashlib.sha256(item["id"].encode("utf-8")).hexdigest()
+        file_name = f"{item_digest}{file_suffix}"
 
         content = self._get_file_content_by_url(item)
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -172,6 +172,58 @@ def test_list_resources(sharepoint_reader):
     assert file_paths[1] == Path("dummy_site_name/dummy_folder_path/file2.txt")
 
 
+def test_download_same_named_files_from_different_folders(sharepoint_reader):
+    sharepoint_reader.attach_permission_metadata = False
+    remote_paths = [
+        Path("dummy_site_name/Contracts/2025/report.txt"),
+        Path("dummy_site_name/Contracts/2026/report.txt"),
+    ]
+    items = {
+        remote_paths[0]: {
+            "id": "item-2025",
+            "name": "report.txt",
+            "parentReference": {"path": "/drive/root:/Contracts/2025"},
+        },
+        remote_paths[1]: {
+            "id": "item-2026",
+            "name": "report.txt",
+            "parentReference": {"path": "/drive/root:/Contracts/2026"},
+        },
+    }
+
+    with (
+        patch.object(SharePointReader, "list_resources", return_value=remote_paths),
+        patch.object(
+            SharePointReader,
+            "_get_item_from_path",
+            side_effect=lambda path: items[path],
+        ),
+        patch.object(
+            SharePointReader,
+            "_get_file_content_by_url",
+            side_effect=lambda item: f"content:{item['id']}".encode(),
+        ),
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        metadata = sharepoint_reader._download_files_and_extract_metadata(
+            "dummy_folder_id", temp_dir
+        )
+        documents = sharepoint_reader._load_documents_with_metadata(
+            metadata, temp_dir, recursive=False
+        )
+
+        local_names = {Path(file_path).name for file_path in metadata}
+        assert len(metadata) == 2
+        assert len(local_names) == 2
+        assert all(Path(file_path).suffix == ".txt" for file_path in metadata)
+        assert "report.txt" not in local_names
+
+    assert {doc.metadata["file_id"]: doc.text for doc in documents} == {
+        "item-2025": "content:item-2025",
+        "item-2026": "content:item-2026",
+    }
+
+
 def test_load_documents_with_metadata(sharepoint_reader):
     # Setting the _drive_id_endpoint manually to avoid the AttributeError
     sharepoint_reader._drive_id_endpoint = (

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
@@ -1949,7 +1949,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1988,7 +1988,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },


### PR DESCRIPTION
# Description

Prevent `SharePointReader` from silently overwriting files from different
SharePoint folders when they have the same filename.

The reader previously used only `item["name"]` for the temporary download path.
As a result, distinct files such as:

```text
Contracts/2025/report.txt
Contracts/2026/report.txt
```

were both written to `<temp>/report.txt`. The later download replaced the
earlier file and its metadata, causing one document to disappear from the
ingestion result.

This change:

- derives the internal staging filename from a SHA-256 digest of the Graph
  `driveItem.id`;
- preserves the original final extension for file parser selection;
- keeps the original filename in document metadata;
- keeps downloads in a flat temporary directory, avoiding local path-length
  and remote hierarchy concerns;
- adds a regression test with two same-named files from different folders,
  verifying that both contents and metadata are preserved.

No new dependencies are introduced.

Fixes #22318

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

The regression test verifies:

- two Graph items with different IDs and parent folders but the same name;
- two distinct temporary files;
- preservation of the `.txt` extension;
- preservation of both document contents and file IDs.

Validation:

```text
19 passed
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing package unit tests pass locally
- [x] I ran `uv run make format; uv run make lint`

Disclosure: this change was AI-assisted. I manually reviewed the implementation
and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
