### PR TITLE
fix(box): prevent duplicate filename overwrites

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import shutil
@@ -148,8 +149,10 @@ def download_file_by_id(box_client: BoxClient, box_file: File, temp_dir: str) ->
         BoxAPIError: If an error occurs while interacting with the Box API.
 
     """
-    # Save the downloaded file to the specified local directory.
-    file_path = os.path.join(temp_dir, box_file.name)
+    # Use the remote file ID to keep same-named files from different folders distinct.
+    file_id_digest = hashlib.sha256(box_file.id.encode()).hexdigest()
+    file_extension = os.path.splitext(box_file.name)[1]
+    file_path = os.path.join(temp_dir, f"{file_id_digest}{file_extension}")
 
     try:
         file_stream: ByteStream = box_client.downloads.download_file(box_file.id)

--- a/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-box"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers box integration"
 authors = [{name = "Box Developer Relations", email = "dx@box.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_reader.py
@@ -1,11 +1,13 @@
 import datetime
-import pytest
+import importlib
+from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from box_sdk_gen import BoxClient
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.box import BoxReader
-
-from box_sdk_gen import BoxClient
-
 
 from tests.conftest import get_testing_data
 
@@ -29,6 +31,62 @@ def test_reader_init(box_client_ccg_unit_testing: BoxClient):
     # assert new_reader is not None
     # assert new_reader.box_client_id == reader.box_client_id
     # assert new_reader.box_client_secret == reader.box_client_secret
+
+
+def test_reader_preserves_same_named_files_from_different_folders(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    box_reader_module = importlib.import_module(
+        "llama_index.readers.box.BoxReader.base"
+    )
+    box_files = [
+        SimpleNamespace(
+            id="file-2025", name="report.txt", parent=SimpleNamespace(id="folder-2025")
+        ),
+        SimpleNamespace(
+            id="file-2026", name="report.txt", parent=SimpleNamespace(id="folder-2026")
+        ),
+    ]
+    contents = {
+        "file-2025": b"2025 report",
+        "file-2026": b"2026 report",
+    }
+    box_client = SimpleNamespace(
+        downloads=SimpleNamespace(
+            download_file=lambda file_id: BytesIO(contents[file_id])
+        )
+    )
+
+    monkeypatch.setattr(
+        box_reader_module, "add_extra_header_to_box_client", lambda x: x
+    )
+    monkeypatch.setattr(box_reader_module, "box_check_connection", lambda _: None)
+    monkeypatch.setattr(
+        box_reader_module,
+        "get_box_files_details",
+        lambda **_: box_files,
+    )
+    monkeypatch.setattr(
+        box_reader_module,
+        "box_file_to_llama_document_metadata",
+        lambda file: {
+            "box_file_id": file.id,
+            "name": file.name,
+            "parent": file.parent.id,
+        },
+    )
+    reader = BoxReader(box_client=box_client)
+    documents = reader.load_data(file_ids=[file.id for file in box_files])
+
+    documents_by_id = {
+        document.metadata["box_file_id"]: document for document in documents
+    }
+    assert set(documents_by_id) == {"file-2025", "file-2026"}
+    assert documents_by_id["file-2025"].get_content() == "2025 report"
+    assert documents_by_id["file-2026"].get_content() == "2026 report"
+    assert documents_by_id["file-2025"].metadata["parent"] == "folder-2025"
+    assert documents_by_id["file-2026"].metadata["parent"] == "folder-2026"
+    assert all(document.metadata["name"] == "report.txt" for document in documents)
 
 
 ####################################################################################################

--- a/llama-index-integrations/readers/llama-index-readers-box/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-box/uv.lock
@@ -1837,7 +1837,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-box"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "box-sdk-gen" },
@@ -1875,7 +1875,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },


### PR DESCRIPTION
# Description

Prevent `BoxReader` from silently overwriting files from different Box folders when they have the same filename.

The reader previously staged every download in one temporary directory using only `box_file.name`. Distinct files such as `Contracts/2025/report.txt` and `Contracts/2026/report.txt` were therefore both written to `<temp>/report.txt`, causing the later content and metadata to replace the earlier one.

This change:

- derives the internal staging filename from a SHA-256 digest of the unique Box file ID;
- preserves the original final extension for parser selection;
- preserves the original filename and parent in document metadata;
- adds a deterministic regression test proving both same-named files retain their content and metadata.

No new dependencies are introduced.

Fixes #22324

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

The regression test uses two files with different IDs and parent folders but the same `report.txt` name, and verifies that both contents, IDs, parents, and original names are preserved.

Validation:

```text
11 passed, 44 skipped
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing package unit tests pass locally
- [x] I ran `uv run make format; uv run make lint`

Disclosure: this change was AI-assisted. I manually reviewed the implementation and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
