### PR TITLE
fix(minio): prevent duplicate filename overwrites

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
@@ -5,6 +5,7 @@ A loader that fetches a file or iterates through a directory on Minio.
 
 """
 
+import hashlib
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -110,7 +111,6 @@ class MinioReader(BaseReader):
                     bucket_name=self.bucket, prefix=self.prefix, recursive=True
                 )
                 for i, obj in enumerate(objects):
-                    file_name = obj.object_name.split("/")[-1]
                     if self.num_files_limit is not None and i > self.num_files_limit:
                         break
 
@@ -125,7 +125,10 @@ class MinioReader(BaseReader):
                     if is_dir or is_bad_ext:
                         continue
 
-                    filepath = f"{temp_dir}/{file_name}"
+                    object_digest = hashlib.sha256(
+                        obj.object_name.encode("utf-8")
+                    ).hexdigest()
+                    filepath = str(Path(temp_dir) / f"{object_digest}{suffix}")
                     minio_client.fget_object(self.bucket, obj.object_name, filepath)
 
             loader = SimpleDirectoryReader(

--- a/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-minio"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers minio integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
@@ -1,3 +1,6 @@
+import hashlib
+from pathlib import Path
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.minio import BotoMinioReader, MinioReader
 
@@ -8,3 +11,40 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in MinioReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_minio_reader_preserves_same_named_objects(monkeypatch):
+    object_contents = {
+        "contracts/2025/report.txt": "2025 report",
+        "contracts/2026/report.txt": "2026 report",
+    }
+    downloaded_paths = []
+
+    class FakeObject:
+        def __init__(self, object_name):
+            self.object_name = object_name
+
+    class FakeMinio:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def list_objects(self, bucket_name, prefix, recursive):
+            return [FakeObject(object_name) for object_name in object_contents]
+
+        def fget_object(self, bucket_name, object_name, file_path):
+            downloaded_paths.append(Path(file_path))
+            Path(file_path).write_text(object_contents[object_name])
+
+    monkeypatch.setattr("minio.Minio", FakeMinio)
+
+    documents = MinioReader(
+        bucket="documents",
+        minio_endpoint="example.invalid",
+    ).load_data()
+
+    assert len(documents) == 2
+    assert {document.text for document in documents} == set(object_contents.values())
+    assert {path.name for path in downloaded_paths} == {
+        f"{hashlib.sha256(object_name.encode('utf-8')).hexdigest()}.txt"
+        for object_name in object_contents
+    }

--- a/llama-index-integrations/readers/llama-index-readers-minio/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-minio/uv.lock
@@ -1861,7 +1861,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-minio"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# Description

Prevent the native `MinioReader` from silently overwriting objects whose full keys differ but whose basenames match.

The reader previously flattened both objects below to `<temp>/report.txt`:

```text
contracts/2025/report.txt
contracts/2026/report.txt
```

This change:

- derives each internal staging filename from a SHA-256 digest of the full object key;
- preserves the original final extension for parser selection;
- adds a mocked regression test proving that both same-named objects are loaded with their correct contents;
- leaves the Boto3-based MinIO reader unchanged.

No new dependencies are introduced.

Fixes #22325

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Validation:

```text
2 passed
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] I ran `uv run make format; uv run make lint`

Disclosure: this change was AI-assisted. I manually reviewed the implementation and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
