### PR TITLE
fix(azure-blob): prevent staging filename collisions

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
@@ -5,6 +5,7 @@ A loader that fetches a file or iterates through a directory from Azure Storage 
 
 """
 
+import hashlib
 import logging
 import math
 import os
@@ -38,6 +39,12 @@ FileMetadataCallable = Annotated[
     Callable[[str], Dict],
     WithJsonSchema({"type": "string"}),
 ]
+
+
+def _get_staging_file_name(blob_name: str) -> str:
+    """Create a deterministic, flat staging name for a blob."""
+    digest = hashlib.sha256(blob_name.encode("utf-8")).hexdigest()
+    return f"{digest}{Path(blob_name).suffix}"
 
 
 class SanitizedJSONEncoder(json.JSONEncoder):
@@ -136,19 +143,18 @@ class AzStorageBlobReader(
             )
 
         for obj in blobs_list:
-            sanitized_file_name = obj.name.replace("/", "-") if not self.blob else obj
-            download_file_path = os.path.join(temp_dir, sanitized_file_name)
-            logger.info(f"Start download of {sanitized_file_name}")
+            blob_name = obj.name if not self.blob else obj
+            staging_file_name = _get_staging_file_name(blob_name)
+            download_file_path = os.path.join(temp_dir, staging_file_name)
+            logger.info(f"Start download of {blob_name}")
             start_time = time.time()
             blob_client = container_client.get_blob_client(obj)
             stream = blob_client.download_blob()
             with open(file=download_file_path, mode="wb") as download_file:
                 stream.readinto(download_file)
-            blob_meta[sanitized_file_name] = blob_client.get_blob_properties()
+            blob_meta[staging_file_name] = blob_client.get_blob_properties()
             end_time = time.time()
-            logger.debug(
-                f"{sanitized_file_name} downloaded in {end_time - start_time} seconds."
-            )
+            logger.debug(f"{blob_name} downloaded in {end_time - start_time} seconds.")
 
         return blob_meta
 
@@ -239,13 +245,12 @@ class AzStorageBlobReader(
             blob_client = container_client.get_blob_client(resource_id)
             stream = blob_client.download_blob()
             with tempfile.TemporaryDirectory() as temp_dir:
-                download_file_path = os.path.join(
-                    temp_dir, resource_id.replace("/", "-")
-                )
+                staging_file_name = _get_staging_file_name(resource_id)
+                download_file_path = os.path.join(temp_dir, staging_file_name)
                 with open(file=download_file_path, mode="wb") as download_file:
                     stream.readinto(download_file)
                 return self._load_documents_with_metadata(
-                    {resource_id: blob_client.get_blob_properties()}, temp_dir
+                    {staging_file_name: blob_client.get_blob_properties()}, temp_dir
                 )
         except Exception as e:
             logger.error(

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-azstorage-blob"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers azstorage_blob integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/tests/test_readers_azstorage_blob.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/tests/test_readers_azstorage_blob.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.azstorage_blob import AzStorageBlobReader
 
@@ -23,3 +25,46 @@ def test_serialize():
 
     new_reader = AzStorageBlobReader.parse_raw(json)
     assert new_reader.container_name == reader.container_name
+
+
+def test_load_data_preserves_blobs_with_colliding_sanitized_names(mocker):
+    blob_contents = {
+        "contracts/2025-report.txt": b"first report",
+        "contracts-2025/report.txt": b"second report",
+    }
+
+    class BlobStream:
+        def __init__(self, content: bytes) -> None:
+            self.content = content
+
+        def readinto(self, file) -> None:
+            file.write(self.content)
+
+    class BlobClient:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def download_blob(self) -> BlobStream:
+            return BlobStream(blob_contents[self.name])
+
+        def get_blob_properties(self):
+            return {"name": self.name, "metadata": {"source": self.name}}
+
+    container_client = mocker.Mock()
+    container_client.list_blobs.return_value = [
+        SimpleNamespace(name=name) for name in blob_contents
+    ]
+    container_client.get_blob_client.side_effect = lambda obj: BlobClient(obj.name)
+
+    reader = AzStorageBlobReader(container_name=test_container_name)
+    mocker.patch.object(reader, "_get_container_client", return_value=container_client)
+
+    documents = reader.load_data()
+
+    assert len(documents) == 2
+    documents_by_name = {document.metadata["name"]: document for document in documents}
+    assert set(documents_by_name) == set(blob_contents)
+    for name, content in blob_contents.items():
+        document = documents_by_name[name]
+        assert document.get_content() == content.decode()
+        assert document.metadata["metadata"] == {"source": name}

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/uv.lock
@@ -1877,7 +1877,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-azstorage-blob"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
# Description

Prevent `AzStorageBlobReader` from silently overwriting distinct blobs whose names collide after `/` is replaced with `-`.

The reader previously mapped both blobs below to `<temp>/contracts-2025-report.txt`:

```text
contracts/2025-report.txt
contracts-2025/report.txt
```

This change:

- derives each internal staging filename from a SHA-256 digest of the full blob name;
- preserves the original final extension for parser selection;
- keeps each blob's original metadata associated with its staged file;
- applies the same staging rule to batch and single-resource loading;
- adds a mocked regression test proving that both colliding names retain their contents and metadata.

No new dependencies are introduced.

Fixes #22326

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Validation:

```text
3 passed
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [ ] I ran `uv run make format; uv run make lint`

Targeted Ruff checks were run successfully for both modified Python files.

Disclosure: this change was AI-assisted. I manually reviewed the implementation and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
