### PR TITLE
fix(onedrive): prevent duplicate filename overwrites

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -1,5 +1,6 @@
 """OneDrive files reader."""
 
+import hashlib
 import logging
 import os
 import tempfile
@@ -265,9 +266,11 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         - str: The file path of the download file
 
         """
-        # Extract download URL and filename from the provided item.
+        # Extract download URL and derive a collision-resistant staging filename.
         file_download_url = item["@microsoft.graph.downloadUrl"]
-        file_name = item["name"]
+        file_suffix = Path(item["name"]).suffix
+        item_digest = hashlib.sha256(item["id"].encode("utf-8")).hexdigest()
+        file_name = f"{item_digest}{file_suffix}"
 
         # Download the file.
         file_data = requests.get(file_download_url)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-onedrive"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers microsoft_onedrive integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,3 +1,8 @@
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.microsoft_onedrive import OneDriveReader
@@ -31,6 +36,62 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+def test_download_same_named_files_from_different_folders():
+    reader = OneDriveReader(
+        client_id=test_client_id,
+        tenant_id=test_tenant_id,
+    )
+    items = [
+        {
+            "id": "item-2025",
+            "name": "report.txt",
+            "size": 17,
+            "file": {"mimeType": "text/plain"},
+            "parentReference": {"path": "/drive/root:/Contracts/2025"},
+            "@microsoft.graph.downloadUrl": "https://example.invalid/2025",
+        },
+        {
+            "id": "item-2026",
+            "name": "report.txt",
+            "size": 17,
+            "file": {"mimeType": "text/plain"},
+            "parentReference": {"path": "/drive/root:/Contracts/2026"},
+            "@microsoft.graph.downloadUrl": "https://example.invalid/2026",
+        },
+    ]
+    responses = [
+        SimpleNamespace(content=b"content:item-2025"),
+        SimpleNamespace(content=b"content:item-2026"),
+    ]
+
+    with (
+        patch(
+            "llama_index.readers.microsoft_onedrive.base.requests.get",
+            side_effect=responses,
+        ),
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        payloads = [
+            reader._check_approved_mimetype_and_download_file(item, temp_dir)
+            for item in items
+        ]
+        documents = reader._load_documents_with_metadata(
+            payloads, temp_dir, recursive=False
+        )
+
+        local_names = {Path(payload.downloaded_file_path).name for payload in payloads}
+        assert len(local_names) == 2
+        assert all(
+            Path(payload.downloaded_file_path).suffix == ".txt" for payload in payloads
+        )
+        assert "report.txt" not in local_names
+
+    assert {doc.metadata["file_id"]: doc.text for doc in documents} == {
+        "item-2025": "content:item-2025",
+        "item-2026": "content:item-2026",
+    }
 
 
 @pytest.fixture()

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/uv.lock
@@ -1824,7 +1824,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-onedrive"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

Prevent `OneDriveReader` from silently overwriting files from different folders when they share the same filename.

The reader previously used only `item["name"]` for the temporary download path. This change derives the internal staging filename from a SHA-256 digest of `driveItem.id`, preserves the original final extension for parser selection, and keeps the original filename and remote path in metadata.

A regression test uses two Graph items from different parent folders with the same `report.txt` name and verifies that both temporary files, contents, file IDs, and documents are preserved.

No new dependencies are introduced.

Fixes #22327

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Validation:

```text
3 passed, 1 skipped
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing package unit tests pass locally
- [x] I ran `uv run make format; uv run make lint`

Disclosure: this change was AI-assisted. I manually reviewed the implementation and validated it with the package test suite and targeted static checks.

---

For context, this PR is part of a coordinated set of related reader fixes identified during the same audit:

- #22322 — SharePoint recursive discovery
- #22323 — SharePoint filename collisions
- #22328 — Box filename collisions
- #22329 — MinIO filename collisions
- #22330 — Azure Blob staging collisions
- #22331 — OneDrive filename collisions

I intentionally kept these changes in separate PRs because each reader is an independently versioned package and may require its own implementation discussion, testing expectations, and merge decision.
