### PR TITLE
fix(cohere): bind documents before reading it in get_cohere_chat_request

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/llama_index/llms/cohere/base.py
@@ -229,13 +229,13 @@ class Cohere(FunctionCallingLLM):
         """
         additional_kwargs = messages[-1].additional_kwargs
 
+        messages, documents = remove_documents_from_messages(messages)
+
         # cohere SDK will fail loudly if both connectors and documents are provided
         if additional_kwargs.get("documents", []) and documents and len(documents) > 0:
             raise ValueError(
                 "Received documents both as a keyword argument and as an prompt additional keyword argument. Please choose only one option."
             )
-
-        messages, documents = remove_documents_from_messages(messages)
 
         tool_results: Optional[List[Dict[str, Any]]] = (
             _messages_to_cohere_tool_results_curr_chat_turn(messages)

--- a/llama-index-integrations/llms/llama-index-llms-cohere/tests/test_llms_cohere.py
+++ b/llama-index-integrations/llms/llama-index-llms-cohere/tests/test_llms_cohere.py
@@ -202,3 +202,47 @@ def test_invoke_tool_calls() -> None:
         "a": 3,
         "b": 4,
     }
+
+
+def test_get_cohere_chat_request_documents_in_additional_kwargs():
+    """
+    A message carrying additional_kwargs['documents'] must not crash.
+
+    Regression: get_cohere_chat_request read the local `documents` in its guard
+    before binding it with `messages, documents = remove_documents_from_messages(...)`,
+    so a truthy additional_kwargs['documents'] raised UnboundLocalError.
+    """
+    with mock.patch("llama_index.llms.cohere.base.cohere.Client", autospec=True):
+        llm = Cohere(api_key="dummy", temperature=0.3)
+
+    messages = [
+        ChatMessage(
+            content="What color is the sky?",
+            role=MessageRole.USER,
+            additional_kwargs={"documents": [{"text": "The sky is blue."}]},
+        ),
+    ]
+
+    request = llm.get_cohere_chat_request(messages)
+    assert request["message"] == "What color is the sky?"
+
+
+def test_get_cohere_chat_request_documents_from_both_sources_raises_value_error():
+    """
+    Documents from both a DocumentMessage and additional_kwargs['documents'] must
+    raise the guard's intended ValueError, not UnboundLocalError.
+    """
+    with mock.patch("llama_index.llms.cohere.base.cohere.Client", autospec=True):
+        llm = Cohere(api_key="dummy", temperature=0.3)
+
+    messages = [
+        DocumentMessage(content="The sky is blue."),
+        ChatMessage(
+            content="What color is the sky?",
+            role=MessageRole.USER,
+            additional_kwargs={"documents": [{"text": "The sky is blue."}]},
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="both as a keyword argument"):
+        llm.get_cohere_chat_request(messages)


### PR DESCRIPTION
## Root cause

`Cohere.get_cohere_chat_request` reads the local `documents` in its "documents supplied twice" guard before that variable is bound:

```python
additional_kwargs = messages[-1].additional_kwargs

# guard reads `documents` here ...
if additional_kwargs.get("documents", []) and documents and len(documents) > 0:
    raise ValueError(
        "Received documents both as a keyword argument and as an prompt additional keyword argument. Please choose only one option."
    )

messages, documents = remove_documents_from_messages(messages)  # ... but it is bound here
```

`documents` is a function-local with no binding until the `remove_documents_from_messages` call one line below the guard, and the signature (`self, messages, *, connectors=None, stop_sequences=None, **kwargs`) has no `documents` parameter. Python short-circuits `and`, so when the last message's `additional_kwargs["documents"]` is falsy (the common case) `documents` is never evaluated and the bug stays hidden. As soon as a message carries a truthy `additional_kwargs["documents"]`, the guard evaluates the unbound local and raises `UnboundLocalError: cannot access local variable 'documents' where it is not associated with a value` instead of the ValueError it was written to raise. This crashes `chat`, `stream_chat`, `achat`, and `astream_chat`, which all call this method. The guard has raised UnboundLocalError since it was introduced in #15144.

## Invariant

A variable must be bound before it is read; the conflict guard must raise its intended ValueError, not crash with UnboundLocalError.

## Fix

Move `messages, documents = remove_documents_from_messages(messages)` above the guard, so `documents` is bound before the guard reads it. The guard then fires exactly as its written condition intends: documents present both as `DocumentMessage`s and in `additional_kwargs["documents"]` raise the ValueError; every other case proceeds. `additional_kwargs` is still captured from the original `messages[-1]` on the line above, so no other behavior changes.

## Verification

Ran in a clean `python:3.11-slim` Docker container against this branch's source (provenance confirmed by printing the loaded module's `__file__` and the source order of the two lines):

- Two new regression tests in `tests/test_llms_cohere.py`:
  - a message with `additional_kwargs["documents"]` and no `DocumentMessage` returns a request instead of crashing,
  - documents supplied via both a `DocumentMessage` and `additional_kwargs["documents"]` raise the intended ValueError.

  Both FAIL on current `main` with UnboundLocalError and PASS on this branch.
- Full package suite: `pytest tests/` gives 13 passed, 1 skipped (the skip is the `COHERE_API_KEY`-gated live test; there is no network in the container).
- `ruff check` and `ruff format --check` are clean on both changed files.

What I did not verify: I did not make a live Cohere API call. The change is control-flow only (a variable is now bound before it is read) and does not alter the request payload for any path that did not already crash, so a live call is not needed to establish correctness here.

This change was written with AI assistance and reviewed before submission.
