### PR TITLE
fix(qdrant): SPARSE query mode silently falls back to dense search when misconfigured

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1068,8 +1068,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 "Please provide `query_str` in the VectorStoreQuery."
             )
         elif (
-            query.mode == VectorStoreQueryMode.SPARSE
-            and self._sparse_query_fn is None
+            query.mode == VectorStoreQueryMode.SPARSE and self._sparse_query_fn is None
         ):
             raise ValueError(
                 "Sparse search requires a sparse query function. "
@@ -1245,8 +1244,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 "Please provide `query_str` in the VectorStoreQuery."
             )
         elif (
-            query.mode == VectorStoreQueryMode.SPARSE
-            and self._sparse_query_fn is None
+            query.mode == VectorStoreQueryMode.SPARSE and self._sparse_query_fn is None
         ):
             raise ValueError(
                 "Sparse search requires a sparse query function. "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1068,6 +1068,15 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 "Please provide `query_str` in the VectorStoreQuery."
             )
         elif (
+            query.mode == VectorStoreQueryMode.SPARSE
+            and self._sparse_query_fn is None
+        ):
+            raise ValueError(
+                "Sparse search requires a sparse query function. "
+                "Please provide `sparse_query_fn` in the constructor or via "
+                "`set_query_functions`."
+            )
+        elif (
             query.mode == VectorStoreQueryMode.HYBRID
             and self.enable_hybrid
             and self._sparse_query_fn is not None
@@ -1234,6 +1243,15 @@ class QdrantVectorStore(BasePydanticVectorStore):
             raise ValueError(
                 "Sparse search requires a query string. "
                 "Please provide `query_str` in the VectorStoreQuery."
+            )
+        elif (
+            query.mode == VectorStoreQueryMode.SPARSE
+            and self._sparse_query_fn is None
+        ):
+            raise ValueError(
+                "Sparse search requires a sparse query function. "
+                "Please provide `sparse_query_fn` in the constructor or via "
+                "`set_query_functions`."
             )
         elif (
             query.mode == VectorStoreQueryMode.HYBRID

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1057,6 +1057,16 @@ class QdrantVectorStore(BasePydanticVectorStore):
                 "Hybrid search is not enabled. Please build the query with "
                 "`enable_hybrid=True` in the constructor."
             )
+        elif query.mode == VectorStoreQueryMode.SPARSE and not self.enable_hybrid:
+            raise ValueError(
+                "Sparse search requires hybrid mode to be enabled. "
+                "Please build the query with `enable_hybrid=True` in the constructor."
+            )
+        elif query.mode == VectorStoreQueryMode.SPARSE and query.query_str is None:
+            raise ValueError(
+                "Sparse search requires a query string. "
+                "Please provide `query_str` in the VectorStoreQuery."
+            )
         elif (
             query.mode == VectorStoreQueryMode.HYBRID
             and self.enable_hybrid
@@ -1214,6 +1224,16 @@ class QdrantVectorStore(BasePydanticVectorStore):
             raise ValueError(
                 "Hybrid search is not enabled. Please build the query with "
                 "`enable_hybrid=True` in the constructor."
+            )
+        elif query.mode == VectorStoreQueryMode.SPARSE and not self.enable_hybrid:
+            raise ValueError(
+                "Sparse search requires hybrid mode to be enabled. "
+                "Please build the query with `enable_hybrid=True` in the constructor."
+            )
+        elif query.mode == VectorStoreQueryMode.SPARSE and query.query_str is None:
+            raise ValueError(
+                "Sparse search requires a query string. "
+                "Please provide `query_str` in the VectorStoreQuery."
             )
         elif (
             query.mode == VectorStoreQueryMode.HYBRID

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -1079,3 +1079,121 @@ async def test_aquery_falsy_shard_identifier_not_dropped() -> None:
         query = VectorStoreQuery(query_embedding=[1.0, 0.0], similarity_top_k=1)
         await store.aquery(query, shard_identifier=0)
         mock_gen.assert_called_once_with(0)
+
+
+def test_query_sparse_without_enable_hybrid_raises() -> None:
+    """
+    Regression: query() must raise ValueError when mode=SPARSE but enable_hybrid=False.
+
+    Previously the SPARSE branch was silently skipped and a dense search was
+    returned instead, giving no indication the requested mode was not honoured.
+    """
+    from qdrant_client import QdrantClient as SyncQdrantClient
+
+    client = SyncQdrantClient(":memory:")
+    store = QdrantVectorStore(
+        collection_name="test_sparse_guard_sync",
+        client=client,
+        enable_hybrid=False,
+    )
+    node = TextNode(
+        text="hello",
+        id_="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        embedding=[1.0, 0.0],
+    )
+    store.add([node])
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str="hello",
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="enable_hybrid=True"):
+        store.query(query)
+
+
+def test_query_sparse_without_query_str_raises() -> None:
+    """
+    Regression: query() must raise ValueError when mode=SPARSE but query_str=None.
+
+    Previously query_str=None caused the SPARSE branch to be skipped and the call
+    silently fell through to a dense search.
+    """
+    from qdrant_client import QdrantClient as SyncQdrantClient
+
+    client = SyncQdrantClient(":memory:")
+    # Pass mock sparse fns so enable_hybrid=True doesn't try to import fastembed.
+    sparse_fn = MagicMock(return_value=([[0]], [[1.0]]))
+    store = QdrantVectorStore(
+        collection_name="test_sparse_no_str_sync",
+        client=client,
+        enable_hybrid=True,
+        sparse_doc_fn=sparse_fn,
+        sparse_query_fn=sparse_fn,
+    )
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str=None,
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="query_str"):
+        store.query(query)
+
+
+@pytest.mark.asyncio
+async def test_aquery_sparse_without_enable_hybrid_raises() -> None:
+    """
+    Regression: aquery() must raise ValueError when mode=SPARSE but enable_hybrid=False.
+    """
+    aclient = AsyncQdrantClient(":memory:")
+    store = QdrantVectorStore(
+        collection_name="test_sparse_guard_async",
+        aclient=aclient,
+        client=None,
+        enable_hybrid=False,
+    )
+    node = TextNode(
+        text="hello",
+        id_="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        embedding=[1.0, 0.0],
+    )
+    await store.async_add([node])
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str="hello",
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="enable_hybrid=True"):
+        await store.aquery(query)
+
+
+@pytest.mark.asyncio
+async def test_aquery_sparse_without_query_str_raises() -> None:
+    """
+    Regression: aquery() must raise ValueError when mode=SPARSE but query_str=None.
+    """
+    aclient = AsyncQdrantClient(":memory:")
+    # Pass mock sparse fns so enable_hybrid=True doesn't try to import fastembed.
+    sparse_fn = MagicMock(return_value=([[0]], [[1.0]]))
+    store = QdrantVectorStore(
+        collection_name="test_sparse_no_str_async",
+        aclient=aclient,
+        client=None,
+        enable_hybrid=True,
+        sparse_doc_fn=sparse_fn,
+        sparse_query_fn=sparse_fn,
+    )
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str=None,
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="query_str"):
+        await store.aquery(query)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -1197,3 +1197,67 @@ async def test_aquery_sparse_without_query_str_raises() -> None:
     )
     with pytest.raises(ValueError, match="query_str"):
         await store.aquery(query)
+
+
+def test_query_sparse_without_sparse_query_fn_raises() -> None:
+    """
+    Regression: query() must raise ValueError when mode=SPARSE but
+    _sparse_query_fn is None.
+
+    set_query_functions() is a public method that lets callers clear
+    sparse_query_fn after construction. Previously this caused the SPARSE
+    branch to be skipped and dense results were returned silently.
+    """
+    from qdrant_client import QdrantClient as SyncQdrantClient
+
+    sparse_fn = MagicMock(return_value=([[0]], [[1.0]]))
+    client = SyncQdrantClient(":memory:")
+    store = QdrantVectorStore(
+        collection_name="test_sparse_no_fn_sync",
+        client=client,
+        enable_hybrid=True,
+        sparse_doc_fn=sparse_fn,
+        sparse_query_fn=sparse_fn,
+    )
+    store.set_query_functions(sparse_query_fn=None)
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str="hello",
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="sparse_query_fn"):
+        store.query(query)
+
+
+@pytest.mark.asyncio
+async def test_aquery_sparse_without_sparse_query_fn_raises() -> None:
+    """
+    Regression: aquery() must raise ValueError when mode=SPARSE but
+    _sparse_query_fn is None.
+
+    set_query_functions() is a public method that lets callers clear
+    sparse_query_fn after construction. Previously this caused the SPARSE
+    branch to be skipped and dense results were returned silently.
+    """
+    sparse_fn = MagicMock(return_value=([[0]], [[1.0]]))
+    aclient = AsyncQdrantClient(":memory:")
+    store = QdrantVectorStore(
+        collection_name="test_sparse_no_fn_async",
+        aclient=aclient,
+        client=None,
+        enable_hybrid=True,
+        sparse_doc_fn=sparse_fn,
+        sparse_query_fn=sparse_fn,
+    )
+    store.set_query_functions(sparse_query_fn=None)
+
+    query = VectorStoreQuery(
+        query_embedding=[1.0, 0.0],
+        query_str="hello",
+        mode=VectorStoreQueryMode.SPARSE,
+        similarity_top_k=1,
+    )
+    with pytest.raises(ValueError, match="sparse_query_fn"):
+        await store.aquery(query)


### PR DESCRIPTION
VectorStoreQueryMode.HYBRID raises a clear ValueError when requested without 
enable_hybrid=True. VectorStoreQueryMode.SPARSE had no equivalent guard for 
any of its three misconfiguration paths, so it silently fell through to a 
regular dense vector search instead:

1. mode=SPARSE with enable_hybrid=False
2. mode=SPARSE, enable_hybrid=True, but query_str=None
3. mode=SPARSE, enable_hybrid=True, valid query_str, but sparse_query_fn is 
   None (reachable via set_query_functions())

Confirmed all three empirically -- each silently returned dense-search 
results with no error, no warning, in both query() and aquery(). Someone 
deliberately requesting sparse/keyword search would get dense results 
instead, with no indication the requested mode wasn't honored.

All three now raise a clear ValueError instead. Fixed in both query() and 
aquery().

6 new regression tests (3 misconfiguration paths x sync/async). Full suite 
passes, ruff clean.