### PR TITLE
fix(agent): fix swapped agent names in handoff-denied error message

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -82,7 +82,7 @@ async def handoff(ctx: Context, to_agent: str, reason: str) -> str:
     if can_handoff_to.get(
         current_agent_name, []
     ) is not None and to_agent not in can_handoff_to.get(current_agent_name, []):
-        return f"Agent {to_agent} cannot hand off to {current_agent_name}. Please select a valid agent to hand off to."
+        return f"Agent {current_agent_name} cannot hand off to {to_agent}. Please select a valid agent to hand off to."
 
     await ctx.store.set("next_agent", to_agent)
     handoff_output_prompt = await ctx.store.get(

--- a/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_multi_agent_workflow.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 from llama_index.core.agent.workflow import AgentInput
 from llama_index.core.agent.workflow.function_agent import FunctionAgent
-from llama_index.core.agent.workflow.multi_agent_workflow import AgentWorkflow
+from llama_index.core.agent.workflow.multi_agent_workflow import AgentWorkflow, handoff
 from llama_index.core.agent.workflow.react_agent import ReActAgent
 from llama_index.core.llms import (
     ChatMessage,
@@ -726,3 +726,41 @@ async def test_run_id_default(
     assert handler.run_id is not None
     assert isinstance(handler.run_id, str)
     handler.cancel()
+
+
+@pytest.mark.asyncio
+async def test_handoff_disallowed_error_message_names_correct_agents():
+    """
+    A disallowed handoff must name the current agent as the one that cannot hand off.
+
+    The message had the two names the wrong way round, so it told the model the target
+    agent was the one refusing, which is the opposite of what the policy said.
+    """
+
+    class _FakeStore:
+        def __init__(self, data: dict) -> None:
+            self.data = data
+
+        async def get(self, key: str, default=None):
+            return self.data.get(key, default)
+
+        async def set(self, key: str, value) -> None:
+            self.data[key] = value
+
+    class _FakeCtx:
+        def __init__(self, data: dict) -> None:
+            self.store = _FakeStore(data)
+
+    ctx = _FakeCtx(
+        {
+            "agents": ["researcher", "writer", "reviewer"],
+            "current_agent_name": "researcher",
+            # researcher may only hand off to writer, not reviewer
+            "can_handoff_to": {"researcher": ["writer"]},
+        }
+    )
+
+    result = await handoff(ctx, to_agent="reviewer", reason="need review")
+
+    assert "researcher cannot hand off to reviewer" in result
+    assert "reviewer cannot hand off to researcher" not in result


### PR DESCRIPTION
## Problem

When `AgentWorkflow`'s `handoff` tool rejects a handoff because the target agent isn't in the current agent's `can_handoff_to` list, the returned message has the agent names swapped:

```python
return f"Agent {to_agent} cannot hand off to {current_agent_name}. Please select a valid agent to hand off to."
```

But the condition actually being checked is `to_agent not in can_handoff_to.get(current_agent_name, [])` -- i.e. `current_agent_name` is the one that cannot hand off, and `to_agent` is the one it cannot hand off to. The message says the opposite.

Reproduction:
```python
import asyncio
from llama_index.core.agent.workflow.multi_agent_workflow import handoff

class FakeStore:
    def __init__(self, data): self.data = data
    async def get(self, key, default=None): return self.data.get(key, default)
    async def set(self, key, value): self.data[key] = value

class FakeCtx:
    def __init__(self, data): self.store = FakeStore(data)

async def main():
    ctx = FakeCtx({
        "agents": ["researcher", "writer", "reviewer"],
        "current_agent_name": "researcher",
        "can_handoff_to": {"researcher": ["writer"]},  # researcher may NOT hand off to reviewer
    })
    print(await handoff(ctx, to_agent="reviewer", reason="need review"))

asyncio.run(main())
# Prints: "Agent reviewer cannot hand off to researcher..."
# Should print: "Agent researcher cannot hand off to reviewer..."
```

This message is returned directly as the `handoff` tool's output and fed back to the LLM driving the workflow, so the backwards phrasing gives the model factually incorrect information about which agent is restricted -- it could reasonably interpret this as "reviewer is the one with the restriction" rather than itself.

## Fix

Swap the f-string arguments so the message correctly reads `"Agent {current_agent_name} cannot hand off to {to_agent}."`

## Testing

Added `test_handoff_disallowed_error_message_names_correct_agents`, which calls `handoff()` directly with a minimal fake `Context`/store and asserts the message names the correct agent as the one that cannot hand off. This branch (disallowed handoff between two *valid* agents) had no prior test coverage -- the existing `test_invalid_handoff` only covers handing off to a nonexistent agent name.

Ran the full `tests/agent/workflow/test_multi_agent_workflow.py` suite; all pass except `test_workflow_with_state`, which fails identically on unmodified `main` in this environment (confirmed via `git stash`) and is unrelated to this change.