### PR TITLE
fix(sambanova): emit empty delta on usage-only final stream chunk

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/llama_index/llms/sambanovasystems/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/llama_index/llms/sambanovasystems/base.py
@@ -551,6 +551,10 @@ class SambaNovaCloud(LLM):
                     ),
                 }
             else:
+                # A usage-only / final chunk has choices == [] and carries no new
+                # text, so its delta must be empty; otherwise the previous chunk's
+                # content_delta is re-emitted and "".join(deltas) != message.content.
+                content_delta = ""
                 additional_kwargs = {
                     "id": partial_response["id"],
                     "finish_reason": finish_reason,

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-sambanovasystems"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index llms sambanova cloud and sambastudio integration"
 authors = [{name = "Rodrigo Maldonado", email = "rodrigo.maldonado@pucp.edu.pe"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/tests/test_llms_sambanovasystems.py
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/tests/test_llms_sambanovasystems.py
@@ -214,6 +214,35 @@ def test_init():
     _ = SambaStudio(sambastudio_url="fake/stream/url", sambastudio_api_key="fake")
 
 
+def test_stream_chat_usage_chunk_emits_empty_delta():
+    """Usage-only final chunk (choices == []) must yield an empty delta so concatenated deltas equal the final content."""
+    client = SambaNovaCloud(sambanova_api_key="fake")
+
+    def fake_streaming_request(messages_dicts, stop=None):
+        yield {
+            "id": "id-0",
+            "choices": [{"delta": {"content": "Hello"}, "finish_reason": None}],
+        }
+        # include_usage=True (the default) appends a trailing usage-only chunk
+        yield {
+            "id": "id-0",
+            "choices": [],
+            "usage": {"total_tokens": 5},
+            "model": "Meta-Llama-3.1-8B-Instruct",
+            "system_fingerprint": "fp",
+            "created": 1,
+        }
+
+    client._handle_streaming_request = fake_streaming_request
+
+    messages = [ChatMessage(role=MessageRole.USER, content="hi")]
+    responses = list(client.stream_chat(messages))
+
+    joined_deltas = "".join(r.delta for r in responses)
+    assert joined_deltas == responses[-1].message.content == "Hello"
+    assert responses[-1].delta == ""
+
+
 if __name__ == "__main__":
     test_sambanovacloud()
     test_sambastudio()

--- a/llama-index-integrations/llms/llama-index-llms-sambanovasystems/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-sambanovasystems/uv.lock
@@ -1790,7 +1790,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-sambanovasystems"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# Description

`SambaNovaCloud` sets `stream_options={"include_usage": True}` by default (`base.py:201-204`), so a streaming response ends with a usage-only chunk where `choices == []`. In `stream_chat`, that final chunk takes the `else` branch (`base.py:553-561`), which builds `additional_kwargs` but never reassigns `content_delta`. The trailing `yield` then re-emits the previous chunk's token as its delta:

```python
yield ChatResponse(
    message=ChatMessage(role=role, content=content, additional_kwargs=additional_kwargs),
    delta=content_delta,   # still the last text chunk's content on the usage chunk
    raw=partial_response,
)
```

So `"".join(r.delta for r in client.stream_chat(...))` no longer equals the final `message.content`: any consumer that rebuilds the text from deltas (the usual streaming pattern) gets the last token duplicated. `message.content` itself stays correct, only the re-emitted `delta` is wrong.

The invariant a streaming generator should hold is that the concatenation of the `delta`s equals the final `message.content`, and a usage-only chunk carries no new text, so its delta must be `""`. This is what the OpenAI-compatible reference implementations do.

There is no tracking issue; this was found by reading the code and reproduced as described below.

## Fix

Set `content_delta = ""` in the `else` (empty-choices) branch so the usage-only chunk yields an empty delta. One line plus a comment; no behavior changes for the text chunks or for `message.content`.

## Version Bump?

- [x] Yes (`0.6.0` to `0.6.1`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added a new unit test.

Added `test_stream_chat_usage_chunk_emits_empty_delta`. It stubs `_handle_streaming_request` to yield a text chunk followed by the usage-only chunk (`choices == []`, plus `usage`/`model`/`system_fingerprint`/`created`) that the provider sends when `include_usage=True`, then asserts `"".join(deltas) == final content == "Hello"` and that the last delta is `""`.

Verified in a clean Docker container (`python:3.11`) against current `main`:

- Before the fix the test fails with `assert 'HelloHello' == 'Hello'`.
- After the fix it passes, and the full `tests/test_llms_sambanovasystems.py` file is green (the live-API tests are skipped without a key).
- `ruff check`, `ruff format --check`, and `codespell` pass on the two changed files.

Not verified: I did not call the real SambaNova Cloud endpoint (no API key). The test reproduces the usage-chunk shape via a stub, using the exact fields the existing `else` branch already reads.

AI assistance: this change was prepared with AI assistance. I reproduced the bug on `main`, validated the fix with the Docker differential and repo lint above, and reviewed the diff line by line.
