### PR TITLE
Fix filename collisions when downloading Azure Storage blobs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/llama_index/readers/azstorage_blob/base.py
@@ -136,19 +136,25 @@ class AzStorageBlobReader(
             )
 
         for obj in blobs_list:
-            sanitized_file_name = obj.name.replace("/", "-") if not self.blob else obj
-            download_file_path = os.path.join(temp_dir, sanitized_file_name)
-            logger.info(f"Start download of {sanitized_file_name}")
+            file_name = obj if self.blob else obj.name
+
+            download_file_path = os.path.join(temp_dir, file_name)
+
+            os.makedirs(os.path.dirname(download_file_path), exist_ok=True)
+
+            logger.info(f"Start download of {file_name}")
             start_time = time.time()
+
             blob_client = container_client.get_blob_client(obj)
             stream = blob_client.download_blob()
-            with open(file=download_file_path, mode="wb") as download_file:
+
+            with open(download_file_path, "wb") as download_file:
                 stream.readinto(download_file)
-            blob_meta[sanitized_file_name] = blob_client.get_blob_properties()
+
+            blob_meta[file_name] = blob_client.get_blob_properties()
+
             end_time = time.time()
-            logger.debug(
-                f"{sanitized_file_name} downloaded in {end_time - start_time} seconds."
-            )
+            logger.debug(f"{file_name} downloaded in {end_time - start_time} seconds.")
 
         return blob_meta
 
@@ -187,14 +193,14 @@ class AzStorageBlobReader(
         """Load documents from a directory and extract metadata."""
 
         def get_metadata(file_name: str) -> Dict[str, Any]:
-            sanitized_file_name = os.path.basename(file_name)
-            metadata_sanitized = files_metadata.get(sanitized_file_name, {})
+            relative_file_name = os.path.relpath(file_name, temp_dir)
+            metadata_sanitized = files_metadata.get(relative_file_name, {})
             try:
                 json_str = json.dumps(metadata_sanitized, cls=SanitizedJSONEncoder)
                 clean_metadata = json.loads(json_str)
             except (TypeError, ValueError) as e:
                 logger.error(
-                    f"Failed to serialize/deserialize metadata for '{sanitized_file_name}': {e}"
+                    f"Failed to serialize/deserialize metadata for '{relative_file_name}': {e}"
                 )
                 clean_metadata = {}
             return dict(**clean_metadata)

--- a/llama-index-integrations/readers/llama-index-readers-azstorage-blob/tests/test_readers_azstorage_blob.py
+++ b/llama-index-integrations/readers/llama-index-readers-azstorage-blob/tests/test_readers_azstorage_blob.py
@@ -1,3 +1,7 @@
+import os
+import tempfile
+from types import SimpleNamespace
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.azstorage_blob import AzStorageBlobReader
 
@@ -19,7 +23,59 @@ def test_serialize():
     assert len(schema) > 0
     assert "container_name" in schema["properties"]
 
-    json = reader.json(exclude_unset=True)
+    json_data = reader.json(exclude_unset=True)
 
-    new_reader = AzStorageBlobReader.parse_raw(json)
+    new_reader = AzStorageBlobReader.parse_raw(json_data)
     assert new_reader.container_name == reader.container_name
+
+
+def test_download_files_preserves_distinct_blob_names(monkeypatch):
+    class MockDownloadStream:
+        def __init__(self, text):
+            self.text = text
+
+        def readinto(self, fp):
+            fp.write(self.text.encode("utf-8"))
+
+    class MockBlobClient:
+        def __init__(self, blob):
+            self.blob = blob
+
+        def download_blob(self):
+            if self.blob.name == "contracts/2025-report.txt":
+                return MockDownloadStream("Quarterly report")
+            return MockDownloadStream("Annual report")
+
+        def get_blob_properties(self):
+            return {
+                "creation_time": None,
+                "last_modified": None,
+                "last_accessed_on": None,
+            }
+
+    class MockContainerClient:
+        def list_blobs(self, name_starts_with=None, include=None):
+            return [
+                SimpleNamespace(name="contracts/2025-report.txt"),
+                SimpleNamespace(name="contracts-2025/report.txt"),
+            ]
+
+        def get_blob_client(self, blob):
+            return MockBlobClient(blob)
+
+    monkeypatch.setattr(
+        AzStorageBlobReader,
+        "_get_container_client",
+        lambda self: MockContainerClient(),
+    )
+
+    reader = AzStorageBlobReader(container_name="test")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        metadata = reader._download_files_and_extract_metadata(temp_dir)
+
+        assert os.path.exists(os.path.join(temp_dir, "contracts", "2025-report.txt"))
+
+        assert os.path.exists(os.path.join(temp_dir, "contracts-2025", "report.txt"))
+
+        assert len(metadata) == 2


### PR DESCRIPTION
# Description

This PR fixes a filename collision issue in `AzStorageBlobReader` when downloading blobs with distinct names that could previously map to the same local filename.

Previously, blob names such as:

- `contracts/2025-report.txt`
- `contracts-2025/report.txt`

could overwrite each other during download because their paths were flattened into the same filename.

This change preserves the original blob directory structure when writing files to the temporary download directory, ensuring each blob is stored at a unique path.

Fixes #22326

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Additional testing performed:

```bash
pytest
ruff check .
ruff format .
```

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
