### PR TITLE
fix(minio): MinioReader drops objects sharing a basename

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
@@ -5,6 +5,7 @@ A loader that fetches a file or iterates through a directory on Minio.
 
 """
 
+import os
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -101,7 +102,10 @@ class MinioReader(BaseReader):
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.key:
                 suffix = Path(self.key).suffix
-                _, filepath = tempfile.mkstemp(dir=temp_dir, suffix=suffix)
+                fd, filepath = tempfile.mkstemp(dir=temp_dir, suffix=suffix)
+                # close the mkstemp handle so the download can write to the
+                # file and the temp dir can be cleaned up on Windows
+                os.close(fd)
                 minio_client.fget_object(
                     bucket_name=self.bucket, object_name=self.key, file_path=filepath
                 )
@@ -109,8 +113,8 @@ class MinioReader(BaseReader):
                 objects = minio_client.list_objects(
                     bucket_name=self.bucket, prefix=self.prefix, recursive=True
                 )
+                temp_root = Path(temp_dir).resolve()
                 for i, obj in enumerate(objects):
-                    file_name = obj.object_name.split("/")[-1]
                     if self.num_files_limit is not None and i > self.num_files_limit:
                         break
 
@@ -125,11 +129,20 @@ class MinioReader(BaseReader):
                     if is_dir or is_bad_ext:
                         continue
 
-                    filepath = f"{temp_dir}/{file_name}"
-                    minio_client.fget_object(self.bucket, obj.object_name, filepath)
+                    # one directory per object so same-named files don't overwrite
+                    file_name = Path(obj.object_name.replace("\\", "/")).name
+                    download_dir = temp_root / f"{i:08d}"
+                    filepath = (download_dir / file_name).resolve()
+                    if not file_name or not filepath.is_relative_to(download_dir):
+                        raise ValueError(f"Unsafe object name: {obj.object_name}")
+                    download_dir.mkdir()
+                    minio_client.fget_object(
+                        self.bucket, obj.object_name, str(filepath)
+                    )
 
             loader = SimpleDirectoryReader(
                 temp_dir,
+                recursive=True,
                 file_extractor=self.file_extractor,
                 required_exts=self.required_exts,
                 filename_as_id=self.filename_as_id,

--- a/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-minio"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers minio integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.minio import BotoMinioReader, MinioReader
 
@@ -8,3 +13,123 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in MinioReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def _mock_minio_client(contents):
+    client = mock.MagicMock()
+    client.list_objects.return_value = [
+        SimpleNamespace(object_name=name) for name in contents
+    ]
+
+    def fget_object(bucket_name, object_name, file_path):
+        Path(file_path).write_text(contents[object_name])
+
+    client.fget_object.side_effect = fget_object
+    return client
+
+
+def test_objects_with_same_basename_are_all_loaded():
+    contents = {
+        "contracts/2025/report.txt": "2025 report",
+        "contracts/2026/report.txt": "2026 report",
+    }
+    client = _mock_minio_client(contents)
+
+    with mock.patch("minio.Minio", return_value=client):
+        documents = MinioReader(
+            bucket="documents", minio_endpoint="localhost:9000"
+        ).load_data()
+
+    assert client.fget_object.call_count == 2
+    destinations = {call.args[2] for call in client.fget_object.call_args_list}
+    assert len(destinations) == 2
+    assert len(documents) == 2
+    assert {doc.text for doc in documents} == {"2025 report", "2026 report"}
+    assert all(doc.metadata["file_name"] == "report.txt" for doc in documents)
+    assert len({doc.metadata["file_path"] for doc in documents}) == 2
+
+
+def test_same_basename_ids_unique_with_filename_as_id():
+    contents = {
+        "contracts/2025/report.txt": "2025 report",
+        "contracts/2026/report.txt": "2026 report",
+    }
+    client = _mock_minio_client(contents)
+
+    with mock.patch("minio.Minio", return_value=client):
+        documents = MinioReader(
+            bucket="documents",
+            minio_endpoint="localhost:9000",
+            filename_as_id=True,
+        ).load_data()
+
+    assert len({doc.id_ for doc in documents}) == 2
+
+
+def test_object_name_with_backslash_stays_in_temp_dir(tmp_path):
+    contents = {"..\\evil.txt": "payload"}
+    client = _mock_minio_client(contents)
+
+    with mock.patch(
+        "llama_index.readers.minio.minio_client.base.tempfile.TemporaryDirectory"
+    ) as mock_temp_dir:
+        mock_temp_dir.return_value.__enter__.return_value = str(tmp_path)
+        mock_temp_dir.return_value.__exit__.return_value = False
+        with mock.patch("minio.Minio", return_value=client):
+            documents = MinioReader(
+                bucket="documents", minio_endpoint="localhost:9000"
+            ).load_data()
+
+    destination = Path(client.fget_object.call_args.args[2])
+    assert destination == tmp_path.resolve() / "00000000" / "evil.txt"
+    assert len(documents) == 1
+    assert documents[0].text == "payload"
+
+
+def test_unsafe_object_name_raises():
+    contents = {"contracts/..": "payload"}
+    client = _mock_minio_client(contents)
+
+    with mock.patch("minio.Minio", return_value=client):
+        with pytest.raises(ValueError, match="Unsafe object name"):
+            MinioReader(bucket="documents", minio_endpoint="localhost:9000").load_data()
+
+    client.fget_object.assert_not_called()
+
+
+def test_file_metadata_receives_download_paths():
+    contents = {
+        "contracts/2025/report.txt": "2025 report",
+        "contracts/2026/report.txt": "2026 report",
+    }
+    client = _mock_minio_client(contents)
+
+    with mock.patch("minio.Minio", return_value=client):
+        documents = MinioReader(
+            bucket="documents",
+            minio_endpoint="localhost:9000",
+            file_metadata=lambda path: {"src_path": path},
+        ).load_data()
+
+    assert len(documents) == 2
+    metadata_paths = {Path(doc.metadata["src_path"]).resolve() for doc in documents}
+    download_paths = {
+        Path(call.args[2]).resolve() for call in client.fget_object.call_args_list
+    }
+    assert metadata_paths == download_paths
+
+
+def test_single_key_branch_unchanged():
+    contents = {"contracts/2025/report.txt": "single file"}
+    client = _mock_minio_client(contents)
+
+    with mock.patch("minio.Minio", return_value=client):
+        documents = MinioReader(
+            bucket="documents",
+            key="contracts/2025/report.txt",
+            minio_endpoint="localhost:9000",
+        ).load_data()
+
+    client.list_objects.assert_not_called()
+    assert len(documents) == 1
+    assert documents[0].text == "single file"

--- a/llama-index-integrations/readers/llama-index-readers-minio/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-minio/uv.lock
@@ -1861,7 +1861,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-minio"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# Description

`MinioReader.load_data()` reduces every object key to its final path segment and downloads all objects into one flat temp directory:

```python
file_name = obj.object_name.split("/")[-1]
filepath = f"{temp_dir}/{file_name}"
```

Objects like `contracts/2025/report.txt` and `contracts/2026/report.txt` both land at `<temp>/report.txt`, so the later download silently overwrites the earlier one and `SimpleDirectoryReader` returns one document instead of two. No error or warning is produced.

This PR downloads each object into its own zero-padded per-object subdirectory (`<temp>/<index>/<basename>`), keeps the file extension so `required_exts` and `file_extractor` still apply, reads the temp dir recursively, and raises `ValueError` for object names that would resolve outside the download directory instead of writing to an arbitrary location.

While adding coverage for the single-key branch, I also found that `tempfile.mkstemp` leaked its open file descriptor there, which makes every single-key `load_data()` crash at temp-dir cleanup on Windows (WinError 32). Fixed by closing the descriptor.

The boto3-based reader in this package is not affected (it already generates a unique temp name per object) and is unchanged.

Fixes #22325

## New Package?

- [ ] No

## Version Bump?

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Six new tests in `tests/test_readers_minio.py` mock the Minio client: two objects sharing a basename produce two distinct download paths and two documents (fails on current main with one document), `filename_as_id` ids stay unique, a backslashed object name stays inside the temp dir (asserted against a known temp path), an escaping object name raises `ValueError` before any download, `file_metadata` receives the real download paths, and the single-key branch still works.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

Per the AI guidelines in CONTRIBUTING.md: I used AI assistance while developing this fix and its tests; I reviewed and verified all of it myself (repro before/after, full package test run, and the repo pre-commit suite including mypy).