### PR TITLE
fix(box): BoxReader drops files sharing a name

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
@@ -148,8 +148,10 @@ def download_file_by_id(box_client: BoxClient, box_file: File, temp_dir: str) ->
         BoxAPIError: If an error occurs while interacting with the Box API.
 
     """
-    # Save the downloaded file to the specified local directory.
-    file_path = os.path.join(temp_dir, box_file.name)
+    # One directory per file id so files sharing a name don't overwrite each other.
+    file_dir = os.path.join(temp_dir, box_file.id)
+    os.makedirs(file_dir, exist_ok=True)
+    file_path = os.path.join(file_dir, os.path.basename(box_file.name))
 
     try:
         file_stream: ByteStream = box_client.downloads.download_file(box_file.id)

--- a/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxReader/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxReader/base.py
@@ -351,6 +351,7 @@ class BoxReader(BoxReaderBase):
 
             simple_loader = SimpleDirectoryReader(
                 input_dir=temp_dir,
+                recursive=True,
                 file_metadata=get_metadata,
                 file_extractor=self.file_extractor,
             )

--- a/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-box"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers box integration"
 authors = [{name = "Box Developer Relations", email = "dx@box.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_same_named_files.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_same_named_files.py
@@ -1,0 +1,67 @@
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from box_sdk_gen import BoxClient
+
+from llama_index.readers.box import BoxReader
+from llama_index.readers.box.BoxAPI.box_api import download_file_by_id
+from llama_index.readers.box.BoxReader import base as box_reader_base
+
+
+def _box_file(file_id: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=file_id, name=name)
+
+
+def _mock_client() -> mock.MagicMock:
+    client = mock.MagicMock(spec=BoxClient)
+    client.downloads = mock.MagicMock()
+    client.downloads.download_file.side_effect = lambda file_id: io.BytesIO(
+        f"content of {file_id}".encode()
+    )
+    return client
+
+
+def test_download_file_by_id_same_name_files_do_not_collide(tmp_path):
+    client = _mock_client()
+    file_a = _box_file("111", "report.txt")
+    file_b = _box_file("222", "report.txt")
+
+    path_a = download_file_by_id(
+        box_client=client, box_file=file_a, temp_dir=str(tmp_path)
+    )
+    path_b = download_file_by_id(
+        box_client=client, box_file=file_b, temp_dir=str(tmp_path)
+    )
+
+    assert path_a == str(tmp_path / "111" / "report.txt")
+    assert path_b == str(tmp_path / "222" / "report.txt")
+    assert Path(path_a).read_text() == "content of 111"
+    assert Path(path_b).read_text() == "content of 222"
+
+
+def test_load_data_returns_all_same_named_files():
+    client = _mock_client()
+    reader = BoxReader(box_client=client)
+    reader._box_client = client
+    box_files = [_box_file("111", "report.txt"), _box_file("222", "report.txt")]
+
+    with (
+        mock.patch.object(box_reader_base, "box_check_connection"),
+        mock.patch.object(
+            box_reader_base, "get_box_files_details", return_value=box_files
+        ),
+        mock.patch.object(
+            box_reader_base,
+            "box_file_to_llama_document_metadata",
+            side_effect=lambda f: {"box_file_id": f.id},
+        ),
+    ):
+        documents = reader.load_data(file_ids=["111", "222"])
+
+    assert len(documents) == 2
+    assert {(doc.text, doc.metadata["box_file_id"]) for doc in documents} == {
+        ("content of 111", "111"),
+        ("content of 222", "222"),
+    }

--- a/llama-index-integrations/readers/llama-index-readers-box/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-box/uv.lock
@@ -1837,7 +1837,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-box"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "box-sdk-gen" },
@@ -1875,7 +1875,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "ipython", specifier = "==8.10.0" },


### PR DESCRIPTION
# Description

`download_file_by_id` writes every Box file to `os.path.join(temp_dir, box_file.name)`, so two files with the same name from different folders overwrite each other and `BoxReader.load_data()` silently returns fewer documents. The metadata mapping in `load_data` is keyed by the downloaded path, so the surviving document could also carry the wrong file's metadata.

This PR downloads each file into a subdirectory named after its Box file id (unique per file), reads the temp dir recursively, and leaves everything else unchanged. The Text Extraction and Box AI reader variants do not use this download path and are unaffected.

Note on the lockfile: `uv.lock` picks up the current `pyproject.toml` black dev constraint (`<=26.5.1`) in addition to the version bump; the committed lock was stale relative to pyproject and any uv command regenerates that line.

Fixes #22324

## New Package?

- [ ] No

## Version Bump?

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Two tests in `tests/test_readers_box_same_named_files.py` mock the Box client: same-named files produce distinct `<temp>/<file id>/<name>` paths with the right contents (fails on current main with identical paths), and `load_data` returns both documents with each text paired to its own file's metadata (fails on current main with one document).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

Per the AI guidelines in CONTRIBUTING.md: I used AI assistance while developing this fix and its tests; I reviewed and verified all of it myself (before/after test runs and the repo pre-commit checks).