### PR TITLE
fix(onedrive): OneDriveReader drops same-named files from different folders

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/llama_index/readers/microsoft_onedrive/base.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from typing import Any, Dict, List, Optional, Union
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import requests
 from llama_index.core.readers import SimpleDirectoryReader
@@ -272,8 +272,21 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
         # Download the file.
         file_data = requests.get(file_download_url)
 
-        # Save the downloaded file to the specified local directory.
-        file_path = os.path.join(local_dir, file_name)
+        # Save the downloaded file to a directory keyed by the item id, so
+        # same-named files from different folders do not overwrite each other.
+        # The id must be a single plain path component on every platform so
+        # ids cannot alias each other or escape the download directory.
+        item_id = item["id"]
+        if (
+            item_id in ("", ".", "..")
+            or item_id != PureWindowsPath(item_id).name
+            or item_id != PurePosixPath(item_id).name
+            or item_id != item_id.rstrip(". ")
+        ):
+            raise ValueError(f"Unsafe drive item id: {item_id}")
+        file_dir = Path(local_dir) / item_id
+        file_dir.mkdir(exist_ok=True)
+        file_path = os.path.join(str(file_dir), os.path.basename(file_name))
         with open(file_path, "wb") as f:
             f.write(file_data.content)
 
@@ -667,8 +680,11 @@ class OneDriveReader(BasePydanticReader, ResourcesReaderMixin, FileSystemReaderM
                     temp_dir=temp_dir,
                 )
                 logger.debug("Downloaded %d files from OneDriveReader", len(payloads))
+                # Files are downloaded into per-item subdirectories, so the
+                # local read is always recursive; `recursive` only controls
+                # OneDrive folder traversal above.
                 return self._load_documents_with_metadata(
-                    payloads, temp_dir, recursive=recursive
+                    payloads, temp_dir, recursive=True
                 )
         except Exception as e:
             logger.error(

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-onedrive"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers microsoft_onedrive integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/tests/test_readers_microsoft_onedrive.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+from unittest import mock
+
 import pytest
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.microsoft_onedrive import OneDriveReader
+from llama_index.readers.microsoft_onedrive.base import _OneDriveResourcePayload
 
 test_client_id = "test_client_id"
 test_tenant_id = "test_tenant_id"
@@ -31,6 +35,97 @@ def test_serialize():
     assert new_reader.client_id == reader.client_id
     assert new_reader.tenant_id == reader.tenant_id
     assert new_reader.required_exts == reader.required_exts
+
+
+def _drive_item(item_id: str, name: str, url: str) -> dict:
+    return {"id": item_id, "name": name, "@microsoft.graph.downloadUrl": url}
+
+
+def _mock_requests_get(url):
+    return mock.Mock(content=f"content of {url}".encode())
+
+
+def test_download_same_named_files_do_not_collide(tmp_path):
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+    item_a = _drive_item("A1", "report.txt", "url_a")
+    item_b = _drive_item("B2", "report.txt", "url_b")
+
+    with mock.patch(
+        "llama_index.readers.microsoft_onedrive.base.requests.get",
+        side_effect=_mock_requests_get,
+    ):
+        path_a = reader._download_file_by_url(item_a, str(tmp_path))
+        path_b = reader._download_file_by_url(item_b, str(tmp_path))
+
+    assert path_a == str(tmp_path / "A1" / "report.txt")
+    assert path_b == str(tmp_path / "B2" / "report.txt")
+    assert Path(path_a).read_text() == "content of url_a"
+    assert Path(path_b).read_text() == "content of url_b"
+
+
+@pytest.mark.parametrize(
+    "item_id",
+    ["..", ".", "", "x/../A1", "x\\..\\A1", "/A1", "C:A1", "A1.", "A1 "],
+)
+def test_unsafe_drive_item_id_raises(tmp_path, item_id):
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+    item = _drive_item(item_id, "report.txt", "url_a")
+
+    with mock.patch(
+        "llama_index.readers.microsoft_onedrive.base.requests.get",
+        side_effect=_mock_requests_get,
+    ):
+        with pytest.raises(ValueError, match="Unsafe drive item id"):
+            reader._download_file_by_url(item, str(tmp_path))
+
+
+def test_load_data_recursive_false_still_reads_downloaded_files():
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+    item = _drive_item("A1", "report.txt", "url_a")
+
+    def fake_download(**kwargs):
+        with mock.patch(
+            "llama_index.readers.microsoft_onedrive.base.requests.get",
+            side_effect=_mock_requests_get,
+        ):
+            path = reader._download_file_by_url(item, kwargs["temp_dir"])
+        return [
+            _OneDriveResourcePayload(
+                resource_info={"item_id": "A1"}, downloaded_file_path=path
+            )
+        ]
+
+    with mock.patch.object(
+        reader, "_get_downloaded_files_metadata", side_effect=fake_download
+    ):
+        documents = reader.load_data(recursive=False)
+
+    assert len(documents) == 1
+    assert documents[0].text == "content of url_a"
+
+
+def test_load_documents_with_metadata_same_named_files(tmp_path):
+    reader = OneDriveReader(client_id=test_client_id, tenant_id=test_tenant_id)
+    item_a = _drive_item("A1", "report.txt", "url_a")
+    item_b = _drive_item("B2", "report.txt", "url_b")
+
+    with mock.patch(
+        "llama_index.readers.microsoft_onedrive.base.requests.get",
+        side_effect=_mock_requests_get,
+    ):
+        payloads = [
+            _OneDriveResourcePayload(
+                resource_info={"item_id": item["id"]},
+                downloaded_file_path=reader._download_file_by_url(item, str(tmp_path)),
+            )
+            for item in (item_a, item_b)
+        ]
+
+    documents = reader._load_documents_with_metadata(payloads, str(tmp_path))
+
+    assert len(documents) == 2
+    assert {doc.text for doc in documents} == {"content of url_a", "content of url_b"}
+    assert {doc.metadata["item_id"] for doc in documents} == {"A1", "B2"}
 
 
 @pytest.fixture()

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-onedrive/uv.lock
@@ -1824,7 +1824,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-onedrive"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`_download_file_by_url` writes every drive item to `os.path.join(local_dir, item['name'])`, so two files with the same name from different OneDrive folders overwrite each other in the temp dir and `load_data()` silently returns fewer documents.

This PR downloads each item into a subdirectory named after its drive item id. The id must be a single plain path component on every platform (checked against both Windows and POSIX name rules, no trailing dots or spaces, not `.`/`..`), so ids cannot alias each other or escape the download directory; anything else raises `ValueError`. The local read of the temp dir is now always recursive, while the `recursive` parameter keeps controlling OneDrive folder traversal as documented.

Fixes #22327

## New Package?

- [ ] No

## Version Bump?

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

New tests in `tests/test_readers_microsoft_onedrive.py`: same-named items land at distinct exact `<temp>/<item id>/<name>` paths with the right contents (fails on current main), documents keep their own metadata through `_load_documents_with_metadata`, `load_data(recursive=False)` still returns the downloaded documents, and nine hostile item-id forms (`..`, separators, drive-relative, trailing dot/space, ...) raise `ValueError`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

Per the AI guidelines in CONTRIBUTING.md: I used AI assistance while developing this fix and its tests; I reviewed and verified all of it myself (before/after test runs and the repo pre-commit checks).