### PR TITLE
fix(readers-minio): prevent name collisions for nested files in MinioReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
@@ -125,8 +125,11 @@ class MinioReader(BaseReader):
                     if is_dir or is_bad_ext:
                         continue
 
-                    filepath = f"{temp_dir}/{file_name}"
-                    minio_client.fget_object(self.bucket, obj.object_name, filepath)
+                    filepath = Path(temp_dir) / obj.object_name
+                    filepath.parent.mkdir(parents=True, exist_ok=True)
+                    minio_client.fget_object(
+                        self.bucket, obj.object_name, str(filepath)
+                    )
 
             loader = SimpleDirectoryReader(
                 temp_dir,
@@ -135,6 +138,7 @@ class MinioReader(BaseReader):
                 filename_as_id=self.filename_as_id,
                 num_files_limit=self.num_files_limit,
                 file_metadata=self.file_metadata,
+                recursive=True,
             )
 
             return loader.load_data()

--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/minio_client/base.py
@@ -131,6 +131,8 @@ class MinioReader(BaseReader):
                         self.bucket, obj.object_name, str(filepath)
                     )
 
+            # recursive=True is required: because we preserve prefix structures to prevent collision,
+            # we must instruct SimpleDirectoryReader to recursively descend into subdirectories.
             loader = SimpleDirectoryReader(
                 temp_dir,
                 file_extractor=self.file_extractor,

--- a/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+from pathlib import Path
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.minio import BotoMinioReader, MinioReader
 
@@ -8,3 +10,43 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in MinioReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+@patch("minio.Minio")
+def test_minio_reader_nested_objects(mock_minio_class) -> None:
+    mock_client = MagicMock()
+    mock_minio_class.return_value = mock_client
+
+    # Mock objects returned by list_objects
+    mock_obj1 = MagicMock()
+    mock_obj1.object_name = "contracts/2025/report.txt"
+    mock_obj1.is_dir = False
+
+    mock_obj2 = MagicMock()
+    mock_obj2.object_name = "contracts/2026/report.txt"
+    mock_obj2.is_dir = False
+
+    mock_client.list_objects.return_value = [mock_obj1, mock_obj2]
+
+    # Track downloaded paths
+    downloaded_paths = []
+
+    def mock_fget_object(bucket_name, object_name, file_path):
+        downloaded_paths.append(file_path)
+        # Create dummy file to simulate download
+        Path(file_path).write_text(f"content from {object_name}")
+
+    mock_client.fget_object.side_effect = mock_fget_object
+
+    reader = MinioReader(
+        bucket="test-bucket",
+        minio_endpoint="localhost:9000",
+    )
+
+    documents = reader.load_data()
+
+    # Assert both files were downloaded without overwriting each other
+    assert len(downloaded_paths) == 2
+    assert any("contracts/2025/report.txt" in str(p) for p in downloaded_paths)
+    assert any("contracts/2026/report.txt" in str(p) for p in downloaded_paths)
+    assert len(documents) == 2


### PR DESCRIPTION
Resolves #22325.

### Description
`MinioReader` previously downloaded all bucket objects into a single flat temporary directory structure using only their basenames. This caused files in different subdirectories with identical names (e.g. `dir1/report.txt` and `dir2/report.txt`) to overwrite each other during the fetch process, resulting in lost data.

### Changes
- Recreated the prefix/path structure under the temporary folder by using the full object key name instead of just the split basename.
- Enabled recursive mode (`recursive=True`) in the delegated `SimpleDirectoryReader` to correctly parse nested files under the temporary directory.
- Added a mock regression test verifying that nested files with same names are fully preserved without overwriting each other.