### PR TITLE
fix: avoid IndexError in truncate_text on whitespace-only input

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -20,7 +20,8 @@ def truncate_text(text: str, text_splitter: TextSplitter) -> str:
 
     """
     chunks = text_splitter.split_text(text)
-    return chunks[0]
+    # Whitespace-only input yields no chunks (the splitter drops it); return "".
+    return chunks[0] if chunks else ""
 
 
 def split_text_keep_separator(text: str, separator: str) -> List[str]:

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -41,6 +41,15 @@ def test_truncate_token() -> None:
     assert text == "foo"
 
 
+def test_truncate_whitespace_only_text() -> None:
+    """Whitespace-only text yields no chunks; truncate_text must not raise."""
+    text_splitter = TokenTextSplitter(chunk_size=20, chunk_overlap=0)
+    # The splitter drops the whitespace-only chunk, returning [].
+    assert text_splitter.split_text("   ") == []
+    # Previously this raised IndexError (chunks[0] on an empty list).
+    assert truncate_text("   ", text_splitter) == ""
+
+
 def test_split_long_token() -> None:
     """Test split a really long token."""
     token = "a" * 100


### PR DESCRIPTION
### Problem

`truncate_text` returns the first chunk without guarding the empty case:

```python
def truncate_text(text: str, text_splitter: TextSplitter) -> str:
    chunks = text_splitter.split_text(text)
    return chunks[0]
```

For **whitespace-only** text (`"   "`, newline-only node content, ...), both
`SentenceSplitter` and `TokenTextSplitter` return an empty list — they strip and
drop the whitespace-only chunk — so `chunks[0]` raises `IndexError`.

This is reachable from public callers that feed arbitrary node/chunk text in,
e.g. `PromptHelper.truncate` and `get_numbered_text_from_nodes`. For instance,
`get_numbered_text_from_nodes` on a node whose content is just newlines joins it
to spaces and hands it to `truncate_text`, which then crashes.

(`split_text("")` is special-cased to `[""]` and does **not** crash; only
non-empty whitespace input triggers the empty-list path.)

### Fix

Return `""` when the splitter produces no chunks, matching the docstring intent.

### Test

Added `test_truncate_whitespace_only_text` in
`tests/text_splitter/test_token_splitter.py`: it asserts the splitter returns
`[]` for `"   "` and that `truncate_text` returns `""` instead of raising. Fails
before the change (`IndexError`), passes after. Full `tests/text_splitter/` suite
passes (24 passed).

```
$ uv run -- pytest tests/text_splitter/
24 passed, 15 skipped
```

`ruff check` passes on the changed files.

---

*Disclosure: I used AI assistance (Claude) to find this crash-on-edge-input and
draft the test. I reviewed the change, ran the suite, and take responsibility for
its correctness.*
