### PR TITLE
fix: don't mutate caller's chat_history in ChatSummaryMemoryBuffer.get

### DIFF
--- a/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
+++ b/llama-index-core/llama_index/core/memory/chat_summary_memory_buffer.py
@@ -168,7 +168,10 @@ class ChatSummaryMemoryBuffer(BaseMemory):
         self, input: Optional[str] = None, initial_token_count: int = 0, **kwargs: Any
     ) -> List[ChatMessage]:
         """Get chat history."""
-        chat_history = self.get_all()
+        # Copy the list: get_all() returns the store's list by reference, and
+        # _split_messages_summary_or_full_text pops from it. Without the copy,
+        # this read-style call would mutate the caller's own chat_history list.
+        chat_history = list(self.get_all())
         if len(chat_history) == 0:
             return []
 

--- a/llama-index-core/tests/memory/test_chat_summary_memory_buffer.py
+++ b/llama-index-core/tests/memory/test_chat_summary_memory_buffer.py
@@ -293,6 +293,23 @@ def test_max_tokens_without_summarizer() -> None:
     assert len(memory.get()) == 2
 
 
+def test_get_does_not_mutate_caller_chat_history() -> None:
+    # get() is a read-style call and must not mutate the list the caller passed
+    # to from_defaults. Previously it popped messages off the shared list object.
+    chat_history = [
+        ChatMessage(role=MessageRole.USER, content=f"Message {i}") for i in range(6)
+    ]
+    # token_limit small enough that only the last two messages fit.
+    token_limit = len(tokenizer("Message 5")) + len(tokenizer("Message 4"))
+    memory = ChatSummaryMemoryBuffer.from_defaults(
+        chat_history=chat_history, token_limit=token_limit
+    )
+
+    memory.get()
+
+    assert len(chat_history) == 6
+
+
 @pytest.mark.skipif(not openai_installed, reason="OpenAI not installed")
 def test_max_tokens_with_summarizer(summarizer_llm) -> None:
     max_tokens = 1


### PR DESCRIPTION
### Problem

`ChatSummaryMemoryBuffer.get()` is a read-style call, but it mutates the list the
caller passed to `from_defaults(chat_history=...)`:

```python
def get(self, ...):
    chat_history = self.get_all()          # returns the store's list BY REFERENCE
    ...
    (full_text, to_summarize) = self._split_messages_summary_or_full_text(chat_history)
```

`get_all()` returns `self.chat_store.get_messages(...)`, which hands back the
stored list object by reference, and `from_defaults` stored the caller's list by
reference (`set_messages` does `self.store[key] = messages`).
`_split_messages_summary_or_full_text` then does `chat_history.pop()` on that
shared object — so a plain `memory.get()` silently removes messages from the
**user's own list**.

#### Reproduction

```python
chat_history = [ChatMessage(role=USER, content=f"Message {i}") for i in range(6)]
mem = ChatSummaryMemoryBuffer.from_defaults(chat_history=chat_history, token_limit=<fits 2>)
mem.get()
len(chat_history)   # 4, not 6  -- two messages were popped off the caller's list
```

(The repo's own tests sidestep this by passing `chat_history=SOMETHING.copy()`.)

### Fix

Copy the list in `get()` (`chat_history = list(self.get_all())`) before splitting,
so the in-place pops operate on a local copy. `get()` already rebuilds the store
afterward via `reset()` + `set()`, so mutating the shared list was never needed
for correctness.

### Test

Added `test_get_does_not_mutate_caller_chat_history` (llm=None path, no summarizer,
no network): passes a list of 6 messages, calls `get()`, asserts the caller's list
still has 6. Fails before the change (len 4), passes after. Full memory suite
passes (15 passed).

```
$ uv run -- pytest tests/memory/test_chat_summary_memory_buffer.py
15 passed
```

`ruff check` passes on the changed files.

---

*Disclosure: I used AI assistance (Claude) to find this input-mutation bug and
draft the test. I reviewed the change, ran the suite, and take responsibility for
its correctness.*
