### PR TITLE
fix: align embeddings with sorted order in EmbeddingRecencyPostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/node_recency.py
+++ b/llama-index-core/llama_index/core/postprocessor/node_recency.py
@@ -129,7 +129,11 @@ class EmbeddingRecencyPostprocessor(BaseNodePostprocessor):
         sorted_nodes: List[NodeWithScore] = [nodes[idx] for idx in sorted_node_idxs]
 
         # get embeddings for each node
-        texts = [node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes]
+        # NOTE: build in sorted_nodes order, since the dedup loop below indexes
+        # text_embeddings by position into sorted_nodes (idx2), not into nodes.
+        texts = [
+            node.get_content(metadata_mode=MetadataMode.EMBED) for node in sorted_nodes
+        ]
         text_embeddings = self.embed_model.get_text_embedding_batch(texts=texts)
 
         node_ids_to_skip: Set[str] = set()

--- a/llama-index-core/tests/postprocessor/test_node_recency.py
+++ b/llama-index-core/tests/postprocessor/test_node_recency.py
@@ -1,0 +1,84 @@
+"""Tests for EmbeddingRecencyPostprocessor dedup (no network/LLM)."""
+
+from typing import List
+
+import pytest
+
+from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.postprocessor.node_recency import (
+    EmbeddingRecencyPostprocessor,
+)
+from llama_index.core.schema import MetadataMode, NodeWithScore, QueryBundle, TextNode
+
+pandas = pytest.importorskip("pandas")
+
+
+class _ContentEmbedding(BaseEmbedding):
+    """Deterministic, content-dependent embedding: alpha->[1,0], beta->[0,1]."""
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "_ContentEmbedding"
+
+    def _vec(self, text: str) -> List[float]:
+        return [1.0, 0.0] if "alpha" in text else [0.0, 1.0]
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return self._vec(query)
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return self._vec(text)
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._vec(query)
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return self._vec(text)
+
+
+def test_embedding_recency_dedup_keeps_unique_when_input_not_date_sorted() -> None:
+    # Input order differs from descending-date order (the normal retriever case).
+    # Two 'alpha' duplicates and one unique 'beta'; the older alpha should be
+    # dropped and beta kept. Previously the embedding list was built in input
+    # order but indexed by date-sorted position, so beta was dropped instead.
+    nodes = [
+        NodeWithScore(
+            node=TextNode(
+                id_="n0",
+                text="alpha",
+                metadata={"date": "2020-01-01"},
+                excluded_embed_metadata_keys=["date"],
+            )
+        ),
+        NodeWithScore(
+            node=TextNode(
+                id_="n1",
+                text="alpha",
+                metadata={"date": "2020-01-03"},
+                excluded_embed_metadata_keys=["date"],
+            )
+        ),
+        NodeWithScore(
+            node=TextNode(
+                id_="n2",
+                text="beta",
+                metadata={"date": "2020-01-02"},
+                excluded_embed_metadata_keys=["date"],
+            )
+        ),
+    ]
+
+    postprocessor = EmbeddingRecencyPostprocessor(
+        embed_model=_ContentEmbedding(), similarity_cutoff=0.5
+    )
+    result = postprocessor.postprocess_nodes(
+        nodes, query_bundle=QueryBundle(query_str="q")
+    )
+
+    contents = sorted(n.node.get_content(metadata_mode=MetadataMode.NONE) for n in result)
+    # The unique 'beta' must survive; exactly one 'alpha' is kept.
+    assert contents == ["alpha", "beta"]
+    kept_ids = {n.node.node_id for n in result}
+    assert "n2" in kept_ids  # beta kept
+    assert "n1" in kept_ids  # newest alpha kept
+    assert "n0" not in kept_ids  # older alpha dropped


### PR DESCRIPTION
### Problem

`EmbeddingRecencyPostprocessor` deduplicates near-identical nodes, but the
embedding list and the dedup loop index disagree:

```python
sorted_nodes = [nodes[idx] for idx in sorted_node_idxs]        # date-sorted (newest first)

texts = [node.get_content(...) for node in nodes]              # built in ORIGINAL order
text_embeddings = self.embed_model.get_text_embedding_batch(texts=texts)

for idx, node in enumerate(sorted_nodes):
    ...
    for idx2 in range(idx + 1, len(sorted_nodes)):            # idx2 indexes sorted_nodes
        if np.dot(query_embedding, text_embeddings[idx2]) > cutoff:   # ...but text_embeddings is in nodes order
            node_ids_to_skip.add(sorted_nodes[idx2].node.node_id)
```

`text_embeddings` is built in the original `nodes` order, but indexed by `idx2`,
a position into the date-sorted `sorted_nodes`. Whenever the caller's node order
differs from newest-first date order — the normal case, since retrievers return
relevance order — the dedup compares the **wrong** embeddings, so unique content
is silently dropped while duplicates are kept.

#### Reproduction

3 nodes: `alpha`(2020-01-01), `alpha`(2020-01-03), `beta`(2020-01-02) in that
(non-date-sorted) input order, with a deterministic content embedding
(`alpha->[1,0]`, `beta->[0,1]`) and `similarity_cutoff=0.5`. Expected: keep the
newest `alpha` + the unique `beta`, drop the older `alpha`. Actual before the fix:
both `alpha` duplicates kept, `beta` dropped.

### Fix

Build `texts` from `sorted_nodes`, so `text_embeddings[idx2]` refers to the same
node the loop is examining.

### Test

Added `tests/postprocessor/test_node_recency.py` with a small deterministic,
content-dependent embedding (no network/LLM; `pandas` is imported via
`importorskip`). It feeds nodes in non-date order and asserts the unique node
survives and the older duplicate is dropped. Fails before the change (keeps two
`alpha`, drops `beta`), passes after.

```
$ uv run -- pytest tests/postprocessor/test_node_recency.py
1 passed
```

`ruff check` passes on the changed files.

---

*Disclosure: I used AI assistance (Claude) to find this index-misalignment bug
and draft the test. I reviewed the change, ran the suite, and take responsibility
for its correctness.*
