### PR TITLE
fix(dashscope): handle both multimodal embedding response shapes

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/llama_index/embeddings/dashscope/base.py
@@ -147,7 +147,16 @@ def get_multimodal_embedding(
         model=model, input=input, api_key=api_key, kwargs=kwargs
     )
     if response.status_code == HTTPStatus.OK:
-        return response.output["embedding"]
+        output = response.output
+        if "embeddings" in output:
+            # Newer DashScope API versions return a list of embedding
+            # objects (each with "embedding", "index", "type") instead of a
+            # single "embedding" key. get_multimodal_embedding always sends
+            # a single fused/weighted input, so exactly one result comes
+            # back; take it, falling back to the older shape below for
+            # accounts/regions still on the previous response format.
+            return output["embeddings"][0]["embedding"]
+        return output["embedding"]
     else:
         logger.error("Calling MultiModalEmbedding failed, details: %s" % response)
         return []

--- a/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/tests/test_embeddings_dashscope.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-dashscope/tests/test_embeddings_dashscope.py
@@ -1,7 +1,65 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
 from llama_index.core.embeddings.multi_modal_base import MultiModalEmbedding
 from llama_index.embeddings.dashscope import DashScopeEmbedding
+from llama_index.embeddings.dashscope.base import get_multimodal_embedding
 
 
 def test_dashscope_embedding_class():
     names_of_base_classes = [b.__name__ for b in DashScopeEmbedding.__mro__]
     assert MultiModalEmbedding.__name__ in names_of_base_classes
+
+
+def test_get_multimodal_embedding_parses_new_list_response_shape():
+    """
+    Regression: newer DashScope API versions return a list of embedding
+    objects under "embeddings" instead of a single "embedding" key. Without
+    handling this shape, the real embedding vector was never extracted.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.OK
+    mock_response.output = {
+        "embeddings": [
+            {"embedding": [0.1, 0.2, 0.3], "index": 0, "type": "text"}
+        ]
+    }
+
+    with patch("dashscope.MultiModalEmbedding.call", return_value=mock_response):
+        result = get_multimodal_embedding(
+            model="multimodal-embedding-one-peace-v1",
+            input=[{"factor": 1, "text": "hello"}],
+        )
+
+    assert result == [0.1, 0.2, 0.3]
+
+
+def test_get_multimodal_embedding_parses_legacy_single_response_shape():
+    """
+    The older DashScope response shape (a single "embedding" key) must
+    keep working for accounts/regions still on the previous API version.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.OK
+    mock_response.output = {"embedding": [0.4, 0.5, 0.6]}
+
+    with patch("dashscope.MultiModalEmbedding.call", return_value=mock_response):
+        result = get_multimodal_embedding(
+            model="multimodal-embedding-one-peace-v1",
+            input=[{"factor": 1, "text": "hello"}],
+        )
+
+    assert result == [0.4, 0.5, 0.6]
+
+
+def test_get_multimodal_embedding_returns_empty_list_on_failure():
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.BAD_REQUEST
+
+    with patch("dashscope.MultiModalEmbedding.call", return_value=mock_response):
+        result = get_multimodal_embedding(
+            model="multimodal-embedding-one-peace-v1",
+            input=[{"factor": 1, "text": "hello"}],
+        )
+
+    assert result == []


### PR DESCRIPTION
# Description

`get_multimodal_embedding()` in `llama-index-embeddings-dashscope` parsed `response.output["embedding"]` (singular). Per #21532, newer DashScope API versions return the result under `response.output["embeddings"]` (plural, a list of `{embedding, index, type}` objects) instead — causing a `KeyError` on the new shape.

I don't have DashScope API access from this environment to independently observe the live response, so rather than blindly swapping one key for the other on secondhand evidence, this handles **both** shapes: prefer the newer `"embeddings"` list when present, falling back to the legacy `"embedding"` key otherwise. This fixes the reported error for accounts already on the new API while staying correct for any still on the old one — no regression either way.

Fixes #21532

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added tests for: the new list-shaped response (fails on `main` with the exact reported `KeyError`, passes with this fix), the legacy single-key response (passes either way — confirms no regression), and the existing failure-status path.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (internal bug fix)
- [ ] I have added Google Colab support for the newly added notebooks — N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (4 passed; ~55% coverage on the changed package)
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
