### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example for OpenAILike

### DIFF
--- a/docs/examples/llm/daoxe.ipynb
+++ b/docs/examples/llm/daoxe.ipynb
@@ -1,0 +1,57 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DaoXE (OpenAI-compatible gateway)\n",
+    "\n",
+    "This notebook shows [OpenAILike](https://docs.llamaindex.ai/) pointed at [DaoXE](https://daoxe.com),\n",
+    "a multi-model multi-protocol API gateway.\n",
+    "\n",
+    "Set `DAOXE_API_KEY` and `DAOXE_MODEL` (exact account model ID from `GET /v1/models`).\n",
+    "Disclosure: example maintained by a DaoXE maintainer. Not available in mainland China.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "%pip install llama-index-llms-openai-like\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import os\n",
+    "from llama_index.llms.openai_like import OpenAILike\n",
+    "\n",
+    "llm = OpenAILike(\n",
+    "    model=os.environ[\"DAOXE_MODEL\"],\n",
+    "    api_base=\"https://daoxe.com/v1\",\n",
+    "    api_key=os.environ[\"DAOXE_API_KEY\"],\n",
+    "    is_chat_model=True,\n",
+    "    is_function_calling_model=True,\n",
+    "    context_window=128000,\n",
+    ")\n",
+    "\n",
+    "resp = llm.complete(\"Reply with OK\")\n",
+    "print(resp)\n"
+   ]
+  }
+ ]
+}

--- a/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-openai-like/README.md
@@ -21,3 +21,31 @@ llm = OpenAILike(
     is_function_calling_model=False,
 )
 ```
+
+## DaoXE (multi-model multi-protocol gateway)
+
+[DaoXE](https://daoxe.com) exposes an OpenAI-compatible Chat Completions API at `https://daoxe.com/v1`.
+Use an API key from the DaoXE dashboard and an **exact** model ID from your account catalog
+(`GET /v1/models`). Do not hardcode a public model price list.
+
+DaoXE also supports OpenAI Responses and Anthropic Messages for other clients; this package uses
+the Chat Completions path via `OpenAILike`.
+
+```python
+import os
+from llama_index.llms.openai_like import OpenAILike
+
+llm = OpenAILike(
+    model=os.environ["DAOXE_MODEL"],  # exact ID from your DaoXE account
+    api_base="https://daoxe.com/v1",
+    api_key=os.environ["DAOXE_API_KEY"],
+    is_chat_model=True,
+    is_function_calling_model=True,  # set False if your chosen model lacks tools
+    context_window=128000,  # adjust to the model you select
+)
+
+print(llm.complete("Say hello in one short sentence."))
+```
+
+Examples: https://github.com/seven7763/DaoXE-AI
+


### PR DESCRIPTION
## Summary
- Document [DaoXE](https://daoxe.com) as an OpenAI-compatible multi-model gateway in the `llama-index-llms-openai-like` README.
- Add `docs/examples/llm/daoxe.ipynb` notebook using `OpenAILike` with `api_base=https://daoxe.com/v1` and account-scoped model IDs.

DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients; this example uses Chat Completions only. No static public model/price table.

I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] README example is copy-paste valid
- [ ] Notebook renders