### PR TITLE
fix: preserve original sentence order in SentenceEmbeddingOptimizer

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -162,6 +162,14 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                         f"{idx}. {top_sentences[idx]} ({top_similarities[idx]})"
                     )
 
-            nodes[node_idx].node.set_content(" ".join(top_sentences))
+            # `top_idxs`/`top_sentences` are in similarity-rank order (highest first),
+            # which is the right order for the debug log above but scrambles the
+            # excerpt's reading order. Rebuild the final content in original
+            # document order instead.
+            ordered_sentences = [
+                sentence for _, sentence in sorted(zip(top_idxs, top_sentences))
+            ]
+
+            nodes[node_idx].node.set_content(" ".join(ordered_sentences))
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_optimizer.py
+++ b/llama-index-core/tests/postprocessor/test_optimizer.py
@@ -143,3 +143,32 @@ def test_optimizer(_mock_embeds: Any, _mock_embed: Any) -> None:
         [NodeWithScore(node=orig_node)], query
     )[0]
     assert optimized_node.node.get_content() == "world foo bar"
+
+
+@patch.object(MockEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding)
+@patch.object(
+    MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+def test_optimizer_preserves_original_sentence_order(
+    _mock_embeds: Any, _mock_embed: Any
+) -> None:
+    """
+    Selected sentences must be reassembled in their original document order,
+    not in similarity-rank order (get_top_k_embeddings returns indices sorted
+    by descending similarity).
+    """
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn,
+        percentile_cutoff=1.0,  # keep every sentence
+        context_before=0,
+        context_after=0,
+    )
+    # "foo" (idx 1) is the exact query match (highest similarity); "bar" (idx 0)
+    # is orthogonal (lowest similarity) but appears first in the source text.
+    query = QueryBundle(query_str="foo", embedding=[0, 0, 1, 0, 0])
+    orig_node = TextNode(text="bar foo")
+    optimized_node = optimizer.postprocess_nodes(
+        [NodeWithScore(node=orig_node)], query
+    )[0]
+    assert optimized_node.node.get_content() == "bar foo"


### PR DESCRIPTION
## Problem

`SentenceEmbeddingOptimizer._postprocess_nodes` shortens a node's text by picking the top-k most query-relevant sentences via `get_top_k_embeddings()`, then joins them to build the excerpt:

```python
top_similarities, top_idxs = get_top_k_embeddings(...)
...
top_sentences = [... for idx in top_idxs]
...
nodes[node_idx].node.set_content(" ".join(top_sentences))
```

`get_top_k_embeddings()` returns `top_idxs` sorted by **descending similarity**, not by original sentence position:

```python
result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
```

So whenever more than one sentence is selected and the highest-similarity one isn't the first one in the source text, the final excerpt comes out reordered by relevance instead of preserving the original reading order — e.g. for source text `"bar foo"` with a query matching `"foo"` exactly, the optimizer currently returns `"foo bar"` instead of `"bar foo"`.

## Fix

Reorder the selected sentences by their original index before joining into the final content. The debug-log loop right above (which intentionally lists sentences in rank order next to their similarity scores) is left untouched — only the final `set_content()` call now uses document order.

## Testing

- Added `test_optimizer_preserves_original_sentence_order` to `tests/postprocessor/test_optimizer.py`, using the existing mock-embedding pattern in that file. Confirmed it fails against the pre-fix code (`'foo bar' == 'bar foo'` mismatch, verified via `git stash`) and passes with the fix.
- Ran the full `tests/postprocessor/test_optimizer.py` suite (2 passed) plus `ruff check`/`ruff format --check` (clean).

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently verified `get_top_k_embeddings`'s actual sort order and reproduced the wrong output with a throwaway script before writing the regression test.