### PR TITLE
fix: load the actual file when backward-compat loading an unnamespaced vector store

### DIFF
--- a/llama-index-core/llama_index/core/vector_stores/simple.py
+++ b/llama-index-core/llama_index/core/vector_stores/simple.py
@@ -122,9 +122,15 @@ class SimpleVectorStore(BasePydanticVectorStore):
                     namespace = fname.split(NAMESPACE_SEP)[0]
 
                     # handle backwards compatibility with stores that were persisted
+                    # without a namespace prefix: load the actual file found instead
+                    # of re-deriving a namespaced path that won't exist on disk.
                     if namespace == DEFAULT_PERSIST_FNAME:
-                        vector_stores[DEFAULT_VECTOR_STORE] = cls.from_persist_dir(
-                            persist_dir=persist_dir, fs=fs
+                        if fs is not None:
+                            persist_path = concat_dirs(persist_dir, fname)
+                        else:
+                            persist_path = os.path.join(persist_dir, fname)
+                        vector_stores[DEFAULT_VECTOR_STORE] = cls.from_persist_path(
+                            persist_path, fs=fs
                         )
                     else:
                         vector_stores[namespace] = cls.from_persist_dir(

--- a/llama-index-core/tests/vector_stores/test_simple.py
+++ b/llama-index-core/tests/vector_stores/test_simple.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pathlib import Path
 from typing import List
@@ -13,6 +14,7 @@ from llama_index.core.schema import (
 )
 from llama_index.core.vector_stores import SimpleVectorStore
 from llama_index.core.vector_stores.types import (
+    DEFAULT_PERSIST_FNAME,
     ExactMatchFilter,
     MetadataFilters,
     VectorStoreQuery,
@@ -485,3 +487,20 @@ def test_from_namespaced_persist_dir(persist_dir: str) -> None:
         persist_dir=persist_dir
     )
     assert vector_store is not None
+
+
+def test_from_namespaced_persist_dir_loads_legacy_unnamespaced_file(
+    tmp_path: Path,
+) -> None:
+    """
+    A store persisted without a namespace prefix (the pre-namespacing
+    on-disk format) must still load via from_namespaced_persist_dir.
+    """
+    legacy_path = os.path.join(str(tmp_path), DEFAULT_PERSIST_FNAME)
+    SimpleVectorStore().persist(persist_path=legacy_path)
+
+    vector_stores = SimpleVectorStore.from_namespaced_persist_dir(
+        persist_dir=str(tmp_path)
+    )
+
+    assert "default" in vector_stores


### PR DESCRIPTION
## Problem

`SimpleVectorStore.from_namespaced_persist_dir()` detects a legacy store persisted without a namespace prefix (a plain `vector_store.json`, from before the namespace feature existed) via:

```python
if namespace == DEFAULT_PERSIST_FNAME:
    vector_stores[DEFAULT_VECTOR_STORE] = cls.from_persist_dir(
        persist_dir=persist_dir, fs=fs
    )
```

But `from_persist_dir()` (called here with the default namespace) re-derives the path as `f"{namespace}{NAMESPACE_SEP}{DEFAULT_PERSIST_FNAME}"` → `"default__vector_store.json"`. That namespaced filename doesn't exist on disk — the actual legacy file found during the directory listing is just `"vector_store.json"`. Loading then raises `ValueError("No existing ... found")` instead of succeeding, breaking backward compatibility for exactly the case this branch exists to handle.

## Fix

Load the actual file found during the directory listing (`fname`) directly via `from_persist_path()`, instead of calling `from_persist_dir()` which re-derives a path assuming the namespaced format.

## Testing

- Added `test_from_namespaced_persist_dir_loads_legacy_unnamespaced_file`, which persists a store to a plain unnamespaced path (mirroring the real pre-namespacing on-disk format) and confirms `from_namespaced_persist_dir()` loads it under the `"default"` key. Confirmed it fails against the pre-fix code (`ValueError: No existing ... found at .../default__vector_store.json`) and passes after.
- Ran the full `tests/vector_stores/test_simple.py` suite (28 passed — no regressions).
- `ruff check`/`ruff format --check` clean.

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I traced the exact filename mismatch by reading `from_persist_dir`'s path construction, wrote/verified the regression test in both red and green states, and ran the full local test suite before opening this PR.