### PR TITLE
fix(core): avoid IndexError on empty documents in SemanticDoubleMergingSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -231,6 +231,12 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
             text = node.get_content()
             sentences = self.sentence_splitter(text)
             sentences = [s.strip() for s in sentences]
+            # Drop empty/whitespace-only sentences and skip documents that end up
+            # with no sentences; otherwise _create_initial_chunks raises
+            # IndexError on sentences[0] for an empty document (issue #17032).
+            sentences = [s for s in sentences if s]
+            if not sentences:
+                continue
             initial_chunks = self._create_initial_chunks(sentences)
             chunks = self._merge_initial_chunks(initial_chunks)
 

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -146,6 +146,38 @@ def test_embed_model_single_sentence_document() -> None:
     assert nodes[0].get_content() == "Only one sentence here."
 
 
+def test_embed_model_empty_document() -> None:
+    """
+    Empty or whitespace-only documents yield no nodes instead of raising.
+
+    Regression test for issue #17032: ``build_semantic_nodes_from_nodes`` ->
+    ``_create_initial_chunks`` raised ``IndexError`` on ``sentences[0]`` because
+    an empty document produces no sentences.
+    """
+    embed = MockEmbedding(embed_dim=4)
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(embed_model=embed)
+
+    assert splitter.get_nodes_from_documents([Document(text="")]) == []
+    assert splitter.get_nodes_from_documents([Document(text="   \n\t  ")]) == []
+
+
+def test_embed_model_empty_document_in_batch() -> None:
+    """A single empty document must not crash a whole batch of documents."""
+    embed = MockEmbedding(embed_dim=4)
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(embed_model=embed)
+
+    docs = [
+        Document(text="Only one sentence here."),
+        Document(text=""),
+        Document(text="Another standalone sentence."),
+    ]
+    nodes = splitter.get_nodes_from_documents(docs)
+
+    # The two non-empty documents still produce nodes; the empty one is skipped.
+    assert len(nodes) == 2
+    assert all(len(n.get_content()) > 0 for n in nodes)
+
+
 def test_clean_text_advanced() -> None:
     """Test that _clean_text_advanced properly filters out stopwords from a string."""
     from llama_index.core.utils import globals_helper


### PR DESCRIPTION
## Description

`SemanticDoubleMergingSplitterNodeParser` raises `IndexError: list index out of range` on an empty or whitespace-only document.

`build_semantic_nodes_from_nodes()` splits each document into sentences and hands the list straight to `_create_initial_chunks()`, which reads `sentences[0]`:

```python
sentences = self.sentence_splitter(text)
sentences = [s.strip() for s in sentences]
initial_chunks = self._create_initial_chunks(sentences)   # -> sentences[0]
```

For an empty or whitespace-only document the tokenizer returns `[]`, so `sentences[0]` blows up. And since parsing loops over all documents, a single blank document takes the whole run down with it — one empty file in a folder loaded by `SimpleDirectoryReader` is enough. The other parsers already handle this (`SentenceSplitter` short-circuits on `text == ""`, `SemanticSplitterNodeParser` has a branch for "very, very small documents"); this one just missed it.

This is #17032. @logan-markewich suggested dropping the empty sentences there, which is the right direction but doesn't quite close it on its own: for a truly empty document the tokenizer returns nothing, so there's nothing to drop and `sentences[0]` still raises. So the fix filters the empty sentences *and* skips a document that has none left:

```python
sentences = [s.strip() for s in sentences]
# Drop empty/whitespace-only sentences and skip documents that end up
# with no sentences; otherwise _create_initial_chunks raises
# IndexError on sentences[0] for an empty document (issue #17032).
sentences = [s for s in sentences if s]
if not sentences:
    continue
```

An empty document now yields no nodes and the rest of the batch parses normally. Valid documents are unaffected — the filter only removes sentences that are empty after `.strip()`, which real documents don't have, so every chunk boundary stays identical.

Fixes #17032

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — only touches `llama-index-core`, which the template excludes from version bumps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Two tests in `tests/node_parser/test_semantic_double_merging_splitter.py`, following the existing `test_embed_model_*` pattern (`MockEmbedding`, no network or spacy model needed):

- `test_embed_model_empty_document` — an empty and a whitespace-only document each return `[]` instead of raising.
- `test_embed_model_empty_document_in_batch` — an empty document between two real ones no longer kills the batch.

Both fail on `main` with the `IndexError` and pass with this change. Across `tests/node_parser/` + `tests/text_splitter/` (with spacy + `en_core_web_md` installed so nothing skips) the failure set is identical before and after — the only delta is the two new tests going from fail to pass. The pre-existing failures in that suite are unrelated to this change and already fail on the base commit here (7 `ImportError`s in `test_markdown_element.py`, and 2 that assert exact chunk counts tied to `en_core_web_md` similarity scores); happy to file those separately if useful.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no public API change)
- [ ] I have added Google Colab support for the newly added notebooks (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` (`ruff format --check` and `ruff check` both clean on the two changed files)

## AI disclosure

Per CONTRIBUTING.md: I used an AI assistant to help audit this module for empty-input handling and to draft the tests and this description. It's a six-line change I understand and can maintain — I checked it myself by reproducing the original `IndexError` on the real splitter, confirming both tests fail before and pass after, and diffing the surrounding suites against the base commit to confirm no new failures.
