### PR TITLE
docs: remove stale download_loader imports from example notebooks

### DIFF
--- a/docs/examples/citation/pdf_page_reference.ipynb
+++ b/docs/examples/citation/pdf_page_reference.ipynb
@@ -58,7 +58,6 @@
     "from llama_index.core import (\n",
     "    SimpleDirectoryReader,\n",
     "    VectorStoreIndex,\n",
-    "    download_loader,\n",
     "    RAKEKeywordTableIndex,\n",
     ")"
    ]

--- a/docs/examples/index_structs/knowledge_graph/knowledge_graph2.ipynb
+++ b/docs/examples/index_structs/knowledge_graph/knowledge_graph2.ipynb
@@ -311,8 +311,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core import download_loader\n",
-    "\n",
     "from llama_index.readers.papers import ArxivReader\n",
     "\n",
     "loader = ArxivReader()\n",

--- a/docs/examples/query_engine/knowledge_graph_query_engine.ipynb
+++ b/docs/examples/query_engine/knowledge_graph_query_engine.ipynb
@@ -268,8 +268,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core import download_loader\n",
-    "\n",
     "from llama_index.readers.wikipedia import WikipediaReader\n",
     "\n",
     "loader = WikipediaReader()\n",

--- a/docs/examples/retrievers/composable_retrievers.ipynb
+++ b/docs/examples/retrievers/composable_retrievers.ipynb
@@ -57,8 +57,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core import download_loader\n",
-    "\n",
     "from llama_index.readers.file import PyMuPDFReader\n",
     "\n",
     "llama2_docs = PyMuPDFReader().load_data(\n",

--- a/docs/examples/usecases/email_data_extraction.ipynb
+++ b/docs/examples/usecases/email_data_extraction.ipynb
@@ -173,17 +173,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107396a9-4aa7-49b3-9f0f-a755726c19ba",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# get donload_loader\n",
-    "from llama_index.core import download_loader"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "1e9b8a31",
    "metadata": {},
    "outputs": [],

--- a/docs/examples/vector_stores/AsyncIndexCreationDemo.ipynb
+++ b/docs/examples/vector_stores/AsyncIndexCreationDemo.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.core import VectorStoreIndex, download_loader\n",
+    "from llama_index.core import VectorStoreIndex\n",
     "\n",
     "from llama_index.readers.wikipedia import WikipediaReader\n",
     "\n",


### PR DESCRIPTION
# Description

Removes stale, unused `download_loader` imports from example notebooks. `download_loader` is no longer exported from `llama_index.core`, and these notebooks did not call it after importing it.

This keeps the examples importable without changing notebook outputs or execution metadata.

Fixes #

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Checked locally:

- Parsed all six touched notebooks as JSON
- Confirmed no `download_loader` or `donload_loader` references remain in the touched notebooks
- Ran `git diff --check -- <touched notebooks>`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
