### PR TITLE
fix: send instance-level thinking config in Anthropic structured prediction

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -1076,6 +1076,24 @@ class Anthropic(FunctionCallingLLM):
         return tool_selections
 
     @dispatcher.span
+    def _structured_llm_kwargs(
+        self, llm_kwargs: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """
+        Merge instance-level extended-thinking config into structured-prediction kwargs.
+
+        The native structured-output path calls the SDK's parse() directly and does not
+        go through `_get_all_kwargs`, so instance-level `thinking_dict` (and the
+        temperature it requires) must be threaded explicitly. Explicit per-call
+        llm_kwargs take precedence.
+        """
+        kwargs: Dict[str, Any] = {}
+        if self.thinking_dict:
+            kwargs["thinking"] = self.thinking_dict
+            kwargs["temperature"] = self.temperature
+        kwargs.update(llm_kwargs or {})
+        return kwargs
+
     def structured_predict(
         self,
         output_cls: Type[Model],
@@ -1098,7 +1116,7 @@ class Anthropic(FunctionCallingLLM):
             output_format=output_cls,
             system=system,
             betas=["structured-outputs-2025-11-13"],
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         parsed = response.parsed_output
         stop_reason = response.stop_reason
@@ -1132,7 +1150,7 @@ class Anthropic(FunctionCallingLLM):
             output_format=output_cls,
             system=system,
             betas=["structured-outputs-2025-11-13"],
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         parsed = response.parsed_output
         stop_reason = response.stop_reason
@@ -1168,7 +1186,7 @@ class Anthropic(FunctionCallingLLM):
             output_format=output_cls,
             system=system,
             betas=["structured-outputs-2025-11-13"],
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         parsed = response.parsed_output
         stop_reason = response.stop_reason
@@ -1209,7 +1227,7 @@ class Anthropic(FunctionCallingLLM):
             output_format=output_cls,
             system=system,
             betas=["structured-outputs-2025-11-13"],
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         parsed = response.parsed_output
         stop_reason = response.stop_reason

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-anthropic"
-version = "0.11.8"
+version = "0.11.9"
 description = "llama-index llms anthropic integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -1074,3 +1074,79 @@ def test_structured_output_failure_mock() -> None:
         match="It was not possible to produce a structured response because of max_tokens",
     ):
         sllm.chat(STRUCT_MESSAGES)
+
+
+def _mock_parse_client(parsed_output) -> MagicMock:
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.parsed_output = parsed_output
+    mock_response.stop_reason = None
+    mock_client.beta.messages.parse.return_value = mock_response
+    return mock_client
+
+
+def test_structured_predict_sends_instance_thinking_config() -> None:
+    """
+    Instance-level thinking_dict (and the temperature it requires) must reach
+    beta.messages.parse — the structured path bypasses _get_all_kwargs.
+    See https://github.com/run-llama/llama_index/issues/22358.
+    """
+    thinking = {"type": "enabled", "budget_tokens": 2000}
+    llm = Anthropic(model="claude-sonnet-4-5", api_key="fake", thinking_dict=thinking)
+    llm._client = _mock_parse_client(Note(content="x"))
+
+    llm.structured_predict(Note, PromptTemplate("Take a note about {topic}"), topic="x")
+
+    call_kwargs = llm._client.beta.messages.parse.call_args.kwargs
+    assert call_kwargs["thinking"] == thinking
+    assert call_kwargs["temperature"] == llm.temperature
+
+
+@pytest.mark.asyncio
+async def test_astructured_predict_sends_instance_thinking_config() -> None:
+    from unittest.mock import AsyncMock
+
+    thinking = {"type": "enabled", "budget_tokens": 2000}
+    llm = Anthropic(model="claude-sonnet-4-5", api_key="fake", thinking_dict=thinking)
+    mock_response = MagicMock()
+    mock_response.parsed_output = Note(content="x")
+    mock_response.stop_reason = None
+    llm._aclient = MagicMock()
+    llm._aclient.beta.messages.parse = AsyncMock(return_value=mock_response)
+
+    await llm.astructured_predict(
+        Note, PromptTemplate("Take a note about {topic}"), topic="x"
+    )
+
+    call_kwargs = llm._aclient.beta.messages.parse.call_args.kwargs
+    assert call_kwargs["thinking"] == thinking
+
+
+def test_structured_predict_without_thinking_sends_no_thinking() -> None:
+    llm = Anthropic(model="claude-sonnet-4-5", api_key="fake")
+    llm._client = _mock_parse_client(Note(content="x"))
+
+    llm.structured_predict(Note, PromptTemplate("Take a note about {topic}"), topic="x")
+
+    call_kwargs = llm._client.beta.messages.parse.call_args.kwargs
+    assert "thinking" not in call_kwargs
+    assert "temperature" not in call_kwargs
+
+
+def test_structured_predict_llm_kwargs_override_instance_thinking() -> None:
+    llm = Anthropic(
+        model="claude-sonnet-4-5",
+        api_key="fake",
+        thinking_dict={"type": "enabled", "budget_tokens": 2000},
+    )
+    llm._client = _mock_parse_client(Note(content="x"))
+    per_call = {"type": "enabled", "budget_tokens": 8000}
+
+    llm.structured_predict(
+        Note,
+        PromptTemplate("Take a note about {topic}"),
+        llm_kwargs={"thinking": per_call},
+        topic="x",
+    )
+
+    assert llm._client.beta.messages.parse.call_args.kwargs["thinking"] == per_call


### PR DESCRIPTION
# Description

The native structured-output path in `llama-index-llms-anthropic` calls `beta.messages.parse()` with a fixed argument list and never consults `_get_all_kwargs`, so an instance configured with `thinking_dict` silently never sends `thinking` (or the `temperature` it requires) on `structured_predict` / `astructured_predict` / the stream variants — extended thinking is dropped for structured output only, while chat calls on the same instance think normally. Only per-call `llm_kwargs` survived into the request.

This PR adds a small `_structured_llm_kwargs` helper that merges the instance-level thinking config into the kwargs passed to `parse()` at all four call sites, with explicit per-call `llm_kwargs` taking precedence — mirroring the chat path's behavior.

Verified live: before the fix, a `thinking_dict`-configured instance returned only `['text']` blocks from structured predictions; after the fix the same call sends `thinking` and returns `['thinking', 'text']`.

Addresses the Anthropic half of #22358 (the OpenAI half is a separate PR).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four new mock-client tests assert the kwargs that reach `beta.messages.parse`: instance thinking is sent (sync + async), nothing is sent when thinking isn't configured, and per-call `llm_kwargs` override the instance config.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

🤖 Generated with [Claude Code](https://claude.com/claude-code)