### PR TITLE
fix: send instance-level reasoning_options in OpenAIResponses structured prediction

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -961,6 +961,23 @@ class OpenAIResponses(FunctionCallingLLM):
         """Model name passed to the Responses API. Subclasses may override (e.g. Azure uses a deployment name)."""
         return self.model
 
+    def _structured_llm_kwargs(
+        self, llm_kwargs: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """
+        Merge instance-level reasoning config into structured-prediction kwargs.
+
+        The structured-output path calls responses.parse() directly and does not go
+        through `_get_model_kwargs`, so instance-level `reasoning_options` must be
+        threaded explicitly (same gate as the chat path). Explicit per-call llm_kwargs
+        take precedence.
+        """
+        kwargs: Dict[str, Any] = {}
+        if self.model in O1_MODELS and self.reasoning_options is not None:
+            kwargs["reasoning"] = self.reasoning_options
+        kwargs.update(llm_kwargs or {})
+        return kwargs
+
     @dispatcher.span
     def structured_predict(
         self,
@@ -984,7 +1001,7 @@ class OpenAIResponses(FunctionCallingLLM):
             text_format=output_cls,
             tool_choice="none",
             store=self.store,
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         if response.output_parsed is not None:
             return response.output_parsed
@@ -1013,7 +1030,7 @@ class OpenAIResponses(FunctionCallingLLM):
             text_format=output_cls,
             tool_choice="none",
             store=self.store,
-            **(llm_kwargs or {}),
+            **self._structured_llm_kwargs(llm_kwargs),
         )
         if response.output_parsed is not None:
             return response.output_parsed

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.10"
+version = "0.7.11"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1009,3 +1009,91 @@ def test__parse_response_output(response_output: List[ResponseOutputItem]):
     assert [
         block for block in result.message.blocks if isinstance(block, ThinkingBlock)
     ][3].content == "hello\nworld"
+
+
+def test_structured_predict_sends_instance_reasoning_options():
+    """
+    Instance-level reasoning_options must reach responses.parse — the structured
+    path bypasses _get_model_kwargs.
+    See https://github.com/run-llama/llama_index/issues/22358.
+    """
+
+    class Person(BaseModel):
+        name: str = Field(description="The person's name")
+
+    llm = OpenAIResponses(
+        model="gpt-5.1", api_key="fake", reasoning_options={"effort": "high"}
+    )
+    mock_response = MagicMock()
+    mock_response.output_parsed = Person(name="Alice")
+    llm._client.responses.parse = MagicMock(return_value=mock_response)
+
+    llm.structured_predict(
+        output_cls=Person, prompt=PromptTemplate("Create a profile for a person")
+    )
+
+    call_kwargs = llm._client.responses.parse.call_args.kwargs
+    assert call_kwargs["reasoning"] == {"effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_astructured_predict_sends_instance_reasoning_options():
+    from unittest.mock import AsyncMock
+
+    class Person(BaseModel):
+        name: str = Field(description="The person's name")
+
+    llm = OpenAIResponses(
+        model="gpt-5.1", api_key="fake", reasoning_options={"effort": "high"}
+    )
+    mock_response = MagicMock()
+    mock_response.output_parsed = Person(name="Bob")
+    llm._aclient.responses.parse = AsyncMock(return_value=mock_response)
+
+    await llm.astructured_predict(
+        output_cls=Person, prompt=PromptTemplate("Create a profile for a person")
+    )
+
+    call_kwargs = llm._aclient.responses.parse.call_args.kwargs
+    assert call_kwargs["reasoning"] == {"effort": "high"}
+
+
+def test_structured_predict_non_reasoning_model_sends_no_reasoning():
+    """Mirrors the chat-path gate: non-reasoning models never receive `reasoning`."""
+
+    class Person(BaseModel):
+        name: str = Field(description="The person's name")
+
+    llm = OpenAIResponses(
+        model="gpt-4o-mini", api_key="fake", reasoning_options={"effort": "high"}
+    )
+    mock_response = MagicMock()
+    mock_response.output_parsed = Person(name="Alice")
+    llm._client.responses.parse = MagicMock(return_value=mock_response)
+
+    llm.structured_predict(
+        output_cls=Person, prompt=PromptTemplate("Create a profile for a person")
+    )
+
+    assert "reasoning" not in llm._client.responses.parse.call_args.kwargs
+
+
+def test_structured_predict_llm_kwargs_override_instance_reasoning():
+    class Person(BaseModel):
+        name: str = Field(description="The person's name")
+
+    llm = OpenAIResponses(
+        model="gpt-5.1", api_key="fake", reasoning_options={"effort": "high"}
+    )
+    mock_response = MagicMock()
+    mock_response.output_parsed = Person(name="Alice")
+    llm._client.responses.parse = MagicMock(return_value=mock_response)
+
+    llm.structured_predict(
+        output_cls=Person,
+        prompt=PromptTemplate("Create a profile for a person"),
+        llm_kwargs={"reasoning": {"effort": "low"}},
+    )
+
+    call_kwargs = llm._client.responses.parse.call_args.kwargs
+    assert call_kwargs["reasoning"] == {"effort": "low"}


### PR DESCRIPTION
# Description

`OpenAIResponses.structured_predict` / `astructured_predict` call `responses.parse()` with a fixed argument list and never consult `_get_model_kwargs`, so an instance configured with `reasoning_options` silently never sends `reasoning` on structured predictions — for models whose default effort is `none` (e.g. `gpt-5.1`), structured calls do zero reasoning while chat calls on the same instance reason normally. Only per-call `llm_kwargs` survived into the request.

This PR adds a small `_structured_llm_kwargs` helper that merges the instance-level reasoning config into the kwargs passed to `parse()` at both call sites, using the same gate as the chat path (`self.model in O1_MODELS and self.reasoning_options is not None`), with explicit per-call `llm_kwargs` taking precedence. The stream variants are unchanged — they route through the generic function-calling path, whose kwargs assembly already includes `reasoning`.

Verified live: before the fix, a `reasoning_options={'effort': 'high'}` instance spent 0 reasoning tokens on structured predictions; after the fix the same call sends `reasoning` and spends reasoning tokens.

Addresses the OpenAI half of #22358 (the Anthropic half is #22359).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four new mock-client tests assert the kwargs that reach `responses.parse`: instance reasoning is sent (sync + async), non-reasoning models never receive `reasoning` (mirroring the chat-path gate), and per-call `llm_kwargs` override the instance config.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

🤖 Generated with [Claude Code](https://claude.com/claude-code)