### PR TITLE
fix: guard against missing 'text' key in TextNode's dict-form text_resource

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -772,7 +772,7 @@ class TextNode(BaseNode):
             if isinstance(tr, MediaResource):
                 kwargs["text"] = tr.text
             else:
-                kwargs["text"] = tr["text"]
+                kwargs["text"] = tr.get("text") or ""
         super().__init__(*args, **kwargs)
 
     text: str = Field(default="", description="Text content of the node.")

--- a/llama-index-core/tests/schema/test_schema.py
+++ b/llama-index-core/tests/schema/test_schema.py
@@ -86,6 +86,16 @@ def test_text_node_with_text_resource():
     assert text_node.text == "This is a test"
 
 
+def test_text_node_with_dict_text_resource_missing_text_key():
+    """
+    A partial dict-form `text_resource` (e.g. embeddings-only, no 'text' key)
+    should not raise a raw KeyError -- it should fall back to an empty string,
+    matching the default `text` field's own empty-string default.
+    """
+    text_node = TextNode(text_resource={"embeddings": {"dense": [1.0, 2.0]}})
+    assert text_node.text == ""
+
+
 def test_text_node_metadata_separator_consistency() -> None:
     """
     Test that metadata_separator works consistently on TextNode.


### PR DESCRIPTION
## Problem

`TextNode.__init__`'s forward-compat path for a dict-form `text_resource` does a bare subscript:

```python
if "text_resource" in kwargs:
    tr = kwargs.pop("text_resource")
    if isinstance(tr, MediaResource):
        kwargs["text"] = tr.text
    else:
        kwargs["text"] = tr["text"]
```

A partial dict (e.g. one that only sets `embeddings` or another `MediaResource` field, without `text`) raises a raw `KeyError('text')` instead of falling back to an empty string — inconsistent with the field's own `text: str = Field(default="", ...)` default, and with the `isinstance(tr, MediaResource)` branch above it, which never fails this way since `MediaResource.text` always has a default.

```python
TextNode(text_resource={"embeddings": [0.1, 0.2]})
# KeyError: 'text'
```

## Fix

`kwargs["text"] = tr.get("text") or ""`, matching the field's own default and handling a missing key, `None`, and an empty string uniformly.

## Testing

Added `test_text_node_with_dict_text_resource_missing_text_key` to `tests/schema/test_schema.py`. Confirmed via reverting just the fix that it fails against the pre-fix code with the exact `KeyError` and passes after.

- `pytest tests/schema/test_schema.py` — 25/25 passed.
- `ruff check` clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the bare-subscript pattern while auditing `schema.py`'s forward-compat constructors. I reviewed the diff, independently reproduced the crash and the fix by executing both against the actual constructor, and ran the tests/linters myself before opening this PR.