### PR TITLE
fix(core): keep all selections when SelectionOutputParser output is wrapped in an object

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/selection.py
+++ b/llama-index-core/llama_index/core/output_parsers/selection.py
@@ -38,34 +38,39 @@ class Answer(DataClassJsonMixin):
 class SelectionOutputParser(BaseOutputParser):
     REQUIRED_KEYS = frozenset(Answer.__annotations__)
 
-    def _filter_dict(self, json_dict: dict) -> dict:
-        """Filter recursively until a dictionary matches all REQUIRED_KEYS."""
-        output_dict = json_dict
-        for key, val in json_dict.items():
-            if key in self.REQUIRED_KEYS:
-                continue
-            elif isinstance(val, dict):
-                output_dict = self._filter_dict(val)
+    def _filter_dict(self, json_dict: dict) -> List[dict]:
+        """
+        Recursively collect every nested dict that matches all REQUIRED_KEYS.
+
+        A model may wrap the answers in an outer object (e.g. ``{"items": [...]}``), and
+        that list can hold more than one selection, so all matches are returned rather than
+        just the last one encountered.
+        """
+        if self.REQUIRED_KEYS.issubset(json_dict):
+            return [json_dict]
+
+        matches: List[dict] = []
+        for val in json_dict.values():
+            if isinstance(val, dict):
+                matches.extend(self._filter_dict(val))
             elif isinstance(val, list):
                 for item in val:
                     if isinstance(item, dict):
-                        output_dict = self._filter_dict(item)
+                        matches.extend(self._filter_dict(item))
 
-        return output_dict
+        return matches
 
     def _format_output(self, output: List[dict]) -> List[dict]:
         output_json = []
         for json_dict in output:
-            valid = True
-            for key in self.REQUIRED_KEYS:
-                if key not in json_dict:
-                    valid = False
-                    break
+            if self.REQUIRED_KEYS.issubset(json_dict):
+                output_json.append(json_dict)
+                continue
 
-            if not valid:
-                json_dict = self._filter_dict(json_dict)
-
-            output_json.append(json_dict)
+            # Dig the selections out of a wrapper object; keep the original dict when
+            # nothing matches so downstream parsing still surfaces the error.
+            matches = self._filter_dict(json_dict)
+            output_json.extend(matches or [json_dict])
 
         return output_json
 

--- a/llama-index-core/tests/output_parsers/test_selection.py
+++ b/llama-index-core/tests/output_parsers/test_selection.py
@@ -58,6 +58,14 @@ Here is the output in JSON format:
             1,
             id="boss_fight",
         ),
+        pytest.param(
+            """{"items": [
+    {"choice": 1, "reason": "just because"},
+    {"choice": 2, "reason": "why not"}
+]}""",
+            2,
+            id="wrapped_multi",
+        ),
     ],
 )
 def test_parse(
@@ -69,6 +77,26 @@ def test_parse(
     assert len(parsed.parsed_output) == num_match
     assert parsed.parsed_output[0].choice == 1
     assert parsed.parsed_output[0].reason == "just because"
+
+
+def test_parse_wrapped_multiple_selections_preserves_all(
+    output_parser: SelectionOutputParser,
+) -> None:
+    # A model may wrap multiple selections in an outer object; every selection must be
+    # kept, not just the last one encountered.
+    output = (
+        '{"selections": ['
+        '{"choice": 1, "reason": "first"},'
+        '{"choice": 2, "reason": "second"},'
+        '{"choice": 3, "reason": "third"}]}'
+    )
+    parsed = output_parser.parse(output=output)
+    assert [answer.choice for answer in parsed.parsed_output] == [1, 2, 3]
+    assert [answer.reason for answer in parsed.parsed_output] == [
+        "first",
+        "second",
+        "third",
+    ]
 
 
 def test_failed_parse(output_parser: SelectionOutputParser) -> None:


### PR DESCRIPTION
# Description

`SelectionOutputParser._filter_dict` is meant to dig the answer objects out of a wrapper object the model may return — its loop already recurses into nested dicts and lists. But when the wrapper holds a **list of multiple** selection objects, the loop reassigns `output_dict` on every iteration, so only the **last** match survives and every earlier selection is silently dropped:

```python
from llama_index.core.output_parsers.selection import SelectionOutputParser

p = SelectionOutputParser()
p.parse('{"selections": [{"choice": 1, "reason": "a"}, {"choice": 2, "reason": "b"}]}').parsed_output
# before: [Answer(choice=2, reason='b')]                      <-- choice 1 dropped
# after:  [Answer(choice=1, ...), Answer(choice=2, ...)]
```

This matters for `LLMMultiSelector` (used by `RouterQueryEngine` / `RouterRetriever`): a model that returns its multiple selections wrapped in an object — common with JSON-mode / structured output — gets routed to only one tool instead of all of them. Bare arrays (`[a, b]`) already parse correctly; the loss only happens when the answers are nested inside an object. The sibling `question_gen` output parser already handles this wrapped-list shape.

Found by reading the code; no linked issue.

## Fix

`_filter_dict` now recursively **collects every** nested dict matching `REQUIRED_KEYS` and returns the list; `_format_output` extends the result with it, falling back to the original dict when nothing matches so genuinely malformed output still surfaces the existing error. Single-answer wrappers and bare arrays are unchanged.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Not required — this is in `llama-index-core`.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added a wrapped-multi case to `test_parse` and a dedicated `test_parse_wrapped_multiple_selections_preserves_all` that asserts every selection survives in order. Both fail before the fix and pass after; the existing cases (bare array, nested single-answer wrappers `inline_curly` / `boss_fight`) still pass. `ruff` check + format clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
