### PR TITLE
fix(tools-mcp): resolve draft-07 "definitions" refs in create_model_from_json_schema

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -215,7 +215,9 @@ class McpToolSpec(
             A Pydantic model class.
 
         """
-        defs = schema.get("$defs", {})
+        # Draft 2020-12 uses "$defs"; draft-07 emitters (e.g. zod-to-json-schema,
+        # used by TypeScript MCP servers) still use "definitions".
+        defs = {**schema.get("definitions", {}), **schema.get("$defs", {})}
 
         # Process all type definitions
         for cls_name, cls_schema in defs.items():

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -130,8 +130,8 @@ class TypeCreationMixin:
         )
 
     def _extract_ref_name(self: "McpToolSpec", ref_path: str) -> str:
-        """Extract reference name from $ref path."""
-        return ref_path.split("#/$defs/")[-1]
+        """Extract reference name from a $ref path ("#/$defs/X" or "#/definitions/X")."""
+        return ref_path.split("/")[-1]
 
 
 class FieldExtractionMixin:

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -206,6 +206,35 @@ def test_resolve_field_type_delegates_anyof_enums(client: BasicMCPClient):
     assert Literal["z"] in args
 
 
+def test_create_model_from_json_schema_draft07_definitions(client: BasicMCPClient):
+    """
+    Schemas from draft-07 emitters (e.g. zod-to-json-schema, used by TypeScript
+    MCP servers) store definitions under "definitions" and reference them as
+    "#/definitions/X". These previously resolved to a NoneType annotation
+    because only "$defs" was consulted, silently breaking the tool's arguments.
+    """
+    tool_spec = McpToolSpec(client)
+
+    schema = {
+        "type": "object",
+        "properties": {"person": {"$ref": "#/definitions/Draft07Person"}},
+        "required": ["person"],
+        "definitions": {
+            "Draft07Person": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+    }
+
+    model = tool_spec.create_model_from_json_schema(schema, model_name="Draft07Model")
+
+    person_model = model.model_fields["person"].annotation
+    assert person_model is not type(None)
+    assert person_model.model_fields["name"].annotation is str
+
+
 def test_additional_properties_false_parsing(client: BasicMCPClient):
     """Test that schemas with additionalProperties: false are parsed correctly."""
     from typing import Dict, Any


### PR DESCRIPTION
# Description

`McpToolSpec.create_model_from_json_schema` only consults the draft 2020-12 `"$defs"` key when collecting schema definitions, and `_extract_ref_name` only understands `"#/$defs/X"` pointers. Tool schemas produced by draft-07 emitters — notably `zod-to-json-schema`, which backs many TypeScript MCP servers — store definitions under `"definitions"` and reference them as `"#/definitions/X"`. These refs fell through both lookups and resolved to a `NoneType` annotation, so a required object argument silently became `"type": "null"` and the tool's arguments were broken.

Reproduction on `main`:

```python
schema = {
    "type": "object",
    "properties": {"person": {"$ref": "#/definitions/Person"}},
    "required": ["person"],
    "definitions": {
        "Person": {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]},
    },
}
model = tool_spec.create_model_from_json_schema(schema)
model.model_fields["person"].annotation  # <class 'NoneType'> before this fix
```

The fix is two small changes in the `llama-index-tools-mcp` package:
- collect defs from `"definitions"` alongside `"$defs"` (2020-12 wins on collision)
- extract the ref name from the last path segment so both pointer styles resolve

The existing `"$defs"` behavior is unchanged (covered by existing tests). This is related in area to #22141 (inline nested objects) but is a distinct defect with a distinct fix — none of the open PRs on that issue touch defs collection or ref-name parsing.

Note: this fix was developed with AI assistance; I reviewed the changes and ran the package tests locally.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added new unit/integration tests (`test_create_model_from_json_schema_draft07_definitions`; it fails on `main` with a `NoneType` annotation and passes with this change)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Google Colab support for the newly added notebooks (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods