### PR TITLE
deprecate llama-index-callbacks-langfuse in favor of instrumentation module

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/global_handlers.py
+++ b/llama-index-core/llama_index/core/callbacks/global_handlers.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Optional
 from llama_index.core.callbacks.base_handler import BaseCallbackHandler
 from llama_index.core.callbacks.simple_llm_handler import SimpleLLMHandler
@@ -100,6 +101,21 @@ def create_global_handler(
             )
         handler = argilla_callback_handler(**eval_params)
     elif eval_mode == "langfuse":
+        warnings.warn(
+            "The `set_global_handler('langfuse')` path is deprecated. "
+            "Migrate to langfuse>=4.7 with the instrumentation module:\n"
+            "  pip install langfuse>=4.7 openinference-instrumentation-llama-index\n"
+            "  from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n"
+            "  LlamaIndexInstrumentor().instrument()\n"
+            "\n"
+            "NOTE: The instrumentor emits OpenTelemetry spans (OpenInference attributes), "
+            "structurally different from legacy callback events. "
+            "Do NOT run both simultaneously — this produces duplicate traces.\n"
+            "\n"
+            "See https://docs.llamaindex.ai/en/stable/examples/observability/Langfuse-Instrumentation/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             from llama_index.callbacks.langfuse import (
                 langfuse_callback_handler,

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/README.md
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/README.md
@@ -1,18 +1,48 @@
-# LlamaIndex Callbacks Integration: Langfuse
+# [DEPRECATED] LlamaIndex Callbacks Integration: Langfuse
 
-[Langfuse](https://langfuse.com/docs) is an open source LLM engineering platform to help teams collaboratively debug, analyze and iterate on their LLM Applications. With the Langfuse integration, you can seamlessly track and monitor performance, traces, and metrics of your LlamaIndex application. Detailed traces of the LlamaIndex context augmentation and the LLM querying processes are captured and can be inspected directly in the Langfuse UI.
+> **⚠️ DEPRECATED** — This package is deprecated and will be removed in a future release.
+> Please migrate to the new Langfuse integration using the instrumentation module.
 
-#### Usage Pattern
+## Migration Guide
+
+Replace the deprecated callback handler with the Langfuse instrumentation module:
+
+### Old (deprecated)
 
 ```python
 from llama_index.core import set_global_handler
 
-# Make sure you've installed the 'llama-index-callbacks-langfuse' integration package.
-
-# NOTE: Set your environment variables 'LANGFUSE_SECRET_KEY', 'LANGFUSE_PUBLIC_KEY' and 'LANGFUSE_HOST'
-# as shown in your langfuse.com project settings.
-
 set_global_handler("langfuse")
 ```
 
-![langfuse-tracing](https://static.langfuse.com/llamaindex-langfuse-docs.gif)
+### New (recommended)
+
+```python
+# pip install langfuse>=4.7 openinference-instrumentation-llama-index
+from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
+
+LlamaIndexInstrumentor().instrument()
+```
+
+Make sure to set your environment variables `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_HOST` as shown in your [Langfuse project settings](https://cloud.langfuse.com).
+
+For the full guide, see the [Langfuse LlamaIndex Integration](https://langfuse.com/docs/integrations/llama-index/get-started) documentation.
+
+---
+
+## Why was this deprecated?
+
+Langfuse now uses LlamaIndex's [OpenInference/OpenTelemetry-based instrumentation module](https://docs.llamaindex.ai/en/stable/module_guides/observability/instrumentation/), which is the recommended tracing path for all LlamaIndex observability integrations.
+
+Key changes:
+- **Before**: `set_global_handler("langfuse")` with `llama-index-callbacks-langfuse`
+- **After**: `from openinference.instrumentation.llama_index import LlamaIndexInstrumentor; LlamaIndexInstrumentor().instrument()` with `langfuse>=4.7`
+- Requires Langfuse [Fast Preview](https://langfuse.com/docs/changelog#fast-preview) (available on Langfuse Cloud and self-hosted instances)
+
+## Migration Risks
+
+### 1. Different data shape (events vs spans)
+The legacy callback emits **callback events**; `LlamaIndexInstrumentor` emits **OpenTelemetry spans** carrying [OpenInference semantic attributes](https://github.com/Arize-AI/openinference) (`llm.model_name`, `retrieval.documents[].id`, `input.value`/`output.value`, token usage). These are structurally different. Dashboards, alerts, or audit queries built against the callback event shape will not break loudly — they receive plausible span-shaped data and silently stop matching expected fields. "Traces still flowing" is a false-positive for migration success if downstream tooling depended on the callback event contract.
+
+### 2. Double-instrumentation during transition
+Do **not** run both the callback handler and the instrumentor simultaneously. With both active, one request emits duplicate traces — the same logical operation counted twice, or two conflicting spans where an audit query expects one. Enable the instrumentor and remove the callback handler in the same change; do not overlap them.

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/llama_index/callbacks/langfuse/__init__.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/llama_index/callbacks/langfuse/__init__.py
@@ -1,3 +1,13 @@
+import warnings
+
+warnings.warn(
+    "llama-index-callbacks-langfuse is deprecated. "
+    "Migrate to langfuse>=4.7 with the instrumentation module. "
+    "See https://docs.llamaindex.ai/en/stable/examples/observability/Langfuse-Instrumentation/",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from llama_index.callbacks.langfuse.base import langfuse_callback_handler
 
 __all__ = ["langfuse_callback_handler"]

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/llama_index/callbacks/langfuse/base.py
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/llama_index/callbacks/langfuse/base.py
@@ -1,11 +1,39 @@
+import warnings
 from typing import Any
 
 from llama_index.core.callbacks.base_handler import BaseCallbackHandler
 
-from langfuse.llama_index import LlamaIndexCallbackHandler
+_DEPRECATION_MSG = (
+    "llama-index-callbacks-langfuse is deprecated and will be removed in a future release. "
+    "Use langfuse>=4.7 with the instrumentation module instead:\n"
+    "  pip install langfuse>=4.7 openinference-instrumentation-llama-index\n"
+    "  from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n"
+    "  LlamaIndexInstrumentor().instrument()\n"
+    "\n"
+    "NOTE: The instrumentor emits OpenTelemetry spans with OpenInference attributes, which "
+    "are structurally different from the legacy callback events. Dashboards, alerts, and "
+    "audit queries built against the old event shape may need updating.\n"
+    "\n"
+    "Do NOT run both the callback and the instrumentor simultaneously — this produces "
+    "duplicate traces.\n"
+    "\n"
+    "See https://docs.llamaindex.ai/en/stable/examples/observability/Langfuse-Instrumentation/"
+)
+
+try:
+    from langfuse.llama_index import LlamaIndexCallbackHandler
+except ImportError:
+    LlamaIndexCallbackHandler = None
 
 
 def langfuse_callback_handler(**eval_params: Any) -> BaseCallbackHandler:
+    warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+    if LlamaIndexCallbackHandler is None:
+        raise ImportError(
+            "langfuse package is required for the deprecated callback handler. "
+            "Install it with `pip install langfuse` or migrate to the "
+            "instrumentation-based integration (see README)."
+        )
     return LlamaIndexCallbackHandler(
         **eval_params, sdk_integration="llama-index_set-global-handler"
     )

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/pyproject.toml
@@ -27,14 +27,17 @@ dev = [
 
 [project]
 name = "llama-index-callbacks-langfuse"
-version = "0.5.0"
-description = "llama-index callbacks langfuse integration"
+version = "0.6.0"
+description = "[DEPRECATED] llama-index callbacks langfuse integration — use langfuse>=4.7 with the instrumentation module instead"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+    "Intended Audience :: Developers",
+]
 dependencies = [
-    "langfuse>=2.21.2,<3",
     "llama-index-core>=0.13.0,<0.15",
 ]
 

--- a/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/uv.lock
+++ b/llama-index-integrations/callbacks/llama-index-callbacks-langfuse/uv.lock
@@ -323,15 +323,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "banks"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1724,25 +1715,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langfuse"
-version = "2.60.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "backoff" },
-    { name = "httpx" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/45/77fdf53c9e9f49bb78f72eba3f992f2f3d8343e05976aabfe1fca276a640/langfuse-2.60.10.tar.gz", hash = "sha256:a26d0d927a28ee01b2d12bb5b862590b643cc4e60a28de6e2b0c2cfff5dbfc6a", size = 152648, upload-time = "2025-09-16T15:08:12.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/69/08584fbd69e14398d3932a77d0c8d7e20389da3e6470210d6719afba2801/langfuse-2.60.10-py3-none-any.whl", hash = "sha256:815c6369194aa5b2a24f88eb9952f7c3fc863272c41e90642a71f3bc76f4a11f", size = 275568, upload-time = "2025-09-16T15:08:10.166Z" },
-]
-
-[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,10 +1770,9 @@ wheels = [
 
 [[package]]
 name = "llama-index-callbacks-langfuse"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
-    { name = "langfuse" },
     { name = "llama-index-core" },
 ]
 
@@ -1829,10 +1800,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "langfuse", specifier = ">=2.21.2,<3" },
-    { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
-]
+requires-dist = [{ name = "llama-index-core", specifier = ">=0.13.0,<0.15" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Deprecates `llama-index-callbacks-langfuse` as requested by the Langfuse team (see #22365). The package wraps the legacy v2-era `LlamaIndexCallbackHandler` which is no longer the recommended integration path.

## Changes

- Mark package as deprecated with Development Status :: 7 - Inactive
- Remove langfuse<3 dependency from pyproject.toml
- Add DeprecationWarning on import and on set_global_handler('langfuse')
- Update README with migration guide to langfuse>=4.7 + LlamaIndexInstrumentor
- Make langfuse import optional in base.py for graceful fallback

## Migration Path

Replace the deprecated callback handler with the OpenInference instrumentation:

```python
# pip install langfuse>=4.7 openinference-instrumentation-llama-index
from openinference.instrumentation.llama_index import LlamaIndexInstrumentor

LlamaIndexInstrumentor().instrument()
See the Langfuse-Instrumentation.ipynb (https://docs.llamaindex.ai/en/stable/examples/observability/Langfuse-Instrumentation/) for a full working example.
Closes #22365

**Checklist answers (check these boxes):**
- **Version Bump?** → ✅ Yes
- **Type of Change** → ✅ This change requires a documentation update
- **How Has This Been Tested?** → ✅ I believe this change is already covered by existing unit tests
- **Suggested Checklist:**
  - ✅ I have performed a self-review of my own code
  - ✅ I have made corresponding changes to the documentation
  - ✅ My changes generate no new warnings