### PR TITLE
fix(pgvector): use type check for numeric filter values

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -735,16 +735,21 @@ class PGVectorStore(BasePydanticVectorStore):
                 f"{self._to_postgres_operator(filter_.operator)}"
             )
         else:
-            # Check if value is a number. If so, cast the metadata value to a float
-            # This is necessary because the metadata is stored as a string
-            try:
+            # If the filter value is a numeric type (int or float), cast the
+            # metadata JSON text to float for the comparison. We check the
+            # Python type explicitly rather than trying float(value) because
+            # Python's float() accepts underscore-separated strings like
+            # "2024_123" (returning 2024123.0) while PostgreSQL's ::float cast
+            # does not, which would produce a DataError at query time.
+            if isinstance(filter_.value, (int, float)) and not isinstance(
+                filter_.value, bool
+            ):
                 return text(
                     f"(metadata_->>'{filter_.key}')::float "
                     f"{self._to_postgres_operator(filter_.operator)} "
                     f"{float(filter_.value)}"
                 )
-            except ValueError:
-                # If not a number, then treat it as a string
+            else:
                 return text(
                     f"metadata_->>'{filter_.key}' "
                     f"{self._to_postgres_operator(filter_.operator)} "

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_vector_stores_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_vector_stores_postgres.py
@@ -1,7 +1,64 @@
-from llama_index.core.vector_stores.types import BasePydanticVectorStore
+from llama_index.core.vector_stores.types import (
+    BasePydanticVectorStore,
+    FilterOperator,
+    MetadataFilter,
+)
 from llama_index.vector_stores.postgres import PGVectorStore
+from llama_index.vector_stores.postgres.base import PGVectorStore as _PGVectorStore
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in PGVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def _make_store() -> PGVectorStore:
+    """Create a minimal PGVectorStore using __new__ so no DB connection is needed."""
+    store = _PGVectorStore.__new__(_PGVectorStore)
+    # _to_postgres_operator only needs the operator enum, so we delegate to the
+    # real implementation; we just avoid touching any DB-related attributes.
+    return store
+
+
+def test_build_filter_clause_string_with_underscores():
+    """String values that look like numbers (e.g., '2024_123') must use string
+    comparison, not a ::float cast. Python's float() accepts underscores, but
+    PostgreSQL's ::float cast does not, so using float() as the type check
+    caused DataError for such values (issue #15962)."""
+    store = _make_store()
+    f = MetadataFilter(key="file_name", value="2024_123", operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" not in sql, f"string value should not use ::float cast; got: {sql}"
+    assert "'2024_123'" in sql
+
+
+def test_build_filter_clause_int_value():
+    """Integer filter values should use the ::float cast for numeric comparison."""
+    store = _make_store()
+    f = MetadataFilter(key="year", value=2024, operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" in sql, f"int value should use ::float cast; got: {sql}"
+    assert "2024" in sql
+
+
+def test_build_filter_clause_float_value():
+    """Float filter values should use the ::float cast."""
+    store = _make_store()
+    f = MetadataFilter(key="score", value=0.9, operator=FilterOperator.GT)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" in sql, f"float value should use ::float cast; got: {sql}"
+
+
+def test_build_filter_clause_plain_number_string():
+    """A string value that happens to be a plain decimal number (e.g., '123')
+    should still use string comparison because the user explicitly provided a
+    string type."""
+    store = _make_store()
+    f = MetadataFilter(key="year", value="123", operator=FilterOperator.EQ)
+    clause = store._build_filter_clause(f)
+    sql = clause.text
+    assert "::float" not in sql, f"string '123' should not use ::float cast; got: {sql}"
+    assert "'123'" in sql


### PR DESCRIPTION
Fixes #15962

Replaces the `float(value)` try/cast in `PGVectorStore._build_filter_clause` with an explicit `isinstance(filter_.value, (int, float))` check (excluding `bool`, which subclasses `int`). This keeps string metadata such as `"2024_123"` in text comparisons and avoids a PostgreSQL `DataError` from the `::float` cast, while still using numeric comparison for actual int/float filter values. `MetadataFilter.value` is a Pydantic `StrictInt`/`StrictFloat`/`StrictStr`, so the Python type is exact and reliable to check.

Adds unit tests for underscore-separated strings, plain numeric strings, int, and float filter values. The tests call `_build_filter_clause` directly with a store built via `__new__` (no DB connection needed), asserting the generated SQL uses `::float` only for real numeric types.

AI assistance disclosure: this change was drafted with AI assistance. I reviewed the fix and tests line by line, confirmed the root cause (Python's `float()` accepts underscore separators like `"2024_123"` but PostgreSQL's `::float` cast rejects them), verified that `MetadataFilter.value`'s Pydantic Strict typing makes the `isinstance` check reliable, and confirmed the tests exercise the real code path (the only `self` reference in the tested branch is the pure `_to_postgres_operator`).
