### PR TITLE
fix: gemini tool request ids 

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -606,7 +606,10 @@ class GoogleGenAI(FunctionCallingLLM):
         for tool_call in tool_calls:
             tool_selections.append(
                 ToolSelection(
-                    tool_id=tool_call.tool_name,
+                    # Use the per-call id when the provider supplies one (Gemini)
+                    # so parallel calls to the same tool can be correlated. Vertex
+                    # AI has no id, so tool_call_id falls back to the tool name.
+                    tool_id=tool_call.tool_call_id or tool_call.tool_name,
                     tool_name=tool_call.tool_name,
                     tool_kwargs=cast(Dict[str, Any], tool_call.tool_kwargs),
                 )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -231,7 +231,12 @@ def chat_from_gemini_response(
                     )
                 content_blocks.append(
                     ToolCallBlock(
-                        tool_call_id=part.function_call.name or "",
+                        # Gemini returns a unique per-call id; Vertex AI does not
+                        # (id is None), so fall back to the tool name to preserve
+                        # the previous behavior for Vertex.
+                        tool_call_id=part.function_call.id
+                        or part.function_call.name
+                        or "",
                         tool_name=part.function_call.name or "",
                         tool_kwargs=part.function_call.args or {},
                     )
@@ -344,6 +349,7 @@ async def chat_message_to_gemini(
     message: ChatMessage,
     file_mode: Literal["inline", "fileapi", "hybrid"] = "hybrid",
     client: Optional[Client] = None,
+    tool_id_to_name: Optional[Dict[str, str]] = None,
 ) -> tuple[types.Content, list[str]]:
     """Convert ChatMessages to Gemini-specific history, including ImageDocuments."""
     unique_tool_calls = []
@@ -404,6 +410,11 @@ async def chat_message_to_gemini(
             part = types.Part.from_function_call(
                 name=block.tool_name, args=cast(Dict[str, Any], block.tool_kwargs)
             )
+            # Echo the per-call id back so the model can pair this call with its
+            # response. Only set it when it's a genuine id (differs from the tool
+            # name), keeping the Vertex AI request byte-for-byte unchanged.
+            if block.tool_call_id and block.tool_call_id != block.tool_name:
+                part.function_call.id = block.tool_call_id
             unique_tool_calls.append((block.tool_name, str(block.tool_kwargs)))
         else:
             msg = f"Unsupported content block type: {type(block).__name__}"
@@ -442,14 +453,23 @@ async def chat_message_to_gemini(
                 part.thought_signature = tool_call.thought_signature
         parts.append(part)
 
-    # the tool call id is the name of the tool
-    # the tool call response is the content of the message, overriding the existing content
-    # (the only content before this should be the tool call)
+    # The tool call response is the content of the message, overriding the
+    # existing content (the only content before this should be the tool call).
+    # The function_response must carry the tool *name* (that is how the model
+    # pairs it with the declared function). When the provider supplied a
+    # per-call id (Gemini), tool_call_id holds that id and we recover the name
+    # from the originating tool call; we also echo the id so parallel calls to
+    # the same tool can be correlated. For Vertex AI (no id) tool_call_id equals
+    # the tool name, so the id is omitted and the request is unchanged.
     if message.additional_kwargs.get("tool_call_id"):
+        tool_call_id = message.additional_kwargs.get("tool_call_id")
+        tool_name = (tool_id_to_name or {}).get(tool_call_id, tool_call_id)
         function_response_part = types.Part.from_function_response(
-            name=message.additional_kwargs.get("tool_call_id"),
+            name=tool_name,
             response={"result": message.content},
         )
+        if tool_call_id and tool_call_id != tool_name:
+            function_response_part.function_response.id = tool_call_id
         return (
             types.Content(
                 role=ROLES_TO_GEMINI[message.role], parts=[function_response_part]
@@ -532,9 +552,18 @@ async def prepare_chat_params(
 
     # Merge messages with the same role
     merged_messages = merge_neighboring_same_role_messages(messages)
+
+    # Map each tool_call_id back to its tool name so that tool-result messages
+    # (which only carry the id) can be serialized with the correct function name.
+    tool_id_to_name: Dict[str, str] = {}
+    for message in merged_messages:
+        for block in message.blocks:
+            if isinstance(block, ToolCallBlock) and block.tool_call_id:
+                tool_id_to_name[block.tool_call_id] = block.tool_name
+
     initial_history_and_names = await asyncio.gather(
         *[
-            chat_message_to_gemini(message, file_mode, client)
+            chat_message_to_gemini(message, file_mode, client, tool_id_to_name)
             for message in merged_messages
         ]
     )

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.9.6"
+version = "0.9.7"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -2096,3 +2096,167 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+def _gemini_response_with_tool_calls(
+    calls: List[dict],
+) -> types.GenerateContentResponse:
+    """Build a minimal GenerateContentResponse containing function calls."""
+    parts = [
+        types.Part(
+            function_call=types.FunctionCall(
+                id=call.get("id"),
+                name=call["name"],
+                args=call["args"],
+            )
+        )
+        for call in calls
+    ]
+    return types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(role="model", parts=parts),
+                finish_reason=types.FinishReason.STOP,
+            )
+        ]
+    )
+
+
+def test_tool_call_id_captured_from_gemini_id() -> None:
+    """Gemini returns a unique per-call id; it must be preserved on the block."""
+    response = _gemini_response_with_tool_calls(
+        [
+            {
+                "id": "call_aaa",
+                "name": "search_information",
+                "args": {"query": "refund"},
+            },
+            {"id": "call_bbb", "name": "search_information", "args": {"query": "ship"}},
+        ]
+    )
+
+    chat_response = chat_from_gemini_response(response, [])
+    tool_blocks = [
+        b for b in chat_response.message.blocks if isinstance(b, ToolCallBlock)
+    ]
+
+    assert len(tool_blocks) == 2
+    # ids are preserved (not collapsed to the tool name)
+    assert tool_blocks[0].tool_call_id == "call_aaa"
+    assert tool_blocks[1].tool_call_id == "call_bbb"
+    assert tool_blocks[0].tool_name == tool_blocks[1].tool_name == "search_information"
+
+
+def test_tool_call_id_falls_back_to_name_for_vertex() -> None:
+    """Vertex AI returns no id (None); fall back to the tool name as before."""
+    response = _gemini_response_with_tool_calls(
+        [
+            {"id": None, "name": "search_information", "args": {"query": "refund"}},
+            {"id": None, "name": "search_information", "args": {"query": "ship"}},
+        ]
+    )
+
+    chat_response = chat_from_gemini_response(response, [])
+    tool_blocks = [
+        b for b in chat_response.message.blocks if isinstance(b, ToolCallBlock)
+    ]
+
+    assert len(tool_blocks) == 2
+    assert tool_blocks[0].tool_call_id == "search_information"
+    assert tool_blocks[1].tool_call_id == "search_information"
+
+
+def test_get_tool_calls_from_response_surfaces_unique_ids(
+    mock_google_genai: GoogleGenAI,
+) -> None:
+    """Parallel calls to the same tool must yield distinct tool_ids (Gemini)."""
+    response = chat_from_gemini_response(
+        _gemini_response_with_tool_calls(
+            [
+                {
+                    "id": "call_aaa",
+                    "name": "search_information",
+                    "args": {"query": "a"},
+                },
+                {
+                    "id": "call_bbb",
+                    "name": "search_information",
+                    "args": {"query": "b"},
+                },
+            ]
+        ),
+        [],
+    )
+
+    tool_calls = mock_google_genai.get_tool_calls_from_response(response)
+    assert [tc.tool_id for tc in tool_calls] == ["call_aaa", "call_bbb"]
+    assert {tc.tool_name for tc in tool_calls} == {"search_information"}
+
+
+@pytest.mark.asyncio
+async def test_tool_response_roundtrip_echoes_id_gemini() -> None:
+    """A Gemini tool result is serialized with the tool name plus the echoed id."""
+    assistant = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_call_id="call_aaa",
+                tool_name="search_information",
+                tool_kwargs={"query": "refund"},
+            )
+        ],
+    )
+    tool_result = ChatMessage(
+        role=MessageRole.TOOL,
+        content="RESULT",
+        additional_kwargs={"tool_call_id": "call_aaa"},
+    )
+
+    _next, chat_kwargs, _ = await prepare_chat_params(
+        "models/gemini-2.0-flash-001", [assistant, tool_result]
+    )
+    parts = [p for c in [*chat_kwargs["history"], _next] for p in (c.parts or [])]
+
+    fn_call = next(p.function_call for p in parts if p.function_call)
+    fn_resp = next(p.function_response for p in parts if p.function_response)
+
+    # name stays the tool name (not the id) so the model can resolve it
+    assert fn_call.name == "search_information"
+    assert fn_resp.name == "search_information"
+    # the id is echoed on both sides so the pair can be correlated
+    assert fn_call.id == "call_aaa"
+    assert fn_resp.id == "call_aaa"
+
+
+@pytest.mark.asyncio
+async def test_tool_response_roundtrip_omits_id_for_vertex() -> None:
+    """Vertex has no id (tool_call_id == tool name); the wire stays unchanged."""
+    assistant = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            ToolCallBlock(
+                tool_call_id="search_information",
+                tool_name="search_information",
+                tool_kwargs={"query": "refund"},
+            )
+        ],
+    )
+    tool_result = ChatMessage(
+        role=MessageRole.TOOL,
+        content="RESULT",
+        additional_kwargs={"tool_call_id": "search_information"},
+    )
+
+    _next, chat_kwargs, _ = await prepare_chat_params(
+        "models/gemini-2.0-flash-001", [assistant, tool_result]
+    )
+    parts = [p for c in [*chat_kwargs["history"], _next] for p in (c.parts or [])]
+
+    fn_call = next(p.function_call for p in parts if p.function_call)
+    fn_resp = next(p.function_response for p in parts if p.function_response)
+
+    assert fn_call.name == "search_information"
+    assert fn_resp.name == "search_information"
+    # no synthetic id is emitted for Vertex
+    assert fn_call.id is None
+    assert fn_resp.id is None

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -460,6 +460,49 @@ def test_get_tool_calls_from_response(llm: GoogleGenAI) -> None:
     assert tool_calls[0].tool_kwargs == {"a": 2, "b": 3}
 
 
+@pytest.mark.skipif(SKIP_GEMINI, reason="GOOGLE_API_KEY not set")
+def test_parallel_tool_calls_have_unique_ids_and_roundtrip(llm: GoogleGenAI) -> None:
+    """
+    Live: parallel calls to the SAME tool must get distinct tool_ids, and
+    sending the results back (with those ids) must complete a valid round trip.
+    """
+
+    def get_step_info(step: int) -> str:
+        """Return the info for a given step number of the onboarding checklist."""
+        data = {1: "create account", 2: "verify email", 3: "done"}
+        return data.get(step, "no such step")
+
+    step_tool = FunctionTool.from_defaults(fn=get_step_info)
+    msg = ChatMessage(
+        "Call get_step_info in parallel for step 1 and step 2 in a single turn."
+    )
+    response = llm.chat_with_tools(user_msg=msg, tools=[step_tool])
+    tool_calls = llm.get_tool_calls_from_response(response, error_on_no_tool_call=False)
+
+    # The model may not always parallelize; only assert uniqueness when it does.
+    if len(tool_calls) >= 2:
+        ids = [tc.tool_id for tc in tool_calls]
+        assert len(set(ids)) == len(ids), (
+            f"parallel calls to the same tool collapsed to duplicate ids: {ids}"
+        )
+        assert all(tc.tool_name == "get_step_info" for tc in tool_calls)
+
+    # Round trip: feed the assistant tool-call message + tool results back and
+    # confirm the follow-up chat succeeds with the new id serialization.
+    history = [msg, response.message]
+    for tc in tool_calls:
+        history.append(
+            ChatMessage(
+                role="tool",
+                content=get_step_info(**tc.tool_kwargs),
+                additional_kwargs={"tool_call_id": tc.tool_id},
+            )
+        )
+
+    followup = llm.chat_with_tools(tools=[step_tool], chat_history=history)
+    assert followup.message is not None
+
+
 def search(query: str) -> str:
     """Search for information about a query."""
     return f"Results for {query}"


### PR DESCRIPTION
# Description

  I found this while debugging an issue with tool-context updates in a voice AI agent workflow using Gemini LLMs.

  `GoogleGenAI.get_tool_calls_from_response()` discarded the unique per-call ID returned by Gemini and used the tool name as `ToolSelection.tool_id` instead. This behavior was present with `llama-index-
  core==0.14.7`, `llama-index-llms-google-genai==0.8.7`, and `google-genai==1.63.0`, and was still present in newer LlamaIndex releases.

  When a model triggers multiple parallel calls to the **same** tool, using the tool name as the ID causes their `ToolSelection.tool_id` values to collide. Their results can then no longer be reliably correlated
  with the calls that produced them.

  This PR:

  - Captures the provider-issued ID using:

    ```python
    tool_call_id = function_call.id or function_call.name

  - Sets ToolSelection.tool_id from tool_call.tool_call_id.
  - Preserves the correct tool name when serializing function_call and function_response.
  - Uses a tool_call_id -> tool_name mapping to recover the function name for tool-result messages.
  - Echoes the ID on function_call.id and function_response.id only when tool_call_id != tool_name.
  - Falls back to the tool name when a provider or model does not return an ID, preserving the previous behavior.
  - Preserves upstream support for attaching image payloads to FunctionResponse.parts.

  For Vertex AI responses without an ID, tool_call_id == tool_name, so no synthetic ID is emitted and the request remains unchanged.

  This changes ToolSelection.tool_id only when the upstream provider supplies an actual call ID. Code that needs the function name should use ToolSelection.tool_name.

  All functional changes are contained in the llama-index-llms-google-genai package; no core-agent changes are required.

  ## New Package?

  - [ ] Yes
  - [x] No

  ## Version Bump?

  - [x] Yes
  - [ ] No

  The post-merge package version is 0.11.2.

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Breaking change (code assuming tool_id == tool_name may observe provider-issued IDs instead)

  ## How Has This Been Tested?

  - [x] I added new unit tests to cover this change
  - [ ] I believe this change is already covered by existing unit tests

  Mocked unit tests:

  - test_tool_call_id_captured_from_gemini_id — confirms that the provider ID is preserved on ToolCallBlock.
  - test_tool_call_id_falls_back_to_name_for_vertex — confirms that a missing ID falls back to the tool name.
  - test_get_tool_calls_from_response_surfaces_unique_ids — confirms that same-tool calls with provider IDs produce distinct ToolSelection.tool_id values.
  - test_tool_response_roundtrip_echoes_id_gemini — confirms that the tool name remains correct and the provider ID is echoed.
  - test_tool_response_roundtrip_omits_id_for_vertex — confirms that no synthetic ID is emitted when the provider omits the ID.

  Versions tested after resolving the merge conflicts:

  - llama-index-llms-google-genai==0.11.2
  - llama-index-core==0.14.24
  - google-genai==2.20.0

  Local package verification:

  - Unit suite without live credentials: 42 passed, 47 skipped
  - Ruff lint: passed
  - Ruff formatting: passed
  - No unresolved merge paths
  - No package-local whitespace errors

  Live Gemini API verification:

  - A multi-turn test using gemini-flash-latest confirmed that provider IDs such as 5ub5qlft, x188y55m, and z6qpv3q9 round-trip with the correct tool name on both function_call and function_response.
  - Test runs has 107 passed, 6 failed.
  - Five failures are actually duie to existing tests that use `gemini-2.0-flash-001`, which Google shut down on June 1, 2026. So, it gives 404 NOT_FOUND. LMK if you want me update those tests @logan-markewich 
  - The parallel-call test completed successfully with gemini-2.5-flash-lite.
  - gemini-2.5-flash returned two parallel calls without provider IDs. So, it correctly used the tool-name fallback

  Live Vertex AI verification:

  - Tested using service-account ADC.
  - The suite produced 2 passed, 4 failed.
  - All four failures use the retired gemini-2.0-flash-001 model and receive 404 NOT_FOUND (same as gemini ones above). I think we should update the tests as well??

  ## Suggested Checklist:

  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added Google Colab support for the newly added notebooks.
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I ran the package formatting and lint checks

  Do let me know your thoughts on this! :)
