### PR TITLE
fix(core): await tool retriever in async query

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/router_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/router_query_engine.py
@@ -375,7 +375,7 @@ class ToolRetrieverRouterQueryEngine(BaseQueryEngine):
         with self.callback_manager.event(
             CBEventType.QUERY, payload={EventPayload.QUERY_STR: query_bundle.query_str}
         ) as query_event:
-            query_engine_tools = self._retriever.retrieve(query_bundle)
+            query_engine_tools = await self._retriever.aretrieve(query_bundle)
             tasks = []
             for query_engine_tool in query_engine_tools:
                 query_engine = query_engine_tool.query_engine

--- a/llama-index-core/tests/query_engine/test_router_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_router_query_engine.py
@@ -100,7 +100,10 @@ async def test_tool_retriever_router_aquery_does_not_block_event_loop():
     tool_b = _make_query_engine_tool("b")
 
     retriever = MagicMock()
-    retriever.retrieve = MagicMock(return_value=[tool_a, tool_b])
+    retriever.retrieve = MagicMock(
+        side_effect=AssertionError("aquery must not use synchronous retrieval")
+    )
+    retriever.aretrieve = AsyncMock(return_value=[tool_a, tool_b])
 
     router = ToolRetrieverRouterQueryEngine(
         retriever=retriever,
@@ -110,5 +113,7 @@ async def test_tool_retriever_router_aquery_does_not_block_event_loop():
 
     await _assert_not_blocked(router.aquery("test query"))
 
+    retriever.retrieve.assert_not_called()
+    retriever.aretrieve.assert_awaited_once()
     assert tool_a.query_engine.aquery.call_count == 1
     assert tool_b.query_engine.aquery.call_count == 1


### PR DESCRIPTION
# Description

`ToolRetrieverRouterQueryEngine._aquery()` used the synchronous tool retriever before dispatching asynchronous query-engine calls. A retriever backed by remote I/O could therefore block the event loop.

This change awaits `ObjectRetriever.aretrieve()` in the asynchronous path while leaving `_query()` on the synchronous `retrieve()` API. The regression test now fails if `aquery()` touches the synchronous method and verifies that the asynchronous retriever is awaited.

Fixes #22369

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (the updated package is `llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added unit-test coverage for this change

Tests and checks:

- `uv run -- pytest tests/query_engine/test_router_query_engine.py -q` (`2 passed`)
- Applicable pre-commit hooks on both changed files: Ruff, Ruff format, Mypy, codespell, whitespace and file checks
- A blocking-retriever reproduction before and after the fix; the async path now calls `aretrieve()` without blocking the background coroutine

## Suggested Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing targeted unit tests pass locally
- [x] Applicable formatting and lint checks pass locally