### PR TITLE
refactor(core): deduplicate SimpleDirectoryReader load_file/aload_file

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -552,6 +552,76 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             return cast(bytes, f.read())
 
     @staticmethod
+    def _resolve_file_reader(
+        input_file: Path | PurePosixPath,
+        file_extractor: dict[str, BaseReader],
+    ) -> BaseReader | None:
+        """
+        Resolve the reader to use for ``input_file``.
+
+        Returns the :class:`BaseReader` registered (or newly instantiated and
+        cached into ``file_extractor``) for the file's suffix, or ``None`` when
+        the file has no dedicated reader and should be read as plain text.
+
+        Shared by :meth:`load_file` and :meth:`aload_file`. Static, like its
+        callers, so it remains usable from parallel worker processes.
+        """
+        default_file_reader_cls = SimpleDirectoryReader.supported_suffix_fn()
+        default_file_reader_suffix = list(default_file_reader_cls.keys())
+
+        file_suffix = input_file.suffix.lower()
+        if file_suffix in default_file_reader_suffix or file_suffix in file_extractor:
+            if file_suffix not in file_extractor:
+                # instantiate file reader if not already
+                reader_cls = default_file_reader_cls[file_suffix]
+                file_extractor[file_suffix] = reader_cls()
+            return file_extractor[file_suffix]
+        return None
+
+    @staticmethod
+    def _reader_load_kwargs(
+        metadata: dict | None,
+        fs: fsspec.AbstractFileSystem | None,
+    ) -> dict[str, Any]:
+        """Build the kwargs passed to ``reader.load_data``/``aload_data``."""
+        kwargs: dict[str, Any] = {"extra_info": metadata}
+        if fs and not is_default_fs(fs):
+            kwargs["fs"] = fs
+        return kwargs
+
+    @staticmethod
+    def _build_reader_documents(
+        docs: list[Document],
+        input_file: Path | PurePosixPath,
+        filename_as_id: bool,
+    ) -> list[Document]:
+        """Apply ``filename_as_id`` doc ids to reader output and return it."""
+        if filename_as_id:
+            for i, doc in enumerate(docs):
+                doc.id_ = f"{input_file!s}_part_{i}"
+        return list(docs)
+
+    @staticmethod
+    def _read_file_as_document(
+        input_file: Path | PurePosixPath,
+        metadata: dict | None,
+        filename_as_id: bool,
+        encoding: str,
+        errors: str,
+        fs: fsspec.AbstractFileSystem | None,
+    ) -> list[Document]:
+        """Read a file with no dedicated reader as a single plain-text Document."""
+        fs = fs or get_default_fs()
+        with fs.open(input_file, errors=errors, encoding=encoding) as f:
+            data = cast(bytes, f.read()).decode(encoding, errors=errors)
+
+        doc = Document(text=data, metadata=metadata or {})  # type: ignore
+        if filename_as_id:
+            doc.id_ = str(input_file)
+
+        return [doc]
+
+    @staticmethod
     def load_file(
         input_file: Path | PurePosixPath,
         file_metadata: Callable[[str], dict],
@@ -587,63 +657,38 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             List[Document]: loaded documents
 
         """
-        # TODO: make this less redundant
-        default_file_reader_cls = SimpleDirectoryReader.supported_suffix_fn()
-        default_file_reader_suffix = list(default_file_reader_cls.keys())
-        metadata: dict | None = None
-        documents: list[Document] = []
+        metadata = file_metadata(str(input_file)) if file_metadata is not None else None
 
-        if file_metadata is not None:
-            metadata = file_metadata(str(input_file))
-
-        file_suffix = input_file.suffix.lower()
-        if file_suffix in default_file_reader_suffix or file_suffix in file_extractor:
-            # use file readers
-            if file_suffix not in file_extractor:
-                # instantiate file reader if not already
-                reader_cls = default_file_reader_cls[file_suffix]
-                file_extractor[file_suffix] = reader_cls()
-            reader = file_extractor[file_suffix]
-
-            # load data -- catch all errors except for ImportError
-            try:
-                kwargs: dict[str, Any] = {"extra_info": metadata}
-                if fs and not is_default_fs(fs):
-                    kwargs["fs"] = fs
-                docs = reader.load_data(input_file, **kwargs)
-            except ImportError as e:
-                # ensure that ImportError is raised so user knows
-                # about missing dependencies
-                raise ImportError(str(e))
-            except Exception as e:
-                if raise_on_error:
-                    raise Exception("Error loading file") from e
-                # otherwise, just skip the file and report the error
-                print(
-                    f"Failed to load file {input_file} with error: {e}. Skipping...",
-                    flush=True,
-                )
-                return []
-
-            # iterate over docs if needed
-            if filename_as_id:
-                for i, doc in enumerate(docs):
-                    doc.id_ = f"{input_file!s}_part_{i}"
-
-            documents.extend(docs)
-        else:
+        reader = SimpleDirectoryReader._resolve_file_reader(input_file, file_extractor)
+        if reader is None:
             # do standard read
-            fs = fs or get_default_fs()
-            with fs.open(input_file, errors=errors, encoding=encoding) as f:
-                data = cast(bytes, f.read()).decode(encoding, errors=errors)
+            return SimpleDirectoryReader._read_file_as_document(
+                input_file, metadata, filename_as_id, encoding, errors, fs
+            )
 
-            doc = Document(text=data, metadata=metadata or {})  # type: ignore
-            if filename_as_id:
-                doc.id_ = str(input_file)
+        # use file readers -- catch all errors except for ImportError
+        try:
+            docs = reader.load_data(
+                input_file,
+                **SimpleDirectoryReader._reader_load_kwargs(metadata, fs),
+            )
+        except ImportError as e:
+            # ensure that ImportError is raised so user knows
+            # about missing dependencies
+            raise ImportError(str(e))
+        except Exception as e:
+            if raise_on_error:
+                raise Exception("Error loading file") from e
+            # otherwise, just skip the file and report the error
+            print(
+                f"Failed to load file {input_file} with error: {e}. Skipping...",
+                flush=True,
+            )
+            return []
 
-            documents.append(doc)
-
-        return documents
+        return SimpleDirectoryReader._build_reader_documents(
+            docs, input_file, filename_as_id
+        )
 
     @staticmethod
     async def aload_file(
@@ -657,63 +702,38 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         fs: fsspec.AbstractFileSystem | None = None,
     ) -> list[Document]:
         """Load file asynchronously."""
-        # TODO: make this less redundant
-        default_file_reader_cls = SimpleDirectoryReader.supported_suffix_fn()
-        default_file_reader_suffix = list(default_file_reader_cls.keys())
-        metadata: dict | None = None
-        documents: list[Document] = []
+        metadata = file_metadata(str(input_file)) if file_metadata is not None else None
 
-        if file_metadata is not None:
-            metadata = file_metadata(str(input_file))
-
-        file_suffix = input_file.suffix.lower()
-        if file_suffix in default_file_reader_suffix or file_suffix in file_extractor:
-            # use file readers
-            if file_suffix not in file_extractor:
-                # instantiate file reader if not already
-                reader_cls = default_file_reader_cls[file_suffix]
-                file_extractor[file_suffix] = reader_cls()
-            reader = file_extractor[file_suffix]
-
-            # load data -- catch all errors except for ImportError
-            try:
-                kwargs: dict[str, Any] = {"extra_info": metadata}
-                if fs and not is_default_fs(fs):
-                    kwargs["fs"] = fs
-                docs = await reader.aload_data(input_file, **kwargs)
-            except ImportError as e:
-                # ensure that ImportError is raised so user knows
-                # about missing dependencies
-                raise ImportError(str(e))
-            except Exception as e:
-                if raise_on_error:
-                    raise
-                # otherwise, just skip the file and report the error
-                print(
-                    f"Failed to load file {input_file} with error: {e}. Skipping...",
-                    flush=True,
-                )
-                return []
-
-            # iterate over docs if needed
-            if filename_as_id:
-                for i, doc in enumerate(docs):
-                    doc.id_ = f"{input_file!s}_part_{i}"
-
-            documents.extend(docs)
-        else:
+        reader = SimpleDirectoryReader._resolve_file_reader(input_file, file_extractor)
+        if reader is None:
             # do standard read
-            fs = fs or get_default_fs()
-            with fs.open(input_file, errors=errors, encoding=encoding) as f:
-                data = cast(bytes, f.read()).decode(encoding, errors=errors)
+            return SimpleDirectoryReader._read_file_as_document(
+                input_file, metadata, filename_as_id, encoding, errors, fs
+            )
 
-            doc = Document(text=data, metadata=metadata or {})  # type: ignore
-            if filename_as_id:
-                doc.id_ = str(input_file)
+        # use file readers -- catch all errors except for ImportError
+        try:
+            docs = await reader.aload_data(
+                input_file,
+                **SimpleDirectoryReader._reader_load_kwargs(metadata, fs),
+            )
+        except ImportError as e:
+            # ensure that ImportError is raised so user knows
+            # about missing dependencies
+            raise ImportError(str(e))
+        except Exception as e:
+            if raise_on_error:
+                raise
+            # otherwise, just skip the file and report the error
+            print(
+                f"Failed to load file {input_file} with error: {e}. Skipping...",
+                flush=True,
+            )
+            return []
 
-            documents.append(doc)
-
-        return documents
+        return SimpleDirectoryReader._build_reader_documents(
+            docs, input_file, filename_as_id
+        )
 
     def load_data(
         self,

--- a/llama-index-core/tests/readers/file/test_base.py
+++ b/llama-index-core/tests/readers/file/test_base.py
@@ -230,6 +230,43 @@ def test_SimpleDirectoryReader_load_file_error(data_path):
         )
 
 
+@pytest.mark.asyncio
+async def test_SimpleDirectoryReader_aload_file_error(data_path):
+    extractor = mock.AsyncMock()
+    extractor.aload_data.side_effect = ValueError("boom")
+
+    # Raise on error: unlike the sync path (which wraps as
+    # ``Exception("Error loading file")``), the async path re-raises the
+    # ORIGINAL exception. Assert the original ValueError propagates and is
+    # NOT wrapped, to lock in this deliberate divergence.
+    with pytest.raises(ValueError, match="boom"):
+        await SimpleDirectoryReader.aload_file(
+            input_file=data_path / "file_0.md",
+            file_metadata=lambda x: {},
+            file_extractor={".md": extractor},
+            raise_on_error=True,
+        )
+
+    # Continue on error
+    docs = await SimpleDirectoryReader.aload_file(
+        input_file=data_path / "file_0.md",
+        file_metadata=lambda x: {},
+        file_extractor={".md": extractor},
+        raise_on_error=False,
+    )
+    assert not docs
+
+    # Always raise ImportError
+    extractor.aload_data.side_effect = ImportError("Module Foo not found.")
+    with pytest.raises(ImportError, match="Module Foo not found."):
+        await SimpleDirectoryReader.aload_file(
+            input_file=data_path / "file_0.md",
+            file_metadata=lambda x: {},
+            file_extractor={".md": extractor},
+            raise_on_error=False,
+        )
+
+
 def test_SimpleDirectoryReader_load_file_unknown(data_path):
     docs = SimpleDirectoryReader.load_file(
         input_file=data_path / "file_0.xyz",


### PR DESCRIPTION
## Summary

`SimpleDirectoryReader.load_file` (sync) and `SimpleDirectoryReader.aload_file`
(async) in `llama-index-core/llama_index/core/readers/file/base.py` duplicated
the same ~55-line branching flow — metadata computation, file-reader
resolution/instantiation, error handling, `filename_as_id` doc-id assignment,
and the plain-text fallback read. Both carried a `# TODO: make this less
redundant` marker.

This PR extracts the shared logic into four private static helpers and
rewrites the two public methods as thin wrappers:

- `_resolve_file_reader` — pick (and cache) the `BaseReader` for a suffix, or
  `None` when the file should be read as plain text
- `_reader_load_kwargs` — build the `extra_info`/`fs` kwargs for the reader
- `_build_reader_documents` — apply `filename_as_id` ids to reader output
- `_read_file_as_document` — the plain-text fallback read

The helpers are kept **static** so `load_file` stays picklable for the
multiprocessing `num_workers` path (`load_data` uses
`partial(SimpleDirectoryReader.load_file, ...)` + `pool.imap`).

Behavior is preserved, including the **deliberate divergence** between the two
entry points that the issue calls out: `load_file` wraps reader failures as
`Exception("Error loading file") from e`, while `aload_file` re-raises the
original exception. No public signature or default behavior changes.

Fixes #21428

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(Refactor / code-quality cleanup — non-breaking, behavior-preserving.)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Ran `pytest tests/readers/file/test_base.py` in `llama-index-core` — 24/24 pass,
including the existing behavior-preservation tests (`load_file`,
`load_file_error` — which asserts the sync `Exception("Error loading file")`
wrap, `load_file_unknown` plain-text path, `load_data`, `aload_data`,
`iter_data`) and a **new** `test_SimpleDirectoryReader_aload_file_error` that
locks in the async path's divergent behavior (re-raises the original
exception, skips on `raise_on_error=False`, always re-raises `ImportError`).
Also verified the multiprocessing `load_data(num_workers=2)` and
`filename_as_id` paths, and ran `ruff check`, `ruff format --check`, and `mypy`
on the changed file — all clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

## Version Bump?

- [ ] Yes
- [x] No

`llama-index-core` is exempt from the per-package version-bump rule.

## New Package?

- [ ] Yes
- [x] No
