### PR TITLE
Don't drop oversized leaf nodes in CodeSplitter

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/code.py
+++ b/llama-index-core/llama_index/core/node_parser/text/code.py
@@ -183,6 +183,16 @@ class CodeSplitter(TextSplitter):
         current_chunk = ""
         max_size = self.max_chars if self.count_mode == "char" else self.max_tokens
 
+        # A leaf node (e.g. a long string literal or comment) has no children to
+        # recurse into. Without this guard the loop below never runs and the
+        # node's text is silently dropped when the node is larger than max_size,
+        # losing content. Emit the node's span (from the parent's cursor) as a
+        # single chunk; an atomic token that cannot be subdivided is allowed to
+        # exceed the size limit rather than vanish.
+        if not node.children:
+            leaf_text = text_bytes[last_end : node.end_byte].decode("utf-8")
+            return [leaf_text] if len(leaf_text) > 0 else []
+
         for child in node.children:
             child_text = text_bytes[child.start_byte : child.end_byte].decode("utf-8")
             child_size = (

--- a/llama-index-core/tests/text_splitter/test_code_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_code_splitter.py
@@ -61,6 +61,29 @@ def baz():
 
 
 @pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_oversized_leaf_node_is_not_dropped() -> None:
+    """
+    A leaf node bigger than max_chars must be emitted, not silently lost.
+
+    A long string literal parses to a leaf AST node with no children. The
+    recursive chunker used to return an empty list for such nodes, dropping
+    their text entirely.
+    """
+    if "CI" in os.environ:
+        return
+
+    literal = "a" * 40
+    text = f'x = "{literal}"'
+    code_splitter = CodeSplitter(language="python", chunk_lines=1, max_chars=10)
+
+    chunks = code_splitter.split_text(text)
+
+    # The oversized literal survives as its own chunk instead of vanishing.
+    assert literal in "".join(chunks)
+    assert any(literal in chunk for chunk in chunks)
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
 def test_typescript_code_splitter() -> None:
     """Test case for code splitting using typescript."""
     if "CI" in os.environ:


### PR DESCRIPTION
`CodeSplitter._chunk_node` recurses into oversized children, but a leaf node (a long string literal, comment, or token with no AST children) hit the empty loop and returned `[]`, silently dropping its text.

Emit an oversized leaf as its own chunk instead. An atomic token that cannot be subdivided is allowed to exceed the size limit rather than vanish. Adds a test asserting the literal survives.
