### PR TITLE
Don't crash html_to_df on HTML with no table

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/relational/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/utils.py
@@ -54,7 +54,12 @@ def html_to_df(html_str: str) -> Any:
         )
 
     tree = html.fromstring(html_str)
-    table_element = tree.xpath("//table")[0]
+    table_elements = tree.xpath("//table")
+    if len(table_elements) == 0:
+        # No table in the HTML: return None like md_to_df does for empty
+        # input, rather than raising IndexError on the [0] access.
+        return None
+    table_element = table_elements[0]
     rows = table_element.xpath(".//tr")
 
     data = []

--- a/llama-index-core/tests/node_parser/relational/test_relational_utils.py
+++ b/llama-index-core/tests/node_parser/relational/test_relational_utils.py
@@ -1,0 +1,32 @@
+import pytest
+
+from llama_index.core.node_parser.relational.utils import html_to_df
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("lxml")
+
+
+def test_html_to_df_without_table_returns_none() -> None:
+    """
+    HTML that contains no <table> must return None, not raise IndexError.
+
+    html_to_df is called on the ``text_as_html`` of parsed document elements,
+    which is not guaranteed to wrap the content in a <table>. Accessing
+    ``xpath("//table")[0]`` on such input crashed the whole node parser.
+    """
+    assert html_to_df("<div>Hello, no table here!</div>") is None
+
+
+def test_html_to_df_parses_table() -> None:
+    """A well-formed table is still parsed into a DataFrame."""
+    result = html_to_df(
+        "<table>"
+        "<tr><td>name</td><td>age</td></tr>"
+        "<tr><td>alice</td><td>30</td></tr>"
+        "</table>"
+    )
+    assert result is not None
+    assert list(result.columns) == ["name", "age"]
+    assert result.shape == (1, 2)
+    assert result.iloc[0]["name"] == "alice"
+    assert result.iloc[0]["age"] == "30"


### PR DESCRIPTION
`html_to_df` did `xpath("//table")[0]`, raising `IndexError` on valid HTML with no `<table>`. The `text_as_html` produced by document partitioners is not guaranteed to wrap the content in a table, so this crashed the node parser.

Return `None` like the sibling `md_to_df` does for empty input. Adds tests for the no-table and well-formed-table cases.
