### PR TITLE
fix: PydanticOutputParser.format() leaks brace-escaped (invalid) JSON schema into the final prompt

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/pydantic.py
+++ b/llama-index-core/llama_index/core/output_parsers/pydantic.py
@@ -64,4 +64,8 @@ class PydanticOutputParser(BaseOutputParser, Generic[Model]):
 
     def format(self, query: str) -> str:
         """Format a query with structured output formatting instructions."""
-        return query + "\n\n" + self.get_format_string(escape_json=True)
+        # `format` is applied to an already-formatted prompt (see
+        # `BasePromptTemplate` and `LLM._get_prompt`), after which no further
+        # `str.format`-style pass happens. Escaping the braces here would leak
+        # a `{{`-escaped (invalid) JSON schema into the text sent to the LLM.
+        return query + "\n\n" + self.get_format_string(escape_json=False)

--- a/llama-index-core/tests/output_parsers/test_pydantic.py
+++ b/llama-index-core/tests/output_parsers/test_pydantic.py
@@ -1,9 +1,12 @@
 """Test pydantic output parser."""
 
+import json
+
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.output_parsers.pydantic import PydanticOutputParser
 from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.core.prompts import PromptTemplate
 
 
 class AttrDict(BaseModel):
@@ -58,6 +61,34 @@ def test_pydantic_format() -> None:
     parser = PydanticOutputParser(output_cls=AttrDict)
     formatted_query = parser.format(query)
     assert "hello world" in formatted_query
+
+
+def test_pydantic_format_emits_valid_unescaped_schema() -> None:
+    """format() must emit the real JSON schema, not a '{{'-escaped one."""
+    parser = PydanticOutputParser(output_cls=AttrDict)
+    formatted_query = parser.format("hello world")
+
+    assert "{{" not in formatted_query
+
+    # the embedded schema must be valid JSON
+    schema_str = formatted_query.split("Here's a JSON schema to follow:")[1]
+    schema_str = schema_str.split("Output a valid JSON object")[0].strip()
+    schema = json.loads(schema_str)
+    assert schema["title"] == "AttrDict"
+
+    # the escaped variant is still available for embedding into raw templates
+    assert "{{" in parser.format_string
+
+
+def test_pydantic_output_parser_no_escaped_braces_in_final_prompt() -> None:
+    """The final prompt built by PromptTemplate must contain a valid schema."""
+    parser = PydanticOutputParser(output_cls=AttrDict)
+    prompt = PromptTemplate("Extract the object: {text}", output_parser=parser)
+    final_prompt = prompt.format(text="some text")
+
+    assert "Extract the object: some text" in final_prompt
+    assert "{{" not in final_prompt
+    assert '"title": "AttrDict"' in final_prompt
 
 
 def test_pydantic_format_with_blocks() -> None:


### PR DESCRIPTION
# Description

`PydanticOutputParser.format()` appends the output-format instructions with `escape_json=True`, which doubles every brace in the JSON schema (`{` → `{{`). But `format()` is only ever invoked on the **already-formatted** prompt:

- `BasePromptTemplate`/`PromptTemplate.format()` runs `prompt = self.output_parser.format(prompt)` *after* template variable substitution (`llama_index/core/prompts/base.py`)
- `LLM._get_prompt()` does the same after `prompt.format(...)` (`llama_index/core/llms/llm.py`)
- `format_messages()` likewise runs on fully-formatted messages

No `str.format`-style pass happens after that point, and `SafeFormatter` never unescapes `{{`/`}}` anyway. So the literal text sent to the LLM in every structured-output flow that attaches a `PydanticOutputParser` (e.g. `LLMTextCompletionProgram`, the documented output-parser pattern) is:

```
Here's a JSON schema to follow:
{{"properties": {{"name": {{"title": "Name", "type": "string"}}}}, "required": ["name"], "title": "Album", "type": "object"}}
```

— a syntactically invalid JSON schema shown to the model right after the instruction "Here's a JSON schema to follow".

**Fix:** `format()` now appends the instructions with `escape_json=False`, so the final prompt contains the real, valid schema. The `format_string` property is unchanged (still escaped) for users who embed it into a raw template string *before* formatting, where escaping is still the correct behavior.

Note this is distinct from (and complementary to) #22075: that PR fixes `SafeFormatter`'s handling of `{{`/`}}` escapes in *template* text (the pre-format path, e.g. `SelectionOutputParser`). This PR fixes the post-format path in `PydanticOutputParser.format()`, which #22075 does not touch — the schema here is appended after formatting, so no formatter pass ever sees it.

## New Package?

- [x] No

## Version Bump?

- [x] No (llama-index-core)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Two new tests in `llama-index-core/tests/output_parsers/test_pydantic.py`:

- `test_pydantic_format_emits_valid_unescaped_schema` — asserts `format()` output contains no `{{` and that the embedded schema `json.loads()`-parses, while `format_string` stays escaped.
- `test_pydantic_output_parser_no_escaped_braces_in_final_prompt` — end-to-end: `PromptTemplate("...: {text}", output_parser=parser).format(text=...)` yields a final prompt with the valid schema and no doubled braces.

Both tests fail on `main` and pass with the fix. Full related suites pass locally: `python -m pytest tests/output_parsers tests/prompts tests/program tests/evaluation` → **127 passed**. Also verified `SelectionOutputParser` is unaffected (it defines its own `format()`), and that `_extend_prompt`/`SafeFormatter` are safe with raw braces in the appended schema (re.sub replacement values are not re-scanned).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI usage disclosure

Per the "How to Use AI when Contributing" section of CONTRIBUTING.md: I used an AI coding assistant to help trace the call paths of `output_parser.format()` across the codebase and to draft the fix and tests. I verified and validated everything manually: reproduced the doubled-brace prompt on `main` (commit dbdaf89) with a failing test, confirmed the one-line fix makes it pass, audited every in-repo caller of `PydanticOutputParser.format()`/`format_string` for regressions, ran the output_parsers/prompts/program/evaluation test suites locally (127 passed), and ran the repo pre-commit hooks (ruff, ruff-format, mypy, codespell) on the changed files.
