### PR TITLE
fix: return str from img_2_b64 instead of bytes

### DIFF
--- a/llama-index-core/llama_index/core/img_utils.py
+++ b/llama-index-core/llama_index/core/img_utils.py
@@ -22,7 +22,7 @@ def img_2_b64(image: ImageFile, format: str = "JPEG") -> str:
     """
     buff = BytesIO()
     image.save(buff, format=format)
-    return cast(str, base64.b64encode(buff.getvalue()))
+    return base64.b64encode(buff.getvalue()).decode("utf-8")
 
 
 def b64_2_img(data: str) -> ImageFile:

--- a/llama-index-core/tests/test_img_utils.py
+++ b/llama-index-core/tests/test_img_utils.py
@@ -1,0 +1,54 @@
+"""Tests for llama_index.core.img_utils."""
+
+import base64
+import json
+from io import BytesIO
+
+from llama_index.core.img_utils import b64_2_img, img_2_b64
+from PIL import Image
+from PIL.ImageFile import ImageFile
+
+
+def _image() -> ImageFile:
+    buff = BytesIO()
+    Image.new("RGB", (4, 4), (255, 0, 0)).save(buff, format="JPEG")
+    buff.seek(0)
+    return Image.open(buff)
+
+
+def test_img_2_b64_returns_str_not_bytes() -> None:
+    """
+    Regression test for #21186.
+
+    img_2_b64 is annotated `-> str` but returned the bytes from base64.b64encode()
+    wrapped in typing.cast, which only satisfies the type checker and does nothing at
+    runtime. Callers (the file readers) annotate the result `image_str: Optional[str]`
+    and put it on a Document, so the bytes surfaced later as
+    "TypeError: Object of type bytes is not JSON serializable", or as a literal b'...'
+    interpolated into a data URI.
+    """
+    encoded = img_2_b64(_image())
+
+    assert isinstance(encoded, str)
+    # the bytes repr must not leak through string interpolation
+    assert not f"{encoded}".startswith("b'")
+    # and the value must survive JSON serialization, as Document storage requires
+    assert json.loads(json.dumps({"image": encoded}))["image"] == encoded
+
+
+def test_img_2_b64_round_trips_through_b64_2_img() -> None:
+    """The str returned by img_2_b64 must still decode back into an image."""
+    image = _image()
+
+    restored = b64_2_img(img_2_b64(image))
+
+    assert restored.size == image.size
+
+
+def test_img_2_b64_matches_plain_b64encode() -> None:
+    """The encoding itself is unchanged; only its type is."""
+    image = _image()
+    buff = BytesIO()
+    image.save(buff, format="JPEG")
+
+    assert img_2_b64(image) == base64.b64encode(buff.getvalue()).decode("utf-8")


### PR DESCRIPTION
# Description

`img_2_b64` is annotated `-> str` but returned the `bytes` from `base64.b64encode()` wrapped in `typing.cast`. `cast` only satisfies the type checker; it does nothing at runtime, so every caller got `bytes` back from a function whose signature promises `str`.

```python
>>> from llama_index.core.img_utils import img_2_b64
>>> encoded = img_2_b64(image)
>>> type(encoded)
<class 'bytes'>                       # signature says str
>>> json.dumps({"image": encoded})
TypeError: Object of type bytes is not JSON serializable
>>> f"data:image/jpeg;base64,{encoded}"
"data:image/jpeg;base64,b'/9j/4AAQSkZJRgABAQ..."     # the b'' leaks in
```

This is reachable from real code paths rather than theoretical. The four file readers that call it (`image`, `image_caption`, `image_deplot`, `image_vision_llm`) each do:

```python
image_str: Optional[str] = None
if self._keep_image:
    image_str = img_2_b64(image)
```

and place that on a `Document`, so with `keep_image=True` the bytes surface later as the `TypeError` above during serialization, or as a literal `b'...'` interpolated into a data URI.

The fix decodes to utf-8 and drops the `cast`. The encoding itself is unchanged, only its type; `b64_2_img` already accepts the `str` since `base64.b64decode` takes either, so the round trip is unaffected. The `cast` import stays for `b64_2_img`.

Fixes #21186

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

This is `llama-index-core`, which the template excludes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Worth flagging for review: this changes the runtime return type from `bytes` to `str`. It matches the declared signature, the docstring, and what all four in-repo callers already annotate and expect, so it is a fix rather than a break. Any out-of-tree caller relying on the undeclared `bytes` would notice, though it would have been contradicting the type hint to do so.

## How Has This Been Tested?

Added `llama-index-core/tests/test_img_utils.py`, which had no existing coverage:

- `test_img_2_b64_returns_str_not_bytes` — asserts the return is `str`, that no `b'` leaks through interpolation, and that the value survives `json.dumps`, which is what Document storage needs
- `test_img_2_b64_round_trips_through_b64_2_img` — the `str` still decodes back to an image
- `test_img_2_b64_matches_plain_b64encode` — the encoding is byte-for-byte what `base64.b64encode(...).decode("utf-8")` produces, so only the type changed

Verified the tests are meaningful by reverting the one-line fix and re-running: `test_img_2_b64_returns_str_not_bytes` fails on `assert isinstance(encoded, str)`, and `test_img_2_b64_matches_plain_b64encode` fails showing `b'/9j/...'` against `'/9j/...'`. Both pass with the fix. `ruff check` and `ruff format --check` pass on both files.
