### PR TITLE
fix(core): guard against None scores in relative score fusion

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -183,9 +183,9 @@ class QueryFusionRetriever(BaseRetriever):
                 if max_score == min_score:
                     node_with_score.score = 1.0 if max_score > 0 else 0.0
                 else:
-                    node_with_score.score = (node_with_score.score - min_score) / (
-                        max_score - min_score
-                    )
+                    node_with_score.score = (
+                        (node_with_score.score or 0.0) - min_score
+                    ) / (max_score - min_score)
                 # Scale by the weight of the retriever
                 retriever_idx = query_tuple[1]
                 existing_score = node_with_score.score or 0.0

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -4,12 +4,43 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.retrievers import QueryFusionRetriever
-from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
+from llama_index.core.schema import IndexNode, NodeWithScore, QueryBundle, TextNode
 
 
 class MockRetriever(BaseRetriever):
     def _retrieve(self, query_bundle: QueryBundle):
         return [NodeWithScore(node=TextNode(text="result"), score=1.0)]
+
+
+class MockUnscoredRetriever(BaseRetriever):
+    """
+    Stands in for retrievers that do not assign scores.
+
+    ``SummaryIndexRetriever`` and ``KeywordTableRetriever`` both build
+    ``NodeWithScore`` without a score.
+    """
+
+    def _retrieve(self, query_bundle: QueryBundle):
+        return [NodeWithScore(node=TextNode(text="unscored", id_="unscored"))]
+
+
+class MockMixedRetriever(BaseRetriever):
+    """
+    Returns a scored node plus an ``IndexNode`` resolved by recursive retrieval.
+
+    ``BaseRetriever._handle_recursive_retrieval`` delegates the ``IndexNode`` to
+    the object it maps to and splices the result back in as-is, so the final list
+    mixes scored and unscored nodes.
+    """
+
+    def _retrieve(self, query_bundle: QueryBundle):
+        return [
+            NodeWithScore(node=TextNode(text="scored", id_="scored"), score=0.9),
+            NodeWithScore(
+                node=IndexNode(text="ref", id_="ref", index_id="sub_index"),
+                score=0.4,
+            ),
+        ]
 
 
 @pytest.mark.asyncio
@@ -33,3 +64,50 @@ async def test_aretrieve_uses_async_query_generation():
     await retriever.aretrieve("test query")
 
     assert async_called
+
+
+@pytest.mark.parametrize("mode", ["relative_score", "dist_based_score"])
+def test_score_fusion_handles_unscored_nodes(mode: str):
+    """Score-based fusion must not crash when a retriever yields unscored nodes."""
+    retriever = QueryFusionRetriever(
+        retrievers=[
+            MockMixedRetriever(object_map={"sub_index": MockUnscoredRetriever()}),
+            MockRetriever(),
+        ],
+        llm=MockLLM(),
+        mode=mode,
+        num_queries=1,
+        use_async=False,
+        similarity_top_k=10,
+    )
+
+    nodes = retriever.retrieve("test query")
+
+    texts = [node.node.text for node in nodes]
+    assert "unscored" in texts, f"Unscored node was dropped, got {texts}"
+    assert all(isinstance(node.score, float) for node in nodes), (
+        f"Expected every fused node to carry a float score, got "
+        f"{[(n.node.text, n.score) for n in nodes]}"
+    )
+
+
+@pytest.mark.parametrize("mode", ["relative_score", "dist_based_score"])
+def test_score_fusion_ranks_unscored_nodes_last(mode: str):
+    """An unscored node is treated as 0.0 and must not outrank a scored one."""
+    retriever = QueryFusionRetriever(
+        retrievers=[
+            MockMixedRetriever(object_map={"sub_index": MockUnscoredRetriever()})
+        ],
+        llm=MockLLM(),
+        mode=mode,
+        num_queries=1,
+        use_async=False,
+        similarity_top_k=10,
+    )
+
+    nodes = retriever.retrieve("test query")
+    scores = {node.node.text: node.score for node in nodes}
+
+    assert scores["scored"] > scores["unscored"], (
+        f"Scored node should outrank unscored node, got {scores}"
+    )


### PR DESCRIPTION
# Description

`QueryFusionRetriever._relative_score_fusion` rescales each node's score without guarding against `None`:

```python
node_with_score.score = (node_with_score.score - min_score) / (max_score - min_score)
```

`NodeWithScore.score` is `Optional[float]`, and every other score read in this file already coerces it with `or 0.0` — including the line immediately below this one, and the list comprehension that computes `min_score`/`max_score`. This was the only unguarded read, so `min_score`/`max_score` were computed correctly while the per-node rescale raised:

```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

This affects `mode="relative_score"` and `mode="dist_based_score"`. The `reciprocal_rerank` and `simple` modes were already safe, which is likely why it went unnoticed.

The crash requires a single retriever to return a mix of scored and unscored nodes (if every score in one result set is `None`, they all collapse to `0.0` and the `max_score == min_score` branch is taken instead). Recursive retrieval produces exactly that mix: `BaseRetriever._handle_recursive_retrieval` resolves an `IndexNode` through `_retrieve_from_object`, which returns a nested retriever's results as-is, and splices them back alongside the normally scored nodes. Retrievers that build `NodeWithScore` without a score — `SummaryIndexRetriever`, `KeywordTableRetriever`, the tree retrievers — therefore make score-based fusion crash whenever they are reachable as a sub-retriever.

The fix applies the same `or 0.0` coercion used elsewhere in the file, so an unscored node is normalized to the bottom of the range rather than crashing.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

This only touches `llama-index-core`, which the template exempts from version bumps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added parametrized regression tests over both affected modes in `llama-index-core/tests/retrievers/test_fusion_retriever.py`, using a retriever that returns a scored node plus an `IndexNode` mapped to an unscored sub-retriever. The tests reproduce the real recursive-retrieval path rather than hand-constructing a fusion input.

Confirmed the tests fail on the current `main` with the exact `TypeError` above, and pass with the fix applied. They cover both that fusion no longer raises and that an unscored node is ranked below a scored one, so the normalization behavior is pinned and not just the absence of an exception.

Also ran the full `llama-index-core` suite (1452 passed; the 3 failures in `test_llama_debug`, `test_json`, and `test_media_resource` reproduce unchanged on a clean checkout of `main` on this platform and are unrelated), plus `mypy llama_index` and the pre-commit suite over the changed files.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
