### PR TITLE
feat: add ScrapeUnblockerWebReader to llama-index-readers-web

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/__init__.py
@@ -30,6 +30,9 @@ from llama_index.readers.web.rss.base import (
 from llama_index.readers.web.rss_news.base import (
     RssNewsReader,
 )
+from llama_index.readers.web.scrapeunblocker_web.base import (
+    ScrapeUnblockerWebReader,
+)
 from llama_index.readers.web.scrapfly_web.base import (
     ScrapflyReader,
 )
@@ -75,6 +78,7 @@ __all__ = [
     "ReadabilityWebPageReader",
     "RssReader",
     "RssNewsReader",
+    "ScrapeUnblockerWebReader",
     "ScrapflyReader",
     "ScrapyWebReader",
     "SimpleWebPageReader",

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapeunblocker_web/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapeunblocker_web/__init__.py
@@ -1,0 +1,5 @@
+"""ScrapeUnblocker Web Reader module."""
+
+from llama_index.readers.web.scrapeunblocker_web.base import ScrapeUnblockerWebReader
+
+__all__ = ["ScrapeUnblockerWebReader"]

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapeunblocker_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/scrapeunblocker_web/base.py
@@ -1,0 +1,218 @@
+"""ScrapeUnblocker Web Reader."""
+
+import json
+import time
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+from llama_index.core.bridge.pydantic import Field, PrivateAttr, field_validator
+from llama_index.core.readers.base import BasePydanticReader
+from llama_index.core.schema import Document
+
+
+class ScrapeUnblockerWebReader(BasePydanticReader):
+    """
+    ScrapeUnblocker Web Reader.
+
+    Read web pages through the ScrapeUnblocker API, which renders pages in a real
+    browser behind anti-bot protections (Cloudflare, DataDome, PerimeterX, Akamai)
+    and returns the resulting HTML or AI-parsed JSON.
+
+    Args:
+        api_key (str): ScrapeUnblocker API key. Get one at https://www.scrapeunblocker.com
+        parsed_data (Optional[bool]): Return AI-parsed structured JSON instead of raw
+            HTML. Default False.
+        proxy_country (Optional[str]): Two-letter country code for the exit IP, for
+            geo-restricted or localised content (e.g. "us", "de").
+        time_sleep (Optional[int]): Seconds to wait after page load before capturing,
+            for content that streams in late.
+        get_cookies (Optional[bool]): Also return the cookies set by the target site.
+            Default False.
+        method (Optional[str]): Page interaction to perform before capturing, such as
+            waiting for a selector.
+        value (Optional[str]): Argument for `method` (for example the CSS selector to
+            wait for).
+        method_timeout (Optional[int]): Seconds to wait for `method` before giving up.
+        base_url (Optional[str]): API base URL. Override to target staging.
+        timeout (Optional[int]): Client-side HTTP timeout in seconds. Default 180.
+
+    Examples:
+        `pip install llama-index-readers-web`
+
+        ```python
+        from llama_index.readers.web import ScrapeUnblockerWebReader
+
+        reader = ScrapeUnblockerWebReader(api_key="your-api-key")
+        documents = reader.load_data(urls=["https://example.com"])
+        ```
+
+    """
+
+    is_remote: bool = True
+    api_key: str = Field(description="ScrapeUnblocker API key")
+    parsed_data: Optional[bool] = Field(
+        default=False,
+        description="Return AI-parsed structured JSON instead of raw HTML.",
+    )
+    proxy_country: Optional[str] = Field(
+        default=None,
+        description="Two-letter country code for the exit IP, for geo-restricted content.",
+    )
+    time_sleep: Optional[int] = Field(
+        default=None,
+        description="Seconds to wait after page load before capturing the page.",
+    )
+    get_cookies: Optional[bool] = Field(
+        default=False,
+        description="Also return the cookies set by the target site.",
+    )
+    method: Optional[str] = Field(
+        default=None,
+        description="Page interaction to perform before capturing, e.g. waiting for a selector.",
+    )
+    value: Optional[str] = Field(
+        default=None,
+        description="Argument for `method`, e.g. the CSS selector to wait for.",
+    )
+    method_timeout: Optional[int] = Field(
+        default=None,
+        description="Seconds to wait for `method` before giving up.",
+    )
+    base_url: Optional[str] = Field(
+        default="https://api.scrapeunblocker.com",
+        description="API base URL. Override to target staging.",
+    )
+    timeout: Optional[int] = Field(
+        default=180,
+        description="Client-side HTTP timeout in seconds.",
+    )
+
+    _endpoint: str = PrivateAttr(default="/getPageSource")
+
+    @field_validator("proxy_country")
+    @classmethod
+    def validate_proxy_country(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not isinstance(v, str) or len(v) != 2 or not v.isalpha():
+            raise ValueError(
+                "proxy_country must be a two-letter country code, e.g. 'us' or 'de'"
+            )
+        return v.lower()
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if not self.api_key:
+            raise ValueError("api_key is required")
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "ScrapeUnblockerWebReader"
+
+    def _prepare_request_params(
+        self, url: str, extra_params: Optional[Dict] = None
+    ) -> Dict[str, Any]:
+        """Build the query string for one request."""
+        params: Dict[str, Any] = {
+            "url": url,
+            "parsed_data": self.parsed_data,
+            "get_cookies": self.get_cookies,
+            "proxy_country": self.proxy_country,
+            "time_sleep": self.time_sleep,
+            "method": self.method,
+            "value": self.value,
+            "method_timeout": self.method_timeout,
+        }
+
+        if extra_params:
+            params.update(extra_params)
+
+        # The API treats an absent parameter as "use the default", so drop empties
+        # rather than sending nulls.
+        return {k: v for k, v in params.items() if v is not None and v is not False}
+
+    def _make_request(
+        self, url: str, extra_params: Optional[Dict] = None
+    ) -> requests.Response:
+        """Call the ScrapeUnblocker API for a single URL."""
+        response = requests.post(
+            f"{self.base_url.rstrip('/')}{self._endpoint}",
+            params=self._prepare_request_params(url, extra_params),
+            headers={"X-ScrapeUnblocker-Key": self.api_key},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response
+
+    def _extract_metadata(
+        self, response: requests.Response, url: str
+    ) -> Dict[str, Any]:
+        """Collect response metadata for the Document."""
+        return {
+            "source_url": url,
+            "scraped_at": time.time(),
+            "status_code": response.status_code,
+            "content_type": response.headers.get("Content-Type", ""),
+            "content_length": len(response.content),
+            "scrapeunblocker_config": {
+                "parsed_data": self.parsed_data,
+                "proxy_country": self.proxy_country,
+                "get_cookies": self.get_cookies,
+                "method": self.method,
+            },
+        }
+
+    def _process_response_content(self, response: requests.Response) -> str:
+        """Return page text; parsed_data responses come back as JSON."""
+        if self.parsed_data:
+            try:
+                return json.dumps(response.json(), ensure_ascii=False)
+            except ValueError:
+                # Fall back to the raw body if the API returned HTML anyway.
+                return response.text
+        return response.text
+
+    def load_data(
+        self, urls: Union[str, List[str]], extra_params: Optional[Dict] = None, **kwargs
+    ) -> List[Document]:
+        """
+        Load data from URLs using the ScrapeUnblocker API.
+
+        Args:
+            urls: Single URL string or list of URLs to scrape
+            extra_params: Additional query parameters for this specific request
+            **kwargs: Additional keyword arguments (for compatibility)
+
+        Returns:
+            List of Document objects containing scraped content and metadata
+
+        """
+        if isinstance(urls, str):
+            urls = [urls]
+
+        documents = []
+
+        for url in urls:
+            try:
+                response = self._make_request(url, extra_params)
+                documents.append(
+                    Document(
+                        text=self._process_response_content(response),
+                        metadata=self._extract_metadata(response, url),
+                    )
+                )
+            except Exception as e:
+                # One unreachable URL should not discard the rest of the batch.
+                documents.append(
+                    Document(
+                        text=f"Error scraping {url}: {e!s}",
+                        metadata={
+                            "source_url": url,
+                            "error": str(e),
+                            "scraped_at": time.time(),
+                            "status": "failed",
+                        },
+                    )
+                )
+
+        return documents

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_scrapeunblocker_web.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_scrapeunblocker_web.py
@@ -1,0 +1,159 @@
+"""Tests for ScrapeUnblockerWebReader."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from llama_index.core.schema import Document
+from llama_index.readers.web import ScrapeUnblockerWebReader
+
+
+@pytest.fixture
+def api_key() -> str:
+    """Test API key fixture."""
+    return "test_api_key_123"
+
+
+@pytest.fixture
+def test_url() -> str:
+    """Test URL fixture."""
+    return "https://example.com"
+
+
+@pytest.fixture
+def mock_html_response() -> str:
+    """Mock HTML response content."""
+    return """
+    <html>
+    <head><title>Test Page</title></head>
+    <body>
+        <h1>Welcome to Test Page</h1>
+        <p>This is a test paragraph.</p>
+    </body>
+    </html>
+    """
+
+
+def _mock_response(text: str, status_code: int = 200, json_data=None) -> Mock:
+    response = Mock(spec=requests.Response)
+    response.text = text
+    response.content = text.encode()
+    response.status_code = status_code
+    response.headers = {"Content-Type": "text/html"}
+    response.raise_for_status = Mock()
+    if json_data is not None:
+        response.json = Mock(return_value=json_data)
+    return response
+
+
+def test_class_name(api_key: str) -> None:
+    assert ScrapeUnblockerWebReader(api_key=api_key).class_name() == (
+        "ScrapeUnblockerWebReader"
+    )
+
+
+def test_is_remote(api_key: str) -> None:
+    assert ScrapeUnblockerWebReader(api_key=api_key).is_remote is True
+
+
+def test_missing_api_key_raises() -> None:
+    with pytest.raises(ValueError):
+        ScrapeUnblockerWebReader(api_key="")
+
+
+def test_invalid_proxy_country_raises(api_key: str) -> None:
+    with pytest.raises(ValueError):
+        ScrapeUnblockerWebReader(api_key=api_key, proxy_country="usa")
+
+
+def test_proxy_country_normalised(api_key: str) -> None:
+    reader = ScrapeUnblockerWebReader(api_key=api_key, proxy_country="US")
+    assert reader.proxy_country == "us"
+
+
+def test_prepare_request_params_drops_unset(api_key: str, test_url: str) -> None:
+    reader = ScrapeUnblockerWebReader(api_key=api_key)
+    params = reader._prepare_request_params(test_url)
+    assert params == {"url": test_url}
+
+
+def test_prepare_request_params_includes_options(api_key: str, test_url: str) -> None:
+    reader = ScrapeUnblockerWebReader(
+        api_key=api_key, proxy_country="de", time_sleep=5, parsed_data=True
+    )
+    params = reader._prepare_request_params(test_url)
+    assert params["url"] == test_url
+    assert params["proxy_country"] == "de"
+    assert params["time_sleep"] == 5
+    assert params["parsed_data"] is True
+
+
+def test_extra_params_override(api_key: str, test_url: str) -> None:
+    reader = ScrapeUnblockerWebReader(api_key=api_key, proxy_country="de")
+    params = reader._prepare_request_params(test_url, {"proxy_country": "fr"})
+    assert params["proxy_country"] == "fr"
+
+
+@patch("llama_index.readers.web.scrapeunblocker_web.base.requests.post")
+def test_load_data_single_url(
+    mock_post: Mock, api_key: str, test_url: str, mock_html_response: str
+) -> None:
+    mock_post.return_value = _mock_response(mock_html_response)
+    reader = ScrapeUnblockerWebReader(api_key=api_key)
+
+    documents = reader.load_data(test_url)
+
+    assert len(documents) == 1
+    assert isinstance(documents[0], Document)
+    assert "Welcome to Test Page" in documents[0].text
+    assert documents[0].metadata["source_url"] == test_url
+    assert documents[0].metadata["status_code"] == 200
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["headers"]["X-ScrapeUnblocker-Key"] == api_key
+    assert kwargs["params"]["url"] == test_url
+
+
+@patch("llama_index.readers.web.scrapeunblocker_web.base.requests.post")
+def test_load_data_multiple_urls(
+    mock_post: Mock, api_key: str, mock_html_response: str
+) -> None:
+    mock_post.return_value = _mock_response(mock_html_response)
+    reader = ScrapeUnblockerWebReader(api_key=api_key)
+
+    documents = reader.load_data(["https://a.com", "https://b.com"])
+
+    assert len(documents) == 2
+    assert mock_post.call_count == 2
+
+
+@patch("llama_index.readers.web.scrapeunblocker_web.base.requests.post")
+def test_load_data_parsed_data_returns_json(
+    mock_post: Mock, api_key: str, test_url: str
+) -> None:
+    payload = {"title": "Test Page", "price": "9.99"}
+    mock_post.return_value = _mock_response("{}", json_data=payload)
+    reader = ScrapeUnblockerWebReader(api_key=api_key, parsed_data=True)
+
+    documents = reader.load_data(test_url)
+
+    assert json.loads(documents[0].text) == payload
+
+
+@patch("llama_index.readers.web.scrapeunblocker_web.base.requests.post")
+def test_load_data_error_does_not_abort_batch(
+    mock_post: Mock, api_key: str, mock_html_response: str
+) -> None:
+    ok = _mock_response(mock_html_response)
+    failing = Mock(spec=requests.Response)
+    failing.raise_for_status = Mock(side_effect=requests.HTTPError("403 Forbidden"))
+    mock_post.side_effect = [failing, ok]
+
+    reader = ScrapeUnblockerWebReader(api_key=api_key)
+    documents = reader.load_data(["https://blocked.com", "https://ok.com"])
+
+    assert len(documents) == 2
+    assert documents[0].metadata["status"] == "failed"
+    assert "403 Forbidden" in documents[0].metadata["error"]
+    assert "Welcome to Test Page" in documents[1].text


### PR DESCRIPTION
## Description

Adds `ScrapeUnblockerWebReader` to `llama-index-readers-web`. ScrapeUnblocker
renders pages in a real browser behind anti-bot protections (Cloudflare,
DataDome, PerimeterX, Akamai) and returns either raw HTML or AI-parsed JSON.

The reader follows the existing `ZenRowsWebReader` shape: a `BasePydanticReader`
subclass with `Field`-documented options, `class_name()`, and per-URL error
documents so one failing URL does not discard the rest of a batch.

Options map to the public API: `parsed_data`, `proxy_country`, `time_sleep`,
`get_cookies`, `method`, `value`, `method_timeout`.

```python
from llama_index.readers.web import ScrapeUnblockerWebReader

reader = ScrapeUnblockerWebReader(api_key="your-api-key")
documents = reader.load_data(urls=["https://example.com"])
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added new unit/integration tests - `tests/test_scrapeunblocker_web.py`,
      12 tests covering parameter building, validation, single and multi-URL
      loading, `parsed_data` JSON handling, and batch-level error isolation
- [x] Verified end-to-end against the live API on JS-heavy, bot-protected pages
      (a TripAdvisor attraction page and an amazon.de product page), both
      returning full rendered HTML
