### PR TITLE
docs: fix broken imports and examples in integration READMEs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-outlook-emails/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-outlook-emails/README.md
@@ -23,7 +23,7 @@ To use this loader, `client_id`, `client_secret`, and `tenant_id` of the registe
 This loader fetches emails from a specified folder in an Outlook mailbox.
 
 ```python
-from llama_index.readers.outlook_emails import OutlookEmailReader
+from llama_index.readers.microsoft_outlook_emails import OutlookEmailReader
 
 loader = OutlookEmailReader(
     client_id="<Client ID of the app>",

--- a/llama-index-integrations/readers/llama-index-readers-paddle-ocr/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-paddle-ocr/README.md
@@ -10,12 +10,12 @@ Users can input the path of the academic PDF document `file` which they want to 
 
 ## Usage
 
-Here's an example usage of the PDFPaddleOCR.
+Here's an example usage of the PDFPaddleOCRReader.
 
 ```python
-from llama_index.readers.paddle_ocr import PDFPaddleOCR
+from llama_index.readers.paddle_ocr import PDFPaddleOCRReader
 
-reader = PDFPaddleOCR()
+reader = PDFPaddleOCRReader()
 
 pdf_path = Path("/path/to/pdf")
 

--- a/llama-index-integrations/tools/llama-index-tools-desearch/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-desearch/README.md
@@ -1,7 +1,3 @@
-Here's a README for the `Desearch` integration, modeled after the example you provided:
-
----
-
 # LlamaIndex Tools Integration: Desearch
 
 This tool connects to Desearch to enable your agent to perform searches across various platforms like web, Twitter, and more.
@@ -17,9 +13,11 @@ Here's an example usage of the `DesearchToolSpec`.
 To get started, you will need a [Desearch API key](https://console.desearch.ai/api-keys)
 
 ```python
-# %pip install llama-index llama-index-core desearch-py
+# %pip install llama-index llama-index-core llama-index-tools-desearch
 
-from llama_index_desearch.tools import DesearchToolSpec
+import os
+
+from llama_index.tools.desearch import DesearchToolSpec
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.llms.openai import OpenAI
 
@@ -41,7 +39,3 @@ print(await agent.run("Can you find the latest news on quantum computing?"))
 - **web_search_tool**: Perform a basic web search using the Desearch API.
 
 This loader is designed to be used as a way to load data as a Tool in an Agent.
-
----
-
-You can copy and paste this into your README file. Let me know if you need any more modifications!

--- a/llama-index-integrations/tools/llama-index-tools-jina/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-jina/README.md
@@ -16,17 +16,17 @@ This tool enables agents to search and retrieve results from the Jina search api
 
 This tool has a more extensive example usage documented in a Jupyter notebook [here](./examples/jina_search.ipynb)
 
-Here's an example usage of the JinaSearchToolSpec.
+Here's an example usage of the JinaToolSpec.
 
 ```python
-from llama_index.tools.jina import JinaSearchToolSpec
+from llama_index.tools.jina import JinaToolSpec
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.llms.openai import OpenAI
 
-tool_spec = JinaSearchToolSpec()
+tool_spec = JinaToolSpec()
 
 agent = FunctionAgent(
-    tools=JinaSearchToolSpec.to_tool_list(),
+    tools=tool_spec.to_tool_list(),
     llm=OpenAI(model="gpt-4.1"),
 )
 

--- a/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-wolfram-alpha/README.md
@@ -13,7 +13,7 @@ Here's an example usage of the WolframAlphaToolSpec.
 
 ```python
 from llama_index.tools.wolfram_alpha import WolframAlphaToolSpec
-from llama_index.agent.core.agent import FunctionAgent
+from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.llms.openai import OpenAI
 
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-firestore/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-firestore/README.md
@@ -15,7 +15,7 @@ pip install llama-index-vector-stores-firestore
 Minimal example:
 
 ```python
-from llama_index_vector_stores_firestore import FirestoreVectorStore
+from llama_index.vector_stores.firestore import FirestoreVectorStore
 
 store = FirestoreVectorStore(
     collection_name=COLLECTION_NAME,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-hnswlib/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-hnswlib/README.md
@@ -15,18 +15,18 @@ A minimal example:
 
 ```python
 import hnswlib
-from llama_index.vector_stores_hnswlib import HnswlibVectorStore
+from llama_index.vector_stores.hnswlib import HnswlibVectorStore
 
 space = "ip"  # distance function
 dim = 768  # embedding dimension
 hnswlib_index = hnswlib.Index(space, dim)
 hnswlib_index.init_index(max_elements=10)
 
-hnsw_vector_store = HnswlibVectorStore(hnswlib_index=index)
+hnsw_vector_store = HnswlibVectorStore(hnswlib_index=hnswlib_index)
 ```
 
 ## More examples and references
 
-A detailed usage guede can be found [in this demo notebook](https://docs.llamaindex.ai/en/stable/examples/vector_stores/HnswlibIndexDemo.html) in the LlamaIndex docs.
+A detailed usage guide can be found [in this demo notebook](https://docs.llamaindex.ai/en/stable/examples/vector_stores/HnswlibIndexDemo.html) in the LlamaIndex docs.
 
 Hnswlib documentation and implementation can be found [here](https://github.com/nmslib/hnswlib).


### PR DESCRIPTION
# Description

While going through the integration READMEs I noticed several usage examples that break on the very first line if you copy-paste them. This PR fixes the ones I could verify against the actual package source on main:

- **tools/jina**: the README imports `JinaSearchToolSpec`, but the package only exports `JinaToolSpec` (`llama_index/tools/jina/__init__.py`). Also `to_tool_list()` was being called on the class instead of the `tool_spec` instance created two lines above.
- **readers/paddle-ocr**: `PDFPaddleOCR` does not exist, the exported class is `PDFPaddleOCRReader`.
- **tools/desearch**: `from llama_index_desearch.tools import ...` is not a real module, the correct path is `llama_index.tools.desearch`. Also added the missing `import os` (the example uses `os.environ`), made the install comment include the package itself, and removed leftover LLM generation text at the top and bottom of the file ("Here's a README for the Desearch integration, modeled after the example you provided" / "You can copy and paste this into your README file"). Related cleanup to #22149 which caught a different leftover line in the same file.
- **vector_stores/firestore**: `from llama_index_vector_stores_firestore import ...` -> `from llama_index.vector_stores.firestore import ...`
- **readers/microsoft-outlook-emails**: `llama_index.readers.outlook_emails` -> `llama_index.readers.microsoft_outlook_emails` (matches the actual package dir)
- **vector_stores/hnswlib**: `llama_index.vector_stores_hnswlib` -> `llama_index.vector_stores.hnswlib`, plus the example passed an undefined variable `index` where the variable defined above is `hnswlib_index`, and one small typo (guede -> guide)
- **tools/wolfram-alpha**: `from llama_index.agent.core.agent import FunctionAgent` is not a real path, `FunctionAgent` lives in `llama_index.core.agent.workflow` (matches what the other tool READMEs use)

Each fix was checked against the package `__init__.py` exports and class definitions rather than guessed. Docs only, no code changes.

## New Package?

- [x] No

## Version Bump?

- [x] No (README-only changes, following the precedent of #22139)

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests (docs only; every corrected import path was verified against the actual module layout and `__init__.py` exports in this repo)

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

---

Small disclosure: I'm a college freshman trying to get into open source, and I used Claude Code to help sweep the READMEs for broken imports. I manually double checked every single one against the package source before touching it, but if I got something wrong I'd genuinely love to know so I can learn from it :)
