### PR TITLE
fix(core): don't inflate a 0.0 node score to 1.0 in TimeWeightedPostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/node_recency.py
+++ b/llama-index-core/llama_index/core/postprocessor/node_recency.py
@@ -191,7 +191,7 @@ class TimeWeightedPostprocessor(BaseNodePostprocessor):
         similarities = []
         for node_with_score in nodes:
             # embedding similarity score
-            score = node_with_score.score or 1.0
+            score = node_with_score.score if node_with_score.score is not None else 1.0
             node = node_with_score.node
             # time score
             if node.metadata is None:

--- a/llama-index-core/tests/postprocessor/test_base.py
+++ b/llama-index-core/tests/postprocessor/test_base.py
@@ -300,6 +300,28 @@ def test_time_weighted_postprocessor() -> None:
     assert cast(Dict, nodes[3].metadata)[key] == 3
 
 
+def test_time_weighted_postprocessor_zero_score() -> None:
+    """A node with a legitimate 0.0 score should not be treated as unscored."""
+    key = "__last_accessed__"
+    # same recency for both nodes, so only the embedding score should matter
+    nodes = [
+        TextNode(text="Irrelevant node.", id_="1", metadata={key: 0}),
+        TextNode(text="Relevant node.", id_="2", metadata={key: 0}),
+    ]
+    node_with_scores = [
+        NodeWithScore(node=nodes[0], score=0.0),
+        NodeWithScore(node=nodes[1], score=0.9),
+    ]
+
+    postprocessor = TimeWeightedPostprocessor(
+        top_k=1, time_decay=0.99999, time_access_refresh=False, now=4.0
+    )
+    result_nodes_with_score = postprocessor.postprocess_nodes(node_with_scores)
+
+    assert len(result_nodes_with_score) == 1
+    assert result_nodes_with_score[0].node.get_content() == "Relevant node."
+
+
 @pytest.mark.skipif(not spacy_installed, reason="spacy not installed")
 def test_keyword_postprocessor() -> None:
     """Test keyword processor."""


### PR DESCRIPTION
# Description

`TimeWeightedPostprocessor` defaults missing embedding scores with:

```python
score = node_with_score.score or 1.0
```

The `or` also catches a legitimate similarity score of exactly `0.0` (it's falsy) and silently replaces it with the maximum default of `1.0`. The final rank is `score + time_similarity`, so the least relevant node in the batch can jump above genuinely relevant ones.

This is not just a theoretical input: `QueryFusionRetriever` with relative score fusion min-max normalizes scores, so the lowest-ranked node always comes through with exactly `0.0`. Feed that into the time weighted postprocessor and the worst node gets treated as the best.

Quick repro on current main:

```python
from llama_index.core.postprocessor import TimeWeightedPostprocessor
from llama_index.core.schema import NodeWithScore, TextNode

key = "__last_accessed__"
nodes = [
    NodeWithScore(node=TextNode(text="irrelevant", metadata={key: 0}), score=0.0),
    NodeWithScore(node=TextNode(text="relevant", metadata={key: 0}), score=0.9),
]
pp = TimeWeightedPostprocessor(top_k=1, time_access_refresh=False, now=4.0)
print(pp.postprocess_nodes(nodes)[0].node.get_content())
# prints "irrelevant" (the 0.0 node scored 1.0 + time, beating the 0.9 node)
```

The fix is an explicit `is not None` check so only actually-unscored nodes get the `1.0` default. Nodes with `score=None` keep the exact same behavior as before.

Fixes the same falsy-value bug class as #22126 and #22169.

## New Package?

- [x] No

## Version Bump?

- [x] No (llama-index-core)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_time_weighted_postprocessor_zero_score`: two nodes with identical recency, scores 0.0 and 0.9, top_k=1. On current main it fails (the 0.0 node wins), with the fix it passes. Full `tests/postprocessor/test_base.py` passes locally, and the existing time weighted tests are unaffected.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

---

Honesty note: I'm a freshman in college getting started with open source, and I leaned on Claude Code to help scan for this falsy-score bug pattern. The repro, the fix, and the test I worked through and verified myself before opening this. If I misjudged the intended semantics here I would honestly love the correction, still learning :)
