### PR TITLE
fix(core): strip ```python marker from code fences not at string start in parse_code_markdown

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -68,7 +68,7 @@ def parse_code_markdown(text: str, only_last: bool) -> List[str]:
 
     # Regular expression pattern to match code within triple backticks with
     # a Python marker. Like: ```python df.columns```
-    python_str_pattern = re.compile(r"^```python", re.IGNORECASE)
+    python_str_pattern = re.compile(r"^```python", re.IGNORECASE | re.MULTILINE)
     text = python_str_pattern.sub("```", text)
 
     # Find all matches of the pattern in the text

--- a/llama-index-core/tests/output_parsers/test_utils.py
+++ b/llama-index-core/tests/output_parsers/test_utils.py
@@ -1,4 +1,4 @@
-from llama_index.core.output_parsers.utils import extract_json_str
+from llama_index.core.output_parsers.utils import extract_json_str, parse_code_markdown
 
 
 def test_extract_json_str() -> None:
@@ -22,3 +22,18 @@ Here is the valid JSON:
 }\
 """
     assert extract_json_str(input) == expected
+
+
+def test_python_language_marker_not_leaked_when_fence_not_at_start() -> None:
+    text = "Here is the code:\n```python\nx = 1\n```"
+    result = parse_code_markdown(text, only_last=False)
+    assert len(result) == 1
+    assert "python" not in result[0]
+    assert result[0].strip() == "x = 1"
+
+
+def test_python_language_marker_not_leaked_multiple_blocks() -> None:
+    text = "```python\na = 1\n```\nand then\n```python\nb = 2\n```"
+    result = parse_code_markdown(text, only_last=False)
+    assert [r.strip() for r in result] == ["a = 1", "b = 2"]
+    assert all("python" not in r for r in result)


### PR DESCRIPTION
### What's broken

`parse_code_markdown` (`llama-index-core/.../output_parsers/utils.py`) strips the `python` language marker with a pattern compiled **without** `re.MULTILINE`:

```python
python_str_pattern = re.compile(r"^```python", re.IGNORECASE)
text = python_str_pattern.sub("```", text)
```

`^` only matches position 0 of the whole string, so the marker is stripped **only when the fence is the very first thing in the text**. A fence preceded by prose (the common case — an LLM emits code after some explanation) or any second/third block keeps its `python` marker, which then lands inside the captured code:

```python
parse_code_markdown("Here is the code:\n```python\nx = 1\n```", only_last=False)
# ['python\nx = 1\n']   -- expected ['x = 1\n']
```

Feeding that `python\n<code>` to a code executor raises `SyntaxError`.

### Fix

Add `re.MULTILINE` so `^` matches each line start (where markdown fences live), stripping the marker from every fence regardless of position — matching the function's documented intent.

### Tests

Adds two cases to `tests/output_parsers/test_utils.py` (fence after prose; multiple blocks). Full `tests/output_parsers/` passes (13). Fence-at-start, uppercase ```PYTHON, and no-fence fallback still behave correctly.