### PR TITLE
docs: add SERPdive agent tool example notebook

### DIFF
--- a/docs/examples/tools/serpdive.ipynb
+++ b/docs/examples/tools/serpdive.ipynb
@@ -1,0 +1,175 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SERPdive\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/tools/serpdive.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "[SERPdive](https://serpdive.com) is an AI search API built for agents: your agent asks a question, the API returns answer-ready web content that is extracted, cleaned, and sized for LLM consumption. On a [public, replayable 1,000-question benchmark](https://github.com/edendalexis/serpdive-benchmark), SERPdive runs at the same speed as Tavily, feeds your LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels.\n",
+    "\n",
+    "The `llama-index-tools-serpdive` package turns every search result into a `Document` whose text is the actual content of the page, with url, title and date in the metadata: ready for an agent to quote and cite, or for a RAG pipeline to index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-tools-serpdive llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Get a free API key (no card required) at [serpdive.com/dashboard/keys](https://serpdive.com/dashboard/keys) and set it as the `SERPDIVE_API_KEY` environment variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "if not os.environ.get(\"SERPDIVE_API_KEY\"):\n",
+    "    os.environ[\"SERPDIVE_API_KEY\"] = getpass.getpass(\"SERPdive API key:\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Direct usage\n",
+    "\n",
+    "The tool spec exposes a single function, `serpdive_search`. It takes a natural language query, in any language, and returns a list of `Document` objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The biggest problem with solid-state batteries may finally be solved | ScienceDaily | https://www.sciencedaily.com/releases/2026/07/260710003533.htm\n",
+      "Solid-State Batteries 2026: Advances, Challenges & Applications | https://www.bonnenbatteries.com/solid-state-batteries-advances-challenges-future-use-cases/\n",
+      "Solid-State Batteries 2026-2036: Technology, Forecasts, Players: IDTechEx | https://www.idtechex.com/en/research-report/solid-state-batteries/1130\n",
+      "\n",
+      "Yuwei Zhang, first author of the new publication and head of the group \"Chemo-Mechanics of Battery Materials\" at MPI-SusMat.\n",
+      "ScienceDaily, 10 July 2026. <www.sciencedaily.com/releases/2026/07/260710003533.htm>.\n",
+      "The biggest problem with solid-state batteries may finally be solved.\n",
+      "18, 2022 \u0097 A new di\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index_tools_serpdive import SerpdiveToolSpec\n",
+    "\n",
+    "tool_spec = SerpdiveToolSpec()\n",
+    "\n",
+    "documents = tool_spec.serpdive_search(\"latest developments in solid state batteries\")\n",
+    "for doc in documents[:3]:\n",
+    "    print(doc.metadata.get(\"title\"), \"|\", doc.metadata[\"url\"])\n",
+    "print()\n",
+    "print(documents[0].text[:300])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Going deeper\n",
+    "\n",
+    "The default model, `mako`, returns the fact-carrying sentences of each page, fast. For deep research, `moby` returns the full readable text of each page. `max_results` puts a hard cap (1-10) on delivered results; by default the engine picks its calibrated mix.\n",
+    "\n",
+    "There is no country or locale parameter to configure: the language of the query picks where the search runs, automatically. Failed searches are never billed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://www.sciencedaily.com/releases/2026/07/260710003533.htm', 'https://www.bonnenbatteries.com/solid-state-batteries-advances-challenges-future-use-cases/', 'https://christopherchico.substack.com/p/solid-state-batteries-why-mass-production']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "deep_spec = SerpdiveToolSpec(model=\"moby\", max_results=3)\n",
+    "\n",
+    "documents = deep_spec.serpdive_search(\"why are solid state batteries hard to manufacture at scale\")\n",
+    "[doc.metadata[\"url\"] for doc in documents]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use within an agent\n",
+    "\n",
+    "`to_tool_list()` converts the spec into function tools any LlamaIndex agent can call. The tool description tells the model when to search, so a plain question is enough to trigger it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=tool_spec.to_tool_list(),\n",
+    "    llm=OpenAI(model=\"gpt-5.5\"),\n",
+    ")\n",
+    "\n",
+    "response = await agent.run(\n",
+    "    \"What is holding back mass production of solid state batteries? Cite your sources.\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Links\n",
+    "\n",
+    "- [API reference](https://serpdive.com/docs)\n",
+    "- [Public benchmark](https://github.com/edendalexis/serpdive-benchmark) (replayable end to end: same questions, same judge, your machine)\n",
+    "- [Package repo](https://github.com/serpdive/llama-index-tools-serpdive)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/tools/serpdive.ipynb
+++ b/docs/examples/tools/serpdive.ipynb
@@ -91,7 +91,7 @@
    "source": [
     "### Going deeper\n",
     "\n",
-    "The default model, `mako`, returns the fact-carrying sentences of each page, fast. For deep research, `moby` returns the full readable text of each page. `max_results` puts a hard cap (1-10) on delivered results; by default the engine picks its calibrated mix.\n",
+    "The default model, `mako`, returns the fact-carrying sentences of each page, fast. `krill` is the free tier: unlimited under fair use, the smallest useful payload, one request at a time, at low priority. For deep research, `moby` returns the full readable text of each page. `max_results` puts a hard cap (1-10) on delivered results; by default the engine picks its calibrated mix.\n",
     "\n",
     "There is no country or locale parameter to configure: the language of the query picks where the search runs, automatically. Failed searches are never billed."
    ]

--- a/docs/src/content/docs/framework/community/integrations.md
+++ b/docs/src/content/docs/framework/community/integrations.md
@@ -19,6 +19,7 @@ The full set of data loaders are found on [LlamaHub](https://llamahub.ai/)
 The full set of agent tools are found on [LlamaHub](https://llamahub.ai/)
 
 - [MCP Toolbox](/python/examples/tools/mcp_toolbox)
+- [SERPdive](/python/examples/tools/serpdive)
 
 ## LLMs
 


### PR DESCRIPTION
# Description

Adds an example notebook for [SERPdive](https://serpdive.com), an AI search API for agents, and lists it under Agent Tools on the community integrations page.

Per the current contributing policy (no new integration packages in this repo), the integration itself lives in its own repository and is published on PyPI independently: [`llama-index-tools-serpdive`](https://pypi.org/project/llama-index-tools-serpdive/) ([repo](https://github.com/serpdive/llama-index-tools-serpdive), MIT). It exposes a `SerpdiveToolSpec` that returns each search result as a `Document` whose text is the extracted page content. This PR is docs only: it adds `docs/examples/tools/serpdive.ipynb` (the search cells carry real executed outputs) and one line in `docs/src/content/docs/framework/community/integrations.md`, following the precedent of other externally maintained tools documented by notebook (e.g. Klavis, MCP Toolbox).

Fixes # (no linked issue)

## New Package?

- [ ] No (docs only; the package lives outside this repo per the integrations policy)

## Version Bump?

- [ ] No (docs only)

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] The notebook's search cells were executed for real against the production API; their outputs are included verbatim. The package itself is covered by unit tests in its own repository.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
