### PR TITLE
docs(indices): add docstrings to public as_retriever/enum/property accessors

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -164,14 +164,23 @@ class BaseIndex(Generic[IS], ABC):
 
     @property
     def storage_context(self) -> StorageContext:
+        """Get the storage context containing the docstore, index store, and vector store."""
         return self._storage_context
 
     @property
     def summary(self) -> str:
+        """Get the summary string stored on the underlying index struct."""
         return str(self._index_struct.summary)
 
     @summary.setter
     def summary(self, new_summary: str) -> None:
+        """
+        Set the summary string on the underlying index struct and persist it.
+
+        Args:
+            new_summary (str): The new summary string to store.
+
+        """
         self._index_struct.summary = new_summary
         self._storage_context.index_store.add_index_struct(self._index_struct)
 
@@ -486,7 +495,15 @@ class BaseIndex(Generic[IS], ABC):
         ...
 
     @abstractmethod
-    def as_retriever(self, **kwargs: Any) -> BaseRetriever: ...
+    def as_retriever(self, **kwargs: Any) -> BaseRetriever:
+        """
+        Return a retriever for this index.
+
+        Concrete subclasses must override this to build a retriever appropriate
+        for their index type. Keyword arguments are forwarded to the retriever
+        constructor.
+        """
+        ...
 
     def as_query_engine(
         self, llm: Optional[LLMType] = None, **kwargs: Any

--- a/llama-index-core/llama_index/core/indices/empty/base.py
+++ b/llama-index-core/llama_index/core/indices/empty/base.py
@@ -44,6 +44,20 @@ class EmptyIndex(BaseIndex[EmptyIndexStruct]):
         )
 
     def as_retriever(self, **kwargs: Any) -> BaseRetriever:
+        """
+        Return a retriever for the empty index.
+
+        The returned retriever yields no nodes; it exists so the empty index
+        can be composed with other indices and used for pure LLM calls.
+
+        Args:
+            **kwargs: Additional keyword arguments forwarded to the retriever
+                constructor.
+
+        Returns:
+            BaseRetriever: An ``EmptyIndexRetriever`` bound to this index.
+
+        """
         # NOTE: lazy import
         from llama_index.core.indices.empty.retrievers import EmptyIndexRetriever
 
@@ -52,6 +66,23 @@ class EmptyIndex(BaseIndex[EmptyIndexStruct]):
     def as_query_engine(
         self, llm: Optional[LLMType] = None, **kwargs: Any
     ) -> BaseQueryEngine:
+        """
+        Return a query engine for the empty index.
+
+        Forces ``response_mode="generation"`` unless the caller explicitly
+        requests it; any other response mode is rejected because the empty
+        index has no nodes to synthesize from.
+
+        Args:
+            llm (Optional[LLMType]): LLM to use for generation. Defaults to
+                ``Settings.llm``.
+            **kwargs: Additional keyword arguments forwarded to
+                ``BaseIndex.as_query_engine``.
+
+        Returns:
+            BaseQueryEngine: A query engine configured for pure generation.
+
+        """
         if "response_mode" not in kwargs:
             kwargs["response_mode"] = "generation"
         else:

--- a/llama-index-core/llama_index/core/indices/keyword_table/base.py
+++ b/llama-index-core/llama_index/core/indices/keyword_table/base.py
@@ -35,6 +35,16 @@ DQKET = DEFAULT_QUERY_KEYWORD_EXTRACT_TEMPLATE
 
 
 class KeywordTableRetrieverMode(str, Enum):
+    """
+    Retrieval strategies supported by keyword-table indexes.
+
+    Attributes:
+        DEFAULT: Extract keywords from the query with an LLM and look them up.
+        SIMPLE: Extract keywords using a simple keyword extractor.
+        RAKE: Extract keywords using the RAKE algorithm.
+
+    """
+
     DEFAULT = "default"
     SIMPLE = "simple"
     RAKE = "rake"

--- a/llama-index-core/llama_index/core/indices/list/base.py
+++ b/llama-index-core/llama_index/core/indices/list/base.py
@@ -21,6 +21,16 @@ from llama_index.core.utils import get_tqdm_iterable
 
 
 class ListRetrieverMode(str, Enum):
+    """
+    Retrieval strategies supported by the SummaryIndex.
+
+    Attributes:
+        DEFAULT: Iterate through the indexed nodes in order.
+        EMBEDDING: Retrieve nodes using embedding-based similarity.
+        LLM: Use an LLM to select which nodes to retrieve.
+
+    """
+
     DEFAULT = "default"
     EMBEDDING = "embedding"
     LLM = "llm"
@@ -72,6 +82,27 @@ class SummaryIndex(BaseIndex[IndexList]):
         embed_model: Optional[BaseEmbedding] = None,
         **kwargs: Any,
     ) -> BaseRetriever:
+        """
+        Return a retriever for the summary index.
+
+        Args:
+            retriever_mode (Union[str, ListRetrieverMode]): The retrieval strategy
+                to use. Defaults to ``ListRetrieverMode.DEFAULT``.
+            llm (Optional[LLM]): LLM used when ``retriever_mode`` is ``LLM``.
+                Defaults to ``Settings.llm``.
+            embed_model (Optional[BaseEmbedding]): Embedding model used when
+                ``retriever_mode`` is ``EMBEDDING``. Defaults to
+                ``Settings.embed_model``.
+            **kwargs: Additional keyword arguments forwarded to the retriever
+                constructor.
+
+        Returns:
+            BaseRetriever: A summary index retriever of the requested mode.
+
+        Raises:
+            ValueError: If ``retriever_mode`` is not a supported value.
+
+        """
         from llama_index.core.indices.list.retrievers import (
             SummaryIndexEmbeddingRetriever,
             SummaryIndexLLMRetriever,

--- a/llama-index-core/llama_index/core/indices/tree/base.py
+++ b/llama-index-core/llama_index/core/indices/tree/base.py
@@ -23,6 +23,17 @@ from llama_index.core.storage.docstore.types import RefDocInfo
 
 
 class TreeRetrieverMode(str, Enum):
+    """
+    Retrieval strategies supported by the TreeIndex.
+
+    Attributes:
+        SELECT_LEAF: Traverse the tree from the root, selecting a single leaf.
+        SELECT_LEAF_EMBEDDING: Select a leaf using embedding-based similarity.
+        ALL_LEAF: Retrieve all leaf nodes directly, bypassing the tree structure.
+        ROOT: Synthesize an answer from the root node summaries.
+
+    """
+
     SELECT_LEAF = "select_leaf"
     SELECT_LEAF_EMBEDDING = "select_leaf_embedding"
     ALL_LEAF = "all_leaf"
@@ -97,6 +108,25 @@ class TreeIndex(BaseIndex[IndexGraph]):
         embed_model: Optional[BaseEmbedding] = None,
         **kwargs: Any,
     ) -> BaseRetriever:
+        """
+        Return a retriever for the tree index.
+
+        Args:
+            retriever_mode (Union[str, TreeRetrieverMode]): The tree traversal
+                strategy to use. Defaults to ``TreeRetrieverMode.SELECT_LEAF``.
+                Modes that traverse the tree (``SELECT_LEAF``,
+                ``SELECT_LEAF_EMBEDDING``, ``ROOT``) require the tree to have
+                been built during index construction.
+            embed_model (Optional[BaseEmbedding]): Embedding model used when
+                ``retriever_mode`` is ``SELECT_LEAF_EMBEDDING``. Defaults to
+                ``Settings.embed_model``.
+            **kwargs: Additional keyword arguments forwarded to the retriever
+                constructor.
+
+        Returns:
+            BaseRetriever: A tree retriever of the requested mode.
+
+        """
         # NOTE: lazy import
         from llama_index.core.indices.tree.all_leaf_retriever import (
             TreeAllLeafRetriever,

--- a/llama-index-core/llama_index/core/indices/vector_store/base.py
+++ b/llama-index-core/llama_index/core/indices/vector_store/base.py
@@ -110,6 +110,22 @@ class VectorStoreIndex(BaseIndex[IndexDict]):
         return self._vector_store
 
     def as_retriever(self, **kwargs: Any) -> BaseRetriever:
+        """
+        Return a retriever for the vector store index.
+
+        Wraps a ``VectorIndexRetriever`` bound to the nodes currently held by
+        this index. Keyword arguments are forwarded to the retriever
+        constructor and typically control similarity top-k, filters, and
+        embedding model overrides.
+
+        Args:
+            **kwargs: Additional keyword arguments forwarded to
+                ``VectorIndexRetriever``.
+
+        Returns:
+            BaseRetriever: A ``VectorIndexRetriever`` bound to this index.
+
+        """
         # NOTE: lazy import
         from llama_index.core.indices.vector_store.retrievers import (
             VectorIndexRetriever,


### PR DESCRIPTION
## Summary

Adds Google-style docstrings to 12 public symbols across 6 index modules that previously had no docstrings:

- `indices/base.py`: `storage_context`, `summary` getter/setter, abstract `as_retriever`
- `indices/list/base.py`: `ListRetrieverMode` enum, `SummaryIndex.as_retriever`
- `indices/tree/base.py`: `TreeRetrieverMode` enum, `TreeIndex.as_retriever`
- `indices/empty/base.py`: `EmptyIndex.as_retriever`, `EmptyIndex.as_query_engine`
- `indices/keyword_table/base.py`: `KeywordTableRetrieverMode` enum
- `indices/vector_store/base.py`: `VectorStoreIndex.as_retriever`

Ruff auto-fixed 17 D213/D413 docstring formatting issues.

## Type of change

- [x] Documentation update (non-breaking)

## Disclosure

This patch was written with the assistance of an AI code agent (opencode). I have reviewed every change and confirmed they pass linting and tests.

## Checklist

- [x] My code follows the style guidelines (ruff lint + format clean)
- [x] I ran tests (296 passed, `tests/indices/`)
- [x] I have added/updated docstrings for public API
- [x] These changes do not break existing tests