### PR TITLE
Log silent exceptions instead of swallowing them

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -3,12 +3,14 @@
 import asyncio
 import contextvars
 import concurrent.futures
+import logging
 from itertools import zip_longest
 from typing import Any, Coroutine, Iterable, List, Optional, TypeVar
 
 import llama_index.core.instrumentation as instrument
 
 dispatcher = instrument.get_dispatcher(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_asyncio_module(show_progress: bool = False) -> Any:
@@ -102,8 +104,12 @@ def run_async_tasks(
         # run the operation w/o tqdm on hitting a fatal
         # may occur in some environments where tqdm.asyncio
         # is not supported
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(
+                "Falling back to plain asyncio.gather for async tasks; "
+                "tqdm-based progress bar is unavailable: %s",
+                e,
+            )
 
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)

--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -241,7 +241,10 @@ class BaseContentBlock(ABC, BaseModel):
                     data = url.split(";base64,")[1]
                     decoded_data = base64.b64decode(data)
                     return filetype.guess(decoded_data)
-                except Exception:
+                except Exception as e:
+                    _logger.debug(
+                        "Could not determine mimetype from inline data url: %s", e
+                    )
                     return None
         return None
 

--- a/llama-index-core/llama_index/core/program/streaming_utils.py
+++ b/llama-index-core/llama_index/core/program/streaming_utils.py
@@ -5,6 +5,7 @@ This module provides utilities for processing streaming responses that contain
 structured data directly in the message content (not in function calls).
 """
 
+import logging
 from typing import Optional, Type, Union
 
 from pydantic import ValidationError
@@ -16,6 +17,8 @@ from llama_index.core.program.utils import (
     create_flexible_model,
 )
 from llama_index.core.types import Model
+
+logger = logging.getLogger(__name__)
 
 
 def process_streaming_content_incremental(
@@ -118,7 +121,10 @@ def _extract_partial_list_progress(
         # Try to create object with updated data
         return partial_output_cls.model_validate(current_data)
 
-    except Exception:
+    except Exception as e:
+        logger.debug(
+            "Failed to extract partial list progress from streaming content: %s", e
+        )
         return None
 
 
@@ -155,5 +161,10 @@ def _parse_partial_list_items(
 
         return items
 
-    except Exception:
+    except Exception as e:
+        logger.debug(
+            "Failed to parse partial list items for field '%s': %s",
+            field_name,
+            e,
+        )
         return []

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -966,6 +966,38 @@ def test_image_block_resolve_image_data_url_invalid():
         b.resolve_image()
 
 
+def test_mimetype_from_inline_url_logs_debug_on_failure(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When both mimetype detection paths fail, a debug log should be emitted."""
+    import logging
+
+    import filetype
+
+    from llama_index.core.base.llms.types import ImageBlock
+
+    def _raise(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("boom")
+
+    # Force the outer get_type and the inner b64decode/guess to raise so the
+    # innermost except (which logs) is exercised.
+    monkeypatch.setattr(filetype, "get_type", _raise)
+    monkeypatch.setattr(filetype, "guess", _raise)
+    monkeypatch.setattr(base64, "b64decode", _raise)
+
+    data_url = "data:image/png;base64,iVBORw0KGgo="
+
+    with caplog.at_level(logging.DEBUG, logger="llama_index.core.base.llms.types"):
+        result = ImageBlock.mimetype_from_inline_url(data_url)
+
+    assert result is None
+    assert any(
+        "Could not determine mimetype from inline data url" in record.message
+        and record.levelno == logging.DEBUG
+        for record in caplog.records
+    ), [r.message for r in caplog.records]
+
+
 def test_image_block_resolve_error():
     with pytest.raises(
         ValueError, match="No valid source provided to resolve binary data!"

--- a/llama-index-core/tests/program/test_streaming_utils.py
+++ b/llama-index-core/tests/program/test_streaming_utils.py
@@ -1,6 +1,10 @@
 """Test streaming utilities."""
 
+import logging
 from typing import List, Optional
+
+import pytest
+
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
 from llama_index.core.program.streaming_utils import (
@@ -287,3 +291,58 @@ def test_process_streaming_content_incremental_validation_error_fallback():
     # Should still have the name field
     if hasattr(result, "name"):
         assert result.name == "John"
+
+
+def test_extract_partial_list_progress_logs_debug_on_failure(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When partial-list extraction raises, a debug log should be emitted."""
+    import re
+
+    def _boom(*args: object, **kwargs: object) -> list:
+        raise RuntimeError("regex blew up")
+
+    monkeypatch.setattr(re, "findall", _boom)
+
+    from llama_index.core.program.utils import create_flexible_model
+
+    partial_cls = create_flexible_model(Show)
+    current_show = Show(title="Comedy Show")
+
+    with caplog.at_level(
+        logging.DEBUG, logger="llama_index.core.program.streaming_utils"
+    ):
+        result = _extract_partial_list_progress(
+            '{"jokes": [{"setup": "x"}', Show, current_show, partial_cls
+        )
+
+    assert result is None
+    assert any(
+        "Failed to extract partial list progress" in record.message
+        and record.levelno == logging.DEBUG
+        for record in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_parse_partial_list_items_logs_debug_on_failure(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When partial-list item parsing raises, a debug log should be emitted."""
+    import re
+
+    def _boom(*args: object, **kwargs: object) -> list:
+        raise RuntimeError("regex blew up")
+
+    monkeypatch.setattr(re, "findall", _boom)
+
+    with caplog.at_level(
+        logging.DEBUG, logger="llama_index.core.program.streaming_utils"
+    ):
+        result = _parse_partial_list_items('{"setup": "x"}', "jokes", Show)
+
+    assert result == []
+    assert any(
+        "Failed to parse partial list items" in record.message
+        and record.levelno == logging.DEBUG
+        for record in caplog.records
+    ), [r.message for r in caplog.records]

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,10 @@
 import asyncio
 import contextvars
+import logging
+
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+
+from llama_index.core.async_utils import batch_gather, asyncio_run, run_async_tasks
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +40,30 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_run_async_tasks_tqdm_fallback_logs_warning(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the tqdm progress path fails, a warning should be logged."""
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("tqdm unavailable")
+
+    import nest_asyncio
+
+    monkeypatch.setattr(nest_asyncio, "apply", _boom)
+
+    async def _echo(x: int) -> int:
+        return x
+
+    tasks = [_echo(1), _echo(2)]
+    with caplog.at_level(logging.WARNING, logger="llama_index.core.async_utils"):
+        results = run_async_tasks(tasks, show_progress=True)
+
+    assert results == [1, 2]
+    assert any(
+        "tqdm-based progress bar is unavailable" in record.message
+        and record.levelno == logging.WARNING
+        for record in caplog.records
+    ), [r.message for r in caplog.records]


### PR DESCRIPTION
## Summary

Replaces bare `except: pass/return` with logged exceptions at 4 sites so failures are diagnosable instead of invisible:

- `async_utils.py` (`run_async_tasks`): logs a **WARNING** when the tqdm progress path fails and we fall back to plain `asyncio.gather`.
- `program/streaming_utils.py` (`_extract_partial_list_progress`): logs **DEBUG** when partial-list extraction raises before returning `None`.
- `program/streaming_utils.py` (`_parse_partial_list_items`): logs **DEBUG** when partial-list item parsing raises before returning `[]`.
- `base/llms/types.py` (`mimetype_from_inline_url`): logs **DEBUG** when both mimetype detection attempts fail before returning `None`.

Adds `caplog`-based tests verifying each log is emitted at the correct level with a descriptive message.

## Type of change

- [x] Bug fix (non-breaking — adds diagnostics, no behavior change)

## Disclosure

This patch was written with the assistance of an AI code agent (opencode). I have reviewed every change and confirmed they pass linting and tests.

## Checklist

- [x] My code follows the style guidelines (ruff lint + format clean)
- [x] I ran tests (155 passed across affected modules)
- [x] These changes do not break existing tests