### PR TITLE
fix(core): avoid blocking async rate limiter locks

### DIFF
--- a/llama-index-core/llama_index/core/rate_limiter.py
+++ b/llama-index-core/llama_index/core/rate_limiter.py
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 _SLIDING_WINDOW_SECONDS = 60.0
 
 
+async def _acquire_lock_async(lock: threading.Lock) -> None:
+    """Acquire a thread lock without blocking the event loop."""
+    while not lock.acquire(blocking=False):
+        await asyncio.sleep(0)
+
+
 class BaseRateLimiter(ABC):
     """
     Abstract base class for rate limiters.
@@ -206,12 +212,15 @@ class TokenBucketRateLimiter(BaseRateLimiter, BaseModel):
 
         """
         while True:
-            with self._lock:
+            await _acquire_lock_async(self._lock)
+            try:
                 self._refill()
                 wait = self._wait_time(num_tokens)
                 if wait <= 0:
                     self._consume(num_tokens)
                     return
+            finally:
+                self._lock.release()
             await asyncio.sleep(wait)
 
 
@@ -388,13 +397,16 @@ class SlidingWindowRateLimiter(BaseRateLimiter, BaseModel):
         """
         while True:
             now = time.monotonic()
-            with self._lock:
+            await _acquire_lock_async(self._lock)
+            try:
                 self._prune_request_timestamps(now)
                 self._prune_token_usage(now)
                 wait = self._wait_time(now, num_tokens)
                 if wait <= 0:
                     self._record_usage(now, num_tokens)
                     return
+            finally:
+                self._lock.release()
             await asyncio.sleep(wait)
 
 

--- a/llama-index-core/tests/test_rate_limiter.py
+++ b/llama-index-core/tests/test_rate_limiter.py
@@ -1,6 +1,7 @@
 """Tests for the rate limiter module."""
 
 import asyncio
+import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,7 +15,6 @@ from llama_index.core.rate_limiter import (
     SlidingWindowRateLimiter,
     TokenBucketRateLimiter,
 )
-
 
 # ---------------------------------------------------------------------------
 # BaseRateLimiter contract tests
@@ -179,6 +179,41 @@ async def test_concurrent_async_rate_limiting() -> None:
     tasks = [worker(i) for i in range(20)]
     await asyncio.gather(*tasks)
     assert len(results) == 20
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "limiter",
+    [
+        RateLimiter(requests_per_minute=10),
+        SlidingWindowRateLimiter(requests_per_minute=10),
+    ],
+)
+async def test_async_acquire_does_not_block_on_thread_lock(
+    limiter: BaseRateLimiter,
+) -> None:
+    lock = limiter._lock
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_lock() -> None:
+        with lock:
+            lock_acquired.set()
+            release_lock.wait(timeout=1.0)
+
+    thread = threading.Thread(target=hold_lock)
+    thread.start()
+    assert lock_acquired.wait(timeout=1.0)
+
+    task = asyncio.create_task(limiter.async_acquire())
+    try:
+        await asyncio.sleep(0)
+        release_lock.set()
+        await asyncio.wait_for(task, timeout=0.5)
+    finally:
+        release_lock.set()
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

`TokenBucketRateLimiter.async_acquire()` and `SlidingWindowRateLimiter.async_acquire()` currently enter a blocking `threading.Lock` context on the event-loop thread. If a synchronous caller holds the shared lock, every coroutine on that loop stalls until it is released.

Acquire the existing shared lock with nonblocking attempts and cooperatively yield between attempts. This avoids blocking the event loop while preserving synchronization between synchronous and asynchronous users of the same limiter. Regression coverage holds the lock from a background thread and verifies both limiter implementations continue making async progress.

Fixes #21603

AI assistance was used to inspect the locking paths and draft the implementation and tests. I reviewed the synchronization and cancellation behavior, reproduced the failure on current `main`, and ran the validation below.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Core package change; no version bump is required.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`uv run pytest -q tests/test_rate_limiter.py` (47 passed)

`uv run make format`

`uv run make lint`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format` and `uv run make lint`