### PR TITLE
fix(core): preserve asyncio runtime errors

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -42,39 +42,27 @@ def asyncio_run(coro: Coroutine) -> Any:
     If an event loop is already running, uses threading to run in a separate thread.
     """
     try:
-        # Check if there's an existing event loop
         loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
 
-        # Check if the loop is already running
-        if loop.is_running():
-            # If loop is already running, run in a separate thread
-            # Snapshot the current context so we can propagate contextvars
-            ctx = contextvars.copy_context()
+    if loop.is_running():
+        # Snapshot the current context so we can propagate contextvars
+        ctx = contextvars.copy_context()
 
-            def run_coro_in_thread() -> Any:
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                try:
-                    return ctx.run(new_loop.run_until_complete, coro)
-                finally:
-                    new_loop.close()
+        def run_coro_in_thread() -> Any:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                return ctx.run(new_loop.run_until_complete, coro)
+            finally:
+                new_loop.close()
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(run_coro_in_thread)
-                return future.result()
-        else:
-            # If we're here, there's an existing loop but it's not running
-            return loop.run_until_complete(coro)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(run_coro_in_thread)
+            return future.result()
 
-    except RuntimeError as e:
-        # If we can't get the event loop, we're likely in a different thread
-        try:
-            return asyncio.run(coro)
-        except RuntimeError as e:
-            raise RuntimeError(
-                "Detected nested async. Please use nest_asyncio.apply() to allow nested event loops."
-                "Or, use async entry methods like `aquery()`, `aretriever`, `achat`, etc."
-            )
+    return loop.run_until_complete(coro)
 
 
 def run_async_tasks(

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import contextvars
+
 import pytest
+
 from llama_index.core.async_utils import batch_gather, asyncio_run
 
 
@@ -37,3 +39,32 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_asyncio_run_propagates_runtime_error_when_loop_is_not_running() -> None:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    original_error = RuntimeError("original failure")
+
+    async def fail() -> None:
+        raise original_error
+
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio_run(fail())
+        assert exc_info.value is original_error
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_run_propagates_runtime_error_with_running_loop() -> None:
+    original_error = RuntimeError("original failure")
+
+    async def fail() -> None:
+        raise original_error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio_run(fail())
+    assert exc_info.value is original_error


### PR DESCRIPTION
# Description

`asyncio_run()` currently wraps event-loop discovery and coroutine execution in one broad `try` block. A `RuntimeError` raised by the coroutine is therefore caught as though event-loop discovery failed, and the original diagnostic is replaced by the generic nested-async message.

Limit the fallback to the `asyncio.get_event_loop()` call. Runtime errors raised while executing the coroutine now propagate unchanged in both the non-running-loop and running-loop paths, consistent with the exception-preservation behavior established in #14970.

Fixes #22401

AI assistance was used to inspect the exception paths and draft the implementation and tests. I reproduced the masking behavior on current `main`, reviewed the prior maintainer-approved exception handling change, and ran the validation below.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Core package change; no version bump is required.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`uv run pytest -q tests/test_async_utils.py` (4 passed)

`uv run make format`

`uv run make lint`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format` and `uv run make lint`