### PR TITLE
Keep answer_nums and answer_relevances aligned in choice-select parsing

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -148,13 +148,11 @@ def default_parse_choice_select_answer_fn(
                 )
         if answer_num > num_choices:
             continue
-        answer_nums.append(answer_num)
         # extract just the first digits after the colon.
         try:
             _answer_relevance = re.findall(
                 r"\d+", line_tokens[1].split(":")[1].strip()
             )[0]
-            answer_relevances.append(float(_answer_relevance))
         except (IndexError, ValueError) as e:
             if not raise_error:
                 continue
@@ -164,6 +162,10 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
+        # Append to both lists only after the relevance parses successfully, so a
+        # malformed relevance skips the whole line and the two lists stay aligned.
+        answer_nums.append(answer_num)
+        answer_relevances.append(float(_answer_relevance))
     return answer_nums, answer_relevances
 
 

--- a/llama-index-core/tests/indices/test_utils.py
+++ b/llama-index-core/tests/indices/test_utils.py
@@ -34,3 +34,19 @@ def test_default_parse_choice_select_answer_fn(answer):
     answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
     assert answer_nums == [2, 4]
     assert answer_relevances == [8, 6]
+
+
+def test_default_parse_choice_select_answer_fn_skips_malformed_relevance():
+    """
+    A line with an unparseable relevance must be skipped entirely.
+
+    Otherwise the doc number and its relevance end up in lists of different lengths, so every
+    later choice is paired with the next line's score and the last choice is dropped.
+    """
+    from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
+
+    answer = "Doc: 2, Relevance: 9\nDoc: 1, Relevance: high\nDoc: 3, Relevance: 7"
+    answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
+    assert answer_nums == [2, 3]
+    assert answer_relevances == [9, 7]
+    assert len(answer_nums) == len(answer_relevances)


### PR DESCRIPTION
## Description

`default_parse_choice_select_answer_fn` (`llama_index/core/indices/utils.py`) appended the
document number to `answer_nums` **before** parsing the relevance score:

```python
answer_nums.append(answer_num)
try:
    _answer_relevance = re.findall(r"\d+", line_tokens[1].split(":")[1].strip())[0]
    answer_relevances.append(float(_answer_relevance))
except (IndexError, ValueError):
    if not raise_error:
        continue
```

When the relevance can't be parsed (an LLM emitting `Relevance: high`, `N/A`, or an empty
value — the exact case the `try/except` exists to tolerate, and `raise_error=False` is the
default), the `except` does `continue`, leaving `answer_nums` one element longer than
`answer_relevances`. From that point on the two lists are misaligned, so
`LLMRerank._postprocess_nodes`' `zip(choice_nodes, relevances)` pairs every following choice
with the **next** line's score and silently drops the last selected node.

Example — LLM reranker output:

```
Doc: 2, Relevance: 9
Doc: 1, Relevance: high
Doc: 3, Relevance: 7
```

produced `answer_nums = [2, 1, 3]`, `answer_relevances = [9, 7]` → doc 1 gets doc 3's score
and doc 3 is dropped. No error, just wrong ranking and a lost retrieval result. Also reachable
from `StructuredLLMReranker`, `SummaryIndexLLMRetriever`, and `DocumentSummaryIndexLLMRetriever`.

## Fix

Parse the relevance first and append to **both** lists only after it succeeds, so a malformed
line is skipped from both and the lists stay aligned.

## Tests

Added `test_default_parse_choice_select_answer_fn_skips_malformed_relevance` in
`llama-index-core/tests/indices/test_utils.py`. It asserts the aligned result
(`[2, 3]` / `[9, 7]`) and fails against the previous behaviour (`[2, 1, 3]` / `[9, 7]`). Existing
`test_default_parse_choice_select_answer_fn` cases still pass; `ruff check`/`ruff format` clean.
