### PR TITLE
fix(property_graph): dedupe kg entities within a single insert batch

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -233,13 +233,24 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
             kg_nodes_to_insert.extend(kg_nodes)
             kg_rels_to_insert.extend(kg_rels)
 
-        # filter out duplicate kg nodes
+        # filter out duplicate kg nodes (against store and within this batch)
+        # Within-batch duplicates can appear when the same entity is extracted
+        # from multiple source nodes in one insert; only the first is kept so
+        # vector/graph upserts do not receive repeated ids (#22394).
         kg_node_ids = {node.id for node in kg_nodes_to_insert}
         existing_kg_nodes = self.property_graph_store.get(ids=list(kg_node_ids))
         existing_kg_node_ids = {node.id for node in existing_kg_nodes}
-        kg_nodes_to_insert = [
-            node for node in kg_nodes_to_insert if node.id not in existing_kg_node_ids
-        ]
+        seen_kg_node_ids = set()
+        deduped_kg_nodes: List[LabelledNode] = []
+        for kg_node in kg_nodes_to_insert:
+            if (
+                kg_node.id in existing_kg_node_ids
+                or kg_node.id in seen_kg_node_ids
+            ):
+                continue
+            seen_kg_node_ids.add(kg_node.id)
+            deduped_kg_nodes.append(kg_node)
+        kg_nodes_to_insert = deduped_kg_nodes
 
         # filter out duplicate llama nodes
         existing_nodes = self.property_graph_store.get_llama_nodes(

--- a/llama-index-core/tests/indices/property_graph/test_property_graph.py
+++ b/llama-index-core/tests/indices/property_graph/test_property_graph.py
@@ -66,3 +66,48 @@ def test_construction() -> None:
     index.insert_nodes(kg_extractor([]))
 
     assert index._insert_nodes_to_vector_index.call_count == 0
+
+class MockMultiDocDuplicateEntityExtractor(TransformComponent):
+    """Extract the same entity id from multiple source nodes in one batch."""
+
+    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        out: List[BaseNode] = []
+        for i, node in enumerate(nodes):
+            out.append(
+                TextNode(
+                    id_=f"src-{i}",
+                    text=node.get_content() if hasattr(node, "get_content") else str(node),
+                    metadata={
+                        KG_NODES_KEY: [EntityNode(name="Logan", label="PERSON")],
+                        KG_RELATIONS_KEY: [],
+                    },
+                )
+            )
+        return out
+
+
+def test_within_batch_kg_entity_dedup() -> None:
+    """Same entity extracted from multiple sources inserts once (#22394)."""
+    graph_store = SimplePropertyGraphStore()
+    vector_store = SimpleVectorStore()
+    kg_extractor = MockMultiDocDuplicateEntityExtractor()
+
+    index = PropertyGraphIndex.from_documents(
+        [
+            Document(text="Logan lives in Toronto."),
+            Document(text="Logan works in Canada."),
+        ],
+        property_graph_store=graph_store,
+        vector_store=vector_store,
+        llm=MockLLM(),
+        embed_model=MockEmbedding(embed_dim=256),
+        kg_extractors=[kg_extractor],
+    )
+
+    kg_nodes = graph_store.get(ids=["Logan"])
+    assert len(kg_nodes) == 1
+
+    # vector store should also hold a single Logan entry (not two embeddings)
+    embeddings = vector_store.get("Logan")
+    assert len(embeddings) == 256
+


### PR DESCRIPTION
## Summary
`PropertyGraphIndex` only deduped KG entities against the existing property graph store. When the **same entity id** was extracted from **multiple source documents in one insert batch**, every copy still entered `kg_nodes_to_insert` and was pushed to both the graph store and the vector index (#22394).

## Change
- After filtering store-existing ids, also skip ids already seen in the current batch (keep first)
- Regression test: two source docs both extract `Logan` → one graph node + one vector entry

## Test plan
- [x] `python -m pytest llama-index-core/tests/indices/property_graph/test_property_graph.py -q --noconftest`
  - `test_construction` and `test_within_batch_kg_entity_dedup` passed

Fixes #22394
