### PR TITLE
Skip empty or whitespace-only documents in SemanticDoubleMergingSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -231,6 +231,10 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
             text = node.get_content()
             sentences = self.sentence_splitter(text)
             sentences = [s.strip() for s in sentences]
+            if not sentences:
+                # An empty or whitespace-only document produces no sentences; skip it instead of
+                # indexing sentences[0] in _create_initial_chunks and raising IndexError.
+                continue
             initial_chunks = self._create_initial_chunks(sentences)
             chunks = self._merge_initial_chunks(initial_chunks)
 

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -156,3 +156,14 @@ def test_clean_text_advanced() -> None:
         "this is a test text containing some stopwords like the and a"
     )
     assert cleaned == "test text containing stopwords like"
+
+
+def test_empty_document_returns_no_nodes() -> None:
+    """An empty or whitespace-only document yields no sentences and must not raise IndexError."""
+    # A custom splitter that returns no sentences reproduces the empty/whitespace-document case;
+    # MockEmbedding avoids the spacy model load (as in test_embed_model_path_returns_nodes).
+    splitter = SemanticDoubleMergingSplitterNodeParser(
+        embed_model=MockEmbedding(embed_dim=4),
+        sentence_splitter=lambda text: [],
+    )
+    assert splitter.get_nodes_from_documents([Document(text="")]) == []


### PR DESCRIPTION
## Description

`SemanticDoubleMergingSplitterNodeParser.build_semantic_nodes_from_nodes` passes the sentence
list straight to `_create_initial_chunks`, which starts with `chunk = sentences[0]`:

```python
sentences = self.sentence_splitter(text)
sentences = [s.strip() for s in sentences]
initial_chunks = self._create_initial_chunks(sentences)   # sentences[0]
```

An empty or whitespace-only document (e.g. a blank page from a PDF reader) makes the sentence
splitter return `[]`, so `sentences[0]` raises `IndexError: list index out of range` and aborts
ingestion of the whole batch — one blank document takes down every document parsed alongside it.
`SentenceSplitter` already guards this case (`if text == "": return [text]`).

## Fix

Skip a document that yields no sentences, so an empty/whitespace-only document simply produces no
nodes instead of raising.

## Tests

Added `test_empty_document_returns_no_nodes` in
`llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py`. It uses a splitter
that returns no sentences (so it needs neither spacy nor nltk) and asserts
`get_nodes_from_documents([Document(text="")]) == []`. It fails against the current code with
`IndexError` and passes with the fix; `ruff check`/`ruff format` clean.
