### PR TITLE
fix(core): preserve fenced PGVector SQL queries

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -170,7 +170,7 @@ class PGVectorSQLParser(BaseSQLParser):
             response = response[:sql_result_start]
 
         # this gets you the sql string with [query_vector] placeholders
-        raw_sql_str = response.strip().strip("```sql").strip("```").strip()
+        raw_sql_str = response.replace("```sql", "").replace("```", "").strip()
         query_embedding = self._embed_model.get_query_embedding(query_bundle.query_str)
         query_embedding_str = str(query_embedding)
         return raw_sql_str.replace("[query_vector]", query_embedding_str)

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Tuple
 
 import pytest
 from llama_index.core.async_utils import asyncio_run
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.indices.struct_store.sql_retriever import PGVectorSQLParser
 from llama_index.core.indices.vector_store import VectorStoreIndex
 from llama_index.core.indices.struct_store.base import default_output_parser
 from llama_index.core.indices.struct_store.sql import SQLStructStoreIndex
@@ -16,7 +18,7 @@ from llama_index.core.objects import (
     ObjectIndex,
     SQLTableSchema,
 )
-from llama_index.core.schema import Document, TextNode
+from llama_index.core.schema import Document, QueryBundle, TextNode
 from llama_index.core.utilities.sql_wrapper import SQLDatabase
 from sqlalchemy import (
     Column,
@@ -243,6 +245,15 @@ def test_nl_query_engine_parser(
         nl_query_engine._parse_response_to_sql(response)
         == "SELECT * FROM table WHERE name = ''O''Reilly'';"
     )
+
+
+def test_pgvector_sql_parser_preserves_sql_before_attached_closing_fence() -> None:
+    parser = PGVectorSQLParser(embed_model=MockEmbedding(embed_dim=2))
+    response = "```sql\nSELECT * FROM users```"
+
+    sql = parser.parse_response_to_sql(response, QueryBundle(query_str="query"))
+
+    assert sql == "SELECT * FROM users"
 
 
 def test_sql_table_retriever_query_engine_with_rows_retriever(


### PR DESCRIPTION
## Summary
- Fix `PGVectorSQLParser` SQL fence cleanup so attached closing fences do not strip valid trailing SQL characters.
- Add a regression test for fenced SQL ending with `users`, which previously became `user`.
- Scope is limited to `llama-index-core`; no package/version bump needed.

## Testing
- `uv run --frozen -- pytest llama-index-core/tests/indices/struct_store/test_sql_query.py::test_pgvector_sql_parser_preserves_sql_before_attached_closing_fence -q`
- `uv run --frozen -- pytest llama-index-core/tests/indices/struct_store/test_sql_query.py -q`
- `uv run --frozen -- ruff check llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py llama-index-core/tests/indices/struct_store/test_sql_query.py`
- `uv run --frozen -- ruff format --check llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py llama-index-core/tests/indices/struct_store/test_sql_query.py`

## Notes
- No existing open issue or PR was found for this exact PGVector parser truncation.
