### PR TITLE
fix: TokenTextSplitter oversized-split warning raises TypeError instead of warning

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -211,8 +211,8 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
             split_len = len(self._tokenizer(split))
             if split_len > chunk_size:
                 _logger.warning(
-                    f"Got a split of size {split_len}, ",
-                    f"larger than chunk size {chunk_size}.",
+                    f"Got a split of size {split_len}, "
+                    f"larger than chunk size {chunk_size}."
                 )
 
             # if we exceed the chunk size after adding the new split, then

--- a/llama-index-core/tests/node_parser/test_token_splitter.py
+++ b/llama-index-core/tests/node_parser/test_token_splitter.py
@@ -1,0 +1,23 @@
+import logging
+
+from llama_index.core.node_parser.text.token import TokenTextSplitter
+
+
+def test_oversized_split_warning_is_complete(caplog):
+    """A split larger than chunk_size logs a single, fully-formed warning.
+
+    Previously the warning was built from two f-string arguments, so logging
+    treated the second as a (dropped) %-format arg and getMessage() failed.
+    """
+    splitter = TokenTextSplitter(chunk_size=5, chunk_overlap=0)
+    oversized = "word " * 30  # far more than 5 tokens
+
+    with caplog.at_level(logging.WARNING):
+        splitter._merge([oversized], chunk_size=5)
+
+    warnings = [
+        r.getMessage()  # would raise TypeError if the args bug were present
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    ]
+    assert any("larger than chunk size" in m for m in warnings), warnings


### PR DESCRIPTION
Hi LlamaIndex team, I'm Nishchay. I build in the LLM/agent-tooling space myself (lately an LLM-observability toolkit and some MCP tooling), and LlamaIndex is one of the repos I actually enjoy reading, so I poke at the internals now and then. Found a small but real one in the token splitter.

## The bug

In `TokenTextSplitter._merge`, the oversized-split warning passes two f-strings as separate arguments:

```python
_logger.warning(
    f"Got a split of size {split_len}, ",
    f"larger than chunk size {chunk_size}.",
)
```

`logging` treats the first string as the message and the second as a `%`-format arg. The message has no `%` placeholder, so `record.getMessage()` raises `TypeError: not all arguments converted during string formatting`. In practice, whenever a split ends up larger than `chunk_size` (an unsplittable long token, very small chunk sizes, etc.), emitting that warning throws instead of just warning.

## The fix

Join the two into a single message via implicit string concatenation. Added a regression test at `tests/node_parser/test_token_splitter.py` that emits the warning and calls `getMessage()`; it fails on `main` with the `TypeError` and passes with the fix.

Small one, but it turns a diagnostic warning into an actual exception on a real code path, so figured it was worth cleaning up. Happy to tweak anything.

(On a personal note, genuinely a fan of what the team is building here. If you're ever talking with folks who live in this part of the stack, I'd love to be in that conversation.)