### PR TITLE
fix(core): weight reciprocal rerank fusion

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -124,7 +124,8 @@ class QueryFusionRetriever(BaseRetriever):
         hash_to_node = {}
 
         # compute reciprocal rank scores
-        for nodes_with_scores in results.values():
+        for query_tuple, nodes_with_scores in results.items():
+            retriever_weight = self._retriever_weights[query_tuple[1]]
             for rank, node_with_score in enumerate(
                 sorted(nodes_with_scores, key=lambda x: x.score or 0.0, reverse=True)
             ):
@@ -132,7 +133,7 @@ class QueryFusionRetriever(BaseRetriever):
                 hash_to_node[hash] = node_with_score
                 if hash not in fused_scores:
                     fused_scores[hash] = 0.0
-                fused_scores[hash] += 1.0 / (rank + k)
+                fused_scores[hash] += retriever_weight / (rank + k)
 
         # sort results
         reranked_results = dict(

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -4,6 +4,7 @@ from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.retrievers import QueryFusionRetriever
+from llama_index.core.retrievers.fusion_retriever import FUSION_MODES
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 
 
@@ -33,3 +34,30 @@ async def test_aretrieve_uses_async_query_generation():
     await retriever.aretrieve("test query")
 
     assert async_called
+
+
+def test_reciprocal_rerank_fusion_applies_retriever_weights():
+    retriever = QueryFusionRetriever(
+        retrievers=[MockRetriever(), MockRetriever()],
+        llm=MockLLM(),
+        mode=FUSION_MODES.RECIPROCAL_RANK,
+        retriever_weights=[0.1, 0.9],
+        use_async=False,
+        num_queries=1,
+    )
+    lower_weight_node = NodeWithScore(
+        node=TextNode(text="lower weight result"), score=1.0
+    )
+    higher_weight_node = NodeWithScore(
+        node=TextNode(text="higher weight result"), score=1.0
+    )
+
+    results = retriever._reciprocal_rerank_fusion(
+        {
+            ("query", 0): [lower_weight_node],
+            ("query", 1): [higher_weight_node],
+        }
+    )
+
+    assert results[0].node.text == "higher weight result"
+    assert (results[0].score or 0.0) > (results[1].score or 0.0)


### PR DESCRIPTION
## Summary
- Apply configured retriever weights when calculating reciprocal-rank fusion scores.
- Keep existing reciprocal-rank ordering logic, but preserve the retriever index while scoring each result set.
- Add a regression test showing a higher-weight retriever outranks an equal-rank lower-weight retriever.

Fixes #21444

## Testing
- `uv run --frozen -- pytest llama-index-core/tests/retrievers/test_fusion_retriever.py::test_reciprocal_rerank_fusion_applies_retriever_weights -q`
- `uv run --frozen -- pytest llama-index-core/tests/retrievers/test_fusion_retriever.py -q`
- `uv run --frozen -- ruff check llama-index-core/llama_index/core/retrievers/fusion_retriever.py llama-index-core/tests/retrievers/test_fusion_retriever.py`
- `uv run --frozen -- ruff format --check llama-index-core/llama_index/core/retrievers/fusion_retriever.py llama-index-core/tests/retrievers/test_fusion_retriever.py`
