### PR TITLE
fix(core): make similarity_top_k=0 return no results instead of all

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -31,7 +31,7 @@ def get_top_k_embeddings(
         similarity = similarity_fn(query_embedding_np, emb)  # type: ignore[arg-type]
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
-            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+            if similarity_top_k is not None and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
     result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
 
@@ -136,7 +136,9 @@ def get_top_k_mmr_embeddings(
     results: List[Tuple[Any, Any]] = []
 
     embedding_length = len(embeddings or [])
-    similarity_top_k_count = similarity_top_k or embedding_length
+    similarity_top_k_count = (
+        similarity_top_k if similarity_top_k is not None else embedding_length
+    )
     while len(results) < min(similarity_top_k_count, embedding_length):
         # Calculate the similarity score the for the leading one.
         results.append((score, high_score_id))

--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -121,7 +121,9 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             num_top_k = None
             threshold = None
             if self.percentile_cutoff is not None:
-                num_top_k = int(len(split_text) * self.percentile_cutoff)
+                # Keep at least one sentence: with few sentences the cutoff can
+                # round down to 0, and a top-k of 0 returns nothing.
+                num_top_k = max(1, int(len(split_text) * self.percentile_cutoff))
             if self.threshold_cutoff is not None:
                 threshold = self.threshold_cutoff
 

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -73,6 +73,48 @@ def test_get_top_k_mmr_embeddings() -> None:
         assert np.isclose(result_no_mmr, result_with_mmr, atol=0.00001)
 
 
+def test_get_top_k_embeddings_top_k_zero() -> None:
+    """
+    An explicit similarity_top_k of 0 must return no results.
+
+    Because 0 is falsy, ``if similarity_top_k and ...`` skipped the heap
+    trimming entirely, so asking for zero results silently returned every
+    embedding instead. ``similarity_top_k=None`` is the documented way to
+    request unlimited results.
+    """
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]]
+
+    similarities, ids = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert similarities == []
+    assert ids == []
+
+    # None still means unlimited.
+    similarities, ids = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=None
+    )
+    assert len(ids) == 3
+
+
+def test_get_top_k_mmr_embeddings_top_k_zero() -> None:
+    """MMR variant of the falsy top-k bug: 0 must mean none, None means all."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]]
+
+    similarities, ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert similarities == []
+    assert ids == []
+
+    _, ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=None
+    )
+    assert len(ids) == 3
+
+
 def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
     """
     An explicit mmr_threshold of 0 must request maximum diversity.

--- a/llama-index-core/tests/postprocessor/test_optimizer.py
+++ b/llama-index-core/tests/postprocessor/test_optimizer.py
@@ -143,3 +143,33 @@ def test_optimizer(_mock_embeds: Any, _mock_embed: Any) -> None:
         [NodeWithScore(node=orig_node)], query
     )[0]
     assert optimized_node.node.get_content() == "world foo bar"
+
+
+@patch.object(MockEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding)
+@patch.object(
+    MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+def test_optimizer_percentile_rounds_to_zero(
+    _mock_embeds: Any, _mock_embed: Any
+) -> None:
+    """
+    A percentile_cutoff that rounds down to zero sentences keeps the best one.
+
+    With 4 sentences and percentile_cutoff=0.2, int(4 * 0.2) == 0. The falsy
+    top-k bug in get_top_k_embeddings used to silently keep ALL sentences here,
+    ignoring the cutoff. Now that a top-k of 0 really returns nothing, the
+    optimizer clamps to at least one sentence instead of erroring out.
+    """
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn2,
+        percentile_cutoff=0.2,
+        context_before=0,
+        context_after=0,
+    )
+    query = QueryBundle(query_str="foo", embedding=[0, 0, 1, 0, 0])
+    orig_node = TextNode(text="hello,world,foo,bar")
+    optimized_node = optimizer.postprocess_nodes(
+        [NodeWithScore(node=orig_node)], query
+    )[0]
+    assert optimized_node.node.get_content() == "foo"


### PR DESCRIPTION
# Description

Passing an explicit `similarity_top_k=0` to `get_top_k_embeddings` or `get_top_k_mmr_embeddings` returns every embedding instead of none, because `0` is falsy:

```python
if similarity_top_k and len(similarity_heap) > similarity_top_k:   # never trims when top_k == 0
...
similarity_top_k_count = similarity_top_k or embedding_length      # 0 silently becomes "all"
```

Repro on current main:

```python
from llama_index.core.indices.query.embedding_utils import get_top_k_embeddings

sims, ids = get_top_k_embeddings(
    [1.0, 0.0], [[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]], similarity_top_k=0
)
print(ids)  # [0, 1, 2] on main, expected []
```

This is reachable from user code via `VectorIndexRetriever(similarity_top_k=0)` and `SimpleVectorStore` queries (the value is passed straight through), and internally via `SentenceEmbeddingOptimizer`, where `int(len(sentences) * percentile_cutoff)` can round down to 0. In that case the requested cutoff was silently ignored and the whole node text was kept.

Changes, following the approach #22126 took for the same falsy-value pattern with `mmr_threshold=0` in this same file:

- `0` now means zero results and `None` keeps meaning unlimited, in both `get_top_k_embeddings` and `get_top_k_mmr_embeddings`. This also makes them consistent with `get_top_k_embeddings_learner`, which slices with `[:similarity_top_k]` and therefore already behaved this way.
- `SentenceEmbeddingOptimizer` clamps its percentile-derived top-k to at least 1. Without the clamp, the existing "Optimizer returned zero sentences." ValueError would fire whenever the percentile rounds down to 0. Keeping the single best sentence seems closer to the user's intent than erroring or silently keeping everything, but if you would rather fail loudly there I am happy to change it.

All three new tests fail on main and pass with the fix. Existing tests in the touched areas (postprocessor, vector stores, selectors, list and knowledge graph retrievers) plus the full llama-index-core suite pass locally.

No version bump since this only touches llama-index-core.

## New Package?

- [x] No

## Version Bump?

- [x] No (llama-index-core, handled by release automation)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

For transparency: I am a student doing my first open source contributions and I use Claude Code while working on these. I found this bug reading the retrieval utils after #22126 fixed the neighboring mmr_threshold issue, wrote and ran the repro myself, and reviewed every line of the diff before opening this.
