### PR TITLE
fix(core): apply num_files_limit after filtering in SimpleDirectoryReader

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -365,24 +365,21 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
                     else:
                         rejected_files.add(_Path(str(file)))
 
-        file_refs: list[Union[Path, PurePosixPath]] = []
         limit = (
             self.num_files_limit
             if self.num_files_limit is not None and self.num_files_limit > 0
             else None
         )
-        c = 0
         depth = 1000 if self.recursive else 1
-        for root, _, files in self.fs.walk(
-            str(input_dir), topdown=True, maxdepth=depth
-        ):
-            for file in files:
-                c += 1
-                if limit and c > limit:
-                    break
-                file_refs.append(_Path(root, file))
 
-        for ref in file_refs:
+        def walk_files() -> Generator[Union[Path, PurePosixPath], None, None]:
+            for root, _, files in self.fs.walk(
+                str(input_dir), topdown=True, maxdepth=depth
+            ):
+                for file in files:
+                    yield _Path(root, file)
+
+        for ref in walk_files():
             # Manually check if file is hidden or directory instead of
             # in glob for backwards compatibility.
             is_dir = self._is_directory(ref)
@@ -418,6 +415,8 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
                 continue
             else:
                 all_files.add(ref)
+                if limit is not None and len(all_files) >= limit:
+                    break
 
         new_input_files = sorted(all_files)
 

--- a/llama-index-core/tests/readers/file/test_base.py
+++ b/llama-index-core/tests/readers/file/test_base.py
@@ -102,6 +102,35 @@ def test_SimpleDirectoryReader_file_limit(data_path):
     assert len(r.input_files) == 2
 
 
+def test_SimpleDirectoryReader_file_limit_counts_kept_files(tmp_path):
+    for i in range(3):
+        (tmp_path / f"skipped_{i}.log").write_text("skip me")
+    for i in range(2):
+        (tmp_path / f"kept_{i}.txt").write_text("keep me")
+
+    # the order files come back in is up to the filesystem, so pin it here to
+    # put the files that get filtered out first
+    walked = [
+        (
+            str(tmp_path),
+            [],
+            [
+                "skipped_0.log",
+                "skipped_1.log",
+                "skipped_2.log",
+                "kept_0.txt",
+                "kept_1.txt",
+            ],
+        )
+    ]
+    with mock.patch.object(LocalFileSystem, "walk", return_value=walked):
+        r = SimpleDirectoryReader(
+            input_dir=tmp_path, required_exts=[".txt"], num_files_limit=2
+        )
+
+    assert [f.name for f in r.input_files] == ["kept_0.txt", "kept_1.txt"]
+
+
 def test_SimpleDirectoryReader_list_resources(data_path):
     r = SimpleDirectoryReader(input_dir=data_path, exclude=["excluded*"])
     res = r.list_resources()


### PR DESCRIPTION
# Description

`SimpleDirectoryReader(num_files_limit=N)` can return fewer than N files, or none at all, when the directory also contains files the reader is supposed to skip.

In `_add_files`, the limit is counted against every entry `fs.walk` yields, and that counting happens before any of the reader's filters run:

```python
c = 0
for root, _, files in self.fs.walk(str(input_dir), topdown=True, maxdepth=depth):
    for file in files:
        c += 1
        if limit and c > limit:
            break
        file_refs.append(_Path(root, file))
```

The hidden / empty / `required_exts` / `exclude` checks only run afterwards, over `file_refs`, so a file that is about to be discarded has already spent a slot in the budget.

Repro against main, a directory holding five `.txt` files and two `.md` files:

```python
SimpleDirectoryReader(d, required_exts=[".md"], num_files_limit=2)
# ValueError: No files found in /tmp/...
```

Both `.md` files are there. The walk handed back two `.txt` files first, the extension filter dropped them, and nothing was left. The same thing happens with `exclude=[...]`, with `exclude_empty=True`, and with the default `exclude_hidden=True` in a directory that has dotfiles. Since `fs.walk` order is whatever the filesystem gives back, the result is also not stable between runs on the same directory.

This is a regression from #18983, which moved the limit into the walk to avoid materialising every path. Before that change the slice was applied at the end, over the filtered and sorted list, so `num_files_limit` meant "files to read" as documented.

## Root cause

The counter counts walked files, not kept files.

## The fix

Count files as they are accepted and stop walking once the limit is reached. The walk itself is moved into a generator so it stays lazy and the memory behaviour from #18983 is preserved: nothing buffers the full path list, and with a limit set `all_files` never grows past the limit.

## Version Bump?

Not applicable, this is `llama-index-core`.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_SimpleDirectoryReader_file_limit_counts_kept_files` in `llama-index-core/tests/readers/file/test_base.py`. It builds a directory with three `.log` files and two `.txt` files, pins the walk order so the `.log` files come first (otherwise the test would depend on filesystem ordering), and asserts that `num_files_limit=2` with `required_exts=[".txt"]` returns both `.txt` files. On main it raises `ValueError: No files found in ...`.

`llama-index-core` suite: 1467 passed, 22 skipped, 6 xfailed. `llama-index-readers-file` suite, which has its own `num_files_limit` coverage: 27 passed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
