### PR TITLE
fix(postprocessor): raise clear ValueError for malformed LLM output in PIINodePostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/pii.py
+++ b/llama-index-core/llama_index/core/postprocessor/pii.py
@@ -67,9 +67,20 @@ class PIINodePostprocessor(BaseNodePostprocessor):
 
         response = self.llm.predict(pii_prompt, context_str=text, query_str=task_str)
         splits = response.split("Output Mapping:")
+        if len(splits) < 2:
+            raise ValueError(
+                "Failed to mask PII: the LLM response did not contain the expected "
+                f"'Output Mapping:' section. Got response: {response!r}"
+            )
         text_output = splits[0].strip()
         json_str_output = splits[1].strip()
-        json_dict = json.loads(json_str_output)
+        try:
+            json_dict = json.loads(json_str_output)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                "Failed to mask PII: could not parse the LLM's PII mapping as JSON. "
+                f"Got mapping text: {json_str_output!r}"
+            ) from e
         return text_output, json_dict
 
     def _postprocess_nodes(

--- a/llama-index-core/tests/postprocessor/test_pii.py
+++ b/llama-index-core/tests/postprocessor/test_pii.py
@@ -1,0 +1,56 @@
+"""Test PII postprocessor."""
+
+import pytest
+
+from llama_index.core.base.llms.types import CompletionResponse
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.postprocessor.pii import PIINodePostprocessor
+
+
+class _FixedResponseMockLLM(MockLLM):
+    """MockLLM that always returns a fixed completion, ignoring the prompt."""
+
+    def __init__(self, fixed_response: str) -> None:
+        super().__init__()
+        self._fixed_response = fixed_response
+
+    def complete(self, prompt, formatted=False, **kwargs):
+        return CompletionResponse(text=self._fixed_response)
+
+
+def test_mask_pii_raises_clear_error_when_output_mapping_marker_missing():
+    """
+    An LLM response that doesn't follow the expected 'Output Mapping:' format
+    (e.g. a refusal, or a model that ignores instructions) must fail with a clear
+    ValueError, not a raw IndexError from unpacking a 1-element split().
+    """
+    llm = _FixedResponseMockLLM(fixed_response="I cannot process this request.")
+    postprocessor = PIINodePostprocessor(llm=llm)
+
+    with pytest.raises(ValueError, match="Output Mapping"):
+        postprocessor.mask_pii("Some context containing PII")
+
+
+def test_mask_pii_raises_clear_error_on_invalid_json_mapping():
+    """
+    A response with the marker present but a malformed/non-JSON mapping section
+    must fail with a clear ValueError, not a raw JSONDecodeError.
+    """
+    llm = _FixedResponseMockLLM(
+        fixed_response="Hello [NAME1].\nOutput Mapping:\nnot valid json"
+    )
+    postprocessor = PIINodePostprocessor(llm=llm)
+
+    with pytest.raises(ValueError, match="JSON"):
+        postprocessor.mask_pii("Some context containing PII")
+
+
+def test_mask_pii_succeeds_with_well_formed_response():
+    llm = _FixedResponseMockLLM(
+        fixed_response=('Hello [NAME1].\nOutput Mapping:\n{"NAME1": "Zhang Wei"}')
+    )
+    postprocessor = PIINodePostprocessor(llm=llm)
+
+    text_output, mapping = postprocessor.mask_pii("Hello Zhang Wei.")
+    assert text_output == "Hello [NAME1]."
+    assert mapping == {"NAME1": "Zhang Wei"}


### PR DESCRIPTION
Fixes #22431

## What
`PIINodePostprocessor.mask_pii()` assumed the LLM's response always contains an `"Output Mapping:"` marker followed by valid JSON:

```python
splits = response.split("Output Mapping:")
text_output = splits[0].strip()
json_str_output = splits[1].strip()   # IndexError if marker missing
json_dict = json.loads(json_str_output)  # JSONDecodeError if not valid JSON
```

LLM output is inherently unreliable (refusals, formatting drift, models that ignore instructions, extra trailing text), so neither assumption reliably holds, and this crashed with a raw `IndexError` or `JSONDecodeError` instead of a clear error.

This is the same underlying problem as the closed (but never actually fixed) #9314, which hit the `JSONDecodeError` variant in production via a real model returning extra trailing text after the JSON mapping. The `IndexError` variant (marker missing entirely) was still completely unhandled.

## Fix
- If the `"Output Mapping:"` marker is missing, raise a clear `ValueError` including the raw LLM response.
- If the mapping section isn't valid JSON, raise a clear `ValueError` (chained from the original `JSONDecodeError`) including the raw mapping text.

## Tests
New `tests/postprocessor/test_pii.py` (this module previously had zero test coverage):
- `test_mask_pii_raises_clear_error_when_output_mapping_marker_missing` -- confirmed to fail with a raw `IndexError` against pre-fix code, passes post-fix with a clear `ValueError`.
- `test_mask_pii_raises_clear_error_on_invalid_json_mapping` -- confirmed to fail with a raw `JSONDecodeError` against pre-fix code, passes post-fix.
- `test_mask_pii_succeeds_with_well_formed_response` -- sanity check that the happy path is unaffected (passes both before and after).

## Verification
- `uv run ruff check` / `ruff format --check` on changed files: clean
- `uv run pyright` on changed file: 0 new errors (one pre-existing, unrelated `transformers` import warning further down in the same file, on a different class I didn't touch)
- New tests: 3/3 passing
- `tests/postprocessor/test_base.py` (existing suite): 7 passed, 2 skipped, no regressions