### PR TITLE
feat(readers-notion): support a configurable `base_url`

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-notion/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-notion/README.md
@@ -27,6 +27,17 @@ documents = reader.load_data(
 )
 ```
 
+By default the reader talks to `https://api.notion.com`. To point it at a proxy or a
+Notion-compatible endpoint (for example a self-hosted mock during testing), pass `base_url`
+or set the `NOTION_BASE_URL` environment variable:
+
+```python
+reader = NotionPageReader(
+    integration_token="<Integration Token>",
+    base_url="https://notion-proxy.internal",  # or set NOTION_BASE_URL
+)
+```
+
 Implementation for Notion reader can be found [here](https://docs.llamaindex.ai/en/stable/examples/data_connectors/NotionDemo/)
 
 This loader is designed to be used as a way to load data into

--- a/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
@@ -9,9 +9,15 @@ from llama_index.core.readers.base import BasePydanticReader
 from llama_index.core.schema import Document
 
 INTEGRATION_TOKEN_NAME = "NOTION_INTEGRATION_TOKEN"
-BLOCK_CHILD_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
-DATABASE_URL_TMPL = "https://api.notion.com/v1/databases/{database_id}/query"
-SEARCH_URL = "https://api.notion.com/v1/search"
+BASE_URL_NAME = "NOTION_BASE_URL"
+DEFAULT_BASE_URL = "https://api.notion.com"
+
+# Kept for backward compatibility. The reader now builds request URLs from the instance's
+# ``base_url`` (see ``NotionPageReader.__init__``); these module-level constants describe the
+# default host and are no longer read by the class.
+BLOCK_CHILD_URL_TMPL = DEFAULT_BASE_URL + "/v1/blocks/{block_id}/children"
+DATABASE_URL_TMPL = DEFAULT_BASE_URL + "/v1/databases/{database_id}/query"
+SEARCH_URL = DEFAULT_BASE_URL + "/v1/search"
 
 
 # TODO: Notion DB reader coming soon!
@@ -23,14 +29,23 @@ class NotionPageReader(BasePydanticReader):
 
     Args:
         integration_token (str): Notion integration token.
+        base_url (str): Base URL of the Notion API. Defaults to the ``NOTION_BASE_URL``
+            environment variable, then to ``https://api.notion.com``. Override it to point the
+            reader at a proxy or a Notion-compatible mock server; the reader appends the
+            ``/v1/...`` paths itself.
 
     """
 
     is_remote: bool = True
     token: str
     headers: Dict[str, str]
+    base_url: str = DEFAULT_BASE_URL
 
-    def __init__(self, integration_token: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        integration_token: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
         """Initialize with parameters."""
         if integration_token is None:
             integration_token = os.getenv(INTEGRATION_TOKEN_NAME)
@@ -40,6 +55,10 @@ class NotionPageReader(BasePydanticReader):
                     "variable `NOTION_INTEGRATION_TOKEN`."
                 )
 
+        if base_url is None:
+            base_url = os.getenv(BASE_URL_NAME, DEFAULT_BASE_URL)
+        base_url = base_url.rstrip("/")
+
         token = integration_token
         headers = {
             "Authorization": "Bearer " + token,
@@ -47,12 +66,24 @@ class NotionPageReader(BasePydanticReader):
             "Notion-Version": "2022-06-28",
         }
 
-        super().__init__(token=token, headers=headers)
+        super().__init__(token=token, headers=headers, base_url=base_url)
 
     @classmethod
     def class_name(cls) -> str:
         """Get the name identifier of the class."""
         return "NotionPageReader"
+
+    @property
+    def _block_child_url_tmpl(self) -> str:
+        return self.base_url + "/v1/blocks/{block_id}/children"
+
+    @property
+    def _database_url_tmpl(self) -> str:
+        return self.base_url + "/v1/databases/{database_id}/query"
+
+    @property
+    def _search_url(self) -> str:
+        return self.base_url + "/v1/search"
 
     def _read_block(self, block_id: str, num_tabs: int = 0) -> str:
         """Read a block."""
@@ -60,7 +91,7 @@ class NotionPageReader(BasePydanticReader):
         result_lines_arr = []
         cur_block_id = block_id
         while not done:
-            block_url = BLOCK_CHILD_URL_TMPL.format(block_id=cur_block_id)
+            block_url = self._block_child_url_tmpl.format(block_id=cur_block_id)
             query_dict: Dict[str, Any] = {}
 
             res = self._request_with_retry(
@@ -141,7 +172,7 @@ class NotionPageReader(BasePydanticReader):
 
         res = self._request_with_retry(
             "POST",
-            DATABASE_URL_TMPL.format(database_id=database_id),
+            self._database_url_tmpl.format(database_id=database_id),
             headers=self.headers,
             json=query_dict,
         )
@@ -154,7 +185,7 @@ class NotionPageReader(BasePydanticReader):
             query_dict["start_cursor"] = data.get("next_cursor")
             res = self._request_with_retry(
                 "POST",
-                DATABASE_URL_TMPL.format(database_id=database_id),
+                self._database_url_tmpl.format(database_id=database_id),
                 headers=self.headers,
                 json=query_dict,
             )
@@ -176,7 +207,7 @@ class NotionPageReader(BasePydanticReader):
             if next_cursor is not None:
                 query_dict["start_cursor"] = next_cursor
             res = self._request_with_retry(
-                "POST", SEARCH_URL, headers=self.headers, json=query_dict
+                "POST", self._search_url, headers=self.headers, json=query_dict
             )
             data = res.json()
             for result in data["results"]:
@@ -239,7 +270,7 @@ class NotionPageReader(BasePydanticReader):
         """List all databases in the Notion workspace."""
         query_dict = {"filter": {"property": "object", "value": "database"}}
         res = self._request_with_retry(
-            "POST", SEARCH_URL, headers=self.headers, json=query_dict
+            "POST", self._search_url, headers=self.headers, json=query_dict
         )
         res.raise_for_status()
         data = res.json()
@@ -249,7 +280,7 @@ class NotionPageReader(BasePydanticReader):
         """List all pages in the Notion workspace."""
         query_dict = {"filter": {"property": "object", "value": "page"}}
         res = self._request_with_retry(
-            "POST", SEARCH_URL, headers=self.headers, json=query_dict
+            "POST", self._search_url, headers=self.headers, json=query_dict
         )
         res.raise_for_status()
         data = res.json()

--- a/llama-index-integrations/readers/llama-index-readers-notion/tests/test_readers_notion.py
+++ b/llama-index-integrations/readers/llama-index-readers-notion/tests/test_readers_notion.py
@@ -1,7 +1,70 @@
+from unittest.mock import MagicMock
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.notion import NotionPageReader
+from llama_index.readers.notion.base import DEFAULT_BASE_URL
 
 
 def test_class():
     names_of_base_classes = [b.__name__ for b in NotionPageReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def _search_response() -> MagicMock:
+    res = MagicMock()
+    res.json.return_value = {"results": [{"id": "page-1"}], "next_cursor": None}
+    res.raise_for_status.return_value = None
+    res.status_code = 200
+    return res
+
+
+def test_default_base_url():
+    reader = NotionPageReader(integration_token="secret")
+    assert reader.base_url == DEFAULT_BASE_URL
+
+
+def test_base_url_from_env(monkeypatch):
+    monkeypatch.setenv("NOTION_BASE_URL", "http://localhost:9000")
+    reader = NotionPageReader(integration_token="secret")
+    assert reader.base_url == "http://localhost:9000"
+
+
+def test_explicit_base_url_overrides_env(monkeypatch):
+    monkeypatch.setenv("NOTION_BASE_URL", "http://from-env:9000")
+    reader = NotionPageReader(
+        integration_token="secret", base_url="http://explicit:8000"
+    )
+    assert reader.base_url == "http://explicit:8000"
+
+
+def test_base_url_trailing_slash_stripped():
+    reader = NotionPageReader(integration_token="secret", base_url="http://host:8000/")
+    assert reader.base_url == "http://host:8000"
+
+
+def test_custom_base_url_used_for_requests(mocker):
+    reader = NotionPageReader(
+        integration_token="secret", base_url="http://localhost:8000/notion"
+    )
+    request = mocker.patch(
+        "llama_index.readers.notion.base.requests.request",
+        return_value=_search_response(),
+    )
+
+    reader.search("hello")
+
+    # requests.request(method, url, headers=..., json=...) — url is the 2nd positional arg
+    called_url = request.call_args.args[1]
+    assert called_url == "http://localhost:8000/notion/v1/search"
+
+
+def test_default_base_url_used_for_requests(mocker):
+    reader = NotionPageReader(integration_token="secret")
+    request = mocker.patch(
+        "llama_index.readers.notion.base.requests.request",
+        return_value=_search_response(),
+    )
+
+    reader.search("hello")
+
+    assert request.call_args.args[1] == "https://api.notion.com/v1/search"


### PR DESCRIPTION
# Description

## Background

I've been wiring up the official LlamaIndex readers against a **mock server that reimplements the SaaS APIs** (Slack, Notion, GitHub, Jira, Confluence, Gmail, Drive, S3) so I can exercise reader → `load_data()` end-to-end in tests/CI without hitting the real services or needing live credentials.

For almost every reader this is a one-liner, because the host is configurable:

- `GitHubRepositoryReader` / `GitHubIssuesClient(base_url=...)`
- `S3Reader(s3_endpoint_url=...)`
- `ConfluenceReader(base_url=...)`
- `JiraReader(PATauth={"server_url": ...})`

**`NotionPageReader` is the one exception** — it hardcodes the Notion host in module-level constants:

```python
# llama_index/readers/notion/base.py
BLOCK_CHILD_URL_TMPL = "https://api.notion.com/v1/blocks/{block_id}/children"
DATABASE_URL_TMPL    = "https://api.notion.com/v1/databases/{database_id}/query"
SEARCH_URL           = "https://api.notion.com/v1/search"
```

`__init__` only accepts `integration_token`, and these constants are read directly inside `_read_block` / `query_database` / `search` / `list_databases` / `list_pages`. There is no instance-level hook, so the **only** way to point the reader at anything other than `api.notion.com` is to monkeypatch the module constants at runtime.

## What this PR does

Adds an optional `base_url` to `NotionPageReader`:

```python
NotionPageReader(integration_token=token, base_url="http://localhost:8000/notion")
```

- Resolution order: explicit `base_url` arg → `NOTION_BASE_URL` env var → existing default `https://api.notion.com`.
- Request URLs are now built from the instance's `base_url` (the reader appends the `/v1/...` paths itself); a trailing slash on `base_url` is handled.
- The module-level `SEARCH_URL` / `BLOCK_CHILD_URL_TMPL` / `DATABASE_URL_TMPL` constants are **kept** (derived from the default host) for backward compatibility, so any code importing them keeps working.

**Fully backward compatible** — with no `base_url` and no env var, behavior is identical to today (still `https://api.notion.com`).

**Notes**: I did not bump the package version or touch the changelog, assuming versioning/release is handled by the maintainers — happy to add a version bump if you'd prefer it in the PR.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks. (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
