### PR TITLE
fix(bedrock): validate empty texts list before Cohere embedding request

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -521,6 +521,10 @@ class BedrockEmbedding(BaseEmbedding):
                 "query": "search_query",
             }
             payload = [payload] if isinstance(payload, str) else payload
+            if isinstance(payload, list) and not payload:
+                raise ValueError(
+                    "Cohere embedding payload must contain at least one text."
+                )
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
             request_body = json.dumps(
                 {


### PR DESCRIPTION
When `BedrockEmbedding._get_request_body()` constructs a Cohere request with an empty `texts` payload, the AWS Bedrock API returns a generic `ValidationException` instead of a clear message.

This PR adds local pre-validation: if the payload for Cohere embeddings is an empty list, raise `ValueError` before calling the API, so users get a meaningful error rather than a cryptic AWS one.

## Test plan

- [ ] Verify syntax via `ast.parse` on the modified file
- [ ] Confirm `ValueError` is raised when `_get_request_body` processes an empty Cohere texts payload