### PR TITLE
feat(query_transform): add StepBackQueryTransform

### DIFF
--- a/docs/examples/query_transformations/StepBackQueryTransformDemo.ipynb
+++ b/docs/examples/query_transformations/StepBackQueryTransformDemo.ipynb
@@ -1,0 +1,289 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/query_transformations/StepBackQueryTransformDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6g7h8",
+   "metadata": {},
+   "source": [
+    "# Step-Back Query Transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i9j0k1l2",
+   "metadata": {},
+   "source": [
+    "If you're opening this Notebook on colab, you will probably need to install LlamaIndex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "m3n4o5p6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q7r8s9t0",
+   "metadata": {},
+   "source": [
+    "### Download Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "u1v2w3x4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p 'data/paul_graham/'\n",
+    "!wget 'https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt' -O 'data/paul_graham/paul_graham_essay.txt'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "y5z6a7b8",
+   "metadata": {},
+   "source": [
+    "#### Load documents and build the VectorStoreIndex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(stream=sys.stdout, level=logging.INFO)\n",
+    "logging.getLogger().addHandler(logging.StreamHandler(stream=sys.stdout))\n",
+    "\n",
+    "from llama_index.core import VectorStoreIndex, SimpleDirectoryReader\n",
+    "from llama_index.core.indices.query.query_transform.base import (\n",
+    "    StepBackQueryTransform,\n",
+    ")\n",
+    "from llama_index.core.query_engine import TransformQueryEngine\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "# load documents\n",
+    "documents = SimpleDirectoryReader(\"./data/paul_graham/\").load_data()\n",
+    "index = VectorStoreIndex.from_documents(documents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g3h4i5j6",
+   "metadata": {},
+   "source": [
+    "## Example: Step-Back Query Transform improves retrieval for specific questions\n",
+    "\n",
+    "Step-back prompting (Zheng et al., 2023) abstracts a specific question into a higher-level, principle-oriented question before retrieval. This helps when the original query contains narrow identifiers, dates, or entities that may not appear verbatim in the retrieved documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "k7l8m9n0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_str = \"What did Paul Graham do after going to RISD?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "o1p2q3r4",
+   "metadata": {},
+   "source": [
+    "#### First, query *without* transformation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "s5t6u7v8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(query_str)\n",
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "w9x0y1z2",
+   "metadata": {},
+   "source": [
+    "#### Now, apply `StepBackQueryTransform`\n",
+    "\n",
+    "The transform generates a step-back question — removing the specific names and dates and asking about the underlying pattern. This abstracted question is used for embedding lookup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_back = StepBackQueryTransform()\n",
+    "step_back_query_engine = TransformQueryEngine(query_engine, step_back)\n",
+    "\n",
+    "# Inspect the step-back question that gets generated\n",
+    "step_back_bundle = step_back(query_str)\n",
+    "print(f\"Original query:  {query_str}\")\n",
+    "print(f\"Step-back query: {step_back_bundle.query_str}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8g9h0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = step_back_query_engine.query(query_str)\n",
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i1j2k3l4",
+   "metadata": {},
+   "source": [
+    "## Example: Step-Back helps with entity-specific queries\n",
+    "\n",
+    "When a query mentions a very specific entity or date that may not appear verbatim in the source text, step-back abstraction can improve recall."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "m5n6o7p8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_str = \"What school did Alice attend between Aug and Nov 1954?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "q9r0s1t2",
+   "metadata": {},
+   "source": [
+    "#### Querying without transformation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "u3v4w5x6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = query_engine.query(query_str)\n",
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "y7z8a9b0",
+   "metadata": {},
+   "source": [
+    "#### Querying with StepBack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_back_bundle = step_back(query_str)\n",
+    "print(f\"Original query:  {query_str}\")\n",
+    "print(f\"Step-back query: {step_back_bundle.query_str}\")\n",
+    "\n",
+    "response = step_back_query_engine.query(query_str)\n",
+    "display(Markdown(f\"<b>{response}</b>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g5h6i7j8",
+   "metadata": {},
+   "source": [
+    "## Customising the step-back prompt\n",
+    "\n",
+    "You can provide your own prompt using `build_step_back_prompt`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "k9l0m1n2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.indices.query.query_transform.base import (\n",
+    "    StepBackQueryTransform,\n",
+    "    build_step_back_prompt,\n",
+    ")\n",
+    "from llama_index.core.prompts.prompt_type import PromptType\n",
+    "\n",
+    "custom_prompt = build_step_back_prompt(\n",
+    "    system_instructions=(\n",
+    "        \"You are an expert at abstracting questions about historical events. \"\n",
+    "        \"Rewrite questions to ask about the general historical pattern or process, \"\n",
+    "        \"removing specific names and dates.\"\n",
+    "    ),\n",
+    "    few_shot_examples=[\n",
+    "        (\n",
+    "            \"Who signed contract #4711 on 2024-03-15?\",\n",
+    "            \"What is the contract-signing process?\",\n",
+    "        ),\n",
+    "        (\n",
+    "            \"How many Grand Slam titles does the winner of the 2020 Australian Open have?\",\n",
+    "            \"What determines a tennis player's Grand Slam success?\",\n",
+    "        ),\n",
+    "    ],\n",
+    "    prompt_type=PromptType.STEP_BACK,\n",
+    ")\n",
+    "\n",
+    "step_back_custom = StepBackQueryTransform(step_back_prompt=custom_prompt)\n",
+    "query_str = \"What did Paul Graham do after RISD?\"\n",
+    "step_back_bundle = step_back_custom(query_str)\n",
+    "print(f\"Custom step-back: {step_back_bundle.query_str}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/src/content/docs/framework/optimizing/advanced_retrieval/query_transformations.md
+++ b/docs/src/content/docs/framework/optimizing/advanced_retrieval/query_transformations.md
@@ -49,6 +49,64 @@ print(response)
 
 Check out our [example notebook](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/query_transformations/HyDEQueryTransformDemo.ipynb) for a full walkthrough.
 
+### Step-Back Query Transformation
+
+[Step-back prompting](https://arxiv.org/abs/2310.06117) (Zheng et al., 2023) asks the LLM to
+abstract a specific question into a higher-level, principle-oriented question before
+retrieval. Retrieving against the abstracted question surfaces documents that explain the
+underlying concept, which often improves recall for queries that contain specific
+identifiers, dates, or narrow entities.
+
+Unlike HyDE — which keeps the original `query_str` and adds a _hypothetical
+document_ to `custom_embedding_strs` — Step-Back _replaces_ `query_str` with the
+abstracted question and sets `custom_embedding_strs=[new_query_str]`. This mirrors
+the return shape of `DecomposeQueryTransform`.
+
+```python
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+from llama_index.core.indices.query.query_transform.base import (
+    StepBackQueryTransform,
+)
+from llama_index.core.query_engine import TransformQueryEngine
+
+documents = SimpleDirectoryReader("../paul_graham_essay/data").load_data()
+index = VectorStoreIndex(documents)
+
+step_back = StepBackQueryTransform()
+query_engine = index.as_query_engine()
+query_engine = TransformQueryEngine(query_engine, query_transform=step_back)
+response = query_engine.query(
+    "What school did Alice attend between Aug and Nov 1954?"
+)
+print(response)
+```
+
+You can also build a custom prompt:
+
+```python
+from llama_index.core.indices.query.query_transform.base import (
+    StepBackQueryTransform,
+    build_step_back_prompt,
+)
+from llama_index.core.prompts.prompt_type import PromptType
+
+custom_prompt = build_step_back_prompt(
+    system_instructions=(
+        "You rewrite domain-specific questions into abstract, principle-oriented ones."
+    ),
+    few_shot_examples=[
+        (
+            "Who signed contract #4711 on 2024-03-15?",
+            "What is the contract-signing process?",
+        ),
+    ],
+    prompt_type=PromptType.STEP_BACK,
+)
+step_back = StepBackQueryTransform(step_back_prompt=custom_prompt)
+```
+
+Check out our [example notebook](https://github.com/jerryjliu/llama_index/blob/main/docs/examples/query_transformations/StepBackQueryTransformDemo.ipynb) for a full walkthrough.
+
 ### Multi-Step Query Transformations
 
 Multi-step query transformations are a generalization on top of existing single-step query transformation approaches.
@@ -84,4 +142,5 @@ print(str(response))
 Check out our [example notebook](https://github.com/jerryjliu/llama_index/blob/main/examples/vector_indices/SimpleIndexDemo-multistep.ipynb) for a full walkthrough.
 
 - [HyDE Query Transform](/python/examples/query_transformations/hydequerytransformdemo)
+- [Step-Back Query Transform](/python/examples/query_transformations/stepbackquerytransformdemo)
 - [Multistep Query](/python/examples/query_transformations/simpleindexdemo-multistep)

--- a/llama-index-core/llama_index/core/indices/query/query_transform/__init__.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/__init__.py
@@ -3,11 +3,13 @@
 from llama_index.core.indices.query.query_transform.base import (
     DecomposeQueryTransform,
     HyDEQueryTransform,
+    StepBackQueryTransform,
     StepDecomposeQueryTransform,
 )
 
 __all__ = [
     "HyDEQueryTransform",
     "DecomposeQueryTransform",
+    "StepBackQueryTransform",
     "StepDecomposeQueryTransform",
 ]

--- a/llama-index-core/llama_index/core/indices/query/query_transform/base.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/base.py
@@ -2,20 +2,23 @@
 
 import dataclasses
 from abc import abstractmethod
-from typing import Dict, Optional, cast
+from typing import Dict, List, Optional, Tuple, cast
 
 from llama_index.core.base.response.schema import Response
 from llama_index.core.indices.query.query_transform.prompts import (
     DEFAULT_DECOMPOSE_QUERY_TRANSFORM_PROMPT,
     DEFAULT_IMAGE_OUTPUT_PROMPT,
+    DEFAULT_STEPBACK_QUERY_TRANSFORM_PROMPT,
     DEFAULT_STEP_DECOMPOSE_QUERY_TRANSFORM_PROMPT,
     DecomposeQueryTransformPrompt,
     ImageOutputQueryTransformPrompt,
+    StepBackQueryTransformPrompt,
     StepDecomposeQueryTransformPrompt,
 )
 from llama_index.core.instrumentation import DispatcherSpanMixin
 from llama_index.core.llms import LLM
-from llama_index.core.prompts import BasePromptTemplate
+from llama_index.core.prompts import BasePromptTemplate, PromptTemplate
+from llama_index.core.prompts.prompt_type import PromptType
 from llama_index.core.prompts.default_prompts import DEFAULT_HYDE_PROMPT
 from llama_index.core.prompts.mixin import (
     PromptDictType,
@@ -210,6 +213,56 @@ class DecomposeQueryTransform(BaseQueryTransform):
         )
 
 
+class StepBackQueryTransform(BaseQueryTransform):
+    """
+    Step-back query transform (Zheng et al., 2023).
+
+    Transforms a specific query into a higher-level, principle-oriented
+    question. As described in `[Take a Step Back: Evoking Reasoning via
+    Abstraction in Large Language Models](https://arxiv.org/abs/2310.06117)`.
+
+    Follows the same return pattern as ``DecomposeQueryTransform``:
+    ``query_str`` is replaced by the abstracted question and
+    ``custom_embedding_strs=[new_query_str]`` so retrievers embed the
+    abstracted question. This is in contrast to ``HyDEQueryTransform``,
+    which keeps ``query_str`` as the original and adds a hypothetical
+    document as an embedding string.
+
+    Args:
+        llm: LLM for generating step-back questions. Defaults to
+            ``Settings.llm``.
+        step_back_prompt: Custom prompt template. Defaults to
+            ``DEFAULT_STEPBACK_QUERY_TRANSFORM_PROMPT``.
+
+    """
+
+    def __init__(
+        self,
+        llm: Optional[LLM] = None,
+        step_back_prompt: Optional[StepBackQueryTransformPrompt] = None,
+    ) -> None:
+        super().__init__()
+        self._llm = llm or Settings.llm
+        self._step_back_prompt: BasePromptTemplate = (
+            step_back_prompt or DEFAULT_STEPBACK_QUERY_TRANSFORM_PROMPT
+        )
+
+    def _get_prompts(self) -> PromptDictType:
+        return {"step_back_prompt": self._step_back_prompt}
+
+    def _update_prompts(self, prompts: PromptDictType) -> None:
+        if "step_back_prompt" in prompts:
+            self._step_back_prompt = prompts["step_back_prompt"]
+
+    def _run(self, query_bundle: QueryBundle, metadata: Dict) -> QueryBundle:
+        query_str = query_bundle.query_str
+        new_query_str = self._llm.predict(self._step_back_prompt, query_str=query_str)
+        return QueryBundle(
+            query_str=new_query_str,
+            custom_embedding_strs=[new_query_str],
+        )
+
+
 class ImageOutputQueryTransform(BaseQueryTransform):
     """
     Image output query transform.
@@ -319,3 +372,45 @@ class StepDecomposeQueryTransform(BaseQueryTransform):
             query_str=new_query_str,
             custom_embedding_strs=query_bundle.custom_embedding_strs,
         )
+
+
+def build_step_back_prompt(
+    system_instructions: str,
+    few_shot_examples: Optional[List[Tuple[str, str]]] = None,
+    original_question_label: str = "Original question",
+    step_back_question_label: str = "Step-back question",
+    cue_text: str = "Step-back question:",
+    prompt_type: "PromptType" = PromptType.CUSTOM,
+) -> PromptTemplate:
+    """
+    Build a step-back PromptTemplate from a role/rules block + optional few-shot pairs.
+
+    Args:
+        system_instructions: Role definition and task rules. Must not contain
+            few-shot examples (those are appended automatically).
+        few_shot_examples: Optional list of ``(original_question, step_back_question)``
+            pairs rendered as few-shot demonstrations before the actual question.
+        original_question_label: Header label for the original question
+            (default ``"Original question"``).
+        step_back_question_label: Header label for the step-back question in
+            few-shot demonstrations (default ``"Step-back question"``).
+        cue_text: Final completion cue passed to the LLM (default
+            ``"Step-back question:"``).
+        prompt_type: ``PromptType`` for the resulting template. Defaults to
+            ``PromptType.CUSTOM``; pass ``PromptType.STEP_BACK`` to use the
+            built-in step-back routing in the mock fixture.
+
+    Returns:
+        A ``PromptTemplate`` with format variable ``{query_str}``.
+
+    """
+    parts: List[str] = [system_instructions]
+    if few_shot_examples:
+        parts.append(
+            "\n\n".join(
+                f"{original_question_label}: {q}\n{step_back_question_label}: {a}"
+                for q, a in few_shot_examples
+            )
+        )
+    parts.append(f"{original_question_label}: {{query_str}}\n\n{cue_text}")
+    return PromptTemplate("\n\n".join(parts), prompt_type=prompt_type)

--- a/llama-index-core/llama_index/core/indices/query/query_transform/prompts.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/prompts.py
@@ -31,6 +31,16 @@ Required template variables: `query_str`, `image_width`
 ImageOutputQueryTransformPrompt = PromptTemplate
 
 
+"""Step-back prompt for query transformation.
+
+PromptTemplate to abstract a specific question into a higher-level question
+following Zheng et al., 2023 ("Take a Step Back").
+
+Required template variables: `query_str`
+"""
+StepBackQueryTransformPrompt = PromptTemplate
+
+
 DEFAULT_DECOMPOSE_QUERY_TRANSFORM_TMPL = (
     "The original question is as follows: {query_str}\n"
     "We have an opportunity to answer some, or all of the question from a "
@@ -126,4 +136,31 @@ DEFAULT_STEP_DECOMPOSE_QUERY_TRANSFORM_TMPL = (
 
 DEFAULT_STEP_DECOMPOSE_QUERY_TRANSFORM_PROMPT = PromptTemplate(
     DEFAULT_STEP_DECOMPOSE_QUERY_TRANSFORM_TMPL
+)
+
+
+DEFAULT_STEPBACK_QUERY_TRANSFORM_TMPL = (
+    "You are an expert at step-back reasoning.\n"
+    "Given a specific question, generate a more general, higher-level question "
+    "that asks about the underlying principle, concept, or pattern.\n"
+    "\n"
+    "Rules:\n"
+    "- Remove specific names, dates, and identifiers.\n"
+    "- Ask about the principle, role, concept, or pattern.\n"
+    "- Answer ONLY with the abstracted question, nothing else.\n"
+    "\n"
+    "Examples:\n"
+    "Specific: 'What school did Alice attend between Aug and Nov 1954?'\n"
+    "Step-back: 'What is Alice's educational and career background?'\n"
+    "\n"
+    "Specific: 'Who signed document X on March 15, 2024?'\n"
+    "Step-back: 'What is the signing authority process for documents?'\n"
+    "\n"
+    "Specific: '{query_str}'\n"
+    "Step-back:"
+)
+
+DEFAULT_STEPBACK_QUERY_TRANSFORM_PROMPT = PromptTemplate(
+    DEFAULT_STEPBACK_QUERY_TRANSFORM_TMPL,
+    prompt_type=PromptType.STEP_BACK,
 )

--- a/llama-index-core/llama_index/core/prompts/prompt_type.py
+++ b/llama-index-core/llama_index/core/prompts/prompt_type.py
@@ -70,6 +70,9 @@ class PromptType(str, Enum):
     # Decompose query transform
     DECOMPOSE = "decompose"
 
+    # Step-back query transform (Zheng et al., 2023)
+    STEP_BACK = "step_back"
+
     # Choice select
     CHOICE_SELECT = "choice_select"
 

--- a/llama-index-core/tests/indices/query/query_transform/__init__.py
+++ b/llama-index-core/tests/indices/query/query_transform/__init__.py
@@ -1,5 +1,8 @@
 """Init file."""
 
-from tests.indices.query.query_transform.mock_utils import MOCK_DECOMPOSE_PROMPT
+from tests.indices.query.query_transform.mock_utils import (
+    MOCK_DECOMPOSE_PROMPT,
+    MOCK_STEPBACK_PROMPT,
+)
 
-__all__ = ["MOCK_DECOMPOSE_PROMPT"]
+__all__ = ["MOCK_DECOMPOSE_PROMPT", "MOCK_STEPBACK_PROMPT"]

--- a/llama-index-core/tests/indices/query/query_transform/mock_utils.py
+++ b/llama-index-core/tests/indices/query/query_transform/mock_utils.py
@@ -2,10 +2,16 @@
 
 from llama_index.core.indices.query.query_transform.prompts import (
     DecomposeQueryTransformPrompt,
+    StepBackQueryTransformPrompt,
 )
 from llama_index.core.prompts.prompt_type import PromptType
 
 MOCK_DECOMPOSE_TMPL = "{context_str}\n{query_str}"
 MOCK_DECOMPOSE_PROMPT = DecomposeQueryTransformPrompt(
     MOCK_DECOMPOSE_TMPL, prompt_type=PromptType.DECOMPOSE
+)
+
+MOCK_STEPBACK_TMPL = "{query_str}"
+MOCK_STEPBACK_PROMPT = StepBackQueryTransformPrompt(
+    MOCK_STEPBACK_TMPL, prompt_type=PromptType.STEP_BACK
 )

--- a/llama-index-core/tests/indices/query/query_transform/test_base.py
+++ b/llama-index-core/tests/indices/query/query_transform/test_base.py
@@ -2,8 +2,12 @@
 
 from llama_index.core.indices.query.query_transform.base import (
     DecomposeQueryTransform,
+    StepBackQueryTransform,
 )
-from tests.indices.query.query_transform.mock_utils import MOCK_DECOMPOSE_PROMPT
+from tests.indices.query.query_transform.mock_utils import (
+    MOCK_DECOMPOSE_PROMPT,
+    MOCK_STEPBACK_PROMPT,
+)
 
 
 def test_decompose_query_transform(patch_llm_predictor) -> None:
@@ -16,3 +20,18 @@ def test_decompose_query_transform(patch_llm_predictor) -> None:
     new_query_bundle = query_transform.run(query_str, {"index_summary": "Foo bar"})
     assert new_query_bundle.query_str == "What is?:Foo bar"
     assert new_query_bundle.embedding_strs == ["What is?:Foo bar"]
+
+
+def test_step_back_query_transform(patch_llm_predictor) -> None:
+    """Test step-back query transform."""
+    query_transform = StepBackQueryTransform(step_back_prompt=MOCK_STEPBACK_PROMPT)
+
+    query_str = "What school did Alice attend between Aug and Nov 1954?"
+    new_query_bundle = query_transform.run(query_str)
+    assert (
+        new_query_bundle.query_str
+        == "step-back(What school did Alice attend between Aug and Nov 1954?)"
+    )
+    assert new_query_bundle.embedding_strs == [
+        "step-back(What school did Alice attend between Aug and Nov 1954?)"
+    ]

--- a/llama-index-core/tests/mock_utils/mock_predict.py
+++ b/llama-index-core/tests/mock_utils/mock_predict.py
@@ -134,6 +134,11 @@ def _mock_decompose_query(prompt_args: Dict) -> str:
     return prompt_args["query_str"] + ":" + prompt_args["context_str"]
 
 
+def _mock_step_back_query(prompt_args: Dict) -> str:
+    """Mock step-back query transform."""
+    return f"step-back({prompt_args['query_str']})"
+
+
 def _mock_pandas(prompt_args: Dict) -> str:
     """Mock pandas prompt."""
     query_str = prompt_args["query_str"]
@@ -212,6 +217,8 @@ def mock_llmpredictor_predict(prompt: BasePromptTemplate, **prompt_args: Any) ->
         response = _mock_sql_response_synthesis_v2(full_prompt_args)
     elif prompt_type == PromptType.DECOMPOSE:
         response = _mock_decompose_query(full_prompt_args)
+    elif prompt_type == PromptType.STEP_BACK:
+        response = _mock_step_back_query(full_prompt_args)
     elif prompt_type == PromptType.CHOICE_SELECT:
         response = _mock_choice_select(full_prompt_args)
     elif prompt_type == PromptType.CONVERSATION:


### PR DESCRIPTION
Introduce StepBackQueryTransform (Zheng et al., 2023) which abstracts specific queries into higher-level, principle-oriented questions before retrieval. This improves recall for queries containing narrow identifiers, dates, or entities that may not appear verbatim in retrieved documents.

- Add StepBackQueryTransform class following DecomposeQueryTransform pattern
- Add DEFAULT_STEPBACK_QUERY_TRANSFORM_PROMPT with built-in examples
- Add build_step_back_prompt() helper for custom prompt creation
- Add PromptType.STEP_BACK enum value
- Add StepBackQueryTransformDemo notebook with usage examples
- Add documentation in query_transformations.md
- Add unit tests and mock utilities

## Type of Change

- [X ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X ] I added new unit tests to cover this change

## Suggested Checklist:

- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] New and existing unit tests pass locally with my changes
- [X ] I ran `uv run make format; uv run make lint` to appease the lint gods
