### PR TITLE
fix: docstring Args descriptions missing from FunctionTool schema sent to the LLM

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -246,9 +246,15 @@ class FunctionTool(AsyncBaseTool):
                     ignore_fields=ignore_fields,
                 )
                 if fn_schema is not None and param_docs:
+                    updated = False
                     for param_name, field in fn_schema.model_fields.items():
                         if not field.description and param_name in param_docs:
                             field.description = param_docs[param_name].strip()
+                            updated = True
+                    if updated:
+                        # pydantic builds the core schema at class creation, so
+                        # field edits only reach model_json_schema() after a rebuild
+                        fn_schema.model_rebuild(force=True, raise_errors=False)
 
             tool_metadata = ToolMetadata(
                 name=name,

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -393,6 +393,25 @@ def test_docstring_param_extraction_google_style():
     assert fields["b"].description == "string input"
 
 
+def test_docstring_descriptions_reach_json_schema():
+    def tool_fn(a: int, b: str) -> str:
+        """
+        Test tool.
+
+        Args:
+            a (int): integer input
+            b (str): string input
+
+        """
+        return f"{a}-{b}"
+
+    tool = FunctionTool.from_defaults(fn=tool_fn)
+    properties = tool.metadata.get_parameters_dict()["properties"]
+
+    assert properties["a"]["description"] == "integer input"
+    assert properties["b"]["description"] == "string input"
+
+
 def test_docstring_ignores_unknown_params():
     def tool_fn(a: int) -> str:
         """


### PR DESCRIPTION
Fixes #22413.

When a tool function documents its parameters in the docstring (Google, Sphinx, or Javadoc style), `FunctionTool.from_defaults` parses those descriptions and copies them onto `fn_schema.model_fields`. The problem is that this happens after `create_model` has already built the pydantic class. Pydantic v2 generates `model_json_schema()` from the core schema that was built at class creation, so mutating `FieldInfo.description` afterwards never shows up in the schema. Inspecting `model_fields` looks fine, but the parameters block actually sent to the LLM has no descriptions, which is why this went unnoticed.

The fix is small: after filling in the descriptions, call `fn_schema.model_rebuild(force=True)` so the core schema is regenerated from the updated fields. This is the approach pydantic documents for modifying fields programmatically. I pass `raise_errors=False` so functions with unresolvable annotations behave exactly as they do today instead of failing earlier, and I only rebuild when a description was actually added.

I added a regression test that asserts the descriptions appear in `get_parameters_dict()` output (the exact payload that reaches the LLM), not just in `model_fields`. It fails on main and passes with this change.

A quick note: I'm Nishchay, I build LLM observability and MCP tooling on the side and use LlamaIndex agents a fair bit, which is how I ran into this. Happy to connect if any of that overlaps with what you're working on.