### PR TITLE
docs: add hybrid retrieval example with QueryFusionRetriever in vector store guide

### DIFF
--- a/docs/src/content/docs/framework/module_guides/indexing/vector_store_index.mdx
+++ b/docs/src/content/docs/framework/module_guides/indexing/vector_store_index.mdx
@@ -42,6 +42,36 @@ By default, VectorStoreIndex stores everything in memory. See [Using Vector Stor
 
     This is especially helpful when you are inserting into a remotely hosted vector database.
 
+### Combining FAISS with Keyword Search (Hybrid-style Retrieval)
+
+For better retrieval results, many developers combine a dense vector store like FAISS with traditional keyword search using `QueryFusionRetriever`.
+
+```python
+from llama_index.core import SimpleKeywordTableIndex
+from llama_index.core.retrievers import (
+    VectorIndexRetriever,
+    KeywordTableSimpleRetriever,
+    QueryFusionRetriever,
+)
+
+# Dense retriever (backed by your FAISS VectorStoreIndex)
+vector_retriever = VectorIndexRetriever(index=index, similarity_top_k=5)
+
+# Keyword retriever
+keyword_index = SimpleKeywordTableIndex.from_documents(documents)
+keyword_retriever = KeywordTableSimpleRetriever(index=keyword_index)
+
+# Fuse the two retrievers
+retriever = QueryFusionRetriever(
+    [vector_retriever, keyword_retriever],
+    num_queries=1,
+    mode="relative_score",
+    similarity_top_k=5,
+)
+```
+
+This approach is commonly used in production RAG systems to improve recall by merging dense (semantic) and keyword-based results.
+
 ### Using the ingestion pipeline to create nodes
 
 If you want more control over how your documents are indexed, we recommend using the ingestion pipeline. This allows you to customize the chunking, metadata, and embedding of the nodes.


### PR DESCRIPTION
## Description

Added a practical subsection showing how to combine FAISS (dense vectors) with keyword search using `QueryFusionRetriever` for improved RAG retrieval.

This is a documentation improvement to help users implement hybrid-style retrieval, which is common in production RAG systems.

## Type of Change
- [x] This change requires a documentation update

## How Has This Been Tested?
- [x] I believe this change is already covered by existing unit tests (documentation only)

## Suggested Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings