### PR TITLE
openai: register OPENAI_BASE_URL fallback for OPENAI_API_BASE env

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/llama_index/embeddings/openai/utils.py
@@ -137,7 +137,8 @@ def resolve_openai_credentials(
     """
     # resolve from param or env
     api_key = get_from_param_or_env("api_key", api_key, "OPENAI_API_KEY", "")
-    api_base = get_from_param_or_env("api_base", api_base, "OPENAI_API_BASE", "")
+    base_url = get_from_param_or_env("api_base", api_base, "OPENAI_BASE_URL", "")
+    api_base = get_from_param_or_env("api_base", api_base, "OPENAI_API_BASE", base_url)
     api_version = get_from_param_or_env(
         "api_version", api_version, "OPENAI_API_VERSION", ""
     )

--- a/llama-index-integrations/embeddings/llama-index-embeddings-openai/tests/test_utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-openai/tests/test_utils.py
@@ -49,6 +49,17 @@ def test_resolve_openai_credentials_with_env_vars(monkeypatch) -> None:
     assert api_base == "env_api_base"
     assert api_version == "env_api_version"
 
+    monkeypatch.delenv("OPENAI_API_BASE")
+    monkeypatch.setenv("OPENAI_BASE_URL", "env_base_url")
+    api_key, api_base, api_version = resolve_openai_credentials()
+    assert api_base == "env_base_url"
+
+    # legacy OPENAI_API_BASE must take precedence over OPENAI_BASE_URL
+    monkeypatch.setenv("OPENAI_API_BASE", "env_api_base")
+    monkeypatch.setenv("OPENAI_BASE_URL", "env_base_url")
+    api_key, api_base, api_version = resolve_openai_credentials()
+    assert api_base == "env_api_base"
+
 
 def test_resolve_openai_credentials_with_openai_module(monkeypatch) -> None:
     monkeypatch.setattr("openai.base_url", "module_api_base")

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/utils.py
@@ -1025,7 +1025,8 @@ def resolve_openai_credentials(
     """
     # resolve from param or env
     api_key = get_from_param_or_env("api_key", api_key, "OPENAI_API_KEY", "")
-    api_base = get_from_param_or_env("api_base", api_base, "OPENAI_API_BASE", "")
+    base_url = get_from_param_or_env("api_base", api_base, "OPENAI_BASE_URL", "")
+    api_base = get_from_param_or_env("api_base", api_base, "OPENAI_API_BASE", base_url)
     api_version = get_from_param_or_env(
         "api_version", api_version, "OPENAI_API_VERSION", ""
     )


### PR DESCRIPTION
# Description

openai supported `OPENAI_API_BASE` back in the day. That is now replaced by `OPENAI_BASE_URL` since https://github.com/openai/openai-python/commit/0733934fbcdda57ae4506563924b63c867f3dcf7. Change introduced here reads `OPENAI_API_BASE` first, falls back to `OPENAI_BASE_URL` otherwise.

At present openai lib users would configure OPENAI_API_KEY, OPENAI_BASE_URL (the two envs openai supports), but require setting up an additional OPENAI_API_BASE as llama-index does not read OPENAI_BASE_URL.

This is a breaking change for the specific case where a project uses two different openai model deployments and sets env OPENAI_BASE_URL, but passes api_key by other means besides default env.
```py
# setenv OPENAI_BASE_URL=

from llama_index.llms.openai import OpenAI
client = OpenAI(api_key=someValNotReadFromOPENAI_API_KEY)
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
