### PR TITLE
fix(sharepoint): prevent path traversal in SharePointReader downloads

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -443,11 +443,17 @@ class SharePointReader(
         # Create the directory if it does not exist and save the file.
         if not os.path.exists(download_dir):
             os.makedirs(download_dir)
-        file_path = os.path.join(download_dir, file_name)
+        resolved_download_dir = Path(download_dir).resolve()
+        file_path = (resolved_download_dir / file_name).resolve()
+        if not file_path.is_relative_to(resolved_download_dir):
+            raise ValueError(
+                f"Item name '{file_name}' resolves outside of the download "
+                f"directory '{download_dir}'."
+            )
         with open(file_path, "wb") as f:
             f.write(content)
 
-        return file_path
+        return str(file_path)
 
     def _get_permissions_info(self, item: Dict[str, Any]) -> Dict[str, str]:
         """

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -215,6 +215,41 @@ def test_load_documents_with_metadata(sharepoint_reader):
         assert documents[1].text == "File 2 content"
 
 
+def test_download_file_by_url_rejects_path_traversal():
+    reader = SharePointReader(
+        client_id=test_client_id,
+        client_secret=test_client_secret,
+        tenant_id=test_tenant_id,
+    )
+    with patch.object(
+        SharePointReader, "_get_file_content_by_url", return_value=b"malicious"
+    ):
+        with tempfile.TemporaryDirectory() as download_dir:
+            for malicious_name in (
+                "../../../../tmp/evil_via_traversal",
+                "/etc/cron.d/evil",
+            ):
+                item = {"name": malicious_name}
+                with pytest.raises(ValueError):
+                    reader._download_file_by_url(item, download_dir)
+
+
+def test_download_file_by_url_normal_name():
+    reader = SharePointReader(
+        client_id=test_client_id,
+        client_secret=test_client_secret,
+        tenant_id=test_tenant_id,
+    )
+    with patch.object(
+        SharePointReader, "_get_file_content_by_url", return_value=b"content"
+    ):
+        with tempfile.TemporaryDirectory() as download_dir:
+            item = {"name": "report.pdf"}
+            file_path = reader._download_file_by_url(item, download_dir)
+            assert Path(file_path).parent == Path(download_dir).resolve()
+            assert Path(file_path).read_bytes() == b"content"
+
+
 def test_required_exts():
     sharepoint_reader = SharePointReader(
         client_id="dummy_client_id",


### PR DESCRIPTION
## Summary

`SharePointReader._download_file_by_url` builds the local save path by joining `download_dir` with the item's `name` field straight from the Graph API, with no validation. `os.path.join` doesn't sanitize its second argument, so an item name that is an absolute path or contains `../` segments causes the write to land outside `download_dir` entirely — a path traversal via any source that can produce such a `name` (direct Graph API calls, migrated/synced content, third-party connectors), not just the SharePoint/OneDrive web UI which itself rejects `/`/`\` in uploaded file names.

## Changes

- `llama_index/readers/microsoft_sharepoint/base.py`: resolve the joined path and verify it is still contained within the resolved `download_dir` before writing; raise `ValueError` otherwise.
- `tests/test_readers_microsoft_sharepoint.py`: add `test_download_file_by_url_rejects_path_traversal` (asserts `../../..` and absolute-path item names are rejected) and `test_download_file_by_url_normal_name` (asserts ordinary file names still download correctly).

Fixes #22317