### PR TITLE
fix(core): use asyncio_run for property graph sync entrypoints

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -1,6 +1,6 @@
-import asyncio
 from typing import Any, Dict, List, Optional, Sequence, Type, TYPE_CHECKING
 
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.data_structs import IndexLPG
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.llms import LLM
@@ -199,7 +199,7 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
 
         # run transformations on nodes to extract triplets
         if self._use_async:
-            nodes = asyncio.run(
+            nodes = asyncio_run(
                 arun_transformations(
                     nodes, self._kg_extractors, show_progress=self._show_progress
                 )
@@ -256,7 +256,7 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
             ]
 
             if self._use_async:
-                embeddings = asyncio.run(
+                embeddings = asyncio_run(
                     self._embed_model.aget_text_embedding_batch(
                         node_texts, show_progress=self._show_progress
                     )
@@ -273,7 +273,7 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
             kg_node_texts = [str(kg_node) for kg_node in kg_nodes_to_insert]
 
             if self._use_async:
-                kg_embeddings = asyncio.run(
+                kg_embeddings = asyncio_run(
                     self._embed_model.aget_text_embedding_batch(
                         kg_node_texts, show_progress=self._show_progress
                     )

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
@@ -1,9 +1,8 @@
-import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union, Tuple
 import re
 import json
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import asyncio_run, run_jobs
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.llms.llm import LLM
 from llama_index.core.graph_stores.types import (
@@ -300,7 +299,7 @@ class DynamicLLMPathExtractor(TransformComponent):
             List[BaseNode]: Processed nodes with extracted information.
 
         """
-        return asyncio.run(self.acall(nodes, show_progress=show_progress, **kwargs))
+        return asyncio_run(self.acall(nodes, show_progress=show_progress, **kwargs))
 
     async def _apredict_without_props(self, text: str) -> str:
         """

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/schema_llm.py
@@ -1,9 +1,8 @@
-import asyncio
 import logging
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union
 
 
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import asyncio_run, run_jobs
 from llama_index.core.bridge.pydantic import create_model, field_validator
 from llama_index.core.graph_stores.types import (
     EntityNode,
@@ -266,7 +265,7 @@ class SchemaLLMPathExtractor(TransformComponent):
         self, nodes: Sequence[BaseNode], show_progress: bool = False, **kwargs: Any
     ) -> List[BaseNode]:
         """Extract triplets from nodes."""
-        return asyncio.run(self.acall(nodes, show_progress=show_progress, **kwargs))
+        return asyncio_run(self.acall(nodes, show_progress=show_progress, **kwargs))
 
     def _prune_invalid_props(
         self, props: Dict[str, Any], allowed_props: Optional[List[str]]

--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/simple_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/simple_llm.py
@@ -1,8 +1,7 @@
-import asyncio
 import logging
 from typing import Any, Callable, Optional, Sequence, Union
 
-from llama_index.core.async_utils import run_jobs
+from llama_index.core.async_utils import asyncio_run, run_jobs
 from llama_index.core.indices.property_graph.utils import (
     default_parse_triplets_fn,
 )
@@ -92,7 +91,7 @@ class SimpleLLMPathExtractor(TransformComponent):
         self, nodes: Sequence[BaseNode], show_progress: bool = False, **kwargs: Any
     ) -> Sequence[BaseNode]:
         """Extract triples from nodes."""
-        return asyncio.run(self.acall(nodes, show_progress=show_progress, **kwargs))
+        return asyncio_run(self.acall(nodes, show_progress=show_progress, **kwargs))
 
     async def _aextract(self, node: BaseNode) -> BaseNode:
         """Extract triples from a node."""

--- a/llama-index-core/tests/indices/property_graph/test_property_graph.py
+++ b/llama-index-core/tests/indices/property_graph/test_property_graph.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 from typing import Any, List
 
+import pytest
+
 from llama_index.core import PropertyGraphIndex, Document, MockEmbedding
 from llama_index.core.graph_stores.simple_labelled import SimplePropertyGraphStore
 from llama_index.core.graph_stores.types import (
@@ -66,3 +68,32 @@ def test_construction() -> None:
     index.insert_nodes(kg_extractor([]))
 
     assert index._insert_nodes_to_vector_index.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_construction_in_running_event_loop() -> None:
+    """
+    Sync construction must work when an event loop is already running.
+
+    _insert_nodes drives its async transform and embedding paths with
+    asyncio_run (use_async and embed_kg_nodes both default to True). The
+    bare asyncio.run() it used before raised "asyncio.run() cannot be
+    called from a running event loop" under Jupyter or an async server;
+    asyncio_run offloads to a worker thread instead. pytest-asyncio gives
+    us the surrounding running loop.
+    """
+    graph_store = SimplePropertyGraphStore()
+    vector_store = SimpleVectorStore()
+    kg_extractor = MockKGExtractor()
+
+    index = PropertyGraphIndex.from_documents(
+        [Document.example()],
+        property_graph_store=graph_store,
+        vector_store=vector_store,
+        llm=MockLLM(),
+        embed_model=MockEmbedding(embed_dim=256),
+        kg_extractors=[kg_extractor],
+    )
+
+    kg_nodes = index.property_graph_store.get(ids=["Logan", "Canada"])
+    assert len(kg_nodes) == 2

--- a/llama-index-core/tests/indices/property_graph/test_transformations.py
+++ b/llama-index-core/tests/indices/property_graph/test_transformations.py
@@ -29,6 +29,29 @@ class FailingMockLLM(MockLLM):
 
 
 @pytest.mark.asyncio
+async def test_extractor_sync_call_in_running_event_loop():
+    """
+    The sync __call__ must work even when an event loop is already running.
+
+    __call__ used to wrap acall in asyncio.run(), which raises
+    "asyncio.run() cannot be called from a running event loop" inside a
+    Jupyter kernel or an async web server. asyncio_run() runs the coroutine
+    in a worker thread when a loop is already running, so the synchronous
+    entrypoints keep working. This test is inside a running loop courtesy of
+    pytest-asyncio.
+    """
+    node = TextNode(text="Logan was born in Canada")
+
+    for extractor in (
+        SimpleLLMPathExtractor(llm=MockLLM()),
+        SchemaLLMPathExtractor(llm=MockLLM()),
+        DynamicLLMPathExtractor(llm=MockLLM()),
+    ):
+        result_nodes = extractor([node])
+        assert len(result_nodes) == 1
+
+
+@pytest.mark.asyncio
 async def test_simple_llm_extractor_error_handling(caplog):
     node = TextNode(text="Test node")
 


### PR DESCRIPTION
# Description

`PropertyGraphIndex` and the LLM path extractors expose synchronous entrypoints that wrap their async work in a bare `asyncio.run()`:

- `PropertyGraphIndex._insert_nodes` at three sites (async transform run, node embedding batch, kg-node embedding batch), reached by `from_documents` / `insert` / `insert_nodes` when `use_async=True`, which is the default
- `SimpleLLMPathExtractor.__call__`, `SchemaLLMPathExtractor.__call__`, `DynamicLLMPathExtractor.__call__`

`asyncio.run()` raises `RuntimeError: asyncio.run() cannot be called from a running event loop` when these sync methods are called from inside an already-running loop, which is the normal situation in a Jupyter notebook or an async web server. So `PropertyGraphIndex.from_documents(...)` blows up in a notebook even though the equivalent code works fine in a plain script.

The codebase already has `llama_index.core.async_utils.asyncio_run` for exactly this case: it runs the coroutine in a worker thread when a loop is already running, and otherwise behaves like `asyncio.run()`. Other sync entrypoints in the library already use it. This PR routes the six property-graph call sites through it and drops the now-unused `import asyncio` from each file.

## Tests

Two tests, both fail on `main` with the running-loop `RuntimeError` and pass with the change (verified locally by stashing the source fix and running them against unmodified source):

- `test_extractor_sync_call_in_running_event_loop` exercises the three extractor `__call__` methods from inside a running loop
- `test_construction_in_running_event_loop` builds a `PropertyGraphIndex` from inside a running loop, covering the three `_insert_nodes` sites

Full `llama-index-core` suite passes locally (1468 passed, 22 skipped, 6 xfailed).

No version bump since this only touches `llama-index-core`.

## New Package?

- [x] No

## Version Bump?

- [x] No (llama-index-core, handled by release automation)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

For transparency: I am a student working on my first open source contributions and I use Claude Code to help me navigate a codebase this large. I hit this while poking at PropertyGraphIndex in a notebook, traced the six sync call sites, and verified the tests fail on main before the fix. Happy to adjust the approach if you would prefer something other than the existing asyncio_run helper.
