### PR TITLE
fix: Arbitrary file read via ImageDocument.metadata["file_path"] 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #21512
+
+Arbitrary file read via ImageDocument.metadata["file_path"] in image_documents_to_base64


### PR DESCRIPTION
Closes #21512

Arbitrary file read via ImageDocument.metadata["file_path"] in image_documents_to_base64

/claim #21512