### PR TITLE
docs: fix broken usage example in azure postgres vector store README

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurepostgresql/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurepostgresql/README.md
@@ -13,14 +13,10 @@ This package provides an integration for using Azure Database for PostgreSQL as 
 
 ## Installation
 
-You can install the package and its dependencies using [uv](https://github.com/astral-sh/uv), pip, or poetry:
+You can install the package using pip:
 
 ```bash
-uv pip install .
-# or
-pip install .
-# or
-poetry install
+pip install llama-index-vector-stores-azurepostgres
 ```
 
 **Dependencies:**
@@ -32,36 +28,53 @@ poetry install
 ## Usage Example
 
 ```python
-import sys
-
-sys.path.insert(0, "/path/to/llama-index-vector-stores-azurepostgresql")
-
-from llama_index.vector_stores.azurepostgresql.base import AzurePGVectorStore
 from llama_index.core import (
+    Settings,
     SimpleDirectoryReader,
     StorageContext,
     VectorStoreIndex,
 )
 from llama_index.llms.azure_openai import AzureOpenAI
 from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
+from llama_index.vector_stores.azure_postgres import AzurePGVectorStore
+from llama_index.vector_stores.azure_postgres.common import (
+    AzurePGConnectionPool,
+    BasicAuth,
+    ConnectionInfo,
+    DiskANN,
+    SSLMode,
+)
 
-# Set up your Azure OpenAI and PostgreSQL connection details
-llm = AzureOpenAI(...)
-embed_model = AzureOpenAIEmbedding(...)
+# Set up the models LlamaIndex should use.
+Settings.llm = AzureOpenAI(...)
+Settings.embed_model = AzureOpenAIEmbedding(...)
+
+# Describe how to reach your Azure Database for PostgreSQL instance. Use a
+# TokenCredential from azure-identity in place of BasicAuth for Entra ID auth.
+connection_info = ConnectionInfo(
+    host="<your-host>.postgres.database.azure.com",
+    dbname="postgres",
+    port=5432,
+    sslmode=SSLMode.require,
+    credentials=BasicAuth(username="<user>", password="<password>"),
+)
+connection_pool = AzurePGConnectionPool(azure_conn_info=connection_info)
+
+# Choose the vector index to create. DiskANN is shown here; HNSW and IVFFlat
+# are also exported from the same module.
+embedding_index = DiskANN(
+    op_class="vector_cosine_ops",
+    max_neighbors=32,
+    l_value_ib=100,
+    l_value_is=100,
+)
 
 vector_store = AzurePGVectorStore.from_params(
-    database="postgres",
-    host="<your-host>.postgres.database.azure.com",
-    port=5432,
-    table_name="my_table",
+    connection_pool=connection_pool,
+    schema_name="public",
+    table_name="llamaindex_vectors",
     embed_dim=1536,
-    pg_diskann_kwargs={
-        "pg_diskann_operator_class": "vector_cosine_ops",
-        "pg_diskann_max_neighbors": 32,
-        "pg_diskann_l_value_ib": 100,
-        "pg_diskann_l_value_is": 100,
-        "pg_diskann_iterative_search": True,
-    },
+    embedding_index=embedding_index,
 )
 
 storage_context = StorageContext.from_defaults(vector_store=vector_store)


### PR DESCRIPTION
# Description

The usage example in the `llama-index-vector-stores-azurepostgres` README does not run against the shipped API, so anyone copy-pasting it hits import and `TypeError` failures immediately:

- It imports `from llama_index.vector_stores.azurepostgresql.base import AzurePGVectorStore`, but the module is `llama_index.vector_stores.azure_postgres` and the class is exported from the package root (`from llama_index.vector_stores.azure_postgres import AzurePGVectorStore`).
- It calls `AzurePGVectorStore.from_params(database=..., host=..., port=..., table_name=..., embed_dim=..., pg_diskann_kwargs={...})`. None of `database`, `host`, `port` or `pg_diskann_kwargs` are parameters. The real signature is `from_params(connection_pool, schema_name, table_name, embed_dim, embedding_index)`.
- It starts with a `sys.path.insert(0, "/path/to/...")` hack instead of a normal install.

This PR rewrites the example to match the package. It builds an `AzurePGConnectionPool` from a `ConnectionInfo`, passes a `DiskANN` instance as `embedding_index`, and calls `from_params` with the parameters it actually accepts. The construction mirrors the package's own tests (`tests/llama_index/conftest.py`, `tests/llama_index/test_vectorstore.py`). The install command now points at the published `llama-index-vector-stores-azurepostgres` package.

I verified the new example against the installed package: all imports resolve, `ConnectionInfo` / `BasicAuth` / `DiskANN` / `SSLMode` construct with the shown arguments, and `inspect.signature(AzurePGVectorStore.from_params)` matches the keywords used. I did not open a live connection since that needs an Azure instance.

## New Package?

- [x] No

## Version Bump?

- [x] No

This is a docs-only change (README), following the precedent of other README-only fixes that merged without a version bump (for example #22139). Happy to bump the patch version if you would prefer the fix to ride out in a release.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

The corrected calls are the same ones the package's unit tests exercise.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

A quick note for transparency: I am a student doing early open source work and I use Claude Code to help me find my way around a repo this big. I checked every corrected symbol against the package source and its tests before opening this.
