### PR TITLE
fix(openai-responses): accumulate streamed text across chunks

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -687,6 +687,28 @@ class OpenAIResponses(FunctionCallingLLM):
             delta,
         )
 
+    @staticmethod
+    def _accumulate_streamed_text(
+        content: str, blocks: List[ContentBlock], is_final: bool
+    ) -> Tuple[str, List[ContentBlock]]:
+        """
+        Fold a text-delta block into the running text so every yielded
+        ChatResponse.message holds the full response accumulated so far, not just
+        the current event's own delta (process_response_event returns only the
+        latter). The terminal ResponseCompletedEvent already carries the true
+        final blocks parsed from the complete response, so it passes through
+        unchanged.
+        """
+        if is_final:
+            return content, blocks
+        merged = [block for block in blocks if not isinstance(block, TextBlock)]
+        for block in blocks:
+            if isinstance(block, TextBlock):
+                content += block.text
+        if content:
+            merged.insert(0, TextBlock(text=content))
+        return content, merged
+
     @llm_retry_decorator
     def _stream_chat(
         self, messages: Sequence[ChatMessage], **kwargs: Any
@@ -702,6 +724,7 @@ class OpenAIResponses(FunctionCallingLLM):
             additional_kwargs = {"built_in_tool_calls": []}
             current_tool_call: Optional[ResponseFunctionToolCall] = None
             local_previous_response_id = self._previous_response_id
+            content = ""
 
             for event in self._client.responses.create(
                 input=message_dicts,
@@ -723,6 +746,9 @@ class OpenAIResponses(FunctionCallingLLM):
                     current_tool_call=current_tool_call,
                     track_previous_responses=self.track_previous_responses,
                     previous_response_id=local_previous_response_id,
+                )
+                content, blocks = OpenAIResponses._accumulate_streamed_text(
+                    content, blocks, isinstance(event, ResponseCompletedEvent)
                 )
 
                 if (
@@ -820,6 +846,7 @@ class OpenAIResponses(FunctionCallingLLM):
             additional_kwargs = {"built_in_tool_calls": []}
             current_tool_call: Optional[ResponseFunctionToolCall] = None
             local_previous_response_id = self._previous_response_id
+            content = ""
 
             response_stream = await self._aclient.responses.create(
                 input=message_dicts,
@@ -843,6 +870,9 @@ class OpenAIResponses(FunctionCallingLLM):
                     current_tool_call=current_tool_call,
                     track_previous_responses=self.track_previous_responses,
                     previous_response_id=local_previous_response_id,
+                )
+                content, blocks = OpenAIResponses._accumulate_streamed_text(
+                    content, blocks, isinstance(event, ResponseCompletedEvent)
                 )
 
                 if (

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.10"
+version = "0.7.11"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1,7 +1,7 @@
 import os
 import httpx
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pathlib import Path
 from typing import List
@@ -19,8 +19,11 @@ from llama_index.llms.openai.responses import OpenAIResponses, ResponseFunctionT
 from llama_index.llms.openai.utils import to_openai_message_dicts, O1_MODELS
 from llama_index.core.tools import FunctionTool
 from llama_index.core.prompts import PromptTemplate
+from openai.types.responses.response import Response
 from openai.types.responses.response_reasoning_item import Content, Summary
 from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseCreatedEvent,
     ResponseOutputMessage,
     ResponseTextDeltaEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
@@ -310,6 +313,87 @@ def test_process_response_event_with_text_annotation():
     assert updated_additional_kwargs["annotations"] == [
         {"type": "test_annotation", "value": 42}
     ]
+
+
+def _text_delta_events(deltas: List[str]) -> List[ResponseTextDeltaEvent]:
+    created_response = MagicMock(spec=Response)
+    created_response.id = "resp_123"
+    created = ResponseCreatedEvent(
+        response=created_response,
+        sequence_number=0,
+        type="response.created",
+    )
+    text_events = [
+        ResponseTextDeltaEvent(
+            content_index=0,
+            item_id="123",
+            output_index=0,
+            delta=delta,
+            type="response.output_text.delta",
+            sequence_number=i + 1,
+            logprobs=[],
+        )
+        for i, delta in enumerate(deltas)
+    ]
+    completed_response = MagicMock(spec=Response)
+    completed_response.output = [
+        ResponseOutputMessage(
+            type="message",
+            content=[
+                {
+                    "type": "output_text",
+                    "text": "".join(deltas),
+                    "annotations": [],
+                }
+            ],
+            role="assistant",
+            id="123",
+            status="completed",
+        )
+    ]
+    completed_response.usage = None
+    completed = ResponseCompletedEvent(
+        response=completed_response,
+        sequence_number=len(deltas) + 1,
+        type="response.completed",
+    )
+    return [created, *text_events, completed]
+
+
+def test_stream_chat_accumulates_text_across_chunks(default_responses_llm):
+    """Each yielded ChatResponse.message must hold the full text streamed so
+    far, not just the current event's own delta (regression for the
+    process_response_event blocks reset every call)."""
+    events = _text_delta_events(["Hello", " world"])
+    default_responses_llm._client.responses.create = MagicMock(
+        return_value=iter(events)
+    )
+
+    chunks = list(default_responses_llm.stream_chat([]))
+
+    texts = [c.message.content for c in chunks]
+    # created, "Hello", "Hello world", "Hello world" (final)
+    assert texts == [None, "Hello", "Hello world", "Hello world"]
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_accumulates_text_across_chunks(default_responses_llm):
+    """Async counterpart of test_stream_chat_accumulates_text_across_chunks."""
+    events = _text_delta_events(["Hello", " world"])
+
+    async def _event_gen():
+        for event in events:
+            yield event
+
+    default_responses_llm._aclient.responses.create = AsyncMock(
+        return_value=_event_gen()
+    )
+
+    response_gen = await default_responses_llm.astream_chat([])
+    chunks = [chunk async for chunk in response_gen]
+
+    texts = [c.message.content for c in chunks]
+    assert texts == [None, "Hello", "Hello world", "Hello world"]
 
 
 def test_get_tool_calls_from_response():


### PR DESCRIPTION
# Description

`OpenAIResponses.stream_chat()` / `astream_chat()` never accumulate streamed text across chunks. `process_response_event()` resets `blocks: List[ContentBlock] = []` on every call and, for a `ResponseTextDeltaEvent`, appends only that event's own `delta` as a `TextBlock`. Both `gen()` loops in `_stream_chat`/`_astream_chat` then yield that per-event `blocks` list directly as `ChatResponse.message`, so every intermediate chunk's message holds only the current delta, not the response accumulated so far. Only the terminal `ResponseCompletedEvent` branch reassigns `blocks = resp.message.blocks` to the true final content, so the last chunk happens to be correct while every earlier one is not.

Streaming two deltas `"Hello"`, `" world"`:

- **before:** intermediate chunks' `message.content` are `"Hello"`, then `" world"` (each just the current delta)
- **after:** intermediate chunks' `message.content` are `"Hello"`, then `"Hello world"` (accumulated), matching the final chunk

Any consumer that reads a mid-stream `ChatResponse.message.content` instead of only summing `.delta` (agents, chat engines, memory writes) sees truncated text on every chunk but the last. The non-streaming `chat()`/`_parse_response_output()` path was never affected; this is streaming-only.

The fix threads a persistent `content` accumulator through both `gen()` loops (`_stream_chat`, `_astream_chat`), mirroring the Chat Completions path's own streaming loop in `base.py` (`content += content_delta`, `blocks.append(TextBlock(text=content))` every iteration). A small static helper, `_accumulate_streamed_text`, folds each event's own `TextBlock` delta into the running text and rebuilds `blocks` with a single accumulated `TextBlock`; the terminal `ResponseCompletedEvent`'s already-final `blocks` pass through unchanged. `process_response_event()`'s own per-event return contract is untouched (its existing unit test asserts the isolated per-event result), so the accumulation lives only in the two callers.

Scope: this fixes text accumulation specifically, which is what the reproduction demonstrates and what `message.content` consumers depend on. Other block types returned per-event (`ThinkingBlock`, completed `ToolCallBlock`, `ImageBlock`) were not part of the reproduction and are unchanged by this PR.

Fixes # (no existing issue; self-reported with a reproduction below).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.7.10 -> 0.7.11)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_stream_chat_accumulates_text_across_chunks` and `test_astream_chat_accumulates_text_across_chunks` to `tests/test_openai_responses.py`: each drives the real `stream_chat()`/`astream_chat()` entry points against a mocked `responses.create()` event sequence (`ResponseCreatedEvent`, two `ResponseTextDeltaEvent`s, `ResponseCompletedEvent`) and asserts every yielded chunk's `message.content` equals the text accumulated so far. Both tests fail on `main` (`' world' != 'Hello world'`) and pass on this branch. Verified in a clean `python:3.12-slim` container: `pip install -e llama-index-core -e llama-index-llms-openai`, full existing suite `tests/test_openai_responses.py` stays green (23 passed, 12 skipped for missing `OPENAI_API_KEY`).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] `ruff check` and `ruff format --check` are clean on the changed files (`codespell` also clean); I could not get the repo's namespace-package `mypy` pre-commit invocation to run cleanly on a pristine, unmodified `main` checkout of this same file either (`Source file found twice under different module names`), so that gate is not evaluated here either way.
