### PR TITLE
fix(core): skip empty nodes in JSONNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/json.py
+++ b/llama-index-core/llama_index/core/node_parser/file/json.py
@@ -66,17 +66,23 @@ class JSONNodeParser(NodeParser):
         json_nodes = []
         if isinstance(data, dict):
             lines = [*self._depth_first_yield(data, 0, [])]
-            json_nodes.extend(
-                build_nodes_from_splits(["\n".join(lines)], node, id_func=self.id_func)
-            )
+            text_split = "\n".join(lines)
+            # Skip empty objects so they don't produce spurious blank nodes.
+            if text_split.strip():
+                json_nodes.extend(
+                    build_nodes_from_splits([text_split], node, id_func=self.id_func)
+                )
         elif isinstance(data, list):
             for json_object in data:
                 lines = [*self._depth_first_yield(json_object, 0, [])]
-                json_nodes.extend(
-                    build_nodes_from_splits(
-                        ["\n".join(lines)], node, id_func=self.id_func
+                text_split = "\n".join(lines)
+                # Skip empty objects so they don't produce spurious blank nodes.
+                if text_split.strip():
+                    json_nodes.extend(
+                        build_nodes_from_splits(
+                            [text_split], node, id_func=self.id_func
+                        )
                     )
-                )
         else:
             raise ValueError("JSON is invalid")
 

--- a/llama-index-core/tests/node_parser/test_json.py
+++ b/llama-index-core/tests/node_parser/test_json.py
@@ -41,3 +41,18 @@ def test_split_invalid_json() -> None:
     input_text = Document(text='{"name": "John", "age": 30,}')
     result = json_splitter.get_nodes_from_documents([input_text])
     assert result == []
+
+
+def test_split_empty_dict_json() -> None:
+    json_splitter = JSONNodeParser()
+    input_text = Document(text="{}")
+    result = json_splitter.get_nodes_from_documents([input_text])
+    assert result == []
+
+
+def test_split_list_with_empty_objects() -> None:
+    json_splitter = JSONNodeParser()
+    input_text = Document(text='[{}, {"name": "John", "age": 30}]')
+    result = json_splitter.get_nodes_from_documents([input_text])
+    assert len(result) == 1
+    assert result[0].text == "name John\nage 30"


### PR DESCRIPTION
# Description

`JSONNodeParser` emits a **spurious blank node** for an empty JSON object. `_depth_first_yield()` yields nothing for `{}`, so `"\n".join(lines)` is `""`, but the empty split is still turned into a node - producing empty-text nodes that pollute the index (wasted embeddings, retrieval noise). This happens for a top-level `{}` and for empty objects inside a list.

**Reproduction (on `main`):**

```python
from llama_index.core.node_parser.file.json import JSONNodeParser
from llama_index.core.schema import Document

parser = JSONNodeParser()
nodes = parser.get_nodes_from_documents(
    [Document(text='[{}, {"name": "John", "age": 30}]')]
)
for n in nodes:
    print(repr(n.text))

# main (buggy):
#   ''                  <- spurious empty node from the {} element
#   'name John\nage 30'
```

**Fix:** only build a node when the accumulated section has non-whitespace content, in both the dict and list branches. This mirrors the `HTMLNodeParser` fix in #22125 (and how `SentenceSplitter` drops whitespace-only chunks). Non-empty objects are unaffected.

After the fix the example yields a single node (`'name John\nage 30'`).

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (change is in `llama-index-core`, which the template excludes from version bumps)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_split_empty_dict_json` (a top-level `{}` yields no nodes) and `test_split_list_with_empty_objects` (an empty object in a list is skipped, real content preserved) to `tests/node_parser/test_json.py`.

**RED check** - both new tests fail on unpatched `main` (the empty node is produced), and pass with the fix:

```
tests/node_parser/test_json.py  7 passed
```

`ruff format` and `ruff check` pass on the changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
