### PR TITLE
docs: fix duplicated word in transformations.md

### DIFF
--- a/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
+++ b/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
@@ -13,7 +13,7 @@ Currently, the following components are `Transformation` objects:
 
 ## Usage Pattern
 
-While transformations are best used with with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
+While transformations are best used with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
 
 ```python
 from llama_index.core.node_parser import SentenceSplitter


### PR DESCRIPTION
Small grammar fix: "best used with with an" -> "best used with an" (duplicated word).

Docs only, no functional changes.