### PR TITLE
docs: fix duplicated word in code comment in lpg_index_guide.md

### DIFF
--- a/docs/src/content/docs/framework/module_guides/indexing/lpg_index_guide.md
+++ b/docs/src/content/docs/framework/module_guides/indexing/lpg_index_guide.md
@@ -609,7 +609,7 @@ class MyCustomRetriever(CustomPGRetriever):
         # optionally do something with self.graph_store
 
     def custom_retrieve(self, query_str: str) -> CUSTOM_RETRIEVE_TYPE:
-        # some some operation with self.graph_store
+        # some operation with self.graph_store
         return "result"
 
     # optional async method


### PR DESCRIPTION
Small grammar fix in an example code comment: "# some some operation" -> "# some operation" (duplicated word).

Docs only, no functional changes.