### PR TITLE
docs: fix duplicated word in terms_definitions_tutorial.md

### DIFF
--- a/docs/src/content/docs/framework/understanding/putting_it_all_together/q_and_a/terms_definitions_tutorial.md
+++ b/docs/src/content/docs/framework/understanding/putting_it_all_together/q_and_a/terms_definitions_tutorial.md
@@ -45,7 +45,7 @@ DEFAULT_TERM_STR = (
     "Make a list of terms and definitions that are defined in the context, "
     "with one pair on each line. "
     "If a term is missing it's definition, use your best judgment. "
-    "Write each line as as follows:\nTerm: <term> Definition: <definition>"
+    "Write each line as follows:\nTerm: <term> Definition: <definition>"
 )
 
 st.title("🦙 Llama Index Term Extractor 🦙")


### PR DESCRIPTION
Small grammar fix in an example prompt string: "Write each line as as follows" -> "Write each line as follows" (duplicated word).

Docs only, no functional changes.