### PR TITLE
Use UTF-8 for Feedly auth token writes

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-feedly-rss/llama_index/readers/feedly_rss/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-feedly-rss/llama_index/readers/feedly_rss/base.py
@@ -34,7 +34,7 @@ class FeedlyRssReader(BaseReader):
 
         if not auth_file.exists() or overwrite:
             auth = self.bearer_token
-            auth_file.write_text(auth.strip())
+            auth_file.write_text(auth.strip(), encoding="utf-8")
 
     def load_data(self, category_name, max_count=100):
         """Get the entries from a feedly category."""

--- a/llama-index-integrations/readers/llama-index-readers-feedly-rss/tests/test_readers_feedly_rss.py
+++ b/llama-index-integrations/readers/llama-index-readers-feedly-rss/tests/test_readers_feedly_rss.py
@@ -5,3 +5,11 @@ from llama_index.readers.feedly_rss import FeedlyRssReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in FeedlyRssReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_setup_auth_writes_utf8_token(tmp_path):
+    reader = FeedlyRssReader(" token-é ")
+
+    reader.setup_auth(directory=tmp_path)
+
+    assert (tmp_path / "access.token").read_text(encoding="utf-8") == "token-é"


### PR DESCRIPTION
## Summary
- write the Feedly RSS access token file with explicit UTF-8 encoding
- add a focused regression test covering a non-ASCII token value

## Problem
`Path.write_text()` uses the platform default encoding when no encoding is specified. That can make the Feedly auth token setup path locale-dependent on Windows or other non-UTF-8 environments.

## Before / After
Before: `access.token` was written with the process default encoding.

After: `access.token` is written with UTF-8, matching the test readback path.

## Verification
- `python -m py_compile llama-index-integrations/readers/llama-index-readers-feedly-rss/llama_index/readers/feedly_rss/base.py llama-index-integrations/readers/llama-index-readers-feedly-rss/tests/test_readers_feedly_rss.py`
- `uv run --project llama-index-integrations/readers/llama-index-readers-feedly-rss pytest llama-index-integrations/readers/llama-index-readers-feedly-rss/tests/test_readers_feedly_rss.py -q`