### PR TITLE
fix(ollama): stop deduping streamed tool calls by name+arguments

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -468,7 +468,6 @@ class Ollama(FunctionCallingLLM):
 
             response_txt = ""
             thinking_txt = ""
-            seen_tool_calls = set()
             all_tool_calls = []
 
             for r in response:
@@ -480,20 +479,14 @@ class Ollama(FunctionCallingLLM):
                 response_txt += r["message"].get("content", "") or ""
                 thinking_txt += r["message"].get("thinking", "") or ""
 
+                # Ollama streams each tool call exactly once, in its own chunk (never
+                # split across chunks, never repeated), so every entry here is new.
+                # Do not dedupe by (name, arguments): two distinct calls can legitimately
+                # share identical arguments, and the client's ToolCall type drops Ollama's
+                # own per-call `id`, so content is the only signal we'd have to key on,
+                # and it is not a safe stand-in for identity.
                 new_tool_calls = [dict(t) for t in r["message"].get("tool_calls") or []]
-                for tool_call in new_tool_calls:
-                    if (
-                        str(tool_call["function"]["name"]),
-                        str(tool_call["function"]["arguments"]),
-                    ) in seen_tool_calls:
-                        continue
-                    seen_tool_calls.add(
-                        (
-                            str(tool_call["function"]["name"]),
-                            str(tool_call["function"]["arguments"]),
-                        )
-                    )
-                    all_tool_calls.append(tool_call)
+                all_tool_calls.extend(new_tool_calls)
                 token_counts = self._get_response_token_counts(r)
                 if token_counts:
                     r["usage"] = token_counts
@@ -552,7 +545,6 @@ class Ollama(FunctionCallingLLM):
 
             response_txt = ""
             thinking_txt = ""
-            seen_tool_calls = set()
             all_tool_calls = []
 
             async for r in response:
@@ -564,20 +556,12 @@ class Ollama(FunctionCallingLLM):
                 response_txt += r["message"].get("content", "") or ""
                 thinking_txt += r["message"].get("thinking", "") or ""
 
+                # See the matching comment in stream_chat: Ollama streams each tool
+                # call exactly once, so accumulate unconditionally rather than
+                # deduping by (name, arguments), which drops distinct calls that
+                # happen to share identical arguments.
                 new_tool_calls = [dict(t) for t in r["message"].get("tool_calls") or []]
-                for tool_call in new_tool_calls:
-                    if (
-                        str(tool_call["function"]["name"]),
-                        str(tool_call["function"]["arguments"]),
-                    ) in seen_tool_calls:
-                        continue
-                    seen_tool_calls.add(
-                        (
-                            str(tool_call["function"]["name"]),
-                            str(tool_call["function"]["arguments"]),
-                        )
-                    )
-                    all_tool_calls.append(tool_call)
+                all_tool_calls.extend(new_tool_calls)
                 token_counts = self._get_response_token_counts(r)
                 if token_counts:
                     r["usage"] = token_counts

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-ollama"
-version = "0.10.1"
+version = "0.10.2"
 description = "llama-index llms ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -493,3 +493,92 @@ async def test_chat_methods_with_tool_input() -> None:
         ablocks.extend(r.message.blocks)
     assert len([block for block in ablocks if isinstance(block, TextBlock)]) > 0
     assert len([block for block in ablocks if isinstance(block, ToolCallBlock)]) == 0
+
+
+def _duplicate_tool_call_chunks():
+    """
+    Two distinct roll_die calls that happen to share identical arguments.
+
+    Mirrors Ollama's real streaming shape (verified against a live server): each
+    tool call arrives whole, in its own chunk, with no repeats.
+    """
+    tool_call = {"function": {"name": "roll_die", "arguments": {}}}
+    return [
+        {"message": {"role": "assistant", "content": "", "tool_calls": [tool_call]}},
+        {"message": {"role": "assistant", "content": "", "tool_calls": [tool_call]}},
+        {"message": {"role": "assistant", "content": ""}},
+    ]
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+
+class _FakeAsyncStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeSyncClient:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def chat(self, **kwargs):
+        return _FakeStream(self._chunks)
+
+
+class _FakeAsyncClient:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def chat(self, **kwargs):
+        return _FakeAsyncStream(self._chunks)
+
+
+def test_stream_chat_keeps_distinct_tool_calls_with_identical_arguments() -> None:
+    """
+    Two genuinely separate tool calls that share name+arguments must both survive.
+
+    Regression test: stream_chat() used to dedupe accumulated tool calls by
+    (name, arguments), so a second call identical in content to an earlier one in
+    the same turn was silently dropped, even though chat() (non-streaming) has
+    always kept both.
+    """
+    chunks = _duplicate_tool_call_chunks()
+    llm = Ollama(
+        model="test-model", context_window=4096, client=_FakeSyncClient(chunks)
+    )
+    final = None
+    for final in llm.stream_chat([ChatMessage(role="user", content="roll it twice")]):
+        pass
+    tool_call_blocks = [
+        block for block in final.message.blocks if isinstance(block, ToolCallBlock)
+    ]
+    assert len(tool_call_blocks) == 2
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_keeps_distinct_tool_calls_with_identical_arguments() -> (
+    None
+):
+    chunks = _duplicate_tool_call_chunks()
+    llm = Ollama(
+        model="test-model", context_window=4096, async_client=_FakeAsyncClient(chunks)
+    )
+    final = None
+    async for final in await llm.astream_chat(
+        [ChatMessage(role="user", content="roll it twice")]
+    ):
+        pass
+    tool_call_blocks = [
+        block for block in final.message.blocks if isinstance(block, ToolCallBlock)
+    ]
+    assert len(tool_call_blocks) == 2


### PR DESCRIPTION
Fixes #22464.

## Root cause

`stream_chat()`/`astream_chat()` accumulate tool calls across chunks into
`all_tool_calls`, guarded by a `seen_tool_calls` set keyed on
`(str(name), str(arguments))`. Ollama streams each tool call exactly once, in its
own chunk, carrying a per-call `id` at the wire level, but this integration's
`ollama` client dependency parses responses into `ollama.Message.ToolCall`, whose
`Function` type declares no `id`/`index` field, so pydantic drops them before this
code ever sees them (confirmed by reading `ollama`'s installed source and by a raw
`POST /api/chat` capture bypassing the client's typed parsing). With no identity
signal left, deduping on content collapses two distinct calls whenever they share
name and arguments, for example calling the same no-argument tool twice in one turn.
`chat()`/`achat()` (non-streaming) never had this dedup and always returned every
call, so this was a real streaming-only regression in round-trip fidelity, not a
model quirk.

## Fix

Drop the content-based dedup and accumulate every tool call from every chunk
unconditionally. This preserves the original intent of the 2025-02-05 change that
introduced `all_tool_calls` (accumulate across chunks instead of overwriting on each
one); the `seen_tool_calls` guard added alongside it is what caused the drop.

## Verification

Docker (`python:3.11-slim`), `llama-index-core` and this package installed
editable from the worktree:

- New regression tests (`tests/test_llms_ollama.py`,
  `test_stream_chat_keeps_distinct_tool_calls_with_identical_arguments` and the
  `astream_chat` counterpart) drive `stream_chat`/`astream_chat` through a fake
  client emitting two chunks with identical `name`/`arguments`, mirroring Ollama's
  real per-call chunk shape. Both fail on `main` (1 tool call recovered instead of
  2) and pass on this branch.
- Full existing suite for the package still passes (3 passed, 18 skipped; the 18
  are the file's existing live-model tests, already skipped without a running
  Ollama server, unchanged by this PR).
- End to end against a real Ollama server (`qwen2.5:7b`), prompting it to call a
  no-arg tool twice in one turn: `main` recovers 1 `ToolCallBlock`, this branch
  recovers 2.
- `pre-commit run` (ruff, ruff-format, mypy, codespell, prettier) on the changed
  files, clean.

Not verified: behavior across every Ollama server version, since the two fields
this fix reasons about (`id`, `index`) aren't observable through this package's
client dependency at all in the current release.
