### PR TITLE
fix(mcp): support per-invocation workflow factories

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/README.md
@@ -94,6 +94,18 @@ workflow = LoudWorkflow()
 mcp = workflow_as_mcp(workflow, start_event_model=RunEvent)
 ```
 
+By default, the same workflow instance handles every tool invocation. If the
+workflow stores mutable state on the instance, provide a factory to isolate that
+state between invocations:
+
+```python
+mcp = workflow_as_mcp(
+    LoudWorkflow(),
+    start_event_model=RunEvent,
+    workflow_factory=LoudWorkflow,
+)
+```
+
 Then, you can launch the MCP server (assuming you have the `mcp[cli]` extra installed):
 
 ```bash

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from mcp.client.session import ClientSession
 from mcp.server.fastmcp import FastMCP, Context
@@ -79,6 +79,7 @@ def workflow_as_mcp(
     workflow_name: Optional[str] = None,
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
+    workflow_factory: Optional[Callable[[], Workflow]] = None,
     **fastmcp_init_kwargs: Any,
 ) -> FastMCP:
     """
@@ -97,6 +98,10 @@ def workflow_as_mcp(
         start_event_model (optional):
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
+        workflow_factory (optional):
+            A callable that creates a fresh workflow for each tool invocation. The
+            returned workflow must accept the same start event as `workflow`. By
+            default, the provided workflow instance is reused.
         **fastmcp_init_kwargs:
             Additional keyword arguments to pass to the FastMCP constructor.
 
@@ -119,16 +124,21 @@ def workflow_as_mcp(
 
     @app.tool(name=workflow_name, description=workflow_description)
     async def _workflow_tool(run_args: StartEventCLS, context: Context) -> Any:
+        active_workflow = workflow_factory() if workflow_factory else workflow
+
         # Handle edge cases where the start event is an Event or a BaseModel
         # If the workflow does not have a custom StartEvent class, then we need to handle the event differently
 
-        if isinstance(run_args, Event) and workflow._start_event_class != StartEvent:
-            handler = workflow.run(start_event=run_args)
+        if (
+            isinstance(run_args, Event)
+            and active_workflow._start_event_class != StartEvent
+        ):
+            handler = active_workflow.run(start_event=run_args)
         elif isinstance(run_args, BaseModel):
-            handler = workflow.run(**run_args.model_dump())
+            handler = active_workflow.run(**run_args.model_dump())
         elif isinstance(run_args, dict):
             start_event = StartEventCLS.model_validate(run_args)
-            handler = workflow.run(start_event=start_event)
+            handler = active_workflow.run(start_event=start_event)
         else:
             raise ValueError(f"Invalid start event type: {type(run_args)}")
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.4.9"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_workflow_as_mcp.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+import pytest
+
+from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+from llama_index.tools.mcp import workflow_as_mcp
+
+
+class TenantStartEvent(StartEvent):
+    tenant_id: str
+
+
+class CountingWorkflow(Workflow):
+    def __init__(self) -> None:
+        super().__init__(timeout=30)
+        self.history: list[str] = []
+
+    @step
+    async def count(self, event: TenantStartEvent) -> StopEvent:
+        self.history.append(event.tenant_id)
+        return StopEvent(result=list(self.history))
+
+
+async def _call_workflow(app: Any, tenant_id: str) -> list[str]:
+    result = await app.call_tool(
+        "CountingWorkflow",
+        {"run_args": {"tenant_id": tenant_id}},
+    )
+    return [item.text for item in result]
+
+
+@pytest.mark.asyncio
+async def test_workflow_factory_isolates_invocations() -> None:
+    template = CountingWorkflow()
+    instances: list[CountingWorkflow] = []
+
+    def workflow_factory() -> CountingWorkflow:
+        workflow = CountingWorkflow()
+        instances.append(workflow)
+        return workflow
+
+    app = workflow_as_mcp(template, workflow_factory=workflow_factory)
+
+    assert await _call_workflow(app, "alice") == ["alice"]
+    assert await _call_workflow(app, "bob") == ["bob"]
+    assert len(instances) == 2
+    assert template.history == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_instance_retains_existing_reuse_behavior() -> None:
+    workflow = CountingWorkflow()
+    app = workflow_as_mcp(workflow)
+
+    assert await _call_workflow(app, "alice") == ["alice"]
+    assert await _call_workflow(app, "bob") == ["alice", "bob"]
+    assert workflow.history == ["alice", "bob"]


### PR DESCRIPTION
# Description

`workflow_as_mcp` currently closes over one `Workflow` instance and reuses it for every MCP tool invocation. Any mutable state stored on `self` is consequently shared across callers.

This change adds an optional `workflow_factory` that creates a fresh compatible workflow for each invocation. Existing callers retain the current instance-reuse behavior when no factory is provided. The README documents both lifecycle modes, and the MCP integration package version is bumped from 0.4.8 to 0.4.9.

Fixes #22071

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Validation performed:

- Regression first: the factory isolation test failed because `workflow_factory` was forwarded to `FastMCP`; the legacy reuse test passed.
- `pytest tests/test_workflow_as_mcp.py -q`: 2 passed.
- Complete `llama-index-tools-mcp` suite: 53 passed.
- Configured pre-commit checks for all changed files passed: private-key detection, Ruff, Ruff format, Mypy, documentation formatting, Prettier, and codespell.
- `toml-sort --check` passed for the version bump.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] The implementation is small and self-explanatory; no additional inline comments are needed
- [x] I have made corresponding changes to the documentation
- [x] Notebook changes are not applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the repository-configured formatting and lint hooks for every changed file

## AI Assistance

AI assistance was used for initial codebase analysis and test scaffolding. I manually reviewed the implementation, reproduced the failure before the fix, verified backward compatibility, and ran the complete integration package suite and configured quality checks.