### PR TITLE
fix(ollama): honor per-call think=False

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -401,7 +401,8 @@ class Ollama(FunctionCallingLLM):
         ollama_messages = self._convert_to_ollama_messages(messages)
 
         tools = kwargs.pop("tools", None)
-        think = kwargs.pop("think", None) or self.thinking
+        think = kwargs.pop("think", None)
+        think = self.thinking if think is None else think
         format = kwargs.pop("format", "json" if self.json_mode else None)
 
         response = self.client.chat(
@@ -451,7 +452,8 @@ class Ollama(FunctionCallingLLM):
         ollama_messages = self._convert_to_ollama_messages(messages)
 
         tools = kwargs.pop("tools", None)
-        think = kwargs.pop("think", None) or self.thinking
+        think = kwargs.pop("think", None)
+        think = self.thinking if think is None else think
         format = kwargs.pop("format", "json" if self.json_mode else None)
 
         def gen() -> ChatResponseGen:
@@ -535,7 +537,8 @@ class Ollama(FunctionCallingLLM):
         ollama_messages = self._convert_to_ollama_messages(messages)
 
         tools = kwargs.pop("tools", None)
-        think = kwargs.pop("think", None) or self.thinking
+        think = kwargs.pop("think", None)
+        think = self.thinking if think is None else think
         format = kwargs.pop("format", "json" if self.json_mode else None)
 
         async def gen() -> ChatResponseAsyncGen:
@@ -619,7 +622,8 @@ class Ollama(FunctionCallingLLM):
         ollama_messages = self._convert_to_ollama_messages(messages)
 
         tools = kwargs.pop("tools", None)
-        think = kwargs.pop("think", None) or self.thinking
+        think = kwargs.pop("think", None)
+        think = self.thinking if think is None else think
         format = kwargs.pop("format", "json" if self.json_mode else None)
 
         response = await self.async_client.chat(

--- a/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-ollama"
-version = "0.10.1"
+version = "0.10.2"
 description = "llama-index llms ollama integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from ollama import Client
@@ -51,6 +52,32 @@ tool = FunctionTool.from_defaults(fn=generate_song)
 def test_embedding_class() -> None:
     names_of_base_classes = [b.__name__ for b in Ollama.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+@pytest.mark.asyncio
+async def test_per_call_think_false_overrides_default() -> None:
+    response = {"message": {"content": "", "role": "assistant"}}
+    client = MagicMock()
+    client.chat.side_effect = [response, [response]]
+
+    async def stream_response():
+        yield response
+
+    async_client = MagicMock()
+    async_client.chat = AsyncMock(side_effect=[response, stream_response()])
+    llm = Ollama(model="test", thinking=True, client=client, async_client=async_client)
+    messages = [ChatMessage(role="user", content="Hello!")]
+
+    llm.chat(messages, think=False)
+    list(llm.stream_chat(messages, think=False))
+    await llm.achat(messages, think=False)
+    stream = await llm.astream_chat(messages, think=False)
+    _ = [item async for item in stream]
+
+    assert all(call.kwargs["think"] is False for call in client.chat.call_args_list)
+    assert all(
+        call.kwargs["think"] is False for call in async_client.chat.call_args_list
+    )
 
 
 @pytest.mark.skipif(
@@ -207,7 +234,7 @@ async def test_async_chat_with_tools() -> None:
 def test_chat_with_think() -> None:
     llm = Ollama(model=thinking_test_model, thinking=True, request_timeout=360)
     response = llm.chat(
-        [ChatMessage(role="user", content="Hello! What is 32 * 4?")], think=False
+        [ChatMessage(role="user", content="Hello! What is 32 * 4?")], think=True
     )
     assert response is not None
     assert str(response).strip() != ""
@@ -309,7 +336,7 @@ def test_chat_with_thinking_input() -> None:
                 content="Based on your previous reasoning, can you now tell me the result of 50*200?",
             ),
         ],
-        think=False,
+        think=True,
     )
     assert response is not None
     assert str(response).strip() != ""
@@ -343,7 +370,7 @@ def test_chat_with_thinking_input() -> None:
 async def test_async_chat_with_think() -> None:
     llm = Ollama(model=thinking_test_model, thinking=True)
     response = await llm.achat(
-        [ChatMessage(role="user", content="Hello! What is 32 * 4?")], think=False
+        [ChatMessage(role="user", content="Hello! What is 32 * 4?")], think=True
     )
     assert response is not None
     assert str(response).strip() != ""

--- a/llama-index-integrations/llms/llama-index-llms-ollama/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/uv.lock
@@ -1824,7 +1824,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-ollama"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

Preserve an explicit per-call `think=False` override by falling back to the
instance-level `thinking` setting only when the keyword is absent or `None`.
This applies consistently to synchronous, streaming, and asynchronous chat
methods. The regression test covers all four paths, and the existing thinking
integration tests now explicitly request `think=True`.

Fixes #22467

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Local validation:

- `.venv/bin/pytest tests -q` (3 passed, 18 skipped)
- `.venv/bin/ruff check llama_index/llms/ollama/base.py tests/test_llms_ollama.py`
- `.venv/bin/ruff format --check llama_index/llms/ollama/base.py tests/test_llms_ollama.py`
- `uv lock --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
