### PR TITLE
fix(opensearch): apply .keyword to NIN and ALL set operators

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/llama_index/vector_stores/opensearch/base.py
@@ -409,6 +409,14 @@ class OpensearchVectorClient:
         op = filter.operator
 
         equality_postfix = ".keyword" if self._is_text_field(value=filter.value) else ""
+        # Set operators receive a list, so the postfix depends on every element
+        # being a text value rather than on the list itself.
+        set_postfix = (
+            ".keyword"
+            if isinstance(filter.value, list)
+            and all(self._is_text_field(value=val) for val in filter.value)
+            else ""
+        )
 
         if op == FilterOperator.EQ:
             return {"term": {f"{key}{equality_postfix}": filter.value}}
@@ -426,18 +434,15 @@ class OpensearchVectorClient:
                 }
             }
         elif op in [FilterOperator.IN, FilterOperator.ANY]:
-            if isinstance(filter.value, list) and all(
-                self._is_text_field(val) for val in filter.value
-            ):
-                return {"terms": {f"{key}.keyword": filter.value}}
-            else:
-                return {"terms": {key: filter.value}}
+            return {"terms": {f"{key}{set_postfix}": filter.value}}
         elif op == FilterOperator.NIN:
-            return {"bool": {"must_not": {"terms": {key: filter.value}}}}
+            return {
+                "bool": {"must_not": {"terms": {f"{key}{set_postfix}": filter.value}}}
+            }
         elif op == FilterOperator.ALL:
             return {
                 "terms_set": {
-                    key: {
+                    f"{key}{set_postfix}": {
                         "terms": filter.value,
                         "minimum_should_match_script": {"source": "params.num_terms"},
                     }

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_client.py
@@ -651,6 +651,48 @@ def test_filter_all(
 
 
 @pytest.mark.skipif(opensearch_not_available, reason="opensearch is not available")
+@pytest.mark.parametrize(
+    ("operator", "value", "exp_doc_ids"),
+    [
+        (FilterOperator.IN, ["Product Management"], {"match1"}),
+        (FilterOperator.ANY, ["Product Management"], {"match1"}),
+        (FilterOperator.NIN, ["Product Management"], {"match2", "other"}),
+        (FilterOperator.ALL, ["Product Management"], {"match1"}),
+    ],
+)
+def test_filter_set_operators_multi_word_values(
+    os_stores: List[OpensearchVectorStore],
+    insert_document,
+    operator: FilterOperator,
+    value: List[str],
+    exp_doc_ids: Set[str],
+):
+    """
+    Set operators must match multi-word text values exactly.
+
+    Single lowercase words happen to survive analysis on a text field, so this
+    exercises values the standard analyzer would otherwise tokenize.
+    """
+    for os_store in os_stores:
+        for metadata, id_ in [
+            ({"category": ["Product Management"]}, "match1"),
+            ({"category": ["Product Marketing"]}, "match2"),
+            ({"category": ["Accounting"]}, "other"),
+        ]:
+            insert_document(os_store, doc_id=id_, metadata=metadata)
+
+        query = _get_sample_vector_store_query(
+            filters=MetadataFilters(
+                filters=[MetadataFilter(key="category", value=value, operator=operator)]
+            )
+        )
+        query_result = os_store.query(query)
+
+        doc_ids = {node.id_ for node in query_result.nodes}
+        assert doc_ids == exp_doc_ids
+
+
+@pytest.mark.skipif(opensearch_not_available, reason="opensearch is not available")
 def test_filter_text_match(
     os_stores: List[OpensearchVectorStore],
     insert_document,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_filters_unit.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-opensearch/tests/test_opensearch_filters_unit.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from llama_index.core.vector_stores.types import FilterOperator, MetadataFilter
 from llama_index.vector_stores.opensearch.base import OpensearchVectorClient
 
@@ -41,3 +43,69 @@ def test_parse_filter_text_match_insensitive_uses_match_query() -> None:
     assert parsed == {
         "match": {"metadata.name": {"query": "john doe", "fuzziness": "AUTO"}}
     }
+
+
+TEXT_VALUES = ["Product Management", "Product Marketing"]
+NUMERIC_VALUES = [1, 2, 3]
+
+
+def _terms_set_query(field: str, values: list) -> dict:
+    return {
+        "terms_set": {
+            field: {
+                "terms": values,
+                "minimum_should_match_script": {"source": "params.num_terms"},
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("operator", "expected"),
+    [
+        (FilterOperator.IN, {"terms": {"metadata.category.keyword": TEXT_VALUES}}),
+        (FilterOperator.ANY, {"terms": {"metadata.category.keyword": TEXT_VALUES}}),
+        (
+            FilterOperator.NIN,
+            {
+                "bool": {
+                    "must_not": {"terms": {"metadata.category.keyword": TEXT_VALUES}}
+                }
+            },
+        ),
+        (
+            FilterOperator.ALL,
+            _terms_set_query("metadata.category.keyword", TEXT_VALUES),
+        ),
+    ],
+)
+def test_parse_filter_set_operators_use_keyword_for_text_values(
+    operator: FilterOperator, expected: dict
+) -> None:
+    """Every set operator must target the .keyword subfield for text values."""
+    client = _make_client()
+    flt = MetadataFilter(key="category", value=TEXT_VALUES, operator=operator)
+
+    assert client._parse_filter(flt) == expected
+
+
+@pytest.mark.parametrize(
+    ("operator", "expected"),
+    [
+        (FilterOperator.IN, {"terms": {"metadata.score": NUMERIC_VALUES}}),
+        (FilterOperator.ANY, {"terms": {"metadata.score": NUMERIC_VALUES}}),
+        (
+            FilterOperator.NIN,
+            {"bool": {"must_not": {"terms": {"metadata.score": NUMERIC_VALUES}}}},
+        ),
+        (FilterOperator.ALL, _terms_set_query("metadata.score", NUMERIC_VALUES)),
+    ],
+)
+def test_parse_filter_set_operators_skip_keyword_for_non_text_values(
+    operator: FilterOperator, expected: dict
+) -> None:
+    """Numeric values have no .keyword subfield, so the bare field is used."""
+    client = _make_client()
+    flt = MetadataFilter(key="score", value=NUMERIC_VALUES, operator=operator)
+
+    assert client._parse_filter(flt) == expected


### PR DESCRIPTION
## Description

`_parse_filter` applied the `.keyword` subfield postfix to `IN` and `ANY`, but `NIN` and `ALL` queried the analyzed field instead. Since the standard analyzer tokenizes and lowercases text, a multi-word metadata value never matches a `terms` query against the analyzed field — so `NIN` silently excluded nothing and `ALL` silently matched nothing.

This is a wrong-results bug rather than an error: no exception is raised, the query just returns the wrong set.

Reproduced directly against OpenSearch 2.19.0 with documents `{"category": ["Product Management"]}` / `["Product Marketing"]` / `["Accounting"]`:

| operator | query the code emitted | result | expected |
|---|---|---|---|
| `IN` | `terms` on `metadata.category.keyword` | `match1` | `match1` ✅ |
| `NIN` | `must_not terms` on `metadata.category` | `match1, match2, other` | `match2, other` ❌ |
| `ALL` | `terms_set` on `metadata.category` | *(empty)* | `match1` ❌ |

Switching the two broken operators to `metadata.category.keyword` returns the expected sets.

The existing `test_filter_in` already parametrizes `NIN` and passes, because its fixture values are single lowercase words (`"product"`). Those survive analysis on a text field and match by accident, which is what hid this. The new e2e test uses multi-word values to close that gap.

## Fix

Hoist the list-aware postfix into a single `set_postfix` and apply it to all four set operators (`IN`, `ANY`, `NIN`, `ALL`). This also removes the duplicated branch that `IN`/`ANY` previously carried. Numeric values are unaffected — they have no `.keyword` subfield, so the bare field is still used.

## Tests

- `tests/test_opensearch_filters_unit.py` — parametrized unit tests asserting the exact emitted query for all four set operators, for both text and numeric values (no OpenSearch required).
- `tests/test_opensearch_client.py::test_filter_set_operators_multi_word_values` — e2e regression test with multi-word values.

Verified locally against OpenSearch 2.19.0 (`tests/docker-compose.yml`):

```
uv run -- pytest tests/test_opensearch_filters_unit.py tests/test_opensearch_client.py -k filter
# 45 passed
```

`ruff format` and `ruff check` are clean. One pre-existing error in `test_efficient_filtering_used_when_enabled` reproduces identically on unmodified `main` and is unrelated to this change.
