### PR TITLE
fix(postgres): bind metadata filter values instead of interpolating them

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import re
+import uuid
 from typing import (
     Any,
     Dict,
@@ -688,36 +690,44 @@ class PGVectorStore(BasePydanticVectorStore):
             return "="
 
     def _build_filter_clause(self, filter_: MetadataFilter) -> Any:
-        if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
-            # Expects a single value in the metadata, and a list to compare
+        # Filter values are bound as parameters rather than interpolated into
+        # the SQL string, so that a value containing a quote cannot break (or
+        # alter) the statement. Each clause needs its own parameter name,
+        # because several clauses are combined into a single statement.
+        param = f"filter_value_{uuid.uuid4().hex}"
 
-            # In Python, to create a tuple with a single element, you need to include a comma after the element
-            # This code will correctly format the IN clause whether there is one element or multiple elements in the list:
-            filter_value = ", ".join(f"'{e}'" for e in filter_.value)
+        if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
+            # Expects a single value in the metadata, and a list to compare.
+            # A bare string is treated as a single value rather than as an
+            # iterable of characters.
+            filter_value = (
+                list(filter_.value)
+                if isinstance(filter_.value, (list, tuple, set))
+                else [filter_.value]
+            )
+            negate = "NOT " if filter_.operator == FilterOperator.NIN else ""
 
             return text(
-                f"metadata_->>'{filter_.key}' "
-                f"{self._to_postgres_operator(filter_.operator)} "
-                f"({filter_value})"
-            )
+                f"{negate}metadata_->>'{filter_.key}' = ANY(cast(:{param} as text[]))"
+            ).bindparams(**{param: [str(e) for e in filter_value]})
         elif filter_.operator in [FilterOperator.ANY, FilterOperator.ALL]:
             # Expects a text array stored in the metadata, and a list of values to compare
             # Works with text[] arrays using PostgreSQL ?| (ANY) and ?& (ALL) operators
             # Example: metadata_::jsonb->'tags' ?| array['AI', 'ML']
-            filter_value = ", ".join(f"'{e}'" for e in filter_.value)
-
             return text(
                 f"metadata_::jsonb->'{filter_.key}' "
                 f"{self._to_postgres_operator(filter_.operator)} "
-                f"array[{filter_value}]"
-            )
+                f"cast(:{param} as text[])"
+            ).bindparams(**{param: [str(e) for e in filter_.value]})
         elif filter_.operator == FilterOperator.CONTAINS:
-            # Expects a list stored in the metadata, and a single value to compare
+            # Expects a list stored in the metadata, and a single value to compare.
+            # The cast is required because asyncpg cannot infer the type of a
+            # bare bind parameter on the jsonb @> operator.
             return text(
                 f"metadata_::jsonb->'{filter_.key}' "
                 f"{self._to_postgres_operator(filter_.operator)} "
-                f"'[\"{filter_.value}\"]'"
-            )
+                f"cast(:{param} as jsonb)"
+            ).bindparams(**{param: json.dumps([filter_.value])})
         elif (
             filter_.operator == FilterOperator.TEXT_MATCH
             or filter_.operator == FilterOperator.TEXT_MATCH_INSENSITIVE
@@ -726,8 +736,8 @@ class PGVectorStore(BasePydanticVectorStore):
             return text(
                 f"metadata_->>'{filter_.key}' "
                 f"{self._to_postgres_operator(filter_.operator)} "
-                f"'%{filter_.value}%'"
-            )
+                f":{param}"
+            ).bindparams(**{param: f"%{filter_.value}%"})
         elif filter_.operator == FilterOperator.IS_EMPTY:
             # Where the operator is is_empty, we need to check if the metadata is null
             return text(
@@ -748,8 +758,8 @@ class PGVectorStore(BasePydanticVectorStore):
                 return text(
                     f"metadata_->>'{filter_.key}' "
                     f"{self._to_postgres_operator(filter_.operator)} "
-                    f"'{filter_.value}'"
-                )
+                    f":{param}"
+                ).bindparams(**{param: str(filter_.value)})
 
     def _recursively_apply_filters(self, filters: List[MetadataFilters]) -> Any:
         """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -1,3 +1,4 @@
+import json
 import asyncio
 from typing import Any, Dict, Generator, List, Union, Optional
 from unittest.mock import MagicMock, AsyncMock
@@ -3220,3 +3221,84 @@ async def test_mmr_query_filters_out_empty_embeddings_in_mixed_results(use_async
     assert "e1" not in result.ids
     assert "v1" in result.ids
     assert "v2" in result.ids
+
+
+# ================== Filter binding tests (no database required) ==================
+
+# Operators that take a single value rather than a list.
+_SCALAR_FILTER_OPERATORS = (
+    FilterOperator.CONTAINS,
+    FilterOperator.TEXT_MATCH,
+    FilterOperator.TEXT_MATCH_INSENSITIVE,
+    FilterOperator.EQ,
+)
+
+
+def _filter_clause(operator: FilterOperator, value: Any, key: str = "name") -> Any:
+    """Build a filter clause without needing a live database."""
+    store = PGVectorStore.construct()
+    return PGVectorStore._build_filter_clause(
+        store, MetadataFilter(key=key, value=value, operator=operator)
+    )
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        FilterOperator.IN,
+        FilterOperator.NIN,
+        FilterOperator.ANY,
+        FilterOperator.ALL,
+        FilterOperator.CONTAINS,
+        FilterOperator.TEXT_MATCH,
+        FilterOperator.TEXT_MATCH_INSENSITIVE,
+        FilterOperator.EQ,
+    ],
+)
+def test_build_filter_clause_binds_values_instead_of_interpolating(
+    operator: FilterOperator,
+) -> None:
+    """
+    A value containing a quote must not reach the SQL string.
+
+    Interpolating it would produce invalid SQL, and a crafted value could
+    change the meaning of the statement.
+    """
+    hostile = "x') OR 1=1 --"
+    value = hostile if operator in _SCALAR_FILTER_OPERATORS else [hostile]
+
+    clause = _filter_clause(operator, value)
+
+    # The value stays out of the SQL text and is carried as a bind parameter.
+    assert hostile not in str(clause)
+
+    bound = list(clause.compile().params.values())
+    assert len(bound) == 1
+    # CONTAINS encodes its operand as JSON; the others pass it through.
+    if operator is FilterOperator.CONTAINS:
+        assert json.loads(bound[0]) == [hostile]
+    elif operator in _SCALAR_FILTER_OPERATORS:
+        assert hostile in bound[0]
+    else:
+        assert bound[0] == [hostile]
+
+
+@pytest.mark.parametrize("operator", [FilterOperator.IN, FilterOperator.NIN])
+def test_build_filter_clause_treats_bare_string_as_one_value(
+    operator: FilterOperator,
+) -> None:
+    """A scalar string must not be iterated over character by character."""
+    clause = _filter_clause(operator, "abc")
+
+    assert list(clause.compile().params.values()) == [["abc"]]
+
+
+def test_build_filter_clause_uses_distinct_parameter_names() -> None:
+    """
+    Clauses are combined into one statement, so their bind parameters must
+    not collide.
+    """
+    first = _filter_clause(FilterOperator.IN, ["a"], key="k1")
+    second = _filter_clause(FilterOperator.IN, ["b"], key="k2")
+
+    assert set(first.compile().params) & set(second.compile().params) == set()


### PR DESCRIPTION
## Description

`_build_filter_clause` interpolated metadata filter values directly into the SQL string via f-strings. This produced three distinct failures, all verified against PostgreSQL 16.13 + pgvector:

**1. A value containing a single quote produces invalid SQL.**

`MetadataFilter(key="name", value=["O'Brien"], operator=IN)` built `metadata_->>'name' IN ('O'Brien')`:

```
ERROR:  syntax error at or near "Brien"
```

**2. A crafted value changes the meaning of the statement.**

`value=["x') OR 1=1 --"]` built `metadata_->>'name' IN ('x') OR 1=1 --')`. The injected `OR 1=1` neutralizes the filter, and the query returns **every row in the table** rather than the filtered set:

```
injection -> a,b,c     # all three rows, filter bypassed
```

Since metadata filter values routinely come from user input in a RAG application, this is reachable without any special setup.

**3. IN/NIN iterate a scalar string character by character.**

The comprehension `", ".join(f"'{e}'" for e in filter_.value)` iterates whatever it is given. A scalar `value="abc"` becomes `IN ('a', 'b', 'c')`, which silently matches nothing even when a row holds exactly `"abc"`. The docstring's note about single-element tuples suggests a list was always intended, but nothing enforced it.

## Fix

Bind the values as parameters for `IN`, `NIN`, `ANY`, `ALL`, `CONTAINS`, `TEXT_MATCH`, `TEXT_MATCH_INSENSITIVE`, and the string fallback, and normalize a bare string to a single-element list.

`IN`/`NIN` now use `= ANY(cast(:param as text[]))` rather than `IN (...)`, because an array parameter binds as one value where an `IN` list cannot. `NIN` is expressed as `NOT ... = ANY(...)`.

Two details worth flagging for review:

- **Explicit casts.** asyncpg cannot infer the type of a bare bind parameter on the jsonb operators — `@>` fails with `UndefinedFunctionError` without `cast(:param as jsonb)`. psycopg2 infers it fine, so this only shows up on the async path.
- **Distinct parameter names.** `_recursively_apply_filters` combines clauses into a single statement, so a fixed parameter name makes two filters overwrite each other. Each clause now gets a uuid-suffixed name. (`test_mixed_btree_and_gin_indices` caught this — it combines an `EQ` and a `CONTAINS` filter.)

The `IN` / `NOT IN` branches of `_to_postgres_operator` are now unused by this path. I left them in place rather than remove them, since the method may be referenced elsewhere — happy to drop them if you'd prefer.

## Tests

Added to `tests/test_postgres.py` — these need no database, so they run in CI:

- `test_build_filter_clause_binds_values_instead_of_interpolating` — parametrized over all 8 affected operators, asserts a hostile value never reaches the SQL text and arrives as a bind parameter.
- `test_build_filter_clause_treats_bare_string_as_one_value` — a scalar string is not split into characters.
- `test_build_filter_clause_uses_distinct_parameter_names` — two clauses do not share a parameter name.

Full suite against PostgreSQL 16.13 + pgvector:

```
uv run -- pytest tests/
# 169 passed
```

`ruff format` and `ruff check` are clean.
