### PR TITLE
fix(elasticsearch): honor the filter condition instead of always using AND

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/llama_index/vector_stores/elasticsearch/base.py
@@ -9,6 +9,7 @@ from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.schema import BaseNode, MetadataMode
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
+    FilterCondition,
     MetadataFilters,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -40,6 +41,13 @@ DISTANCE_STRATEGIES = Literal[
     "EUCLIDEAN_DISTANCE",
 ]
 
+# How a MetadataFilters condition maps onto an Elasticsearch bool clause.
+_CONDITION_TO_ES_CLAUSE = {
+    FilterCondition.AND: "must",
+    FilterCondition.OR: "should",
+    FilterCondition.NOT: "must_not",
+}
+
 
 def _to_elasticsearch_filter(
     standard_filters: MetadataFilters, metadata_keyword_suffix: str = ".keyword"
@@ -49,33 +57,32 @@ def _to_elasticsearch_filter(
 
     Args:
         standard_filters: Standard Llama-index filters.
+        metadata_keyword_suffix: Suffix appended to the metadata field name.
 
     Returns:
         Elasticsearch filter.
 
     """
-    if len(standard_filters.legacy_filters()) == 1:
-        filter = standard_filters.legacy_filters()[0]
-        return {
+    operands = [
+        {
             "term": {
                 f"metadata.{filter.key}{metadata_keyword_suffix}": {
                     "value": filter.value,
                 }
             }
         }
-    else:
-        operands = []
-        for filter in standard_filters.legacy_filters():
-            operands.append(
-                {
-                    "term": {
-                        f"metadata.{filter.key}{metadata_keyword_suffix}": {
-                            "value": filter.value,
-                        }
-                    }
-                }
-            )
-        return {"bool": {"must": operands}}
+        for filter in standard_filters.legacy_filters()
+    ]
+
+    # `condition` is optional, and AND is what the previous behavior implied.
+    condition = standard_filters.condition or FilterCondition.AND
+
+    if len(operands) == 1 and condition != FilterCondition.NOT:
+        # A single AND/OR operand needs no bool wrapper. NOT still does,
+        # because the clause has to be negated.
+        return operands[0]
+
+    return {"bool": {_CONDITION_TO_ES_CLAUSE[condition]: operands}}
 
 
 def _to_llama_similarities(scores: List[float]) -> List[float]:

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-elasticsearch/tests/test_vector_stores_elasticsearch.py
@@ -14,6 +14,7 @@ import pytest_asyncio
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.core.vector_stores.types import (
     ExactMatchFilter,
+    FilterCondition,
     MetadataFilters,
     VectorStoreQuery,
     VectorStoreQueryMode,
@@ -378,6 +379,38 @@ async def test_add_to_es_query_with_filters(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [True, False])
+async def test_add_to_es_query_with_or_filters(
+    es_store: ElasticsearchStore,
+    node_embeddings: List[TextNode],
+    use_async: bool,
+) -> None:
+    """An OR condition must return the union, not the intersection."""
+    filters = MetadataFilters(
+        condition=FilterCondition.OR,
+        filters=[
+            ExactMatchFilter(key="author", value="Stephen King"),
+            ExactMatchFilter(key="author", value="Marie Curie"),
+        ],
+    )
+    q = VectorStoreQuery(
+        query_embedding=[1.0, 0.0, 0.0], similarity_top_k=10, filters=filters
+    )
+    if use_async:
+        await es_store.async_add(node_embeddings)
+        res = await es_store.aquery(q)
+    else:
+        es_store.add(node_embeddings)
+        res = es_store.query(q)
+
+    # Treating OR as AND would look for one node by both authors, matching none.
+    assert {node.metadata["author"] for node in res.nodes} == {
+        "Stephen King",
+        "Marie Curie",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [True, False])
 async def test_add_to_es_query_with_es_filters(
     es_store: ElasticsearchStore,
     node_embeddings: List[TextNode],
@@ -589,6 +622,81 @@ def test_metadata_filter_to_es_filter() -> None:
                 {"term": {"metadata.k2": {"value": "v2"}}},
             ]
         }
+    }
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected_clause"),
+    [
+        (FilterCondition.AND, "must"),
+        (FilterCondition.OR, "should"),
+        (FilterCondition.NOT, "must_not"),
+    ],
+)
+def test_metadata_filter_condition_maps_to_bool_clause(
+    condition: FilterCondition, expected_clause: str
+) -> None:
+    """The filter condition must pick the matching Elasticsearch bool clause."""
+    metadata_filters = MetadataFilters(
+        condition=condition,
+        filters=[
+            ExactMatchFilter(key="k1", value="v1"),
+            ExactMatchFilter(key="k2", value="v2"),
+        ],
+    )
+
+    assert _to_elasticsearch_filter(standard_filters=metadata_filters) == {
+        "bool": {
+            expected_clause: [
+                {"term": {"metadata.k1.keyword": {"value": "v1"}}},
+                {"term": {"metadata.k2.keyword": {"value": "v2"}}},
+            ]
+        }
+    }
+
+
+@pytest.mark.parametrize("condition", [FilterCondition.AND, FilterCondition.OR])
+def test_metadata_filter_single_filter_needs_no_bool_wrapper(
+    condition: FilterCondition,
+) -> None:
+    """A lone AND/OR operand is returned unwrapped, as it was before."""
+    metadata_filters = MetadataFilters(
+        condition=condition, filters=[ExactMatchFilter(key="k1", value="v1")]
+    )
+
+    assert _to_elasticsearch_filter(standard_filters=metadata_filters) == {
+        "term": {"metadata.k1.keyword": {"value": "v1"}}
+    }
+
+
+def test_metadata_filter_without_condition_defaults_to_must() -> None:
+    """`condition` is optional; AND is what the previous behavior implied."""
+    metadata_filters = MetadataFilters(
+        condition=None,
+        filters=[
+            ExactMatchFilter(key="k1", value="v1"),
+            ExactMatchFilter(key="k2", value="v2"),
+        ],
+    )
+
+    assert _to_elasticsearch_filter(standard_filters=metadata_filters) == {
+        "bool": {
+            "must": [
+                {"term": {"metadata.k1.keyword": {"value": "v1"}}},
+                {"term": {"metadata.k2.keyword": {"value": "v2"}}},
+            ]
+        }
+    }
+
+
+def test_metadata_filter_single_not_filter_is_wrapped() -> None:
+    """A lone NOT operand still needs the wrapper, so it can be negated."""
+    metadata_filters = MetadataFilters(
+        condition=FilterCondition.NOT, filters=[ExactMatchFilter(key="k1", value="v1")]
+    )
+
+    assert _to_elasticsearch_filter(standard_filters=metadata_filters) == {
+        "bool": {"must_not": [{"term": {"metadata.k1.keyword": {"value": "v1"}}}]}
     }
 
 


### PR DESCRIPTION
## Description

`_to_elasticsearch_filter` hardcoded the `must` clause, so the `condition` on `MetadataFilters` was ignored. `FilterCondition.OR` and `FilterCondition.NOT` were both silently translated as AND.

Nothing raises — the query simply returns the wrong set:

```python
MetadataFilters(
    condition=FilterCondition.OR,
    filters=[
        ExactMatchFilter(key="author", value="Stephen King"),
        ExactMatchFilter(key="author", value="Marie Curie"),
    ],
)
```

```jsonc
// before — asks for documents by BOTH authors at once, so nothing matches
{"bool": {"must": [
  {"term": {"metadata.author.keyword": {"value": "Stephen King"}}},
  {"term": {"metadata.author.keyword": {"value": "Marie Curie"}}}]}}

// after
{"bool": {"should": [ ... ]}}
```

For distinct values of the same key, an OR filter matched **zero** documents where it should have returned the union. `NOT` was inverted the same way — it filtered *for* the values it was meant to exclude.

## Fix

Map the condition onto the corresponding Elasticsearch bool clause:

| `FilterCondition` | bool clause |
|---|---|
| `AND` | `must` |
| `OR` | `should` |
| `NOT` | `must_not` |

Behavior preserved on two edges:

- **A lone AND/OR operand is still returned unwrapped** (a bare `term`, not wrapped in `bool`), exactly as before — `test_metadata_filter_to_es_filter` and the existing e2e filter test cover this. `NOT` does need the wrapper, since the clause has to be negated.
- **`condition=None` is permitted by the model** (the field is `Optional` with an `AND` default, but `None` can be passed explicitly). It now falls back to `must` rather than raising `KeyError`.

One thing I checked specifically, since it would have made this fix wrong: `should` inside a filter context. `minimum_should_match` defaults to 0 in some `bool` arrangements, which would make `should` match everything instead of the union. Verified against Elasticsearch 8.15.0 that a `should` nested in a `bool` — which is how this store composes filters — correctly defaults to requiring one match:

```
should as top-level query           -> ['d1', 'd2']
should nested in filter context     -> ['d1', 'd2']   # same, no over-matching
must (AND) in filter context        -> []             # no doc has both authors
must_not (NOT) in filter context    -> ['d3']
```

## Tests

- `test_metadata_filter_condition_maps_to_bool_clause` — parametrized over AND/OR/NOT, asserts the emitted clause.
- `test_metadata_filter_single_filter_needs_no_bool_wrapper` — the unwrapped single-operand case is unchanged.
- `test_metadata_filter_single_not_filter_is_wrapped` — a lone NOT still gets its wrapper.
- `test_metadata_filter_without_condition_defaults_to_must` — explicit `condition=None`.
- `test_add_to_es_query_with_or_filters` — e2e, asserts OR returns the union of two authors.

Confirmed these tests fail against the current code and pass with the fix — against the pre-fix source, the two OR e2e cases and the OR/NOT unit cases go red (5 failures).

Full suite against Elasticsearch 8.15.0:

```
ES_URL=http://localhost:9201 uv run -- pytest tests/
# 33 passed, 2 skipped
```

`ruff format` and `ruff check` are clean. The 4 `ranked_hybrid` failures in my run are pre-existing — RRF needs a non-basic license, and they fail identically on unmodified `main`.
