### PR TITLE
fix: prevent workflow state sharing in workflow_as_mcp (#22071)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+import warnings
 
 from mcp.client.session import ClientSession
 from mcp.server.fastmcp import FastMCP, Context
@@ -75,21 +76,26 @@ async def aget_tools_from_mcp_url(
 
 
 def workflow_as_mcp(
-    workflow: Workflow,
+    workflow: Union[Type[Workflow], Workflow, Callable[[], Workflow]],
     workflow_name: Optional[str] = None,
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
+    share_instance: bool = False,
     **fastmcp_init_kwargs: Any,
 ) -> FastMCP:
     """
     Convert a workflow to an MCP app.
 
     This will convert any `Workflow` to an MCP app. It will expose the workflow as a tool
-    within MCP, which will
+    within MCP, which will create a fresh workflow instance for each invocation to ensure
+    complete isolation between different MCP clients.
 
     Args:
         workflow:
-            The workflow to convert.
+            The workflow to convert. Can be:
+            - A Workflow class (e.g., CountingWorkflow)
+            - A callable factory that returns a Workflow (e.g., lambda: CountingWorkflow(timeout=30))
+            - A Workflow instance (will extract class; init params will be lost unless share_instance=True)
         workflow_name (optional):
             The name of the workflow. Defaults to the workflow class name.
         workflow_description (optional):
@@ -97,6 +103,11 @@ def workflow_as_mcp(
         start_event_model (optional):
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
+        share_instance (optional):
+            If True, reuses the same workflow instance across all MCP invocations.
+            WARNING: This can cause state pollution and data leakage between different
+            MCP clients/tenants. Only use this if you fully understand the implications.
+            Defaults to False (secure by default).
         **fastmcp_init_kwargs:
             Additional keyword arguments to pass to the FastMCP constructor.
 
@@ -106,29 +117,78 @@ def workflow_as_mcp(
     """
     app = FastMCP(**fastmcp_init_kwargs)
 
+    # Determine the workflow factory and metadata instance
+    if share_instance:
+        # Opt-out: User explicitly wants to share state (old buggy behavior)
+        if not isinstance(workflow, Workflow):
+            raise ValueError(
+                "share_instance=True requires a Workflow instance. "
+                "If you want to share state, pass an instance like: workflow_as_mcp(MyWorkflow(), share_instance=True)"
+            )
+        workflow_factory = None  # Not used in share mode
+        workflow_instance = workflow
+    else:
+        # SECURE BY DEFAULT: Create fresh instances per invocation
+        if isinstance(workflow, type):
+            # It's a class - use it as factory
+            workflow_factory = workflow
+            workflow_instance = workflow()  # For metadata extraction
+        elif isinstance(workflow, Workflow):
+            # It's an instance - extract class and warn about lost params
+            # CHECK THIS BEFORE callable() to avoid treating instances as factories
+            warnings.warn(
+                f"Passing a Workflow instance to workflow_as_mcp will extract its class "
+                f"and create fresh instances without initialization parameters. "
+                f"To preserve init params, pass a lambda: workflow_as_mcp(lambda: {workflow.__class__.__name__}(...)). "
+                f"To share state across invocations (NOT RECOMMENDED), use share_instance=True.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            workflow_class = workflow.__class__
+            workflow_factory = workflow_class
+            workflow_instance = workflow
+        elif callable(workflow):
+            # It's a callable/lambda factory
+            workflow_factory = workflow
+            workflow_instance = workflow()  # Call once for metadata
+        else:
+            raise TypeError(
+                f"workflow must be a Workflow class, instance, or callable factory. "
+                f"Got {type(workflow).__name__}"
+            )
+
     # Dynamically get the start event class -- this is a bit of a hack
-    StartEventCLS = start_event_model or workflow._start_event_class
+    StartEventCLS = start_event_model or workflow_instance._start_event_class
     if StartEventCLS == StartEvent:
         raise ValueError(
             "Must declare a custom StartEvent class in your workflow or provide a start_event_model."
         )
 
     # Get the workflow name and description
-    workflow_name = workflow_name or workflow.__class__.__name__
-    workflow_description = workflow_description or workflow.__doc__
+    workflow_name = workflow_name or workflow_instance.__class__.__name__
+    workflow_description = workflow_description or workflow_instance.__doc__
 
     @app.tool(name=workflow_name, description=workflow_description)
     async def _workflow_tool(run_args: StartEventCLS, context: Context) -> Any:
+        # Determine which workflow instance to use
+        if share_instance:
+            # Use the shared instance (opt-out behavior - NOT RECOMMENDED)
+            wf = workflow_instance
+        else:
+            # SECURE BY DEFAULT: Create a fresh workflow instance for each invocation
+            # This ensures complete isolation between different MCP clients/invocations
+            wf = workflow_factory()
+
         # Handle edge cases where the start event is an Event or a BaseModel
         # If the workflow does not have a custom StartEvent class, then we need to handle the event differently
 
-        if isinstance(run_args, Event) and workflow._start_event_class != StartEvent:
-            handler = workflow.run(start_event=run_args)
+        if isinstance(run_args, Event) and wf._start_event_class != StartEvent:
+            handler = wf.run(start_event=run_args)
         elif isinstance(run_args, BaseModel):
-            handler = workflow.run(**run_args.model_dump())
+            handler = wf.run(**run_args.model_dump())
         elif isinstance(run_args, dict):
             start_event = StartEventCLS.model_validate(run_args)
-            handler = workflow.run(start_event=start_event)
+            handler = wf.run(start_event=start_event)
         else:
             raise ValueError(f"Invalid start event type: {type(run_args)}")
 


### PR DESCRIPTION
Add share_instance parameter (default False) to create fresh workflow instances per invocation, preventing cross-tenant data leakage.

- Secure by default: creates new instance for each MCP tool call
- Supports classes, instances, and factory callables
- Deprecation warning when passing instances
- Opt-out via share_instance=True for legacy behavior

# Description

Fixes cross-tenant data leakage in workflow_as_mcp by creating fresh workflow instances per invocation instead of sharing state.

Added share_instance parameter (default False) for secure-by-default behavior. Supports classes, instances, and factory callables.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Manually tested with reproduction case from Issue #22071:
  - Verified secure-by-default behavior (no state pollution)
  - Verified lambda factory preserves init params
  - Verified opt-out with share_instance=True


## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
