### PR TITLE
feat(ingestion): add async stream retry and rate-limit interceptor

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/interceptors/__init__.py
+++ b/llama-index-core/llama_index/core/ingestion/interceptors/__init__.py
@@ -1,0 +1,3 @@
+from .async_stream_retry import AsyncStreamRetryInterceptor
+
+__all__ = ["AsyncStreamRetryInterceptor"]

--- a/llama-index-core/llama_index/core/ingestion/interceptors/async_stream_retry.py
+++ b/llama-index-core/llama_index/core/ingestion/interceptors/async_stream_retry.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any, AsyncIterator, Callable, Optional, Sequence, Union
+
+
+class AsyncStreamRetryInterceptor:
+    """Wrap an async iterator producer and retry on transient failures.
+
+    - Exponential backoff with jitter for exceptions and HTTP-like status codes
+    - Intended for vector DB ingestion streams (batches/chunks)
+    - Opt-in: import and use explicitly in pipelines
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        backoff_base: float = 0.2,
+        backoff_factor: float = 2.0,
+        max_backoff: float = 5.0,
+        jitter: float = 0.5,
+        retry_statuses: Sequence[int] = (429, 500, 502, 503, 504),
+        retry_exceptions: Sequence[type[BaseException]] = (TimeoutError, OSError),
+    ) -> None:
+        self.max_retries = max_retries
+        self.backoff_base = backoff_base
+        self.backoff_factor = backoff_factor
+        self.max_backoff = max_backoff
+        self.jitter = jitter
+        self.retry_statuses = set(retry_statuses)
+        self.retry_exceptions = tuple(retry_exceptions)
+
+    async def run(
+        self,
+        producer: Union[Callable[[], AsyncIterator[Any]], AsyncIterator[Any]],
+    ) -> AsyncIterator[Any]:
+        attempt = 0
+        while True:
+            try:
+                ait = producer() if callable(producer) else producer
+                async for item in ait:
+                    yield item
+                return  # completed successfully
+            except Exception as exc:  # noqa: BLE001 - propagate when not retryable
+                if attempt >= self.max_retries or not self._is_retryable(exc):
+                    raise
+                attempt += 1
+                delay = self._compute_backoff(attempt, exc)
+                await asyncio.sleep(delay)
+
+    def _is_retryable(self, exc: BaseException) -> bool:
+        if isinstance(exc, self.retry_exceptions):
+            return True
+        # HTTP-like errors: look for common attributes
+        status = getattr(exc, "status", None) or getattr(exc, "code", None)
+        if isinstance(status, int) and status in self.retry_statuses:
+            return True
+        # response-like container
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            s = getattr(resp, "status", None) or getattr(resp, "status_code", None)
+            if isinstance(s, int) and s in self.retry_statuses:
+                return True
+        return False
+
+    def _retry_after(self, exc: BaseException) -> Optional[float]:
+        # Honor explicit retry_after attributes when present
+        ra = getattr(exc, "retry_after", None)
+        try:
+            return float(ra) if ra is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _compute_backoff(self, attempt: int, exc: BaseException) -> float:
+        ra = self._retry_after(exc)
+        base = min(self.max_backoff, self.backoff_base * (self.backoff_factor ** (attempt - 1)))
+        if ra is not None:
+            base = max(base, ra)
+        if self.jitter > 0:
+            jitter_span = base * self.jitter
+            return max(0.0, base - jitter_span + random.random() * 2 * jitter_span)
+        return max(0.0, base)

--- a/llama-index-core/tests/ingestion/test_async_stream_retry_interceptor.py
+++ b/llama-index-core/tests/ingestion/test_async_stream_retry_interceptor.py
@@ -1,0 +1,37 @@
+import pytest
+
+from llama_index.core.ingestion.interceptors import AsyncStreamRetryInterceptor
+
+
+class FlakyError(Exception):
+    status = 503
+
+
+def flaky_producer_factory(failures: int):
+    calls = {"n": 0}
+
+    async def _gen():
+        calls["n"] += 1
+        if calls["n"] <= failures:
+            raise FlakyError("temporary outage")
+        yield 1
+        yield 2
+
+    return _gen
+
+
+@pytest.mark.asyncio
+async def test_recovers_after_transient_failures():
+    interceptor = AsyncStreamRetryInterceptor(max_retries=3, backoff_base=0.01, max_backoff=0.05, jitter=0.0)
+    results = []
+    async for item in interceptor.run(flaky_producer_factory(failures=2)):
+        results.append(item)
+    assert results == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_gives_up_when_exceeding_retries():
+    interceptor = AsyncStreamRetryInterceptor(max_retries=1, backoff_base=0.01, jitter=0.0)
+    with pytest.raises(FlakyError):
+        async for _ in interceptor.run(flaky_producer_factory(failures=3)):
+            pass


### PR DESCRIPTION
Add an opt-in async stream interceptor for ingestion pipelines that retries transient failures with exponential backoff and honors rate-limit semantics (e.g., 429/503, optional retry_after). Includes unit tests for transient recovery and give-up behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>