### PR TITLE
fix(postgres): bind metadata filter keys instead of interpolating into SQL

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import uuid
 from typing import (
     Any,
     Dict,
@@ -690,9 +691,10 @@ class PGVectorStore(BasePydanticVectorStore):
     def _build_filter_clause(self, filter_: MetadataFilter) -> Any:
         # Bind the metadata key as a SQL parameter so that keys coming from
         # untrusted sources (e.g. an agent choosing which field to filter on)
-        # cannot alter the query.  A unique parameter name per filter object
-        # avoids collisions when multiple clauses are combined with AND/OR.
-        key_param = f"mkey_{id(filter_)}"
+        # cannot alter the query. Use a UUID rather than an object id so the
+        # uniqueness does not depend on CPython object lifetimes. This matches
+        # the parameter naming scheme used by the companion value-binding fix.
+        key_param = f"filter_key_{uuid.uuid4().hex}"
 
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
             # Expects a single value in the metadata, and a list to compare

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/llama_index/vector_stores/postgres/base.py
@@ -688,6 +688,12 @@ class PGVectorStore(BasePydanticVectorStore):
             return "="
 
     def _build_filter_clause(self, filter_: MetadataFilter) -> Any:
+        # Bind the metadata key as a SQL parameter so that keys coming from
+        # untrusted sources (e.g. an agent choosing which field to filter on)
+        # cannot alter the query.  A unique parameter name per filter object
+        # avoids collisions when multiple clauses are combined with AND/OR.
+        key_param = f"mkey_{id(filter_)}"
+
         if filter_.operator in [FilterOperator.IN, FilterOperator.NIN]:
             # Expects a single value in the metadata, and a list to compare
 
@@ -696,10 +702,10 @@ class PGVectorStore(BasePydanticVectorStore):
             filter_value = ", ".join(f"'{e}'" for e in filter_.value)
 
             return text(
-                f"metadata_->>'{filter_.key}' "
+                f"metadata_->>:{key_param} "
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"({filter_value})"
-            )
+            ).bindparams(**{key_param: filter_.key})
         elif filter_.operator in [FilterOperator.ANY, FilterOperator.ALL]:
             # Expects a text array stored in the metadata, and a list of values to compare
             # Works with text[] arrays using PostgreSQL ?| (ANY) and ?& (ALL) operators
@@ -707,49 +713,49 @@ class PGVectorStore(BasePydanticVectorStore):
             filter_value = ", ".join(f"'{e}'" for e in filter_.value)
 
             return text(
-                f"metadata_::jsonb->'{filter_.key}' "
+                f"metadata_::jsonb->:{key_param} "
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"array[{filter_value}]"
-            )
+            ).bindparams(**{key_param: filter_.key})
         elif filter_.operator == FilterOperator.CONTAINS:
             # Expects a list stored in the metadata, and a single value to compare
             return text(
-                f"metadata_::jsonb->'{filter_.key}' "
+                f"metadata_::jsonb->:{key_param} "
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"'[\"{filter_.value}\"]'"
-            )
+            ).bindparams(**{key_param: filter_.key})
         elif (
             filter_.operator == FilterOperator.TEXT_MATCH
             or filter_.operator == FilterOperator.TEXT_MATCH_INSENSITIVE
         ):
             # Where the operator is text_match or ilike, we need to wrap the filter in '%' characters
             return text(
-                f"metadata_->>'{filter_.key}' "
+                f"metadata_->>:{key_param} "
                 f"{self._to_postgres_operator(filter_.operator)} "
                 f"'%{filter_.value}%'"
-            )
+            ).bindparams(**{key_param: filter_.key})
         elif filter_.operator == FilterOperator.IS_EMPTY:
             # Where the operator is is_empty, we need to check if the metadata is null
             return text(
-                f"metadata_->>'{filter_.key}' "
+                f"metadata_->>:{key_param} "
                 f"{self._to_postgres_operator(filter_.operator)}"
-            )
+            ).bindparams(**{key_param: filter_.key})
         else:
             # Check if value is a number. If so, cast the metadata value to a float
             # This is necessary because the metadata is stored as a string
             try:
                 return text(
-                    f"(metadata_->>'{filter_.key}')::float "
+                    f"(metadata_->>:{key_param})::float "
                     f"{self._to_postgres_operator(filter_.operator)} "
                     f"{float(filter_.value)}"
-                )
+                ).bindparams(**{key_param: filter_.key})
             except ValueError:
                 # If not a number, then treat it as a string
                 return text(
-                    f"metadata_->>'{filter_.key}' "
+                    f"metadata_->>:{key_param} "
                     f"{self._to_postgres_operator(filter_.operator)} "
                     f"'{filter_.value}'"
-                )
+                ).bindparams(**{key_param: filter_.key})
 
     def _recursively_apply_filters(self, filters: List[MetadataFilters]) -> Any:
         """

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -3231,7 +3231,8 @@ async def test_mmr_query_filters_out_empty_embeddings_in_mixed_results(use_async
 
 
 def _bare_store() -> PGVectorStore:
-    """Instantiate PGVectorStore without running __init__ (no DB needed).
+    """
+    Instantiate PGVectorStore without running __init__ (no DB needed).
 
     _build_filter_clause / _to_postgres_operator are stateless with respect to
     instance attributes, so a bare instance is enough to exercise them.
@@ -3267,8 +3268,12 @@ def test_filter_key_is_bound_not_interpolated(operator):
     store = _bare_store()
     malicious_key = "author' = 'alice' OR '1'='1' --"
 
-    if operator in (FilterOperator.IN, FilterOperator.NIN,
-                    FilterOperator.ANY, FilterOperator.ALL):
+    if operator in (
+        FilterOperator.IN,
+        FilterOperator.NIN,
+        FilterOperator.ANY,
+        FilterOperator.ALL,
+    ):
         value = ["a", "b"]
     elif operator == FilterOperator.IS_EMPTY:
         value = None
@@ -3285,18 +3290,18 @@ def test_filter_key_is_bound_not_interpolated(operator):
     assert "OR '1'='1'" not in sql
     assert malicious_key not in sql
     # The key is referenced through a bind parameter instead.
-    assert ":mkey_" in sql
+    assert ":filter_key_" in sql
     # And the bound value is exactly the (malicious) key, safely parameterized.
-    bound = list(clause._bindparams.values())[0]
+    bound = next(iter(clause._bindparams.values()))
     assert bound.value == malicious_key
 
 
 def test_filter_key_param_names_are_unique_across_filters():
-    """Combined filters must not collide on the key bind-parameter name.
+    """
+    Combined filters must not collide on the key bind-parameter name.
 
-    Filters combined via AND/OR are held simultaneously in a MetadataFilters
-    list, so their object ids (used to name the bind parameter) are distinct.
-    We keep both alive here to mirror that real usage.
+    Filters combined via AND/OR each receive a UUID-based key parameter, so
+    their names are distinct without depending on object lifetimes.
     """
     store = _bare_store()
     f1 = MetadataFilter(key="k1", value="v1", operator=FilterOperator.EQ)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-postgres/tests/test_postgres.py
@@ -3220,3 +3220,91 @@ async def test_mmr_query_filters_out_empty_embeddings_in_mixed_results(use_async
     assert "e1" not in result.ids
     assert "v1" in result.ids
     assert "v2" in result.ids
+
+
+# ---------------------------------------------------------------------------
+# Metadata filter key parameterization (no database required)
+#
+# Regression tests for SQL injection via MetadataFilter.key: the key must be
+# bound as a SQL parameter, never interpolated into the query string.
+# ---------------------------------------------------------------------------
+
+
+def _bare_store() -> PGVectorStore:
+    """Instantiate PGVectorStore without running __init__ (no DB needed).
+
+    _build_filter_clause / _to_postgres_operator are stateless with respect to
+    instance attributes, so a bare instance is enough to exercise them.
+    """
+    return object.__new__(PGVectorStore)
+
+
+def _compiled(clause) -> str:
+    """Render a SQLAlchemy text clause to its literal SQL string."""
+    return str(clause.compile(compile_kwargs={"literal_binds": False}))
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        FilterOperator.EQ,
+        FilterOperator.NE,
+        FilterOperator.GT,
+        FilterOperator.LT,
+        FilterOperator.GTE,
+        FilterOperator.LTE,
+        FilterOperator.TEXT_MATCH,
+        FilterOperator.TEXT_MATCH_INSENSITIVE,
+        FilterOperator.IS_EMPTY,
+        FilterOperator.CONTAINS,
+        FilterOperator.IN,
+        FilterOperator.NIN,
+        FilterOperator.ANY,
+        FilterOperator.ALL,
+    ],
+)
+def test_filter_key_is_bound_not_interpolated(operator):
+    store = _bare_store()
+    malicious_key = "author' = 'alice' OR '1'='1' --"
+
+    if operator in (FilterOperator.IN, FilterOperator.NIN,
+                    FilterOperator.ANY, FilterOperator.ALL):
+        value = ["a", "b"]
+    elif operator == FilterOperator.IS_EMPTY:
+        value = None
+    else:
+        value = "zzz"
+
+    clause = store._build_filter_clause(
+        MetadataFilter(key=malicious_key, value=value, operator=operator)
+    )
+
+    sql = _compiled(clause)
+
+    # The raw malicious key must never appear verbatim in the SQL text.
+    assert "OR '1'='1'" not in sql
+    assert malicious_key not in sql
+    # The key is referenced through a bind parameter instead.
+    assert ":mkey_" in sql
+    # And the bound value is exactly the (malicious) key, safely parameterized.
+    bound = list(clause._bindparams.values())[0]
+    assert bound.value == malicious_key
+
+
+def test_filter_key_param_names_are_unique_across_filters():
+    """Combined filters must not collide on the key bind-parameter name.
+
+    Filters combined via AND/OR are held simultaneously in a MetadataFilters
+    list, so their object ids (used to name the bind parameter) are distinct.
+    We keep both alive here to mirror that real usage.
+    """
+    store = _bare_store()
+    f1 = MetadataFilter(key="k1", value="v1", operator=FilterOperator.EQ)
+    f2 = MetadataFilter(key="k2", value="v2", operator=FilterOperator.EQ)
+    filters = [f1, f2]  # keep both alive, as MetadataFilters would
+
+    c1 = store._build_filter_clause(filters[0])
+    c2 = store._build_filter_clause(filters[1])
+    p1 = set(c1._bindparams)
+    p2 = set(c2._bindparams)
+    assert p1.isdisjoint(p2)


### PR DESCRIPTION
## Summary

Fixes #22475.

`PGVectorStore._build_filter_clause` interpolated `filter_.key` directly into the SQL string in every operator branch:

```python
f"metadata_->>'{filter_.key}' = ..."
```

A key containing a single quote therefore altered the query. Every in-tree caller passes a literal key today, so this is not reachable through normal use — but it becomes a SQL injection as soon as a key comes from an untrusted source (for example, an agent tool that lets a model choose which metadata field to filter on).

## Fix

Bind the key as a SQL parameter in all branches:

```python
key_param = f"filter_key_{uuid.uuid4().hex}"
text(f"metadata_->>:{key_param} ...").bindparams(**{key_param: filter_.key})
```

The UUID-based parameter name avoids collisions when multiple clauses are combined and does not depend on CPython object lifetimes. It follows the naming approach used by the companion value-binding fix in #22471.

This PR intentionally fixes the key path only. The value interpolation paths are the scope of #22471, which remains open; the two changes should land together (or be folded into one PR) before treating the complete filter surface as parameterized.

## Tests

Added DB-free regression tests (no PostgreSQL required) that:

- [x] assert a malicious key (`author' = 'alice' OR '1'='1' --`) never appears verbatim in the rendered SQL for every operator (EQ/NE/GT/LT/GTE/LTE/TEXT_MATCH/ILIKE/IS_EMPTY/CONTAINS/IN/NIN/ANY/ALL)
- [x] assert the key is carried as a bound parameter
- [x] assert generated UUID bind-parameter names are unique across combined filters
- [ ] coordinate merge order with #22471 so the value and key paths land together

```text
$ pytest tests/test_postgres.py -k filter_key -q
15 passed
```
