### PR TITLE
feat(chat-store-postgres): expose SQLAlchemy engine params via `create_engine_kwargs`

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/llama_index/storage/chat_store/postgres/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from sqlalchemy import (
@@ -75,6 +75,14 @@ class PostgresChatStore(BaseChatStore):
     schema_name: Optional[str] = Field(
         default="public", description="Postgres schema name."
     )
+    create_engine_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Additional keyword arguments to pass to SQLAlchemy's "
+            "create_engine and create_async_engine (e.g. pool_size, "
+            "pool_pre_ping, connect_args)."
+        ),
+    )
 
     _table_class: Optional[Any] = PrivateAttr()
     _session: Optional[sessionmaker] = PrivateAttr()
@@ -82,16 +90,36 @@ class PostgresChatStore(BaseChatStore):
 
     def __init__(
         self,
-        session: sessionmaker,
-        async_session: sessionmaker,
-        table_name: str,
+        session: Optional[sessionmaker] = None,
+        async_session: Optional[sessionmaker] = None,
+        table_name: str = "chatstore",
         schema_name: str = "public",
         use_jsonb: bool = False,
+        connection_string: Optional[str] = None,
+        async_connection_string: Optional[str] = None,
+        debug: bool = False,
+        create_engine_kwargs: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             table_name=table_name.lower(),
             schema_name=schema_name.lower(),
+            create_engine_kwargs=create_engine_kwargs or {},
         )
+
+        # Build the sessions from connection strings when they are not provided
+        # directly, forwarding any extra create_engine_kwargs to the engines.
+        if session is None or async_session is None:
+            if connection_string is None or async_connection_string is None:
+                raise ValueError(
+                    "Either `session` and `async_session`, or `connection_string` "
+                    "and `async_connection_string`, must be provided."
+                )
+            session, async_session = self._connect(
+                connection_string,
+                async_connection_string,
+                debug,
+                self.create_engine_kwargs,
+            )
 
         # Check if legacy table (with 'data_' prefix) exists
         use_legacy_table_name = self._check_legacy_table_exists(
@@ -125,6 +153,7 @@ class PostgresChatStore(BaseChatStore):
         async_connection_string: Optional[str] = None,
         debug: bool = False,
         use_jsonb: bool = False,
+        create_engine_kwargs: Optional[Dict[str, Any]] = None,
     ) -> "PostgresChatStore":
         """Return connection string from database parameters."""
         conn_str = (
@@ -134,13 +163,14 @@ class PostgresChatStore(BaseChatStore):
         async_conn_str = async_connection_string or (
             f"postgresql+asyncpg://{user}:{password}@{host}:{port}/{database}"
         )
-        session, async_session = cls._connect(conn_str, async_conn_str, debug)
         return cls(
-            session=session,
-            async_session=async_session,
             table_name=table_name,
             schema_name=schema_name,
             use_jsonb=use_jsonb,
+            connection_string=conn_str,
+            async_connection_string=async_conn_str,
+            debug=debug,
+            create_engine_kwargs=create_engine_kwargs,
         )
 
     @classmethod
@@ -151,6 +181,7 @@ class PostgresChatStore(BaseChatStore):
         schema_name: str = "public",
         debug: bool = False,
         use_jsonb: bool = False,
+        create_engine_kwargs: Optional[Dict[str, Any]] = None,
     ) -> "PostgresChatStore":
         """Return connection string from database parameters."""
         params = params_from_uri(uri)
@@ -160,16 +191,24 @@ class PostgresChatStore(BaseChatStore):
             schema_name=schema_name,
             debug=debug,
             use_jsonb=use_jsonb,
+            create_engine_kwargs=create_engine_kwargs,
         )
 
     @classmethod
     def _connect(
-        cls, connection_string: str, async_connection_string: str, debug: bool
+        cls,
+        connection_string: str,
+        async_connection_string: str,
+        debug: bool,
+        create_engine_kwargs: Optional[Dict[str, Any]] = None,
     ) -> tuple[sessionmaker, sessionmaker]:
-        _engine = create_engine(connection_string, echo=debug)
+        create_engine_kwargs = create_engine_kwargs or {}
+        _engine = create_engine(connection_string, echo=debug, **create_engine_kwargs)
         session = sessionmaker(_engine)
 
-        _async_engine = create_async_engine(async_connection_string)
+        _async_engine = create_async_engine(
+            async_connection_string, **create_engine_kwargs
+        )
         async_session = sessionmaker(_async_engine, class_=AsyncSession)
         return session, async_session
 

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
@@ -1,5 +1,6 @@
 import time
 from typing import Dict, Generator, Union
+from unittest.mock import MagicMock, patch
 
 import pytest
 import docker
@@ -25,6 +26,43 @@ except ImportError:
 def test_class():
     names_of_base_classes = [b.__name__ for b in PostgresChatStore.__mro__]
     assert BaseChatStore.__name__ in names_of_base_classes
+
+
+@pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
+def test_engine_kwargs_forwarded_to_sqlalchemy():
+    mock_engine = MagicMock()
+    mock_async_engine = MagicMock()
+
+    with (
+        patch(
+            "llama_index.storage.chat_store.postgres.base.create_engine",
+            return_value=mock_engine,
+        ) as mock_ce,
+        patch(
+            "llama_index.storage.chat_store.postgres.base.create_async_engine",
+            return_value=mock_async_engine,
+        ) as mock_cae,
+        patch.object(
+            PostgresChatStore, "_check_legacy_table_exists", return_value=False
+        ),
+        patch.object(PostgresChatStore, "_initialize", return_value=None),
+    ):
+        PostgresChatStore(
+            table_name="test_table",
+            schema_name="test_schema",
+            connection_string="postgresql+psycopg://user:pass@localhost/db",
+            async_connection_string="postgresql+asyncpg://user:pass@localhost/db",
+            create_engine_kwargs={"connect_args": {"timeout": 123}},
+        )
+
+    mock_ce.assert_called_once()
+    _, ce_kwargs = mock_ce.call_args
+    assert ce_kwargs["echo"] is False
+    assert ce_kwargs["connect_args"] == {"timeout": 123}
+
+    mock_cae.assert_called_once()
+    _, cae_kwargs = mock_cae.call_args
+    assert cae_kwargs["connect_args"] == {"timeout": 123}
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This exposes SQLAlchemy engine parameters for the Postgres chat store so that callers can configure database client behavior such as connection timeouts and pooling (for example, asyncpg's timeout via connect_args).

This mirrors the equivalent support already added for the Postgres key-value and document stores (#20951).

## Changes

- Add `create_engine_kwargs` to `PostgresChatStore` and wire it through `__init__`/`from_params`/`from_uri`. Engine construction now happens in `__init__` (`session`/`async_session` remain optional overrides for backward compatibility), so the kwargs reach both the sync and async engines.
- Add a unit test ensuring create_engine_kwargs are forwarded to `sqlalchemy.create_engine` and `sqlalchemy.ext.asyncio.create_async_engine`.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
