### PR TITLE
Update LlamaIndex Cerebras examples

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cerebras/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/README.md
@@ -44,7 +44,7 @@ import os
 from llama_index.core.llms import ChatMessage
 from llama_index.llms.cerebras import Cerebras
 
-llm = Cerebras(model="llama-3.3-70b", api_key=os.environ["CEREBRAS_API_KEY"])
+llm = Cerebras(model="gpt-oss-120b", api_key=os.environ["CEREBRAS_API_KEY"])
 
 messages = [
     ChatMessage(
@@ -63,7 +63,7 @@ import os
 
 from llama_index.llms.cerebras import Cerebras
 
-llm = Cerebras(model="llama-3.3-70b", api_key=os.environ["CEREBRAS_API_KEY"])
+llm = Cerebras(model="gpt-oss-120b", api_key=os.environ["CEREBRAS_API_KEY"])
 
 response = llm.stream_complete("What is Generative AI?")
 for r in response:

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
@@ -15,7 +15,7 @@ class Cerebras(OpenAILike):
         from llama_index.llms.cerebras import Cerebras
 
         # Set up the Cerebras class with the required model and API key
-        llm = Cerebras(model="llama-3.3-70b", api_key="your_api_key")
+        llm = Cerebras(model="gpt-oss-120b", api_key="your_api_key")
 
         # Call the complete method with a query
         response = llm.complete("Why is fast inference important?")

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/tests/test_integration_cerebras.py
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/tests/test_integration_cerebras.py
@@ -7,14 +7,14 @@ from llama_index.llms.cerebras import Cerebras
 
 @pytest.mark.skipif("CEREBRAS_API_KEY" not in os.environ, reason="No Cerebras API key")
 def test_completion():
-    cerebras = Cerebras(model="llama3.1-8b")
+    cerebras = Cerebras(model="gpt-oss-120b")
     resp = cerebras.complete("What color is the sky? Answer in one word.")
     assert resp.text == "Blue."
 
 
 @pytest.mark.skipif("CEREBRAS_API_KEY" not in os.environ, reason="No Cerebras API key")
 def test_stream_completion():
-    cerebras = Cerebras(model="llama3.1-8b")
+    cerebras = Cerebras(model="gpt-oss-120b")
     stream = cerebras.stream_complete(
         "What is 123 + 456? Embed the answer in the stories of the three little pigs"
     )


### PR DESCRIPTION
## Summary

- Moves the Cerebras README, class example, and live integration tests from retired Llama models to gpt-oss-120b.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

## Validation

- Python syntax parsing, git diff check, and comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models