### PR TITLE
fix(reader-file): normalize required extensions and file suffixes for case‑insensitivity

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -278,7 +278,7 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         self.recursive = recursive
         self.exclude_hidden = exclude_hidden
         self.exclude_empty = exclude_empty
-        self.required_exts = required_exts
+        self.required_exts = self._get_norm_exts(required_exts)
         self.num_files_limit = num_files_limit
         self.raise_on_error = raise_on_error
         _Path = Path if is_default_fs(self.fs) else PurePosixPath
@@ -300,6 +300,14 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
         self.file_extractor = file_extractor or {}
         self.file_metadata = file_metadata or _DefaultFileMetadataFunc(self.fs)
         self.filename_as_id = filename_as_id
+
+    @staticmethod
+    def _get_norm_exts(
+        required_exts: Optional[list[str]] = None,
+    ) -> Optional[list[str]]:
+        if required_exts is not None:
+            return [ext.lower() for ext in required_exts]
+        return None
 
     def is_hidden(self, path: Path | PurePosixPath) -> bool:
         return any(
@@ -389,7 +397,8 @@ class SimpleDirectoryReader(BaseReader, ResourcesReaderMixin, FileSystemReaderMi
             skip_because_hidden = self.exclude_hidden and self.is_hidden(ref)
             skip_because_empty = self.exclude_empty and self.is_empty_file(ref)
             skip_because_bad_ext = (
-                self.required_exts is not None and ref.suffix not in self.required_exts
+                self.required_exts is not None
+                and ref.suffix.lower() not in self.required_exts
             )
             skip_because_excluded = ref in rejected_files
             if not skip_because_excluded:

--- a/llama-index-core/tests/readers/file/test_base.py
+++ b/llama-index-core/tests/readers/file/test_base.py
@@ -82,6 +82,54 @@ def test_SimpleDirectoryReader_recursive(data_path):
     ]
 
 
+def test_SimpleDirectoryReader_required_exts_case_insensitive(data_path):
+    # stored extensions are lower-cased
+    r = SimpleDirectoryReader(input_dir=data_path, required_exts=[".MD", ".TXT"])
+    assert r.required_exts == [".md", ".txt"]
+    # only .md / .txt files (non-recursive) are kept
+    assert [f.name for f in r.input_files] == ["excluded_0.txt", "file_0.md"]
+
+    # uppercase required_exts still match lowercase file suffixes
+    r = SimpleDirectoryReader(
+        input_dir=data_path, recursive=True, required_exts=[".MD"]
+    )
+    assert [f.name for f in r.input_files] == ["file_0.md"]
+
+
+def test_SimpleDirectoryReader_required_exts_uppercase_file_suffix(data_path):
+    """Lowercase required_exts must match files with uppercase on-disk suffixes."""
+    # mock the filesystem so the walk reports a file named "file_0.MD"
+    # (uppercase suffix), while is_default_fs keeps the Path-based suffix logic.
+    fake_fs = mock.MagicMock()
+    # isdir distinguishes the (existing) input dir from files inside it
+    fake_fs.isdir = lambda p: str(p) == str(data_path)
+    fake_fs.is_dir = lambda p: False
+    fake_fs.walk.return_value = [(str(data_path), [], ["file_0.MD"])]
+    fake_fs.glob.return_value = []
+    fake_fs.info.return_value = {"size": 16, "type": "file"}
+    fake_fs._parent.return_value = str(data_path)
+    fake_fs.isfile.return_value = True
+
+    r = SimpleDirectoryReader(input_dir=data_path, required_exts=[".md"], fs=fake_fs)
+    # the file with uppercase suffix is still picked up
+    assert [f.name for f in r.input_files] == ["file_0.MD"]
+
+
+def test_SimpleDirectoryReader_required_exts_empty_list(data_path):
+    """An empty required_exts list selects nothing (preserves prior behavior)."""
+    # constructing with an empty list filters out every file and raises,
+    # rather than treating [] as "no filter" (which would ingest the whole tree)
+    with pytest.raises(ValueError, match="No files found in"):
+        SimpleDirectoryReader(input_dir=data_path, required_exts=[])
+
+
+def test__get_norm_exts():
+    assert SimpleDirectoryReader._get_norm_exts(None) is None
+    # empty list stays an empty list, not None (so [] still filters out all files)
+    assert SimpleDirectoryReader._get_norm_exts([]) == []
+    assert SimpleDirectoryReader._get_norm_exts([".MD", ".Txt"]) == [".md", ".txt"]
+
+
 def test_SimpleDirectoryReader_excluded(data_path):
     r = SimpleDirectoryReader(input_dir=data_path, exclude=["excluded*"])
     assert [f.name for f in r.input_files] == ["file_0.md", "file_0.xyz"]


### PR DESCRIPTION

# Description

**Normalize required extensions and file suffixes for case‑insensitivity**

Add `_get_norm_exts` helper to lowercase required extensions at init. Update filter logic to compare lower‑cased file suffixes at runtime against normalized extensions.
Add tests for case‑insensitive required_exts handling. Add test ensuring files with uppercase on‑disk suffixes are included.

Fixes # (issue)

SimpleDirectoryReader previously compared file suffixes (ref.suffix) against required_exts verbatim, making the match case-sensitive. On case-insensitive filesystems such as Windows, this caused files with uppercase suffixes (e.g. 1.PDF, 2.MD) to be missed, regardless of whether the caller passed upper- or lower-case required_exts.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
