### PR TITLE
fix: account for merging_separator length in SemanticDoubleMergingSplitter size guards

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -256,19 +256,23 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
 
     def _create_initial_chunks(self, sentences: List[str]) -> List[str]:
         initial_chunks: List[str] = []
+        # Every join below inserts one `merging_separator`, so the size guards have to account
+        # for its real length instead of assuming a single character.
+        separator_len = len(self.merging_separator)
         chunk = sentences[0]
         new = True
         for sentence in sentences[1:]:
             if new:
                 if (
                     self._similarity(chunk, sentence) < self.initial_threshold
-                    and len(chunk) + len(sentence) + 1 <= self.max_chunk_size
+                    and len(chunk) + len(sentence) + separator_len
+                    <= self.max_chunk_size
                 ):
                     initial_chunks.append(chunk)
                     chunk = sentence
                     continue
                 chunk_sentences = [chunk]
-                if len(chunk) + len(sentence) + 1 <= self.max_chunk_size:
+                if len(chunk) + len(sentence) + separator_len <= self.max_chunk_size:
                     chunk_sentences.append(sentence)
                     chunk = self.merging_separator.join(chunk_sentences)
                     new = False
@@ -280,7 +284,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
                 last_sentences = self.merging_separator.join(chunk_sentences[-2:])
             elif (
                 self._similarity(last_sentences, sentence) > self.appending_threshold
-                and len(chunk) + len(sentence) + 1 <= self.max_chunk_size
+                and len(chunk) + len(sentence) + separator_len <= self.max_chunk_size
             ):
                 chunk_sentences.append(sentence)
                 last_sentences = self.merging_separator.join(chunk_sentences[-2:])
@@ -294,6 +298,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
 
     def _merge_initial_chunks(self, initial_chunks: List[str]) -> List[str]:
         chunks: List[str] = []
+        separator_len = len(self.merging_separator)
         skip = 0
         current = initial_chunks[0]
         for i in range(1, len(initial_chunks)):
@@ -305,7 +310,8 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
                 current = initial_chunks[i]
             elif (
                 self._similarity(current, initial_chunks[i]) > self.merging_threshold
-                and len(current) + len(initial_chunks[i]) + 1 <= self.max_chunk_size
+                and len(current) + len(initial_chunks[i]) + separator_len
+                <= self.max_chunk_size
             ):
                 current += self.merging_separator + initial_chunks[i]
             elif (
@@ -315,7 +321,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
                 and len(current)
                 + len(initial_chunks[i])
                 + len(initial_chunks[i + 1])
-                + 2
+                + 2 * separator_len
                 <= self.max_chunk_size
             ):
                 current += (
@@ -334,7 +340,7 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
                 + len(initial_chunks[i])
                 + len(initial_chunks[i + 1])
                 + len(initial_chunks[i + 2])
-                + 3
+                + 3 * separator_len
                 <= self.max_chunk_size
             ):
                 current += (

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -156,3 +156,43 @@ def test_clean_text_advanced() -> None:
         "this is a test text containing some stopwords like the and a"
     )
     assert cleaned == "test text containing stopwords like"
+
+
+class _AlwaysSimilarSplitter(SemanticDoubleMergingSplitterNodeParser):
+    """Similarity is pinned so only the chunk-size arithmetic decides where chunks end."""
+
+    def _similarity(self, text_a: str, text_b: str) -> float:
+        return 1.0
+
+
+def test_multi_character_merging_separator_respects_max_chunk_size() -> None:
+    """A separator longer than one character must not push merged chunks over max_chunk_size."""
+    max_chunk_size = 100
+    separator = "\n\n---\n\n"
+
+    splitter = _AlwaysSimilarSplitter(
+        max_chunk_size=max_chunk_size, merging_separator=separator, merging_range=1
+    )
+
+    # 50 + 49 + len(" ") == 100, so the old guard treated this as a fit.
+    merged = splitter._merge_initial_chunks(["A" * 50, "B" * 49])
+    assert max(len(chunk) for chunk in merged) <= max_chunk_size
+
+    created = splitter._create_initial_chunks(["A" * 50, "B" * 20, "C" * 20])
+    assert max(len(chunk) for chunk in created) <= max_chunk_size
+
+
+@pytest.mark.parametrize("separator_len", [1, 2, 4, 8, 16])
+def test_merging_never_exceeds_max_chunk_size(separator_len: int) -> None:
+    """Sweep the boundary for a range of separator lengths."""
+    max_chunk_size = 100
+    splitter = _AlwaysSimilarSplitter(
+        max_chunk_size=max_chunk_size,
+        merging_separator="s" * separator_len,
+        merging_range=1,
+    )
+
+    for first in range(1, max_chunk_size - 1):
+        second = max_chunk_size - first - 1
+        merged = splitter._merge_initial_chunks(["A" * first, "B" * second])
+        assert max(len(chunk) for chunk in merged) <= max_chunk_size


### PR DESCRIPTION
# Description

`SemanticDoubleMergingSplitterNodeParser` checks whether a merge will fit inside `max_chunk_size` by adding a literal `1`, `2` or `3` for the separators the join is about to insert:

```python
if len(chunk) + len(sentence) + 1 <= self.max_chunk_size:
    ...
    chunk = self.merging_separator.join(chunk_sentences)
```

That held while the separator was hard-coded to a single space. `merging_separator` became configurable in #18027 and these constants weren't updated, so any separator longer than one character makes the guard under-count and the resulting chunk goes over `max_chunk_size`.

Six guards are affected: three in `_create_initial_chunks`, three in `_merge_initial_chunks` (`+ 1`, `+ 2`, `+ 3` for the one-, two- and three-way merges).

Reproduced with `_similarity` stubbed to `1.0`, so only the size arithmetic decides where chunks end. `max_chunk_size=100`, `merging_range=1`, sweeping every `["A" * a, "B" * (99 - a)]` pair:

| separator length | worst overshoot before | after |
|---|---|---|
| 1 (default) | 0 | 0 |
| 2 | 1 | 0 |
| 4 | 3 | 0 |
| 8 | 7 | 0 |
| 16 | 15 | 0 |

The overshoot is `len(separator) - 1` per join. It's not bounded at one join either — `_create_initial_chunks` appends sentence by sentence, so it accumulates: `["A" * 50, "B" * 20, "C" * 20]` with a 7-character separator comes back as a single 104-character chunk against `max_chunk_size=100`.

Replaced the literals with `len(self.merging_separator)` (and `2 *` / `3 *` for the multi-way merges).

Fixes # (no open issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_multi_character_merging_separator_respects_max_chunk_size` and `test_merging_never_exceeds_max_chunk_size` (parametrised over separator lengths 1/2/4/8/16) in `llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py`.

Stashing only `semantic_double_merging_splitter.py` gives `5 failed, 5 passed, 6 skipped`; the `[1]` case passes on both sides, which is the point — the default separator is unaffected. With the change: `10 passed, 6 skipped`.

Behaviour on the default separator is unchanged: I ran 300 randomised inputs (2-25 sentences, random lengths, `max_chunk_size` in {50, 100, 200}, `merging_range` in {1, 2}, deterministic stubbed similarity) through `_create_initial_chunks` + `_merge_initial_chunks` before and after, and the outputs are byte-identical.

`ruff check` and `ruff format --check` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
