### PR TITLE
fix(core): pass docstring param descriptions into Pydantic schema at creation time

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -244,11 +244,8 @@ class FunctionTool(AsyncBaseTool):
                     fn_to_parse,
                     additional_fields=None,
                     ignore_fields=ignore_fields,
+                    param_descriptions=param_docs,
                 )
-                if fn_schema is not None and param_docs:
-                    for param_name, field in fn_schema.model_fields.items():
-                        if not field.description and param_name in param_docs:
-                            field.description = param_docs[param_name].strip()
 
             tool_metadata = ToolMetadata(
                 name=name,

--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -25,6 +26,7 @@ def create_schema_from_function(
         List[Union[Tuple[str, Type, Any], Tuple[str, Type]]]
     ] = None,
     ignore_fields: Optional[List[str]] = None,
+    param_descriptions: Optional[Dict[str, str]] = None,
 ) -> Type[BaseModel]:
     """
     Create schema from function.
@@ -32,9 +34,12 @@ def create_schema_from_function(
         - datetime.date -> format: "date"
         - datetime.datetime -> format: "date-time"
         - datetime.time -> format: "time"
+    - ``param_descriptions`` (e.g. parsed from a docstring) are used as a
+      fallback when a param has no ``Annotated``/``Field`` description.
     """
     fields = {}
     ignore_fields = ignore_fields or []
+    param_descriptions = param_descriptions or {}
     params = signature(func).parameters
 
     for param_name in params:
@@ -76,21 +81,40 @@ def create_schema_from_function(
         if param_type is params[param_name].empty:
             param_type = Any
 
+        # Use docstring description as fallback when no Annotated/Field description
+        effective_description = description if description is not None else param_descriptions.get(param_name)
+
         if param_default is params[param_name].empty:
             # Required field
             fields[param_name] = (
                 param_type,
-                FieldInfo(description=description, json_schema_extra=json_schema_extra),
+                FieldInfo(
+                    description=effective_description,
+                    json_schema_extra=json_schema_extra,
+                ),
             )
         elif isinstance(param_default, FieldInfo):
             # Field with pydantic.Field as default value
-            fields[param_name] = (param_type, param_default)
+            if param_default.description is None and effective_description is not None:
+                # Merge docstring description into the existing FieldInfo
+                fields[param_name] = (
+                    param_type,
+                    FieldInfo(
+                        default=param_default.default,
+                        default_factory=param_default.default_factory,
+                        description=effective_description,
+                        json_schema_extra=param_default.json_schema_extra,
+                        alias=param_default.alias,
+                    ),
+                )
+            else:
+                fields[param_name] = (param_type, param_default)
         else:
             fields[param_name] = (
                 param_type,
                 FieldInfo(
                     default=param_default,
-                    description=description,
+                    description=effective_description,
                     json_schema_extra=json_schema_extra,
                 ),
             )

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -429,6 +429,90 @@ def test_docstring_with_self_and_context():
     assert "self" not in fields
 
 
+def test_docstring_descriptions_reach_json_schema():
+    """Round-trip test: parsed docstring descriptions must survive serialization.
+
+    Regression test for https://github.com/run-llama/llama_index/issues/22413.
+    Previously, descriptions were mutated onto model_fields after Pydantic v2
+    froze the core schema at create_model() time, so model_json_schema() and
+    to_openai_tool() silently dropped them.
+    """
+
+    def tool_fn(query: str, top_k: int = 5) -> str:
+        """Search the web.
+
+        Args:
+            query (str): The search query string.
+            top_k (int): Number of results to return.
+        """
+        return "ok"
+
+    tool = FunctionTool.from_defaults(fn=tool_fn)
+
+    # 1. model_fields must have descriptions (internal state)
+    fields = tool.metadata.fn_schema.model_fields
+    assert fields["query"].description == "The search query string."
+    assert fields["top_k"].description == "Number of results to return."
+
+    # 2. model_json_schema must also have descriptions (serialized output)
+    schema = tool.metadata.fn_schema.model_json_schema()
+    props = schema["properties"]
+    assert props["query"]["description"] == "The search query string."
+    assert props["top_k"]["description"] == "Number of results to return."
+
+    # 3. to_openai_tool() must also have descriptions (LLM-facing output)
+    oai_props = tool.metadata.to_openai_tool()["function"]["parameters"]["properties"]
+    assert oai_props["query"]["description"] == "The search query string."
+    assert oai_props["top_k"]["description"] == "Number of results to return."
+
+
+def test_docstring_descriptions_reach_json_schema_sphinx_style():
+    """Sphinx-style docstring descriptions must also survive serialization."""
+
+    def tool_fn(a: int, b: str = "default") -> str:
+        """
+        Test tool.
+
+        :param a: integer input value
+        :param b: string input value
+        """
+        return f"{a}-{b}"
+
+    tool = FunctionTool.from_defaults(fn=tool_fn)
+    schema = tool.metadata.fn_schema.model_json_schema()
+    props = schema["properties"]
+
+    assert props["a"]["description"] == "integer input value"
+    assert props["b"]["description"] == "string input value"
+
+
+def test_annotated_description_takes_precedence_over_docstring():
+    """Annotated/Field descriptions must not be overridden by docstring descriptions."""
+    from typing import Annotated
+
+    def tool_fn(
+        a: Annotated[int, "Annotated description"],
+        b: str = "default",
+    ) -> str:
+        """
+        Test tool.
+
+        Args:
+            a (int): Docstring description for a.
+            b (str): Docstring description for b.
+        """
+        return f"{a}-{b}"
+
+    tool = FunctionTool.from_defaults(fn=tool_fn)
+    schema = tool.metadata.fn_schema.model_json_schema()
+    props = schema["properties"]
+
+    # Annotated description wins
+    assert props["a"]["description"] == "Annotated description"
+    # Docstring description used as fallback
+    assert props["b"]["description"] == "Docstring description for b."
+
+
 def test_function_tool_output_document_and_nodes():
     def get_document() -> Document:
         return Document(text="Hello" * 1024)


### PR DESCRIPTION
## Problem

`FunctionTool.from_defaults()` parses per-parameter descriptions from the docstring but they never reach the schema sent to the LLM (`to_openai_tool()` / `model_json_schema()`), because they're assigned to `model_fields[...].description` **after** the Pydantic v2 model is built.

Pydantic v2 freezes the core schema at `create_model()` time. `model_json_schema()` reads from the frozen core schema, not from `model_fields`. Mutating `model_fields[...].description` post-construction is a write to a structure the schema generator doesn't read — the descriptions are stored but never emitted.

**Result**: the LLM receives a tool where every parameter has a name + type but no semantic context. For `query: str` the LLM infers intent from the name, but for `top_k: int` (higher = more or less selective?), `threshold: float` (0.9 = strict or lenient?), `mode: str` (what are the valid values?) — the LLM guesses, and the guess is structurally valid but semantically wrong.

Fixes #22413

## Root Cause

In `function_tool.py`:
```python
fn_schema = create_schema_from_function(...)  # Pydantic v2 freezes core schema here
if fn_schema is not None and param_docs:
    for param_name, field in fn_schema.model_fields.items():
        if not field.description and param_name in param_docs:
            field.description = param_docs[param_name].strip()  # write-after-freeze: never read by schema generator
```

## Fix

Pass `param_descriptions` into `create_schema_from_function()` so descriptions land in the `FieldInfo` objects **before** `create_model()` freezes the core schema:

1. **`utils.py`**: Add `param_descriptions` parameter to `create_schema_from_function()`. Use docstring descriptions as fallback when no `Annotated`/`Field` description is present.
2. **`function_tool.py`**: Pass `param_docs` to `create_schema_from_function()`. Remove the post-hoc mutation.

## Tests

Added 3 new tests:
- `test_docstring_descriptions_reach_json_schema`: Round-trip test verifying descriptions survive from docstring → `model_fields` → `model_json_schema()` → `to_openai_tool()` (Google-style docstring)
- `test_docstring_descriptions_reach_json_schema_sphinx_style`: Same round-trip for Sphinx-style docstrings
- `test_annotated_description_takes_precedence_over_docstring`: Verifies `Annotated` descriptions are not overridden by docstring descriptions

All 60 tests in `tests/tools/` pass.

## AI Disclosure

AI-assisted debugging/initial draft/testing with human review of the diff and test scope (per the contribution workflow).