### PR TITLE
fix(core): don't swallow task exceptions in run_async_tasks(show_progress=True) (#22493)

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -93,17 +93,17 @@ def run_async_tasks(
             # we need to reuse it instead of creating a new one
             nest_asyncio.apply()
             loop = asyncio.get_event_loop()
-
-            async def _tqdm_gather() -> List[Any]:
-                return await tqdm.gather(*tasks_to_execute, desc=progress_bar_desc)
-
-            tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
-            return tqdm_outputs
         # run the operation w/o tqdm on hitting a fatal
         # may occur in some environments where tqdm.asyncio
         # is not supported
         except Exception:
             pass
+        else:
+
+            async def _tqdm_gather() -> List[Any]:
+                return await tqdm.gather(*tasks_to_execute, desc=progress_bar_desc)
+
+            return loop.run_until_complete(_tqdm_gather())
 
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+from llama_index.core.async_utils import batch_gather, asyncio_run, run_async_tasks
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +37,20 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_run_async_tasks_propagates_task_exception_with_progress() -> None:
+    """
+    Validate that show_progress does not change which exception reaches
+    the caller: a task failure must surface instead of being swallowed by
+    the tqdm fallback.
+    """
+
+    async def ok() -> int:
+        return 1
+
+    async def fail() -> None:
+        raise ValueError("ORIGINAL task failure")
+
+    with pytest.raises(ValueError, match="ORIGINAL task failure"):
+        run_async_tasks([ok(), fail()], show_progress=True)


### PR DESCRIPTION
## Description

Fixes #22493.

`run_async_tasks` wraps the whole tqdm branch in `except Exception: pass`. The comment shows the intent is to fall back when `tqdm.asyncio` is unsupported, but the `try` also covers the line that actually runs the tasks:

```python
tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
```

So an exception raised by a *task* is swallowed. Execution then falls through to the non-progress path, which re-awaits coroutines that have already been consumed — the caller ends up with `RuntimeError: Detected nested async...` instead of the real failure, and is pointed at `nest_asyncio.apply()`, which `run_async_tasks` already called a few lines above.

On `main` (`c864fcf`):

```python
run_async_tasks([ok(), fail()], show_progress=False)  # ValueError: ORIGINAL task failure
run_async_tasks([ok(), fail()], show_progress=True)   # RuntimeError: Detected nested async...
```

`show_progress` is cosmetic and should not change error semantics.

## Fix

Narrow the `try` to the optional-dependency setup it was written for (`nest_asyncio` / `tqdm.asyncio` import, `nest_asyncio.apply()`, loop lookup) and move task execution into an `else` branch. Environments without `tqdm.asyncio` still fall back exactly as before; task exceptions now propagate.

This mirrors the shape used in #22403 for the sibling `asyncio_run` issue (#22401), but is a different function and code path — the two changes do not overlap.

## Verification

Against `llama-index-core` with the patch applied:

| case | before | after |
|---|---|---|
| `show_progress=False`, task raises | `ValueError: ORIGINAL task failure` | unchanged |
| `show_progress=True`, task raises | `RuntimeError: Detected nested async...` | `ValueError: ORIGINAL task failure` |
| `show_progress=True`, all tasks succeed | `[0, 1, 2]` | `[0, 1, 2]` (progress bar still rendered) |
| `show_progress=True`, `tqdm.asyncio` unimportable | falls back, returns results | unchanged |

Added `test_run_async_tasks_propagates_task_exception_with_progress` to `llama-index-core/tests/test_async_utils.py`. It fails on `main` (`RuntimeError`) and passes with this change; the file's existing tests still pass (`3 passed`, run with `-W error::RuntimeWarning`).

`ruff@0.11.8` (the pinned pre-commit version) `check` and `format --check` are clean on both files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
