### PR TITLE
fix(core): run_async_tasks no longer swallows task exceptions with show_progress=True

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -85,6 +85,7 @@ def run_async_tasks(
     """Run a list of async tasks."""
     tasks_to_execute: List[Any] = tasks
     if show_progress:
+        tqdm_setup_ok = False
         try:
             import nest_asyncio
             from tqdm.asyncio import tqdm
@@ -97,13 +98,16 @@ def run_async_tasks(
             async def _tqdm_gather() -> List[Any]:
                 return await tqdm.gather(*tasks_to_execute, desc=progress_bar_desc)
 
-            tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
-            return tqdm_outputs
-        # run the operation w/o tqdm on hitting a fatal
+            tqdm_setup_ok = True
+        # fall back to non-tqdm path on import/setup failure
         # may occur in some environments where tqdm.asyncio
         # is not supported
         except Exception:
             pass
+
+        if tqdm_setup_ok:
+            tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
+            return tqdm_outputs
 
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+from llama_index.core.async_utils import batch_gather, asyncio_run, run_async_tasks
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +37,40 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_run_async_tasks_propagates_exceptions_with_progress() -> None:
+    """
+    Regression test: run_async_tasks(show_progress=True) must not swallow
+    task exceptions. Previously the broad ``except Exception: pass`` around
+    the tqdm progress path also caught task errors, then the fallback
+    re-awaited already-consumed coroutines and raised a misleading
+    'Detected nested async' RuntimeError.
+
+    See: https://github.com/run-llama/llama_index/issues/22493
+    """
+
+    async def ok() -> int:
+        return 1
+
+    async def fail() -> int:
+        raise ValueError("ORIGINAL task failure")
+
+    # show_progress=False already works correctly
+    with pytest.raises(ValueError, match="ORIGINAL task failure"):
+        run_async_tasks([ok(), fail()], show_progress=False)
+
+    # show_progress=True must raise the same original exception
+    with pytest.raises(ValueError, match="ORIGINAL task failure"):
+        run_async_tasks([ok(), fail()], show_progress=True)
+
+
+def test_run_async_tasks_success_with_progress() -> None:
+    """run_async_tasks with show_progress=True returns correct results."""
+
+    async def add_one(n: int) -> int:
+        return n + 1
+
+    coroutines = [add_one(n) for n in range(5)]
+    results = run_async_tasks(coroutines, show_progress=True)
+    assert results == [1, 2, 3, 4, 5]


### PR DESCRIPTION
Fixes #22493

## Problem
`run_async_tasks(show_progress=True)` swallows task exceptions. The `except Exception: pass` block wraps both the tqdm import/setup AND the task execution (`loop.run_until_complete`). When a task raises, the exception is silently caught, then the fallback re-awaits already-consumed coroutines and produces a misleading `RuntimeError: Detected nested async`.

## Fix
Separate tqdm setup from task execution. The `except` block now only catches import/setup failures (the original intent). Task execution happens outside the try/except so exceptions propagate correctly.

## Tests
- `test_run_async_tasks_propagates_exceptions_with_progress`: verifies both `show_progress=False` and `show_progress=True` raise the original `ValueError`
- `test_run_async_tasks_success_with_progress`: verifies normal operation still works

## AI Disclosure

AI-assisted debugging/initial draft/testing with human review of the diff and test scope (per the contribution workflow).