### PR TITLE
fix(core): apply the retry check_fn to subclasses of the registered exception

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -236,6 +236,23 @@ class ErrorToRetry:
     check_fn: Optional[Callable[[Any], bool]] = None
 
 
+def _resolve_check_fn(
+    error_checks: Dict[Type[Exception], Optional[Callable[[Exception], bool]]],
+    exception: Exception,
+) -> Optional[Callable[[Exception], bool]]:
+    """
+    Find the check function registered for an exception, honouring subclasses.
+
+    The `except` clause catches subclasses of every registered class, so the lookup has to as
+    well. Walking the MRO keeps "most specific wins": a subclass registered alongside its base
+    still gets its own check function.
+    """
+    for cls in type(exception).__mro__:
+        if cls in error_checks:
+            return error_checks[cls]
+    return None
+
+
 def retry_on_exceptions_with_backoff(
     lambda_fn: Callable,
     errors_to_retry: List[ErrorToRetry],
@@ -277,7 +294,7 @@ def retry_on_exceptions_with_backoff(
             tries += 1
             if tries >= max_tries:
                 raise
-            check_fn = error_checks.get(e.__class__)
+            check_fn = _resolve_check_fn(error_checks, e)
             if check_fn and not check_fn(e):
                 raise
             time.sleep(backoff_secs)
@@ -325,7 +342,7 @@ async def aretry_on_exceptions_with_backoff(
             tries += 1
             if tries >= max_tries:
                 raise
-            check_fn = error_checks.get(e.__class__)
+            check_fn = _resolve_check_fn(error_checks, e)
             if check_fn and not check_fn(e):
                 raise
             await asyncio.sleep(backoff_secs)

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -1,7 +1,7 @@
 """Test utils."""
 
 from pathlib import Path
-from typing import Optional, Type, Union
+from typing import List, Optional, Type, Union
 from unittest import mock
 import os
 import time
@@ -353,3 +353,110 @@ def test_get_cache_dir_env_var_precedence(tmp_path, monkeypatch) -> None:
         mock_user_cache_dir.return_value = "/should/not/be/used"
         get_cache_dir()
         mock_user_cache_dir.assert_not_called()
+
+
+class _APIError(Exception):
+    pass
+
+
+class _RateLimitError(_APIError):
+    pass
+
+
+class _AuthError(_APIError):
+    pass
+
+
+def test_retry_check_fn_applies_to_subclasses() -> None:
+    """
+    The `except` clause catches subclasses, so the check_fn lookup has to as well.
+
+    Registering a base class used to mean its check_fn was skipped for every subclass, so a
+    non-retryable subclass was retried the full max_tries.
+    """
+    checks: List[Exception] = []
+
+    def only_rate_limits(e: Exception) -> bool:
+        checks.append(e)
+        return "rate limit" in str(e).lower()
+
+    def run(exc: Exception) -> int:
+        checks.clear()
+        calls = 0
+
+        def fn() -> None:
+            nonlocal calls
+            calls += 1
+            raise exc
+
+        with pytest.raises(_APIError):
+            retry_on_exceptions_with_backoff(
+                fn,
+                [ErrorToRetry(_APIError, only_rate_limits)],
+                max_tries=3,
+                min_backoff_secs=0,
+                max_backoff_secs=0,
+            )
+        return calls
+
+    # Registered class itself: unchanged.
+    assert run(_APIError("rate limit")) == 3
+    assert run(_APIError("bad request")) == 1
+
+    # Subclasses now go through the same predicate.
+    assert run(_RateLimitError("rate limit")) == 3
+    assert run(_AuthError("invalid api key")) == 1
+
+
+def test_retry_check_fn_prefers_the_most_specific_registration() -> None:
+    """A subclass registered next to its base keeps its own check_fn."""
+    seen: List[str] = []
+
+    def base_check(e: Exception) -> bool:
+        seen.append("base")
+        return True
+
+    def subclass_check(e: Exception) -> bool:
+        seen.append("subclass")
+        return False
+
+    def fn() -> None:
+        raise _RateLimitError("boom")
+
+    with pytest.raises(_RateLimitError):
+        retry_on_exceptions_with_backoff(
+            fn,
+            [
+                ErrorToRetry(_APIError, base_check),
+                ErrorToRetry(_RateLimitError, subclass_check),
+            ],
+            max_tries=3,
+            min_backoff_secs=0,
+            max_backoff_secs=0,
+        )
+
+    assert seen == ["subclass"]
+
+
+@pytest.mark.asyncio
+async def test_aretry_check_fn_applies_to_subclasses() -> None:
+    calls = 0
+
+    def only_rate_limits(e: Exception) -> bool:
+        return "rate limit" in str(e).lower()
+
+    async def fn() -> None:
+        nonlocal calls
+        calls += 1
+        raise _AuthError("invalid api key")
+
+    with pytest.raises(_AuthError):
+        await aretry_on_exceptions_with_backoff(
+            fn,
+            [ErrorToRetry(_APIError, only_rate_limits)],
+            max_tries=3,
+            min_backoff_secs=0,
+            max_backoff_secs=0,
+        )
+
+    assert calls == 1


### PR DESCRIPTION
# Description

`retry_on_exceptions_with_backoff` catches with a tuple of the registered exception classes, which matches subclasses, then looks the check function up by exact class, which doesn't:

```python
exception_class_tuples = tuple(error_checks.keys())
...
except exception_class_tuples as e:          # matches subclasses
    ...
    check_fn = error_checks.get(e.__class__)  # exact match only
    if check_fn and not check_fn(e):
        raise
```

So registering a base class means every subclass is caught but its `check_fn` never runs, and `check_fn` being `None` is treated as "retry unconditionally".

With `ErrorToRetry(APIError, lambda e: "rate limit" in str(e).lower())` and `max_tries=3`:

| raised | calls | `check_fn` runs |
|---|---|---|
| `APIError("rate limit")` | 3 | 2 |
| `APIError("bad request")` | 1 | 1 |
| `RateLimitError("rate limit")` (subclass) | 3 | **0** |
| `AuthError("invalid api key")` (subclass) | **3** | **0** |

The last row is the damaging one — a non-retryable subclass gets the full `max_tries` because the predicate that would have rejected it never runs. Provider SDKs are shaped this way: `openai.RateLimitError` and `openai.AuthenticationError` are both subclasses of `APIStatusError`, so registering the base to catch both and discriminating in `check_fn` is the natural usage and it silently doesn't work.

Resolving through `type(e).__mro__` makes the lookup match the `except` clause. Most specific still wins — a subclass registered next to its base keeps its own `check_fn`. Same change in `aretry_on_exceptions_with_backoff`, which had the identical line.

After:

| raised | calls | `check_fn` runs |
|---|---|---|
| `APIError("rate limit")` | 3 | 2 |
| `APIError("bad request")` | 1 | 1 |
| `RateLimitError("rate limit")` | 3 | 2 |
| `AuthError("invalid api key")` | 1 | 1 |

Fixes # (no open issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Three tests in `llama-index-core/tests/test_utils.py`:

- `test_retry_check_fn_applies_to_subclasses` — the table above, including the two base-class rows that behave identically before and after, so the change is pinned rather than assumed
- `test_retry_check_fn_prefers_the_most_specific_registration` — base and subclass both registered, asserts only the subclass's predicate is consulted
- `test_aretry_check_fn_applies_to_subclasses` — the async path

Stashing only `utils.py` gives `2 failed, 17 passed`; with the change, `19 passed`. The 16 existing tests in the file pass on both sides.

`ruff check` and `ruff format --check` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes