### PR TITLE
fix(core): join the oversized-split warning instead of passing two log arguments

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -211,8 +211,8 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
             split_len = len(self._tokenizer(split))
             if split_len > chunk_size:
                 _logger.warning(
-                    f"Got a split of size {split_len}, ",
-                    f"larger than chunk size {chunk_size}.",
+                    f"Got a split of size {split_len}, "
+                    f"larger than chunk size {chunk_size}."
                 )
 
             # if we exceed the chunk size after adding the new split, then

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -1,7 +1,9 @@
 """Test text splitter."""
 
+import logging
 from typing import List
 
+import pytest
 import tiktoken
 from llama_index.core.node_parser.text import TokenTextSplitter
 from llama_index.core.node_parser.text.utils import truncate_text
@@ -89,3 +91,24 @@ def test_split_with_metadata(english_text: str) -> None:
     for chunk in chunks:
         node_content = chunk + metadata_str
         assert len(tokenizer.encode(node_content)) <= 100
+
+
+def test_oversized_split_warning_is_emitted(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    The oversized-split warning passed two arguments to logger.warning().
+
+    The second was treated as a %-format argument for a message that has no placeholders, so
+    logging raised internally and printed "--- Logging error ---" instead of the warning.
+    """
+    # Every character costs 5 tokens, so no split can get under chunk_size.
+    splitter = TokenTextSplitter(
+        chunk_size=2, chunk_overlap=0, tokenizer=lambda t: ["x"] * (len(t) * 5)
+    )
+
+    logger_name = "llama_index.core.node_parser.text.token"
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        splitter.split_text("ab")
+
+    assert any(
+        "larger than chunk size" in record.getMessage() for record in caplog.records
+    )


### PR DESCRIPTION
# Description

`TokenTextSplitter._merge` passes two arguments to `logger.warning`:

```python
_logger.warning(
    f"Got a split of size {split_len}, ",
    f"larger than chunk size {chunk_size}.",
)
```

The second f-string becomes a positional argument, so `logging` treats it as a `%`-format argument for a message that has no placeholders. Formatting raises inside the handler, `logging` catches it and writes this to stderr instead:

```
--- Logging error ---
Traceback (most recent call last):
  File ".../logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  ...
TypeError: not all arguments converted during string formatting
```

The warning never reaches a handler, so the condition it reports — a chunk coming out larger than `chunk_size` — is invisible to anyone reading logs, and what does appear is a traceback pointing at the logging module rather than at the splitter.

Reachable through the public API whenever the tokenizer's per-character cost exceeds `chunk_size`, which is the case `_split`'s own comment describes ("a single character whose token count already exceeds chunk_size, which happens for multi-token CJK / emoji characters with a small chunk_size"):

```python
splitter = TokenTextSplitter(
    chunk_size=2, chunk_overlap=0, tokenizer=lambda t: ["x"] * (len(t) * 5)
)
splitter.split_text("ab")
```

| | stderr |
|---|---|
| before | `--- Logging error ---` + traceback, twice |
| after | `WARNING ...token:Got a split of size 5, larger than chunk size 2.`, twice |

Concatenating the two literals makes it one message. It's the only occurrence of this shape in `llama-index-core` — I checked with a multiline grep for `logger.*(f"...", f"...")` across the package.

Fixes # (no open issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_oversized_split_warning_is_emitted` in `llama-index-core/tests/text_splitter/test_token_splitter.py` uses `caplog` and asserts the message reaches a record. Stashing only `token.py` gives `1 failed, 7 passed`; with the change, `8 passed`.

`ruff check` and `ruff format --check` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes