### PR TITLE
fix(core): make the sbert rerank ImportError a single message

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/sbert_rerank.py
@@ -38,8 +38,8 @@ class SentenceTransformerRerank(BaseNodePostprocessor):
             from sentence_transformers import CrossEncoder  # pants: no-infer-dep
         except ImportError:
             raise ImportError(
-                "Cannot import sentence-transformers or torch package,",
-                "please `pip install torch sentence-transformers`",
+                "Cannot import sentence-transformers or torch package, "
+                "please `pip install torch sentence-transformers`"
             )
         device = infer_torch_device() if device is None else device
         super().__init__(

--- a/llama-index-core/tests/postprocessor/test_sbert_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_sbert_rerank.py
@@ -1,0 +1,39 @@
+"""Tests for SentenceTransformerRerank."""
+
+import builtins
+import sys
+from typing import Any
+
+import pytest
+
+
+def test_missing_dependency_message_is_a_single_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The ImportError used to be raised with two arguments, so str(e) was a tuple repr.
+
+    Anything logging or displaying it showed quotes, a comma and parentheses around the
+    sentence, including the pip command the message exists to hand the user.
+    """
+    from llama_index.core.postprocessor.sbert_rerank import SentenceTransformerRerank
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "sentence_transformers":
+            raise ImportError("mocked missing dependency")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "sentence_transformers", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError) as exc_info:
+        SentenceTransformerRerank()
+
+    message = str(exc_info.value)
+    assert message == (
+        "Cannot import sentence-transformers or torch package, "
+        "please `pip install torch sentence-transformers`"
+    )
+    assert len(exc_info.value.args) == 1


### PR DESCRIPTION
# Description

`SentenceTransformerRerank.__init__` raises the missing-dependency `ImportError` with two string arguments instead of one concatenated message:

```python
raise ImportError(
    "Cannot import sentence-transformers or torch package,",
    "please `pip install torch sentence-transformers`",
)
```

Python puts each into `args`, so `str(e)` renders the tuple repr:

```
('Cannot import sentence-transformers or torch package,', 'please `pip install torch sentence-transformers`')
```

The pip command the message exists to hand the user arrives wrapped in quotes, a comma and parentheses.

An AST sweep across `llama-index-core` for every `raise X(...)` whose call has two or more string-constant arguments reports this as the only occurrence.

Fixes # (no open issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`llama-index-core/tests/postprocessor/test_sbert_rerank.py` patches `builtins.__import__` so `sentence_transformers` raises, then asserts the resulting message equals the intended sentence and that `len(e.args) == 1`.

Without the change: `assert "('Cannot imp...ansformers`')" == 'Cannot impor...transformers`'`. With it, 1 passed.

`ruff check` and `ruff format --check` clean.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes