### PR TITLE
fix(core): serialize fact memory tool history

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -31,6 +31,7 @@ except ImportError:  # pragma: no cover
 import filetype
 from tinytag import TinyTag, UnsupportedFormatError
 from typing_extensions import Self
+from xml.sax.saxutils import escape
 
 from llama_index.core.async_utils import asyncio_run
 from llama_index.core.bridge.pydantic import (
@@ -1233,6 +1234,11 @@ class ChatMessage(BaseRecursiveContentBlock):
             raise ValueError(
                 "ChatMessage contains multiple blocks, use 'ChatMessage.blocks' instead."
             )
+
+    def to_xml_string(self) -> str:
+        """Serialize the message's text content with its role as XML."""
+        content = escape(self.content or "")
+        return f"<{self.role.value}>{content}</{self.role.value}>"
 
     def __str__(self) -> str:
         return f"{self.role.value}: {self.content}"

--- a/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/fact.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, List, Optional, Union
 
-from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.base.llms.types import ChatMessage, MessageRole, TextBlock
 from llama_index.core.bridge.pydantic import Field, field_validator
 from llama_index.core.llms import LLM
 from llama_index.core.memory.memory import BaseMemoryBlock
@@ -62,6 +62,36 @@ Return ONLY the condensed facts in this exact format:
 
 def get_default_llm() -> LLM:
     return Settings.llm
+
+
+def _prepend_conversation_history(
+    messages: List[ChatMessage], prompt_messages: List[ChatMessage]
+) -> List[ChatMessage]:
+    """Add provider-neutral conversation history to the prompt."""
+    conversation = "\n".join(message.to_xml_string() for message in messages)
+    conversation_block = TextBlock(
+        text=f"<current_conversation>\n{conversation}\n</current_conversation>\n\n"
+    )
+    prompt_messages = [message.model_copy(deep=True) for message in prompt_messages]
+
+    for prompt_message in prompt_messages:
+        if prompt_message.role == MessageRole.USER:
+            prompt_message.blocks.insert(0, conversation_block)
+            return prompt_messages
+
+    history_message = ChatMessage(role=MessageRole.USER, blocks=[conversation_block])
+    insert_at = 0
+    while insert_at < len(prompt_messages) and prompt_messages[insert_at].role in (
+        MessageRole.SYSTEM,
+        MessageRole.DEVELOPER,
+    ):
+        insert_at += 1
+
+    return [
+        *prompt_messages[:insert_at],
+        history_message,
+        *prompt_messages[insert_at:],
+    ]
 
 
 class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
@@ -135,7 +165,9 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
         )
 
         # Get the facts extraction
-        response = await self.llm.achat(messages=[*messages, *prompt_messages])
+        response = await self.llm.achat(
+            messages=_prepend_conversation_history(messages, prompt_messages)
+        )
 
         # Parse the XML response to extract facts
         facts_text = response.message.content or ""
@@ -156,7 +188,9 @@ class FactExtractionMemoryBlock(BaseMemoryBlock[str]):
                 existing_facts=existing_facts_text,
                 max_facts=self.max_facts,
             )
-            response = await self.llm.achat(messages=[*messages, *prompt_messages])
+            response = await self.llm.achat(
+                messages=_prepend_conversation_history(messages, prompt_messages)
+            )
             condensed_facts = self._parse_facts_xml(response.message.content or "")
 
             # The condensed response replaces the fact list wholesale, so only

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -109,6 +109,30 @@ def test_chat_message_from_str():
     assert m.blocks[0].text == "test content"
 
 
+def test_chat_message_to_xml_string_escapes_text_content():
+    message = ChatMessage(role=MessageRole.USER, content="Use <pgvector> & a reranker")
+
+    assert (
+        message.to_xml_string() == "<user>Use &lt;pgvector&gt; &amp; a reranker</user>"
+    )
+
+
+def test_chat_message_to_xml_string_ignores_non_text_blocks():
+    message = ChatMessage(
+        role=MessageRole.ASSISTANT,
+        blocks=[
+            TextBlock(text="I will inspect the index."),
+            ToolCallBlock(
+                tool_name="inspect_index",
+                tool_kwargs={"index": "docs"},
+                tool_call_id="call-1",
+            ),
+        ],
+    )
+
+    assert message.to_xml_string() == "<assistant>I will inspect the index.</assistant>"
+
+
 def test_chat_message_content_legacy_get():
     m = ChatMessage(content="test content")
     assert m.content == "test content"

--- a/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
+++ b/llama-index-core/tests/memory/test_fact_extraction_memory_block.py
@@ -1,7 +1,13 @@
 from typing import Any, List, Sequence
 
 from llama_index.core.async_utils import asyncio_run
-from llama_index.core.base.llms.types import ChatMessage, ChatResponse, MessageRole
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    MessageRole,
+    TextBlock,
+    ToolCallBlock,
+)
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.memory.memory_blocks.fact import (
@@ -21,6 +27,92 @@ class _ScriptedLLM(MockLLM):
         content = self.scripted_responses.pop(0)
         return ChatResponse(
             message=ChatMessage(role=MessageRole.ASSISTANT, content=content)
+        )
+
+
+class _RejectingToolHistoryLLM(_ScriptedLLM):
+    """Reject provider-specific tool history and capture sanitized prompts."""
+
+    captured_messages: List[List[ChatMessage]] = Field(default_factory=list)
+
+    async def achat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponse:
+        for message in messages:
+            if message.role in (MessageRole.FUNCTION, MessageRole.TOOL):
+                raise ValueError("provider rejected raw tool-result history")
+            if any(isinstance(block, ToolCallBlock) for block in message.blocks):
+                raise ValueError("provider rejected raw tool-call history")
+
+        self.captured_messages.append(list(messages))
+        return await super().achat(messages, **kwargs)
+
+
+def _tool_history() -> List[ChatMessage]:
+    return [
+        ChatMessage(
+            role=MessageRole.USER,
+            content="Remember that the deployment uses <pgvector> & HNSW.",
+        ),
+        ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=[
+                TextBlock(text="I will inspect the deployment."),
+                ToolCallBlock(
+                    tool_name="inspect_deployment",
+                    tool_kwargs={"service": "retrieval"},
+                    tool_call_id="call-1",
+                ),
+            ],
+        ),
+        ChatMessage(
+            role=MessageRole.TOOL,
+            content="pgvector is enabled",
+            additional_kwargs={"tool_call_id": "call-1"},
+        ),
+    ]
+
+
+def test_fact_extraction_serializes_tool_history_as_provider_neutral_text() -> None:
+    llm = _RejectingToolHistoryLLM()
+    llm.scripted_responses = ["<facts><fact>deployment uses pgvector</fact></facts>"]
+    block = FactExtractionMemoryBlock(llm=llm)
+
+    asyncio_run(block._aput(_tool_history()))
+
+    assert block.facts == ["deployment uses pgvector"]
+    assert len(llm.captured_messages) == 1
+    rendered = "\n".join(message.content or "" for message in llm.captured_messages[0])
+    assert "<current_conversation>" in rendered
+    assert (
+        "<user>Remember that the deployment uses &lt;pgvector&gt; &amp; HNSW.</user>"
+        in rendered
+    )
+    assert "<assistant>I will inspect the deployment.</assistant>" in rendered
+    assert "<tool>pgvector is enabled</tool>" in rendered
+    assert "inspect_deployment" not in rendered
+
+
+def test_fact_condense_serializes_tool_history_as_provider_neutral_text() -> None:
+    llm = _RejectingToolHistoryLLM()
+    llm.scripted_responses = [
+        "<facts><fact>d</fact></facts>",
+        "<facts><fact>x</fact><fact>y</fact></facts>",
+    ]
+    block = FactExtractionMemoryBlock(llm=llm, facts=["a", "b", "c"], max_facts=3)
+
+    asyncio_run(block._aput(_tool_history()))
+
+    assert block.facts == ["x", "y"]
+    assert len(llm.captured_messages) == 2
+    for messages in llm.captured_messages:
+        assert all(
+            message.role not in (MessageRole.FUNCTION, MessageRole.TOOL)
+            for message in messages
+        )
+        assert all(
+            not any(isinstance(block, ToolCallBlock) for block in message.blocks)
+            for message in messages
         )
 
 


### PR DESCRIPTION
# Description

Fixes #19841.

`FactExtractionMemoryBlock` currently forwards flushed conversation messages directly into auxiliary `achat()` calls. When the history contains tool calls or tool results, providers such as Bedrock Converse receive provider-specific tool content without the original agent's tool configuration and reject the request.

This implementation follows the design proposed in the issue discussion:

- adds `ChatMessage.to_xml_string()` for escaped, text-only role serialization;
- converts flushed history into one provider-neutral XML conversation block;
- prepends that block to the existing fact-extraction and condensation prompts instead of forwarding raw history;
- preserves textual tool results as context while removing provider-specific `ToolCallBlock` semantics;
- applies the same behavior to both extraction and condensation.

No external service or credential is required for regression coverage. A mock LLM deliberately rejects raw tool/function history, reproducing the provider failure class while verifying that both auxiliary calls receive sanitized messages.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

Core package bug fix; no version bump is required.

## Type of Change

- [x] Bug fix (non-breaking change)

## Validation

```text
uv run pytest -q tests
1470 passed, 22 skipped, 6 xfailed

uv run pytest -q tests/memory tests/base/llms
194 passed

uv run mypy llama_index/core/base/llms/types.py llama_index/core/memory/memory_blocks/fact.py
Success: no issues found in 2 source files

uvx pre-commit run --show-diff-on-failure --files <4 changed files>
All applicable hooks passed, including ruff, ruff-format, mypy, prettier, and codespell.
```

## Suggested Checklist

- [x] I performed a self-review.
- [x] I added regression tests that prove the fix.
- [x] New and existing unit tests pass locally.
- [x] The change introduces no new warnings in focused tests.
- [ ] Documentation update required. Not applicable because this is an internal compatibility fix.
- [ ] Google Colab update required. Not applicable.
