### PR TITLE
fix a few typos

### DIFF
--- a/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
+++ b/docs/src/content/docs/framework/module_guides/indexing/index_guide.md
@@ -83,6 +83,6 @@ You can also skip creation, and connect to an existing knowledge graph using an 
 
 Querying a Property Graph Index is also highly flexible. Retrieval works by using several sub-retrievers and combining results. By default, keyword + synoymn expanasion is used, as well as vector retrieval (if your graph was embedded), to retrieve relevant triples.
 
-You can also chose to include the source text in addition to the retrieved triples (unavailble for graphs created outside of LlamaIndex).
+You can also chose to include the source text in addition to the retrieved triples (unavailable for graphs created outside of LlamaIndex).
 
 See more in the [full guide for Property Graphs](/python/framework/module_guides/indexing/lpg_index_guide).

--- a/docs/src/content/docs/framework/optimizing/building_rag_from_scratch.md
+++ b/docs/src/content/docs/framework/optimizing/building_rag_from_scratch.md
@@ -28,7 +28,7 @@ This tutorial shows you how to build a retriever to query a vector store.
 
 ## Building Ingestion/Retrieval from Scratch (Open-Source/Local Components)
 
-This tutoral shows you how to build an ingestion/retrieval pipeline using only
+This tutorial shows you how to build an ingestion/retrieval pipeline using only
 open-source components.
 
 - [Open Source RAG](/python/examples/low_level/oss_ingestion_retrieval)

--- a/docs/src/content/docs/framework/understanding/index.mdx
+++ b/docs/src/content/docs/framework/understanding/index.mdx
@@ -44,7 +44,7 @@ This tutorial has three main parts: **Building a RAG pipeline**, **Building an a
 
   - **[Stateful workflows](/python/llamaagents/workflows/managing_state)**: workflows can maintain state, which is important for building more complex applications.
 
-  - **[Observability](/python/llamaagents/workflows/observability)**: workflows can be traced and debugged using various integrations like Arize Pheonix, OpenTelemetry, and more.
+  - **[Observability](/python/llamaagents/workflows/observability)**: workflows can be traced and debugged using various integrations like Arize Phoenix, OpenTelemetry, and more.
 
 - **[Adding RAG to your agents](/python/framework/understanding/rag)**: Retrieval-Augmented Generation (RAG) is a key technique for getting your data to an LLM, and a component of more sophisticated agentic systems. We'll show you how to enhance your agents with a full-featured RAG pipeline that can answer questions about your data. This includes:
 

--- a/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
+++ b/llama-index-core/llama_index/core/indices/knowledge_graph/retrievers.py
@@ -777,7 +777,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         # Get entities
         entities = self._get_entities(query_bundle.query_str)
         # Before we enable embedding/semantic search, we need to make sure
-        # we don't miss any entities that's synoynm of the entities we extracted
+        # we don't miss any entities that's synonym of the entities we extracted
         # in string matching based retrieval in following steps, thus we expand
         # synonyms here.
         if len(entities) == 0:
@@ -798,7 +798,7 @@ class KnowledgeGraphRAGRetriever(BaseRetriever):
         # Get entities
         entities = await self._aget_entities(query_bundle.query_str)
         # Before we enable embedding/semantic search, we need to make sure
-        # we don't miss any entities that's synoynm of the entities we extracted
+        # we don't miss any entities that's synonym of the entities we extracted
         # in string matching based retrieval in following steps, thus we expand
         # synonyms here.
         if len(entities) == 0:

--- a/llama-index-integrations/node_parser/llama-index-node-parser-slide/llama_index/node_parser/slide/base.py
+++ b/llama-index-integrations/node_parser/llama-index-node-parser-slide/llama_index/node_parser/slide/base.py
@@ -39,7 +39,7 @@ class SlideNodeParser(NodeParser):
 
     window_size: int = Field(
         default=11,
-        description="Window size for the sliding window approach. This is the total number chunks to include in the context window, ideall an odd number.",
+        description="Window size for the sliding window approach. This is the total number chunks to include in the context window, ideally an odd number.",
     )
 
     llm_workers: int = Field(

--- a/llama-index-integrations/retrievers/llama-index-retrievers-pathway/llama_index/retrievers/pathway/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-pathway/llama_index/retrievers/pathway/base.py
@@ -144,7 +144,7 @@ class PathwayRetriever(BaseRetriever):
         items = [
             NodeWithScore(
                 node=TextNode(text=ret["text"], extra_info=ret["metadata"]),
-                # Transform cosine distance into a similairty score
+                # Transform cosine distance into a similarity score
                 # (higher is more similar)
                 score=1 - ret["dist"],
             )

--- a/llama-index-integrations/tools/llama-index-tools-vectara-query/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-vectara-query/README.md
@@ -6,7 +6,7 @@ This tool connects to a Vectara corpus and allows agents to make semantic search
 
 Please note that this usage example relies on version >=0.3.0.
 
-This tool has a more extensive example usage documented in a Jupyter notebok [here](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/tools/llama-index-tools-vectara-query/examples/vectara_query.ipynb)
+This tool has a more extensive example usage documented in a Jupyter notebook [here](https://github.com/run-llama/llama_index/blob/main/llama-index-integrations/tools/llama-index-tools-vectara-query/examples/vectara_query.ipynb)
 
 To use this tool, you'll need a Vectara account (If you don't have an account, you can create one [here](https://vectara.com/integrations/llamaindex)) and the following information in your environment:
 


### PR DESCRIPTION
ran codespell and found a handful of typos:

   - `notebok` → `notebook`
   - `similairty` → `similarity`
   - `ideall` → `ideally`
   - `synoynm` → `synonym`
   - `Pheonix` → `Phoenix`
   - `tutoral` → `tutorial`
   - `unavailble` → `unavailable`  

 ## New Package?

   - [ ] Yes
   - [x] No

   ## Version Bump?

   - [ ] Yes
   - [x] No

   ## Type of Change

   - [x] Bug fix (non-breaking change which fixes an issue)

   ## How Has This Been Tested?

   - [x] I believe this change is already covered by existing unit tests

   ## Suggested Checklist:

   - [x] I have performed a self-review of my own code
   - [x] My changes generate no new warnings'