### PR TITLE
Document Typecast unsynthesizable text errors

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-typecast/llama_index/tools/typecast/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-typecast/llama_index/tools/typecast/base.py
@@ -143,7 +143,8 @@ class TypecastToolSpec(BaseToolSpec):
             UnauthorizedError: If API authentication fails
             PaymentRequiredError: If API quota exceeded
             NotFoundError: If resource not found
-            UnprocessableEntityError: If validation error
+            UnprocessableEntityError: If validation fails or the input text cannot
+                be synthesized. Correct the input before retrying.
             InternalServerError: If Typecast API server error
             TypecastError: If other API error occurs
             IOError: If file save fails


### PR DESCRIPTION
## Summary
- clarify that Typecast 422 errors can mean the input text cannot be synthesized
- tell callers to correct the input before retrying

## Test
- `uv run pytest tests/test_tools_typecast.py` from `llama-index-integrations/tools/llama-index-tools-typecast`