### PR TITLE
fix(google-genai): surface cached_content_token_count in chat response additional_kwargs

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -174,6 +174,11 @@ def chat_from_gemini_response(
         )
         additional_kwargs["total_tokens"] = response.usage_metadata.total_token_count
 
+        if response.usage_metadata.cached_content_token_count:
+            additional_kwargs["cached_content_tokens"] = (
+                response.usage_metadata.cached_content_token_count
+            )
+
         if response.usage_metadata.thoughts_token_count:
             thought_tokens = response.usage_metadata.thoughts_token_count
 

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -936,6 +936,63 @@ def test_cached_content_without_cached_content() -> None:
     assert "cached_content" not in chat_response.raw
 
 
+def _make_mock_response_with_usage(
+    cached_content_token_count: int,
+) -> MagicMock:
+    """Build a minimal mock GenerateContentResponse with usage_metadata."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    mock_response.candidates[0].content.parts = [MagicMock()]
+    mock_response.candidates[0].content.parts[0].text = "Hello"
+    mock_response.candidates[0].content.parts[0].thought = False
+    mock_response.candidates[0].content.parts[0].inline_data = None
+    mock_response.candidates[0].content.parts[0].function_call = None
+    mock_response.candidates[0].content.parts[0].function_response = None
+    mock_response.prompt_feedback = None
+    mock_response.function_calls = None
+    del mock_response.cached_content
+
+    mock_usage = MagicMock()
+    mock_usage.model_dump.return_value = {
+        "prompt_token_count": 150,
+        "candidates_token_count": 30,
+        "total_token_count": 180,
+        "cached_content_token_count": cached_content_token_count,
+        "thoughts_token_count": 0,
+    }
+    mock_usage.prompt_token_count = 150
+    mock_usage.candidates_token_count = 30
+    mock_usage.total_token_count = 180
+    mock_usage.cached_content_token_count = cached_content_token_count
+    mock_usage.thoughts_token_count = 0
+    mock_response.usage_metadata = mock_usage
+    return mock_response
+
+
+def test_cached_content_token_count_surfaced_in_additional_kwargs() -> None:
+    """cached_content_tokens appears in additional_kwargs when cache hits are non-zero."""
+    mock_response = _make_mock_response_with_usage(cached_content_token_count=100)
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.additional_kwargs["prompt_tokens"] == 150
+    assert chat_response.additional_kwargs["completion_tokens"] == 30
+    assert chat_response.additional_kwargs["total_tokens"] == 180
+    assert chat_response.additional_kwargs["cached_content_tokens"] == 100
+
+
+def test_cached_content_token_count_absent_when_zero() -> None:
+    """cached_content_tokens is absent from additional_kwargs when no cache hits."""
+    mock_response = _make_mock_response_with_usage(cached_content_token_count=0)
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert "cached_content_tokens" not in chat_response.additional_kwargs
+    assert chat_response.additional_kwargs["prompt_tokens"] == 150
+
+
 def test_thoughts_in_response() -> None:
     """Test response processing when thought summaries are present."""
     # Mock response without cached_content


### PR DESCRIPTION
## Summary

`chat_from_gemini_response` in the `llama-index-llms-google-genai` integration extracted `thoughts_token_count` from `usage_metadata` but left `cached_content_token_count` uncaptured in `additional_kwargs`. When a request hits a Gemini context cache, callers (tracing libraries, eval frameworks, cost-accounting tools) cannot see how many tokens were served from the cache without digging into the raw `usage_metadata` dict.

This PR adds `cached_content_tokens` to `additional_kwargs` whenever `usage_metadata.cached_content_token_count` is non-zero, using the same conditional pattern already used for `thoughts_token_count`.

## Root Cause / Motivation

`usage_metadata.cached_content_token_count` (the number of prompt tokens that hit a cached context) was already included in `raw[usage_metadata]` via `model_dump()`, but was never promoted to a named key in `additional_kwargs`. The MLFlow Tracing comment in the same block documents the intent: named keys in `additional_kwargs` are the structured contract that downstream consumers rely on. `thoughts_token_count` was handled; `cached_content_token_count` was an oversight.

## Changes

| File | What changed |
|------|-------------|
| `llama_index/llms/google_genai/utils.py` | Add `cached_content_tokens` to `additional_kwargs` when `usage_metadata.cached_content_token_count` is non-zero |
| `tests/test_llms_google_genai.py` | Add `_make_mock_response_with_usage` helper; two new unit tests |

## Testing

- [x] Existing tests pass (23/23 unit tests pass locally)
- [x] New test: `test_cached_content_token_count_surfaced_in_additional_kwargs` — verifies the key is present with correct value when cache hits occur
- [x] New test: `test_cached_content_token_count_absent_when_zero` — verifies the key is absent when no cache was used (no false positives)
- [x] No API key required — all tests use mocks

## Impact

Users who measure cost or track token usage from `chat_response.additional_kwargs` now see how many tokens came from a Gemini context cache. This is especially useful for cost-accounting (cached tokens are billed at a lower rate than fresh input tokens) and for tracing libraries that aggregate token counts per conversation.