### PR TITLE
fix: similarity_top_k=0 returns all embeddings instead of none

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -31,7 +31,9 @@ def get_top_k_embeddings(
         similarity = similarity_fn(query_embedding_np, emb)  # type: ignore[arg-type]
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
-            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+            # `None` means "no limit"; an explicit 0 must return no results.
+            # Testing truthiness would conflate the two and return everything.
+            if similarity_top_k is not None and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
     result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
 
@@ -136,7 +138,10 @@ def get_top_k_mmr_embeddings(
     results: List[Tuple[Any, Any]] = []
 
     embedding_length = len(embeddings or [])
-    similarity_top_k_count = similarity_top_k or embedding_length
+    # `None` means "no limit"; an explicit 0 must return no results.
+    similarity_top_k_count = (
+        similarity_top_k if similarity_top_k is not None else embedding_length
+    )
     while len(results) < min(similarity_top_k_count, embedding_length):
         # Calculate the similarity score the for the leading one.
         results.append((score, high_score_id))

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -108,3 +108,49 @@ def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
         query_embedding, embeddings, similarity_top_k=2
     )
     assert unset_ids == [0, 1]
+
+
+def test_get_top_k_embeddings_top_k_zero() -> None:
+    """
+    An explicit similarity_top_k of 0 must return no results.
+
+    `similarity_top_k` is optional and defaults to None, which means "no
+    limit". Because 0 is falsy, `if similarity_top_k and ...` conflated the two
+    and returned every embedding when a caller explicitly asked for none.
+    """
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [0.7, 0.7]]
+
+    _, result_ids = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_ids == []
+
+    # None still means "no limit".
+    _, unset_ids = get_top_k_embeddings(query_embedding, embeddings)
+    assert len(unset_ids) == len(embeddings)
+
+    # An ordinary limit is unaffected.
+    _, top_2_ids = get_top_k_embeddings(query_embedding, embeddings, similarity_top_k=2)
+    assert len(top_2_ids) == 2
+
+
+def test_get_top_k_mmr_embeddings_top_k_zero() -> None:
+    """An explicit similarity_top_k of 0 must return no results under MMR too."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [0.7, 0.7]]
+
+    _, result_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_ids == []
+
+    # None still means "no limit".
+    _, unset_ids = get_top_k_mmr_embeddings(query_embedding, embeddings)
+    assert len(unset_ids) == len(embeddings)
+
+    # An ordinary limit is unaffected.
+    _, top_2_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=2
+    )
+    assert len(top_2_ids) == 2


### PR DESCRIPTION
Fixes #22508

`get_top_k_embeddings` and `get_top_k_mmr_embeddings` tested `similarity_top_k`
for truthiness, so an explicit `0` was treated the same as `None` ("no limit")
and every embedding was returned — the opposite of what was asked for.

Both now check `is not None`. This matches the `mmr_threshold` fix already in
this file and the behaviour of the sibling `get_top_k_embeddings_learner`,
which uses slicing and handles 0 correctly.

## Tests

Added `test_get_top_k_embeddings_top_k_zero` and
`test_get_top_k_mmr_embeddings_top_k_zero`. Both fail on `main` and pass here.

Each also asserts that `None` still means "no limit" and that an ordinary
limit is unaffected, so the default behaviour is pinned.
