### PR TITLE
docs: add governed action boundary agent example

### DIFF
--- a/docs/examples/agent/governed_action_boundary.ipynb
+++ b/docs/examples/agent/governed_action_boundary.ipynb
@@ -1,0 +1,258 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gate sensitive agent actions with an external checkpoint\n",
+    "\n",
+    "Agents often need tools that can create side effects, such as exporting data, sending a message, or writing to an external system. For those tools, it can be useful to put a deterministic approval boundary immediately before the side effect.\n",
+    "\n",
+    "This example shows one lightweight pattern:\n",
+    "\n",
+    "1. Build a stable action object from the tool arguments.\n",
+    "2. Compute an action hash from canonical JSON.\n",
+    "3. Send the action and hash to an external checkpoint.\n",
+    "4. Allow, pause, or block before the side effect runs.\n",
+    "\n",
+    "The checkpoint can be an internal policy service, a human review queue, or a governance provider such as OSuite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a stable action object\n",
+    "\n",
+    "The action object should include the fields that matter for review and audit. Keep it stable: use explicit field names, avoid timestamps in the hash input, and serialize with sorted keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hashlib\n",
+    "import json\n",
+    "from typing import Any, Literal\n",
+    "\n",
+    "\n",
+    "CheckpointDecision = Literal[\"allow\", \"pause\", \"block\"]\n",
+    "\n",
+    "\n",
+    "def canonical_action_hash(action: dict[str, Any]) -> str:\n",
+    "    \"\"\"Return a stable hash for the action that reviewers approve.\"\"\"\n",
+    "    encoded = json.dumps(\n",
+    "        action,\n",
+    "        sort_keys=True,\n",
+    "        separators=(\",\", \":\"),\n",
+    "    ).encode(\"utf-8\")\n",
+    "    return hashlib.sha256(encoded).hexdigest()\n",
+    "\n",
+    "\n",
+    "def build_export_action(\n",
+    "    *,\n",
+    "    customer_id: str,\n",
+    "    destination: str,\n",
+    "    requested_by: str,\n",
+    ") -> dict[str, Any]:\n",
+    "    return {\n",
+    "        \"schema_version\": \"v1\",\n",
+    "        \"action_type\": \"customer_data_export\",\n",
+    "        \"resource\": {\"customer_id\": customer_id},\n",
+    "        \"destination\": destination,\n",
+    "        \"requested_by\": requested_by,\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checkpoint before the side effect\n",
+    "\n",
+    "`external_checkpoint` is intentionally a stub. In production, this is where you would call a policy engine, queue a human approval task, or record an audit decision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def external_checkpoint(\n",
+    "    *,\n",
+    "    action: dict[str, Any],\n",
+    "    action_hash: str,\n",
+    ") -> CheckpointDecision:\n",
+    "    \"\"\"Replace this stub with your approval, policy, or review service.\"\"\"\n",
+    "    if action[\"destination\"].endswith(\"@example.com\"):\n",
+    "        return \"allow\"\n",
+    "    if action[\"destination\"].endswith(\"@review.example\"):\n",
+    "        return \"pause\"\n",
+    "    return \"block\"\n",
+    "\n",
+    "\n",
+    "def perform_customer_export(\n",
+    "    *,\n",
+    "    customer_id: str,\n",
+    "    destination: str,\n",
+    ") -> str:\n",
+    "    \"\"\"Placeholder for the real export/send/write operation.\"\"\"\n",
+    "    return f\"Exported customer {customer_id} to {destination}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now wrap the sensitive operation in a tool function. The tool constructs the exact action being requested, sends that stable object to the checkpoint, and only performs the side effect on `allow`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def guarded_customer_export(\n",
+    "    customer_id: str,\n",
+    "    destination: str,\n",
+    "    requested_by: str,\n",
+    ") -> str:\n",
+    "    \"\"\"Export customer data after an external checkpoint approves it.\"\"\"\n",
+    "    action = build_export_action(\n",
+    "        customer_id=customer_id,\n",
+    "        destination=destination,\n",
+    "        requested_by=requested_by,\n",
+    "    )\n",
+    "    action_hash = canonical_action_hash(action)\n",
+    "    decision = external_checkpoint(action=action, action_hash=action_hash)\n",
+    "\n",
+    "    if decision == \"allow\":\n",
+    "        result = perform_customer_export(\n",
+    "            customer_id=customer_id,\n",
+    "            destination=destination,\n",
+    "        )\n",
+    "        return f\"Allowed {action_hash}: {result}\"\n",
+    "\n",
+    "    if decision == \"pause\":\n",
+    "        return f\"Paused {action_hash}: waiting for external approval\"\n",
+    "\n",
+    "    return f\"Blocked {action_hash}: external checkpoint denied the action\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can exercise each decision path without calling an LLM:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    guarded_customer_export(\n",
+    "        customer_id=\"cust_123\",\n",
+    "        destination=\"ops@example.com\",\n",
+    "        requested_by=\"agent_session_42\",\n",
+    "    )\n",
+    ")\n",
+    "print(\n",
+    "    guarded_customer_export(\n",
+    "        customer_id=\"cust_123\",\n",
+    "        destination=\"review@review.example\",\n",
+    "        requested_by=\"agent_session_42\",\n",
+    "    )\n",
+    ")\n",
+    "print(\n",
+    "    guarded_customer_export(\n",
+    "        customer_id=\"cust_123\",\n",
+    "        destination=\"unknown@external.test\",\n",
+    "        requested_by=\"agent_session_42\",\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use it as a LlamaIndex agent tool\n",
+    "\n",
+    "The same function can be exposed to a `FunctionAgent`. The important part is that the checkpoint lives inside the tool function, directly before the side effect, rather than relying only on prompting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\", api_key=\"sk-...\")\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    tools=[guarded_customer_export],\n",
+    "    llm=llm,\n",
+    "    system_prompt=(\n",
+    "        \"You help operators export customer data. Use the export tool \"\n",
+    "        \"only when the user provides the customer, destination, and requester.\"\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await agent.run(\n",
+    "    user_msg=(\n",
+    "        \"Export customer cust_123 to ops@example.com. \"\n",
+    "        \"The requester is agent_session_42.\"\n",
+    "    )\n",
+    ")\n",
+    "print(str(response))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -12,6 +12,7 @@ Build powerful AI assistants with LlamaIndex's agent capabilities:
 - [React Agent](/python/examples/agent/react_agent) - Use the ReAct (Reasoning and Acting) pattern with agents
 - [Code Act Agent](/python/examples/agent/code_act_agent) - Agents that can write and execute code
 - [Multi-Agent Workflow](/python/examples/agent/agent_workflow_multi) - Build a multi-agent workflow with `AgentWorkflow`
+- [Governed Action Boundary](/python/examples/agent/governed_action_boundary) - Gate sensitive tool actions with an external checkpoint
 
 You might also be interested in the [general introduction to agents](/python/framework/understanding/agent).
 


### PR DESCRIPTION
## Summary
- add a small agent example for gating sensitive tool actions with an external checkpoint
- show stable action object construction, canonical hashing, and allow/pause/block handling before a side effect
- link the example from the docs examples index

## Validation
- `python3 -m json.tool docs/examples/agent/governed_action_boundary.ipynb >/tmp/governed_action_boundary.validated.json`
- compiled non-LLM notebook code cells with `python3`
- confirmed OSuite is mentioned only once