### PR TITLE
fix(falkordb): correct schema, vector ranking, filters and batching in property graph store

### DIFF
--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
@@ -1,1 +1,119 @@
-# LlamaIndex Graph Stores Integration: Falkordb
+# LlamaIndex Graph Stores Integration: FalkorDB
+
+[FalkorDB](https://www.falkordb.com/) is a fast, low-latency property graph database
+built on a sparse-matrix engine and queried with Cypher. This package provides two
+integrations:
+
+- `FalkorDBPropertyGraphStore` — the modern `PropertyGraphStore` used by `PropertyGraphIndex`
+- `FalkorDBGraphStore` — the legacy triplet-based `GraphStore`
+
+## Installation
+
+```bash
+pip install llama-index-graph-stores-falkordb
+```
+
+## Running FalkorDB
+
+```bash
+docker run -p 6379:6379 -p 3000:3000 -v $PWD/data:/data falkordb/falkordb:latest
+```
+
+The browser UI is then available on <http://localhost:3000>. A managed instance is
+also available on [FalkorDB Cloud](https://app.falkordb.cloud/).
+
+## Usage
+
+```python
+from llama_index.core import Document
+from llama_index.core.indices.property_graph import PropertyGraphIndex
+from llama_index.graph_stores.falkordb import FalkorDBPropertyGraphStore
+
+graph_store = FalkorDBPropertyGraphStore(
+    url="redis://localhost:6379",
+    database="falkor",  # the graph name
+)
+
+index = PropertyGraphIndex.from_documents(
+    [Document(text="Alice works for Acme since 2023.")],
+    property_graph_store=graph_store,
+)
+
+retriever = index.as_retriever(include_text=True)
+print(retriever.retrieve("Who does Alice work for?"))
+```
+
+The store is also a context manager, so the connection is released deterministically:
+
+```python
+with FalkorDBPropertyGraphStore(url="redis://localhost:6379") as graph_store:
+    graph_store.upsert_nodes([...])
+```
+
+### Connecting to a secured instance
+
+Any additional keyword argument is forwarded to the FalkorDB client:
+
+```python
+graph_store = FalkorDBPropertyGraphStore(
+    url="redis://my-instance.falkordb.cloud:6379",
+    username="falkordb",
+    password="...",
+    ssl=True,
+    socket_timeout=30,
+)
+```
+
+## Configuration
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `url` | — | Connection URL, e.g. `redis://localhost:6379`. |
+| `database` | `"falkor"` | Name of the graph to read from and write to. |
+| `refresh_schema` | `True` | Read the graph schema on startup. |
+| `sanitize_query_output` | `True` | Strip oversized values (such as embeddings) from query results. |
+| `create_indexes` | `True` | Create the range and vector indexes used for lookups and vector search. |
+| `timeout` | `None` | Per-query timeout in milliseconds. |
+
+### Indexes
+
+With `create_indexes=True` (the default) the store creates a range index on
+`__Entity__.id` and `Chunk.id`, which is what makes ingestion `MERGE`s and `id`
+lookups fast. A vector index on `__Entity__.embedding` is created lazily, the first
+time a node with an embedding is written, using that embedding's dimension and
+cosine similarity. `vector_query` uses the index when no metadata filters are
+supplied and falls back to an exact scan otherwise.
+
+If the graph already contains a vector index with a different dimension, the store
+logs a warning and falls back to the exact scan — recreate the index (or the graph)
+when you change embedding model.
+
+### Schema
+
+`refresh_schema()` enumerates every label and relationship type in the graph, then
+samples up to 1000 nodes per label to infer property types. Labels are therefore
+always complete, while the reported property *types* are a best-effort sample. The
+`embedding` property is excluded so it never reaches the text-to-Cypher prompt.
+
+## Legacy graph store
+
+```python
+from llama_index.graph_stores.falkordb import FalkorDBGraphStore
+
+graph_store = FalkorDBGraphStore(url="redis://localhost:6379")
+graph_store.upsert_triplet("Alice", "works_for", "Acme")
+```
+
+## Testing
+
+The tests start a throwaway FalkorDB container automatically (Docker required):
+
+```bash
+pytest tests
+```
+
+Set `FALKORDB_TEST_URL` to run them against an already running instance instead:
+
+```bash
+FALKORDB_TEST_URL=redis://localhost:6379 pytest tests
+```

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
@@ -66,14 +66,14 @@ graph_store = FalkorDBPropertyGraphStore(
 
 ## Configuration
 
-| Argument | Default | Description |
-| --- | --- | --- |
-| `url` | — | Connection URL, e.g. `redis://localhost:6379`. |
-| `database` | `"falkor"` | Name of the graph to read from and write to. |
-| `refresh_schema` | `True` | Read the graph schema on startup. |
-| `sanitize_query_output` | `True` | Strip oversized values (such as embeddings) from query results. |
-| `create_indexes` | `True` | Create the range and vector indexes used for lookups and vector search. |
-| `timeout` | `None` | Per-query timeout in milliseconds. |
+| Argument                | Default    | Description                                                             |
+| ----------------------- | ---------- | ----------------------------------------------------------------------- |
+| `url`                   | —          | Connection URL, e.g. `redis://localhost:6379`.                          |
+| `database`              | `"falkor"` | Name of the graph to read from and write to.                            |
+| `refresh_schema`        | `True`     | Read the graph schema on startup.                                       |
+| `sanitize_query_output` | `True`     | Strip oversized values (such as embeddings) from query results.         |
+| `create_indexes`        | `True`     | Create the range and vector indexes used for lookups and vector search. |
+| `timeout`               | `None`     | Per-query timeout in milliseconds.                                      |
 
 ### Indexes
 
@@ -92,7 +92,7 @@ when you change embedding model.
 
 `refresh_schema()` enumerates every label and relationship type in the graph, then
 samples up to 1000 nodes per label to infer property types. Labels are therefore
-always complete, while the reported property *types* are a best-effort sample. The
+always complete, while the reported property _types_ are a best-effort sample. The
 `embedding` property is excluded so it never reaches the text-to-Cypher prompt.
 
 ## Legacy graph store

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/README.md
@@ -91,9 +91,23 @@ when you change embedding model.
 ### Schema
 
 `refresh_schema()` enumerates every label and relationship type in the graph, then
-samples up to 1000 nodes per label to infer property types. Labels are therefore
-always complete, while the reported property _types_ are a best-effort sample. The
-`embedding` property is excluded so it never reaches the text-to-Cypher prompt.
+samples up to 1000 nodes per label to infer property types, and up to 1000
+relationships per type to infer which labels they connect. Labels and relationship
+types are therefore always complete, while the reported property _types_ and
+`(:Start)-[:REL]->(:End)` pairs are a best-effort sample — a combination that occurs
+in fewer than 1 in 1000 relationships of its type may be missed. The `embedding`
+property is excluded so it never reaches the text-to-Cypher prompt.
+
+Sampling matters because `PropertyGraphIndex` refreshes the schema after **every**
+ingestion batch; traversing all relationships instead would make ingestion cost grow
+with the size of the graph.
+
+### Ingestion performance
+
+Every read this store issues is scoped to `__Entity__` or `Chunk` so FalkorDB's
+label-scoped range indexes apply. This is what keeps the per-batch deduplication that
+`PropertyGraphIndex` performs (`get()` twice, plus a schema refresh) from degrading
+into full-graph scans as the graph grows.
 
 ## Legacy graph store
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/base.py
@@ -1,7 +1,8 @@
 """Simple graph store index."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from types import TracebackType
+from typing import Any, Dict, List, Optional, Type
 
 import redis
 from falkordb import FalkorDB
@@ -17,9 +18,11 @@ class FalkorDBGraphStore(GraphStore):
     In this graph store, triplets are stored within FalkorDB.
 
     Args:
-        simple_graph_store_data_dict (Optional[dict]): data dict
-            containing the triplets. See FalkorDBGraphStoreData
-            for more details.
+        url (str): The URL for the FalkorDB database.
+        database (str): The name of the graph to connect to. Defaults to "falkor".
+        node_label (str): The label used for every entity node. Defaults to "Entity".
+        **kwargs (Any): Additional keyword arguments forwarded to the FalkorDB
+            client (e.g. ``username``, ``password``, ``ssl``).
 
     """
 
@@ -33,14 +36,9 @@ class FalkorDBGraphStore(GraphStore):
         """Initialize params."""
         self._node_label = node_label
 
-        self._driver = FalkorDB.from_url(url)
+        self._driver = FalkorDB.from_url(url, **kwargs)
         self._graph = self._driver.select_graph(database)
-
-        try:
-            self._graph.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
-        except redis.ResponseError as e:
-            # TODO: to find an appropriate way to handle this issue.
-            logger.warning("Create index failed: %s", e)
+        self._create_index()
 
         self._database = database
 
@@ -49,6 +47,14 @@ class FalkorDBGraphStore(GraphStore):
             MATCH (n1:`{self._node_label}`)-[r]->(n2:`{self._node_label}`)
             WHERE n1.id = $subj RETURN type(r), n2.id
         """
+
+    def _create_index(self) -> None:
+        """Create the index backing every `id` lookup, if it does not exist."""
+        try:
+            self._graph.query(f"CREATE INDEX FOR (n:`{self._node_label}`) ON (n.id)")
+        except redis.ResponseError as e:
+            if "already indexed" not in str(e).lower():
+                logger.warning("Create index failed: %s", e)
 
     @property
     def client(self) -> None:
@@ -153,7 +159,9 @@ class FalkorDBGraphStore(GraphStore):
 
             # Call FalkorDB with prepared statement
             result = self._graph.query(query, params={"entity": entity})
-            return bool(result.result_set)
+            # `RETURN count(*)` always yields a single row, so the row count
+            # itself carries no information - the counter value does.
+            return bool(result.result_set) and result.result_set[0][0] > 0
 
         delete_rel(subj, obj, rel)
         if not check_edges(subj):
@@ -197,8 +205,39 @@ class FalkorDBGraphStore(GraphStore):
 
         """
         self._graph = self._driver.select_graph(graph_name)
+        self._database = graph_name
+        self._create_index()
 
         try:
             self.refresh_schema()
         except Exception as e:
             raise ValueError(f"Could not refresh schema. Error: {e}")
+
+    def close(self) -> None:
+        """Explicitly close the FalkorDB connection."""
+        if hasattr(self, "_driver"):
+            try:
+                self._driver.connection.close()
+            finally:
+                delattr(self, "_driver")
+
+    def __enter__(self) -> "FalkorDBGraphStore":
+        """Enter the runtime context, enabling `with FalkorDBGraphStore(...)`."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Close the connection when leaving the runtime context."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Best-effort cleanup; prefer `close()` or the context manager."""
+        try:
+            self.close()
+        except Exception:
+            # Suppress any exceptions during garbage collection
+            pass

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
@@ -1,4 +1,7 @@
-from typing import Any, List, Dict, Optional, Tuple
+import logging
+from collections import defaultdict
+from types import TracebackType
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Type
 
 from llama_index.core.graph_stores.prompts import DEFAULT_CYPHER_TEMPALTE
 from llama_index.core.graph_stores.types import (
@@ -16,7 +19,9 @@ from llama_index.core.prompts import PromptTemplate
 from llama_index.core.vector_stores.types import VectorStoreQuery
 
 import redis
-from falkordb import FalkorDB
+from falkordb import Edge, FalkorDB, Node, Path
+
+logger = logging.getLogger(__name__)
 
 
 def remove_empty_values(input_dict):
@@ -37,35 +42,93 @@ def remove_empty_values(input_dict):
 
 
 BASE_ENTITY_LABEL = "__Entity__"
+CHUNK_LABEL = "Chunk"
+EMBEDDING_KEY = "embedding"
 EXCLUDED_LABELS = []
 EXCLUDED_RELS = []
 EXHAUSTIVE_SEARCH_LIMIT = 10000
 # Threshold for returning all available prop values in graph schema
 DISTINCT_VALUE_LIMIT = 10
+# Number of rows sent to the server in a single write statement
+CHUNK_SIZE = 1000
+# Number of entities/relations inspected when deriving the graph schema
+SCHEMA_SAMPLE_SIZE = 1000
+VECTOR_SIMILARITY_FUNCTION = "cosine"
 
-node_properties_query = """
-MATCH (n)
-WITH keys(n) as keys, labels(n) AS labels
-WITH CASE WHEN keys = [] THEN [NULL] ELSE keys END AS keys, labels
-UNWIND labels AS label
-WITH label, keys
-WHERE NOT label IN $EXCLUDED_LABELS
-UNWIND keys AS key
-WITH label, collect(DISTINCT key) AS keys
-RETURN {label:label, keys:keys} AS output
-"""
 
-rel_properties_query = """
-MATCH ()-[r]->()
-WITH keys(r) as keys, type(r) AS types
-WITH CASE WHEN keys = [] THEN [NULL] ELSE keys END AS keys, types
-UNWIND types AS type
-WITH type, keys
-WHERE NOT type IN $EXCLUDED_LABELS
-UNWIND keys AS key WITH type,
-collect(DISTINCT key) AS keys
-RETURN {type:type, keys:keys} AS output
-"""
+def escape_identifier(identifier: str) -> str:
+    """
+    Quote a label, relationship type or property key for safe interpolation.
+
+    FalkorDB does not support escaping a backtick inside a quoted identifier
+    (doubling it is a syntax error), so backticks are stripped rather than
+    escaped. Quoting is required because labels and relationship types are
+    frequently produced by an LLM and may contain spaces or reserved words.
+    """
+    return f"`{str(identifier).replace('`', '')}`"
+
+
+def convert_operator(operator: str) -> str:
+    """Map a llama-index filter operator onto its Cypher equivalent."""
+    mapping = {
+        "==": "=",
+        "!=": "<>",
+        "nin": "IN",
+        "in": "IN",
+        "contains": "CONTAINS",
+        "text_match": "CONTAINS",
+    }
+    return mapping.get(operator, operator)
+
+
+def to_plain_value(value: Any) -> Any:
+    """
+    Convert FalkorDB result objects into plain Python containers.
+
+    The FalkorDB client returns ``Node``/``Edge``/``Path`` instances, which are
+    opaque to ``value_sanitize`` (so embeddings would never be stripped) and
+    render as ``<falkordb.node.Node object at 0x...>`` when a retriever feeds
+    the result of a text-to-Cypher query back to the LLM.
+    """
+    if isinstance(value, Node):
+        return dict(value.properties)
+    if isinstance(value, Edge):
+        return dict(value.properties)
+    if isinstance(value, Path):
+        return {
+            "nodes": [to_plain_value(node) for node in value.nodes()],
+            "relationships": [to_plain_value(edge) for edge in value.edges()],
+        }
+    if isinstance(value, dict):
+        return {key: to_plain_value(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_plain_value(val) for val in value]
+    return value
+
+
+def sample_value_type(value: Any) -> str:
+    """Derive a Cypher-ish type name from a sampled property value."""
+    if isinstance(value, bool):
+        return "BOOLEAN"
+    if isinstance(value, int):
+        return "INTEGER"
+    if isinstance(value, float):
+        return "FLOAT"
+    if isinstance(value, str):
+        return "STRING"
+    if isinstance(value, (list, tuple)):
+        return "LIST"
+    if isinstance(value, dict):
+        return "MAP"
+    return "UNKNOWN"
+
+
+def _batched(rows: List[dict], size: Optional[int] = None) -> Iterator[List[dict]]:
+    """Yield ``rows`` in slices of at most ``size`` elements."""
+    size = size or CHUNK_SIZE
+    for index in range(0, len(rows), size):
+        yield rows[index : index + size]
+
 
 rel_query = """
 MATCH (n)-[r]->(m)
@@ -94,7 +157,15 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
 
     Args:
         url (str): The URL for the FalkorDB database.
-        database (Optional[str]): The name of the database to connect to. Defaults to "falkor".
+        database (Optional[str]): The name of the graph to connect to. Defaults to "falkor".
+        refresh_schema (bool): Whether to read the graph schema on startup. Defaults to True.
+        sanitize_query_output (bool): Whether to strip oversized values (such as
+            embeddings) from query results. Defaults to True.
+        create_indexes (bool): Whether to create the indexes used for fast lookups
+            and vector search. Defaults to True.
+        timeout (Optional[int]): Query timeout in milliseconds. Defaults to None.
+        **falkordb_kwargs (Any): Additional keyword arguments forwarded to the
+            FalkorDB client (e.g. ``username``, ``password``, ``ssl``).
 
     Examples:
         `pip install llama-index-graph-stores-falkordb`
@@ -128,13 +199,24 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
         database: str = "falkor",
         refresh_schema: bool = True,
         sanitize_query_output: bool = True,
+        create_indexes: bool = True,
+        timeout: Optional[int] = None,
         **falkordb_kwargs: Any,
     ) -> None:
         self.sanitize_query_output = sanitize_query_output
-        self._driver = FalkorDB.from_url(url)
+        self._create_indexes = create_indexes
+        self._timeout = timeout
+        self._driver = FalkorDB.from_url(url, **falkordb_kwargs)
         self._graph = self._driver.select_graph(database)
         self._database = database
         self.structured_schema = {}
+        # label -> dimension of the vector index defined on `embedding`
+        self._vector_index_dimensions: Dict[str, int] = {}
+
+        if self._create_indexes:
+            self._create_range_indexes()
+        self._refresh_vector_index_info()
+
         if refresh_schema:
             self.refresh_schema()
 
@@ -142,23 +224,136 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
     def client(self):
         return self._graph
 
+    ### ----- Index management ----- ###
+
+    def _run_index_statement(self, statement: str) -> bool:
+        """Run an index/constraint statement, tolerating "already exists" errors."""
+        try:
+            self.structured_query(statement)
+        except redis.exceptions.ResponseError as e:
+            message = str(e).lower()
+            if "already indexed" in message or "already exists" in message:
+                return True
+            logger.warning("Could not create index with `%s`: %s", statement, e)
+            return False
+        return True
+
+    def _create_range_indexes(self) -> None:
+        """Create the range indexes backing every `id` lookup and MERGE."""
+        for label in (BASE_ENTITY_LABEL, CHUNK_LABEL):
+            self._run_index_statement(
+                f"CREATE INDEX FOR (n:{escape_identifier(label)}) ON (n.id)"
+            )
+
+    def _refresh_vector_index_info(self) -> None:
+        """Record the dimension of every existing vector index on `embedding`."""
+        self._vector_index_dimensions = {}
+        try:
+            indexes = self.structured_query("CALL db.indexes()")
+        except redis.exceptions.ResponseError as e:
+            logger.debug("Could not list indexes: %s", e)
+            return
+
+        for index in indexes or []:
+            types = index.get("types") or {}
+            if "VECTOR" not in (types.get(EMBEDDING_KEY) or []):
+                continue
+            options = (index.get("options") or {}).get(EMBEDDING_KEY) or {}
+            dimension = options.get("dimension")
+            if index.get("label") is not None and dimension is not None:
+                self._vector_index_dimensions[index["label"]] = int(dimension)
+
+    def _ensure_vector_index(self, label: str, dimension: int) -> None:
+        """
+        Create the vector index for ``label`` if it does not exist yet.
+
+        FalkorDB requires the embedding dimension up front, so the index can
+        only be created once the first embedding is known.
+        """
+        if not self._create_indexes:
+            return
+
+        existing = self._vector_index_dimensions.get(label)
+        if existing == dimension:
+            return
+        if existing is not None:
+            logger.warning(
+                "A vector index on `%s`.embedding already exists with dimension %s, "
+                "but an embedding of dimension %s was provided. Vector search will "
+                "fall back to a full scan.",
+                label,
+                existing,
+                dimension,
+            )
+            return
+
+        created = self._run_index_statement(
+            f"CREATE VECTOR INDEX FOR (n:{escape_identifier(label)}) ON (n.{EMBEDDING_KEY}) "
+            f"OPTIONS {{dimension: {int(dimension)}, "
+            f"similarityFunction: '{VECTOR_SIMILARITY_FUNCTION}'}}"
+        )
+        if created:
+            self._refresh_vector_index_info()
+
+    ### ----- Schema ----- ###
+
+    def _sample_node_properties(self) -> List[dict]:
+        """
+        Derive the property types of every node label in the graph.
+
+        Labels are enumerated exhaustively and only the property *values* are
+        sampled, so a label that happens to sit outside the first
+        ``SCHEMA_SAMPLE_SIZE`` scanned nodes still appears in the schema.
+        """
+        excluded = {*EXCLUDED_LABELS, BASE_ENTITY_LABEL}
+        labels = [
+            row["label"]
+            for row in self.structured_query("CALL db.labels()") or []
+            if row["label"] not in excluded
+        ]
+
+        outputs = []
+        for label in labels:
+            rows = self.structured_query(
+                f"""
+                MATCH (n:{escape_identifier(label)})
+                WITH n LIMIT $SAMPLE_SIZE
+                UNWIND [k IN keys(n) WHERE k <> '{EMBEDDING_KEY}'] AS key
+                WITH key, collect(n[key])[0] AS sample
+                RETURN collect({{property: key, sample: sample}}) AS keys
+                """,
+                param_map={"SAMPLE_SIZE": SCHEMA_SAMPLE_SIZE},
+            )
+            outputs.append({"label": label, "keys": rows[0]["keys"] if rows else []})
+        return outputs
+
+    def _sample_rel_properties(self) -> List[dict]:
+        """Derive the property types of every relationship type in the graph."""
+        rel_types = [
+            row["relationshipType"]
+            for row in self.structured_query("CALL db.relationshipTypes()") or []
+            if row["relationshipType"] not in EXCLUDED_RELS
+        ]
+
+        outputs = []
+        for rel_type in rel_types:
+            rows = self.structured_query(
+                f"""
+                MATCH ()-[r:{escape_identifier(rel_type)}]->()
+                WITH r LIMIT $SAMPLE_SIZE
+                UNWIND keys(r) AS key
+                WITH key, collect(r[key])[0] AS sample
+                RETURN collect({{property: key, sample: sample}}) AS keys
+                """,
+                param_map={"SAMPLE_SIZE": SCHEMA_SAMPLE_SIZE},
+            )
+            outputs.append({"type": rel_type, "keys": rows[0]["keys"] if rows else []})
+        return outputs
+
     def refresh_schema(self) -> None:
         """Refresh the schema."""
-        node_query_results = self.structured_query(
-            node_properties_query,
-            param_map={"EXCLUDED_LABELS": [*EXCLUDED_LABELS, BASE_ENTITY_LABEL]},
-        )
-        node_properties = (
-            [el["output"] for el in node_query_results] if node_query_results else []
-        )
-
-        rels_query_result = self.structured_query(
-            rel_properties_query, param_map={"EXCLUDED_LABELS": EXCLUDED_RELS}
-        )
-        rel_properties = (
-            [el["output"] for el in rels_query_result] if rels_query_result else []
-        )
-
+        node_properties = self._sample_node_properties()
+        rel_properties = self._sample_rel_properties()
         rel_objs_query_result = self.structured_query(
             rel_query,
             param_map={"EXCLUDED_LABELS": [*EXCLUDED_LABELS, BASE_ENTITY_LABEL]},
@@ -182,390 +377,33 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
             index = []
 
         self.structured_schema = {
-            "node_props": {el["label"]: el["keys"] for el in node_properties},
-            "rel_props": {el["type"]: el["keys"] for el in rel_properties},
+            "node_props": {
+                el["label"]: self._format_properties(el["keys"])
+                for el in node_properties
+            },
+            "rel_props": {
+                el["type"]: self._format_properties(el["keys"]) for el in rel_properties
+            },
             "relationships": relationships,
             "metadata": {"constraint": constraint, "index": index},
         }
 
-    def upsert_nodes(self, nodes: List[LabelledNode]) -> None:
-        # Lists to hold separated types
-        entity_dicts: List[dict] = []
-        chunk_dicts: List[dict] = []
-
-        # Sort by type
-        for item in nodes:
-            if isinstance(item, EntityNode):
-                entity_dicts.append({**item.dict(), "id": item.id})
-            elif isinstance(item, ChunkNode):
-                chunk_dicts.append({**item.dict(), "id": item.id})
-            else:
-                # Log that we do not support these types of nodes
-                # Or raise an error?
-                pass
-
-        if chunk_dicts:
-            self.structured_query(
-                """
-                UNWIND $data AS row
-                MERGE (c:Chunk {id: row.id})
-                SET c.text = row.text
-                WITH c, row
-                SET c += row.properties
-                WITH c, row.embedding AS embedding
-                WHERE embedding IS NOT NULL
-                SET c.embedding = vecf32(embedding)
-                RETURN count(*)
-                """,
-                param_map={"data": chunk_dicts},
-            )
-
-        if entity_dicts:
-            for entity_dict in entity_dicts:
-                self.structured_query(
-                    f"""
-                    MERGE (e:`__Entity__` {{id: $data.id}})
-                    SET e += $data.properties
-                    SET e.name = $data.name
-                    WITH e
-                    SET e:{entity_dict["label"]}
-                    WITH e
-                    CALL {{
-                        WITH e
-                        WITH e
-                        WHERE $data.embedding IS NOT NULL
-                        SET e.embedding = vecf32($data.embedding)
-                        RETURN count(*) AS count
-                    }}
-                    RETURN count(e) AS cnt
-                    """,
-                    param_map={"data": entity_dict},
-                )
-                # Create MENTIONS relationship if entity has triplet_source_id
-                triplet_source_id = entity_dict.get("properties", {}).get(
-                    "triplet_source_id"
-                )
-                if triplet_source_id:
-                    self.structured_query(
-                        """
-                        MATCH (e:`__Entity__` {id: $entity_id})
-                        MERGE (c:Chunk {id: $chunk_id})
-                        MERGE (e)<-[:MENTIONS]-(c)
-                        """,
-                        param_map={
-                            "entity_id": entity_dict["id"],
-                            "chunk_id": triplet_source_id,
-                        },
-                    )
-
-    def upsert_relations(self, relations: List[Relation]) -> None:
-        """Add relations."""
-        params = [r.dict() for r in relations]
-
-        for param in params:
-            self.structured_query(
-                f"""
-                MERGE (source {{id: $data.source_id}})
-                ON CREATE SET source:Chunk
-                MERGE (target {{id: $data.target_id}})
-                ON CREATE SET target:Chunk
-                WITH source, target
-                CREATE (source)-[r:`{param["label"]}`]->(target)
-                SET r += $data.properties
-                RETURN count(*)
-                """,
-                param_map={"data": param},
-            )
-
-    def get(
-        self,
-        properties: Optional[dict] = None,
-        ids: Optional[List[str]] = None,
-    ) -> List[LabelledNode]:
-        """Get nodes."""
-        cypher_statement = "MATCH (e) "
-
-        params = {}
-        if properties or ids:
-            cypher_statement += "WHERE "
-
-        if ids:
-            cypher_statement += "e.id in $ids "
-            params["ids"] = ids
-
-        if properties:
-            prop_list = []
-            for i, prop in enumerate(properties):
-                prop_list.append(f"e.`{prop}` = $property_{i}")
-                params[f"property_{i}"] = properties[prop]
-            cypher_statement += " AND ".join(prop_list)
-
-        return_statement = """
-        WITH e
-        RETURN e.id AS name,
-               [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
-               e{.* , embedding: Null, id: Null} AS properties
-        """
-        cypher_statement += return_statement
-
-        response = self.structured_query(cypher_statement, param_map=params)
-        response = response if response else []
-
-        nodes = []
-        for record in response:
-            # text indicates a chunk node
-            # none on the type indicates an implicit node, likely a chunk node
-            if "text" in record["properties"] or record["type"] is None:
-                text = record["properties"].pop("text", "")
-                nodes.append(
-                    ChunkNode(
-                        id_=record["name"],
-                        text=text,
-                        properties=remove_empty_values(record["properties"]),
-                    )
+    @staticmethod
+    def _format_properties(keys: Optional[List[Any]]) -> List[Dict[str, str]]:
+        """Turn sampled property values into ``{property, type}`` entries."""
+        formatted = []
+        for key in keys or []:
+            if isinstance(key, dict):
+                formatted.append(
+                    {
+                        "property": key.get("property"),
+                        "type": sample_value_type(key.get("sample")),
+                    }
                 )
             else:
-                nodes.append(
-                    EntityNode(
-                        name=record["name"],
-                        label=record["type"],
-                        properties=remove_empty_values(record["properties"]),
-                    )
-                )
-
-        return nodes
-
-    def get_triplets(
-        self,
-        entity_names: Optional[List[str]] = None,
-        relation_names: Optional[List[str]] = None,
-        properties: Optional[dict] = None,
-        ids: Optional[List[str]] = None,
-    ) -> List[Triplet]:
-        # TODO: handle ids of chunk nodes
-        cypher_statement = "MATCH (e:`__Entity__`) "
-
-        params = {}
-        if entity_names or properties or ids:
-            cypher_statement += "WHERE "
-
-        if entity_names:
-            cypher_statement += "e.name in $entity_names "
-            params["entity_names"] = entity_names
-
-        if ids:
-            cypher_statement += "e.id in $ids "
-            params["ids"] = ids
-
-        if properties:
-            prop_list = []
-            for i, prop in enumerate(properties):
-                prop_list.append(f"e.`{prop}` = $property_{i}")
-                params[f"property_{i}"] = properties[prop]
-            cypher_statement += " AND ".join(prop_list)
-
-        return_statement = f"""
-        WITH e
-        CALL {{
-            WITH e
-            MATCH (e)-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]->(t:__Entity__)
-            RETURN e.name AS source_id, [l in labels(e) WHERE l <> '__Entity__' | l][0] AS source_type,
-                   e{{.* , embedding: Null, name: Null}} AS source_properties,
-                   type(r) AS type,
-                   t.name AS target_id, [l in labels(t) WHERE l <> '__Entity__' | l][0] AS target_type,
-                   t{{.* , embedding: Null, name: Null}} AS target_properties
-            UNION ALL
-            WITH e
-            MATCH (e)<-[r{":`" + "`|`".join(relation_names) + "`" if relation_names else ""}]-(t:__Entity__)
-            RETURN t.name AS source_id, [l in labels(t) WHERE l <> '__Entity__' | l][0] AS source_type,
-                   e{{.* , embedding: Null, name: Null}} AS source_properties,
-                   type(r) AS type,
-                   e.name AS target_id, [l in labels(e) WHERE l <> '__Entity__' | l][0] AS target_type,
-                   t{{.* , embedding: Null, name: Null}} AS target_properties
-        }}
-        RETURN source_id, source_type, type, target_id, target_type, source_properties, target_properties"""
-        cypher_statement += return_statement
-
-        data = self.structured_query(cypher_statement, param_map=params)
-        data = data if data else []
-
-        triples = []
-        for record in data:
-            source = EntityNode(
-                name=record["source_id"],
-                label=record["source_type"],
-                properties=remove_empty_values(record["source_properties"]),
-            )
-            target = EntityNode(
-                name=record["target_id"],
-                label=record["target_type"],
-                properties=remove_empty_values(record["target_properties"]),
-            )
-            rel = Relation(
-                source_id=record["source_id"],
-                target_id=record["target_id"],
-                label=record["type"],
-            )
-            triples.append([source, rel, target])
-        return triples
-
-    def get_rel_map(
-        self,
-        graph_nodes: List[LabelledNode],
-        depth: int = 2,
-        limit: int = 30,
-        ignore_rels: Optional[List[str]] = None,
-    ) -> List[Triplet]:
-        """Get depth-aware rel map."""
-        triples = []
-
-        ids = [node.id for node in graph_nodes]
-        # Needs some optimization
-        response = self.structured_query(
-            f"""
-            WITH $ids AS id_list
-            UNWIND range(0, size(id_list) - 1) AS idx
-            MATCH (e:`__Entity__`)
-            WHERE e.id = id_list[idx]
-            MATCH p=(e)-[r*1..{depth}]-(other)
-            WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
-            UNWIND relationships(p) AS rel
-            WITH distinct rel, idx
-            WITH startNode(rel) AS source,
-                type(rel) AS type,
-                endNode(rel) AS endNode,
-                idx
-            LIMIT $limit
-            RETURN source.id AS source_id, [l in labels(source) WHERE l <> '__Entity__' | l][0] AS source_type,
-                source{{.* , embedding: Null, id: Null}} AS source_properties,
-                type,
-                endNode.id AS target_id, [l in labels(endNode) WHERE l <> '__Entity__' | l][0] AS target_type,
-                endNode{{.* , embedding: Null, id: Null}} AS target_properties,
-                idx
-            ORDER BY idx
-            LIMIT $limit
-            """,
-            param_map={"ids": ids, "limit": limit},
-        )
-        response = response if response else []
-
-        ignore_rels = ignore_rels or []
-        for record in response:
-            if record["type"] in ignore_rels:
-                continue
-
-            source = EntityNode(
-                name=record["source_id"],
-                label=record["source_type"],
-                properties=remove_empty_values(record["source_properties"]),
-            )
-            target = EntityNode(
-                name=record["target_id"],
-                label=record["target_type"],
-                properties=remove_empty_values(record["target_properties"]),
-            )
-            rel = Relation(
-                source_id=record["source_id"],
-                target_id=record["target_id"],
-                label=record["type"],
-            )
-            triples.append([source, rel, target])
-
-        return triples
-
-    def structured_query(
-        self, query: str, param_map: Optional[Dict[str, Any]] = None
-    ) -> Any:
-        param_map = param_map or {}
-
-        result = self._graph.query(query, param_map)
-        full_result = [
-            {h[1]: d[i] for i, h in enumerate(result.header)} for d in result.result_set
-        ]
-
-        if self.sanitize_query_output:
-            return [value_sanitize(el) for el in full_result]
-        return full_result
-
-    def vector_query(
-        self, query: VectorStoreQuery, **kwargs: Any
-    ) -> Tuple[List[LabelledNode], List[float]]:
-        """Query the graph store with a vector store query."""
-        conditions = None
-        if query.filters:
-            conditions = [
-                f"e.{filter.key} {filter.operator.value} {filter.value}"
-                for filter in query.filters.filters
-            ]
-        filters = (
-            f" {query.filters.condition.value} ".join(conditions).replace("==", "=")
-            if conditions is not None
-            else "1 = 1"
-        )
-
-        data = self.structured_query(
-            f"""MATCH (e:`__Entity__`)
-            WHERE e.embedding IS NOT NULL AND ({filters})
-            WITH e, vec.euclideanDistance(e.embedding, vecf32($embedding)) AS score
-            ORDER BY score LIMIT $limit
-            RETURN e.id AS name,
-               [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
-               e{{.* , embedding: Null, name: Null, id: Null}} AS properties,
-               score""",
-            param_map={
-                "embedding": query.query_embedding,
-                "dimension": len(query.query_embedding),
-                "limit": query.similarity_top_k,
-            },
-        )
-        data = data if data else []
-
-        nodes = []
-        scores = []
-        for record in data:
-            node = EntityNode(
-                name=record["name"],
-                label=record["type"],
-                properties=remove_empty_values(record["properties"]),
-            )
-            nodes.append(node)
-            scores.append(record["score"])
-
-        return (nodes, scores)
-
-    def delete(
-        self,
-        entity_names: Optional[List[str]] = None,
-        relation_names: Optional[List[str]] = None,
-        properties: Optional[dict] = None,
-        ids: Optional[List[str]] = None,
-    ) -> None:
-        """Delete matching data."""
-        if entity_names:
-            self.structured_query(
-                "MATCH (n) WHERE n.name IN $entity_names DETACH DELETE n",
-                param_map={"entity_names": entity_names},
-            )
-
-        if ids:
-            self.structured_query(
-                "MATCH (n) WHERE n.id IN $ids DETACH DELETE n",
-                param_map={"ids": ids},
-            )
-
-        if relation_names:
-            for rel in relation_names:
-                self.structured_query(f"MATCH ()-[r:`{rel}`]->() DELETE r")
-
-        if properties:
-            cypher = "MATCH (e) WHERE "
-            prop_list = []
-            params = {}
-            for i, prop in enumerate(properties):
-                prop_list.append(f"e.`{prop}` = $property_{i}")
-                params[f"property_{i}"] = properties[prop]
-            cypher += " AND ".join(prop_list)
-            self.structured_query(cypher + " DETACH DELETE e", param_map=params)
+                # Defensive: older schemas stored bare property names
+                formatted.append({"property": key, "type": "UNKNOWN"})
+        return formatted
 
     def get_schema(self, refresh: bool = False) -> Any:
         if refresh:
@@ -610,6 +448,505 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
             ]
         )
 
+    ### ----- Writes ----- ###
+
+    def upsert_nodes(self, nodes: Sequence[LabelledNode]) -> None:
+        # Lists to hold separated types
+        entity_dicts: List[dict] = []
+        chunk_dicts: List[dict] = []
+
+        # Sort by type
+        for item in nodes:
+            if isinstance(item, EntityNode):
+                entity_dicts.append({**item.model_dump(), "id": item.id})
+            elif isinstance(item, ChunkNode):
+                chunk_dicts.append({**item.model_dump(), "id": item.id})
+            else:
+                logger.warning(
+                    "Unsupported node type `%s`, skipping.", type(item).__name__
+                )
+
+        if chunk_dicts:
+            for batch in _batched(chunk_dicts):
+                self.structured_query(
+                    f"""
+                    UNWIND $data AS row
+                    MERGE (c:{escape_identifier(CHUNK_LABEL)} {{id: row.id}})
+                    SET c.text = row.text
+                    SET c += row.properties
+                    SET c.{EMBEDDING_KEY} = CASE WHEN row.embedding IS NULL
+                        THEN c.{EMBEDDING_KEY} ELSE vecf32(row.embedding) END
+                    RETURN count(*)
+                    """,
+                    param_map={"data": batch},
+                )
+
+        if not entity_dicts:
+            return
+
+        for dimension in {
+            len(entity["embedding"])
+            for entity in entity_dicts
+            if entity.get("embedding")
+        }:
+            self._ensure_vector_index(BASE_ENTITY_LABEL, dimension)
+
+        # FalkorDB has no APOC, so labels cannot be parameterized. Group the
+        # entities by label to keep a single statement per label instead of one
+        # statement per node.
+        entities_by_label: Dict[str, List[dict]] = defaultdict(list)
+        for entity in entity_dicts:
+            entities_by_label[entity["label"]].append(entity)
+
+        for label, rows in entities_by_label.items():
+            for batch in _batched(rows):
+                self.structured_query(
+                    f"""
+                    UNWIND $data AS row
+                    MERGE (e:{escape_identifier(BASE_ENTITY_LABEL)} {{id: row.id}})
+                    SET e += row.properties
+                    SET e.name = row.name
+                    SET e:{escape_identifier(label)}
+                    SET e.{EMBEDDING_KEY} = CASE WHEN row.embedding IS NULL
+                        THEN e.{EMBEDDING_KEY} ELSE vecf32(row.embedding) END
+                    RETURN count(*)
+                    """,
+                    param_map={"data": batch},
+                )
+
+        # Create MENTIONS relationships for entities with a triplet_source_id
+        mentions = [
+            {
+                "entity_id": entity["id"],
+                "chunk_id": entity["properties"]["triplet_source_id"],
+            }
+            for entity in entity_dicts
+            if (entity.get("properties") or {}).get("triplet_source_id")
+        ]
+        for batch in _batched(mentions):
+            self.structured_query(
+                f"""
+                UNWIND $data AS row
+                MATCH (e:{escape_identifier(BASE_ENTITY_LABEL)} {{id: row.entity_id}})
+                MERGE (c:{escape_identifier(CHUNK_LABEL)} {{id: row.chunk_id}})
+                MERGE (e)<-[:MENTIONS]-(c)
+                RETURN count(*)
+                """,
+                param_map={"data": batch},
+            )
+
+    def _existing_chunk_ids(self, ids: List[str]) -> Set[str]:
+        """Return the subset of ``ids`` that already exist as chunk nodes."""
+        found: Set[str] = set()
+        for batch in _batched([{"id": node_id} for node_id in ids]):
+            rows = self.structured_query(
+                f"""
+                UNWIND $data AS row
+                MATCH (c:{escape_identifier(CHUNK_LABEL)} {{id: row.id}})
+                RETURN c.id AS id
+                """,
+                param_map={"data": batch},
+            )
+            found.update(row["id"] for row in rows or [])
+        return found
+
+    def upsert_relations(self, relations: List[Relation]) -> None:
+        """Add relations."""
+        if not relations:
+            return
+
+        # An endpoint that does not exist yet is created with BASE_ENTITY_LABEL
+        # so that a later `upsert_nodes` MERGE matches this very node instead of
+        # inserting a second one with the same id. Endpoints that already exist
+        # as chunks keep their label for the same reason.
+        endpoint_ids = sorted(
+            {relation.source_id for relation in relations}
+            | {relation.target_id for relation in relations}
+        )
+        chunk_ids = self._existing_chunk_ids(endpoint_ids)
+
+        def label_for(node_id: str) -> str:
+            return CHUNK_LABEL if node_id in chunk_ids else BASE_ENTITY_LABEL
+
+        # Neither relationship types nor labels can be parameterized, so group
+        # the rows by every identifier the statement has to interpolate. Merging
+        # on a labelled pattern is also what lets FalkorDB use the `id` indexes
+        # instead of scanning every node in the graph for each row.
+        grouped: Dict[Tuple[str, str, str], List[dict]] = defaultdict(list)
+        for relation in relations:
+            key = (
+                relation.label,
+                label_for(relation.source_id),
+                label_for(relation.target_id),
+            )
+            grouped[key].append(relation.model_dump())
+
+        for (label, source_label, target_label), rows in grouped.items():
+            for batch in _batched(rows):
+                self.structured_query(
+                    f"""
+                    UNWIND $data AS row
+                    MERGE (source:{escape_identifier(source_label)} {{id: row.source_id}})
+                    MERGE (target:{escape_identifier(target_label)} {{id: row.target_id}})
+                    MERGE (source)-[r:{escape_identifier(label)}]->(target)
+                    SET r += row.properties
+                    RETURN count(*)
+                    """,
+                    param_map={"data": batch},
+                )
+
+    ### ----- Reads ----- ###
+
+    def get(
+        self,
+        properties: Optional[dict] = None,
+        ids: Optional[List[str]] = None,
+    ) -> List[LabelledNode]:
+        """Get nodes."""
+        cypher_statement = "MATCH (e) "
+
+        params: Dict[str, Any] = {}
+        conditions: List[str] = []
+
+        if ids:
+            conditions.append("e.id IN $ids")
+            params["ids"] = ids
+
+        if properties:
+            for i, prop in enumerate(properties):
+                conditions.append(f"e.{escape_identifier(prop)} = $property_{i}")
+                params[f"property_{i}"] = properties[prop]
+
+        if conditions:
+            cypher_statement += "WHERE " + " AND ".join(conditions) + " "
+
+        return_statement = """
+        WITH e
+        RETURN e.id AS name,
+               [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
+               e{.* , embedding: Null, id: Null} AS properties
+        """
+        cypher_statement += return_statement
+
+        response = self.structured_query(cypher_statement, param_map=params)
+        response = response if response else []
+
+        nodes = []
+        for record in response:
+            # text indicates a chunk node
+            # none on the type indicates an implicit node, likely a chunk node
+            if "text" in record["properties"] or record["type"] is None:
+                text = record["properties"].pop("text", "")
+                nodes.append(
+                    ChunkNode(
+                        id_=record["name"],
+                        text=text,
+                        properties=remove_empty_values(record["properties"]),
+                    )
+                )
+            else:
+                nodes.append(
+                    EntityNode(
+                        name=record["name"],
+                        label=record["type"],
+                        properties=remove_empty_values(record["properties"]),
+                    )
+                )
+
+        return nodes
+
+    def get_triplets(
+        self,
+        entity_names: Optional[List[str]] = None,
+        relation_names: Optional[List[str]] = None,
+        properties: Optional[dict] = None,
+        ids: Optional[List[str]] = None,
+    ) -> List[Triplet]:
+        # TODO: handle ids of chunk nodes
+        cypher_statement = f"MATCH (e:{escape_identifier(BASE_ENTITY_LABEL)}) "
+
+        params: Dict[str, Any] = {}
+        conditions: List[str] = []
+
+        if entity_names:
+            conditions.append("e.name IN $entity_names")
+            params["entity_names"] = entity_names
+
+        if ids:
+            conditions.append("e.id IN $ids")
+            params["ids"] = ids
+
+        if properties:
+            for i, prop in enumerate(properties):
+                conditions.append(f"e.{escape_identifier(prop)} = $property_{i}")
+                params[f"property_{i}"] = properties[prop]
+
+        if conditions:
+            cypher_statement += "WHERE " + " AND ".join(conditions) + " "
+
+        relation_filter = (
+            ":" + "|".join(escape_identifier(rel) for rel in relation_names)
+            if relation_names
+            else ""
+        )
+
+        base = escape_identifier(BASE_ENTITY_LABEL)
+        return_statement = f"""
+        WITH e
+        CALL {{
+            WITH e
+            MATCH (e)-[r{relation_filter}]->(t:{base})
+            RETURN e.name AS source_id, [l in labels(e) WHERE l <> '{BASE_ENTITY_LABEL}' | l][0] AS source_type,
+                   e{{.* , embedding: Null, name: Null}} AS source_properties,
+                   type(r) AS type, r{{.*}} AS rel_properties,
+                   t.name AS target_id, [l in labels(t) WHERE l <> '{BASE_ENTITY_LABEL}' | l][0] AS target_type,
+                   t{{.* , embedding: Null, name: Null}} AS target_properties
+            UNION ALL
+            WITH e
+            MATCH (e)<-[r{relation_filter}]-(t:{base})
+            RETURN t.name AS source_id, [l in labels(t) WHERE l <> '{BASE_ENTITY_LABEL}' | l][0] AS source_type,
+                   t{{.* , embedding: Null, name: Null}} AS source_properties,
+                   type(r) AS type, r{{.*}} AS rel_properties,
+                   e.name AS target_id, [l in labels(e) WHERE l <> '{BASE_ENTITY_LABEL}' | l][0] AS target_type,
+                   e{{.* , embedding: Null, name: Null}} AS target_properties
+        }}
+        RETURN source_id, source_type, type, rel_properties, target_id, target_type, source_properties, target_properties"""
+        cypher_statement += return_statement
+
+        data = self.structured_query(cypher_statement, param_map=params)
+        data = data if data else []
+
+        triples = []
+        for record in data:
+            source = EntityNode(
+                name=record["source_id"],
+                label=record["source_type"],
+                properties=remove_empty_values(record["source_properties"]),
+            )
+            target = EntityNode(
+                name=record["target_id"],
+                label=record["target_type"],
+                properties=remove_empty_values(record["target_properties"]),
+            )
+            rel = Relation(
+                source_id=record["source_id"],
+                target_id=record["target_id"],
+                label=record["type"],
+                properties=remove_empty_values(record["rel_properties"] or {}),
+            )
+            triples.append([source, rel, target])
+        return triples
+
+    def get_rel_map(
+        self,
+        graph_nodes: List[LabelledNode],
+        depth: int = 2,
+        limit: int = 30,
+        ignore_rels: Optional[List[str]] = None,
+    ) -> List[Triplet]:
+        """Get depth-aware rel map."""
+        triples = []
+
+        ids = [node.id for node in graph_nodes]
+        if not ids:
+            return triples
+
+        # Filter the ignored relationships server side so that they do not eat
+        # into the `limit` budget.
+        ignored = list({*(ignore_rels or [])})
+
+        response = self.structured_query(
+            f"""
+            WITH $ids AS id_list
+            UNWIND range(0, size(id_list) - 1) AS idx
+            MATCH (e:{escape_identifier(BASE_ENTITY_LABEL)})
+            WHERE e.id = id_list[idx]
+            MATCH p=(e)-[r*1..{int(depth)}]-(other)
+            WHERE ALL(rel in relationships(p) WHERE type(rel) <> 'MENTIONS')
+            UNWIND relationships(p) AS rel
+            WITH distinct rel, idx
+            WHERE NOT type(rel) IN $ignore_rels
+            WITH startNode(rel) AS source,
+                type(rel) AS type,
+                rel{{.*}} AS rel_properties,
+                endNode(rel) AS endNode,
+                idx
+            LIMIT $limit
+            RETURN source.id AS source_id, [l in labels(source) WHERE l <> '__Entity__' | l][0] AS source_type,
+                source{{.* , embedding: Null, id: Null}} AS source_properties,
+                type,
+                rel_properties,
+                endNode.id AS target_id, [l in labels(endNode) WHERE l <> '__Entity__' | l][0] AS target_type,
+                endNode{{.* , embedding: Null, id: Null}} AS target_properties,
+                idx
+            ORDER BY idx
+            LIMIT $limit
+            """,
+            param_map={"ids": ids, "limit": int(limit), "ignore_rels": ignored},
+        )
+        response = response if response else []
+
+        for record in response:
+            source = EntityNode(
+                name=record["source_id"],
+                label=record["source_type"],
+                properties=remove_empty_values(record["source_properties"]),
+            )
+            target = EntityNode(
+                name=record["target_id"],
+                label=record["target_type"],
+                properties=remove_empty_values(record["target_properties"]),
+            )
+            rel = Relation(
+                source_id=record["source_id"],
+                target_id=record["target_id"],
+                label=record["type"],
+                properties=remove_empty_values(record["rel_properties"] or {}),
+            )
+            triples.append([source, rel, target])
+
+        return triples
+
+    def structured_query(
+        self, query: str, param_map: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        param_map = param_map or {}
+
+        result = self._graph.query(query, param_map, timeout=self._timeout)
+        full_result = [
+            {
+                header[1]: to_plain_value(value)
+                for header, value in zip(result.header, row)
+            }
+            for row in result.result_set
+        ]
+
+        if self.sanitize_query_output:
+            return [value_sanitize(el) for el in full_result]
+        return full_result
+
+    def vector_query(
+        self, query: VectorStoreQuery, **kwargs: Any
+    ) -> Tuple[List[LabelledNode], List[float]]:
+        """Query the graph store with a vector store query."""
+        conditions = []
+        filter_params: Dict[str, Any] = {}
+        if query.filters:
+            for index, filter_ in enumerate(query.filters.filters):
+                conditions.append(
+                    f"{'NOT ' if filter_.operator.value == 'nin' else ''}"
+                    f"e.{escape_identifier(filter_.key)} "
+                    f"{convert_operator(filter_.operator.value)} $param_{index}"
+                )
+                filter_params[f"param_{index}"] = filter_.value
+        filters = (
+            f" {query.filters.condition.value} ".join(conditions)
+            if conditions
+            else "1 = 1"
+        )
+
+        dimension = len(query.query_embedding or [])
+        use_vector_index = (
+            not conditions
+            and self._vector_index_dimensions.get(BASE_ENTITY_LABEL) == dimension
+        )
+
+        if use_vector_index:
+            data = self.structured_query(
+                f"""CALL db.idx.vector.queryNodes(
+                        '{BASE_ENTITY_LABEL}', '{EMBEDDING_KEY}',
+                        $limit, vecf32($embedding))
+                YIELD node AS e, score
+                RETURN e.id AS name,
+                    [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
+                    e{{.* , embedding: Null, name: Null, id: Null}} AS properties,
+                    1 - score AS score
+                ORDER BY score DESC""",
+                param_map={
+                    "embedding": query.query_embedding,
+                    "limit": int(query.similarity_top_k),
+                },
+            )
+        else:
+            try:
+                data = self.structured_query(
+                    f"""MATCH (e:{escape_identifier(BASE_ENTITY_LABEL)})
+                    WHERE e.{EMBEDDING_KEY} IS NOT NULL AND ({filters})
+                    WITH e, 1 - vec.cosineDistance(e.{EMBEDDING_KEY}, vecf32($embedding)) AS score
+                    ORDER BY score DESC LIMIT $limit
+                    RETURN e.id AS name,
+                    [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
+                    e{{.* , embedding: Null, name: Null, id: Null}} AS properties,
+                    score""",
+                    param_map={
+                        "embedding": query.query_embedding,
+                        "dimension": dimension,
+                        "limit": int(query.similarity_top_k),
+                        **filter_params,
+                    },
+                )
+            except redis.exceptions.ResponseError as e:
+                if "dimension mismatch" in str(e).lower():
+                    raise ValueError(
+                        "The graph contains embeddings whose dimension differs from "
+                        f"the query embedding ({dimension}). Make sure a single "
+                        "embedding model is used for the whole graph."
+                    ) from e
+                raise
+
+        data = data if data else []
+
+        nodes = []
+        scores = []
+        for record in data:
+            node = EntityNode(
+                name=record["name"],
+                label=record["type"],
+                properties=remove_empty_values(record["properties"]),
+            )
+            nodes.append(node)
+            scores.append(record["score"])
+
+        return (nodes, scores)
+
+    def delete(
+        self,
+        entity_names: Optional[List[str]] = None,
+        relation_names: Optional[List[str]] = None,
+        properties: Optional[dict] = None,
+        ids: Optional[List[str]] = None,
+    ) -> None:
+        """Delete matching data."""
+        if entity_names:
+            self.structured_query(
+                "MATCH (n) WHERE n.name IN $entity_names DETACH DELETE n",
+                param_map={"entity_names": entity_names},
+            )
+
+        if ids:
+            self.structured_query(
+                "MATCH (n) WHERE n.id IN $ids DETACH DELETE n",
+                param_map={"ids": ids},
+            )
+
+        if relation_names:
+            for rel in relation_names:
+                self.structured_query(
+                    f"MATCH ()-[r:{escape_identifier(rel)}]->() DELETE r"
+                )
+
+        if properties:
+            cypher = "MATCH (e) WHERE "
+            prop_list = []
+            params = {}
+            for i, prop in enumerate(properties):
+                prop_list.append(f"e.{escape_identifier(prop)} = $property_{i}")
+                params[f"property_{i}"] = properties[prop]
+            cypher += " AND ".join(prop_list)
+            self.structured_query(cypher + " DETACH DELETE e", param_map=params)
+
+    ### ----- Connection management ----- ###
+
     def switch_graph(self, graph_name: str) -> None:
         """
         Switch to the given graph name (`graph_name`).
@@ -622,11 +959,45 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
 
         """
         self._graph = self._driver.select_graph(graph_name)
+        self._database = graph_name
+
+        if self._create_indexes:
+            self._create_range_indexes()
+        self._refresh_vector_index_info()
 
         try:
             self.refresh_schema()
         except Exception as e:
             raise ValueError(f"Could not refresh schema. Error: {e}")
+
+    def close(self) -> None:
+        """Explicitly close the FalkorDB connection."""
+        if hasattr(self, "_driver"):
+            try:
+                self._driver.connection.close()
+            finally:
+                delattr(self, "_driver")
+
+    def __enter__(self) -> "FalkorDBPropertyGraphStore":
+        """Enter the runtime context, enabling `with FalkorDBPropertyGraphStore(...)`."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Close the connection when leaving the runtime context."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Best-effort cleanup; prefer `close()` or the context manager."""
+        try:
+            self.close()
+        except Exception:
+            # Suppress any exceptions during garbage collection
+            pass
 
 
 FalkorDBPGStore = FalkorDBPropertyGraphStore

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/llama_index/graph_stores/falkordb/falkordb_property_graph.py
@@ -43,6 +43,9 @@ def remove_empty_values(input_dict):
 
 BASE_ENTITY_LABEL = "__Entity__"
 CHUNK_LABEL = "Chunk"
+# Every node written by this store carries one of these labels. FalkorDB indexes
+# are label-scoped, so lookups have to name a label to be able to use them.
+STORE_NODE_LABELS = (BASE_ENTITY_LABEL, CHUNK_LABEL)
 EMBEDDING_KEY = "embedding"
 EXCLUDED_LABELS = []
 EXCLUDED_RELS = []
@@ -128,15 +131,6 @@ def _batched(rows: List[dict], size: Optional[int] = None) -> Iterator[List[dict
     size = size or CHUNK_SIZE
     for index in range(0, len(rows), size):
         yield rows[index : index + size]
-
-
-rel_query = """
-MATCH (n)-[r]->(m)
-UNWIND labels(n) as src_label
-UNWIND labels(m) as dst_label
-UNWIND type(r) as rel_type
-RETURN DISTINCT {start: src_label, type: rel_type, end: dst_label} AS output
-"""
 
 
 class FalkorDBPropertyGraphStore(PropertyGraphStore):
@@ -350,19 +344,53 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
             outputs.append({"type": rel_type, "keys": rows[0]["keys"] if rows else []})
         return outputs
 
+    def _sample_rel_triples(self) -> List[dict]:
+        """
+        Derive the (start label, type, end label) triples present in the graph.
+
+        Relationship types are enumerated exhaustively and their endpoint labels
+        are sampled per type. The obvious `MATCH (n)-[r]->(m)` instead traverses
+        every relationship in the graph, and `PropertyGraphIndex` refreshes the
+        schema after *every* ingestion batch, so that cost is paid over and over
+        and grows with the graph.
+        """
+        triples: List[dict] = []
+        seen: Set[Tuple[str, str, str]] = set()
+
+        for row in self.structured_query("CALL db.relationshipTypes()") or []:
+            rel_type = row["relationshipType"]
+            if rel_type in EXCLUDED_RELS:
+                continue
+
+            rows = self.structured_query(
+                f"""
+                MATCH (n)-[r:{escape_identifier(rel_type)}]->(m)
+                WITH n, m LIMIT $SAMPLE_SIZE
+                UNWIND labels(n) AS start_label
+                UNWIND labels(m) AS end_label
+                RETURN DISTINCT start_label, end_label
+                """,
+                param_map={"SAMPLE_SIZE": SCHEMA_SAMPLE_SIZE},
+            )
+            for record in rows or []:
+                key = (record["start_label"], rel_type, record["end_label"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                triples.append(
+                    {
+                        "start": record["start_label"],
+                        "type": rel_type,
+                        "end": record["end_label"],
+                    }
+                )
+        return triples
+
     def refresh_schema(self) -> None:
         """Refresh the schema."""
         node_properties = self._sample_node_properties()
         rel_properties = self._sample_rel_properties()
-        rel_objs_query_result = self.structured_query(
-            rel_query,
-            param_map={"EXCLUDED_LABELS": [*EXCLUDED_LABELS, BASE_ENTITY_LABEL]},
-        )
-        relationships = (
-            [el["output"] for el in rel_objs_query_result]
-            if rel_objs_query_result
-            else []
-        )
+        relationships = self._sample_rel_triples()
 
         # Get constraints & indexes
         try:
@@ -597,14 +625,48 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
 
     ### ----- Reads ----- ###
 
+    def _match_store_nodes(
+        self, conditions: List[str], params: Dict[str, Any]
+    ) -> List[dict]:
+        """
+        Run a node lookup once per store-managed label and merge the results.
+
+        Every node this store writes carries either ``BASE_ENTITY_LABEL`` or
+        ``CHUNK_LABEL``. Scoping the match to those labels is what lets FalkorDB
+        use the `id` range indexes: its indexes are label-scoped, so an
+        unlabelled `MATCH (e)` degrades to an `All Node Scan` of the whole
+        graph. That matters because `PropertyGraphIndex` calls `get()` twice per
+        ingestion batch to deduplicate, making ingestion quadratic.
+        """
+        where = f"WHERE {' AND '.join(conditions)} " if conditions else ""
+        return_statement = f"""
+        WITH e
+        RETURN e.id AS name,
+               [l in labels(e) WHERE l <> '{BASE_ENTITY_LABEL}' | l][0] AS type,
+               e{{.* , embedding: Null, id: Null}} AS properties
+        """
+
+        records: List[dict] = []
+        seen: Set[str] = set()
+        for label in STORE_NODE_LABELS:
+            rows = self.structured_query(
+                f"MATCH (e:{escape_identifier(label)}) {where}{return_statement}",
+                param_map=params,
+            )
+            for record in rows or []:
+                # A node carrying both labels would otherwise be returned twice.
+                if record["name"] in seen:
+                    continue
+                seen.add(record["name"])
+                records.append(record)
+        return records
+
     def get(
         self,
         properties: Optional[dict] = None,
         ids: Optional[List[str]] = None,
     ) -> List[LabelledNode]:
         """Get nodes."""
-        cypher_statement = "MATCH (e) "
-
         params: Dict[str, Any] = {}
         conditions: List[str] = []
 
@@ -617,19 +679,7 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
                 conditions.append(f"e.{escape_identifier(prop)} = $property_{i}")
                 params[f"property_{i}"] = properties[prop]
 
-        if conditions:
-            cypher_statement += "WHERE " + " AND ".join(conditions) + " "
-
-        return_statement = """
-        WITH e
-        RETURN e.id AS name,
-               [l in labels(e) WHERE l <> '__Entity__' | l][0] AS type,
-               e{.* , embedding: Null, id: Null} AS properties
-        """
-        cypher_statement += return_statement
-
-        response = self.structured_query(cypher_statement, param_map=params)
-        response = response if response else []
+        response = self._match_store_nodes(conditions, params)
 
         nodes = []
         for record in response:
@@ -917,17 +967,22 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
         ids: Optional[List[str]] = None,
     ) -> None:
         """Delete matching data."""
+
+        # As in `get()`, the match has to name a label for FalkorDB to be able
+        # to use its (label-scoped) indexes instead of scanning the graph.
+        def delete_by(condition: str, param_map: Dict[str, Any]) -> None:
+            for label in STORE_NODE_LABELS:
+                self.structured_query(
+                    f"MATCH (e:{escape_identifier(label)}) WHERE {condition} "
+                    "DETACH DELETE e",
+                    param_map=param_map,
+                )
+
         if entity_names:
-            self.structured_query(
-                "MATCH (n) WHERE n.name IN $entity_names DETACH DELETE n",
-                param_map={"entity_names": entity_names},
-            )
+            delete_by("e.name IN $entity_names", {"entity_names": entity_names})
 
         if ids:
-            self.structured_query(
-                "MATCH (n) WHERE n.id IN $ids DETACH DELETE n",
-                param_map={"ids": ids},
-            )
+            delete_by("e.id IN $ids", {"ids": ids})
 
         if relation_names:
             for rel in relation_names:
@@ -936,14 +991,12 @@ class FalkorDBPropertyGraphStore(PropertyGraphStore):
                 )
 
         if properties:
-            cypher = "MATCH (e) WHERE "
             prop_list = []
-            params = {}
+            params: Dict[str, Any] = {}
             for i, prop in enumerate(properties):
                 prop_list.append(f"e.{escape_identifier(prop)} = $property_{i}")
                 params[f"property_{i}"] = properties[prop]
-            cypher += " AND ".join(prop_list)
-            self.structured_query(cypher + " DETACH DELETE e", param_map=params)
+            delete_by(" AND ".join(prop_list), params)
 
     ### ----- Connection management ----- ###
 

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/pyproject.toml
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-graph-stores-falkordb"
-version = "0.5.0"
+version = "0.6.0"
 description = "llama-index graph stores falkordb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/conftest.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/conftest.py
@@ -1,0 +1,79 @@
+import os
+import socket
+import time
+import uuid
+from typing import Iterator
+
+import pytest
+
+FALKORDB_IMAGE = "falkordb/falkordb:latest"
+READINESS_TIMEOUT = 60.0
+
+
+def _free_port() -> int:
+    """Return a currently unused TCP port."""
+    with socket.socket() as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_ready(url: str, timeout: float = READINESS_TIMEOUT) -> bool:
+    """Poll ``url`` until FalkorDB answers a trivial query."""
+    from falkordb import FalkorDB
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            FalkorDB.from_url(url).select_graph("readiness").query("RETURN 1")
+            return True
+        except Exception:
+            time.sleep(0.5)
+    return False
+
+
+@pytest.fixture(scope="session")
+def falkordb_url() -> Iterator[str]:
+    """
+    URL of a FalkorDB instance usable by the tests.
+
+    Uses ``FALKORDB_TEST_URL`` when set, otherwise starts a throwaway container
+    on a free port. Skips (rather than fails) when neither is available.
+    """
+    url = os.environ.get("FALKORDB_TEST_URL")
+    if url:
+        if not _wait_until_ready(url, timeout=10):
+            pytest.skip(f"FalkorDB is not reachable at {url}")
+        yield url
+        return
+
+    docker = pytest.importorskip("docker")
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception as exc:  # pragma: no cover - depends on the environment
+        pytest.skip(f"Docker is not available: {exc}")
+
+    port = _free_port()
+    container = client.containers.run(
+        FALKORDB_IMAGE,
+        detach=True,
+        auto_remove=True,
+        name=f"falkordb_test_{uuid.uuid4().hex[:8]}",
+        ports={"6379/tcp": port},
+    )
+    try:
+        url = f"redis://localhost:{port}"
+        if not _wait_until_ready(url):  # pragma: no cover
+            pytest.skip("FalkorDB container did not become ready in time")
+        yield url
+    finally:
+        try:
+            container.stop(timeout=5)
+        except Exception:  # pragma: no cover
+            pass
+
+
+@pytest.fixture()
+def graph_name() -> str:
+    """A unique graph name so tests never share state."""
+    return f"test_{uuid.uuid4().hex}"

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_falkordb_helpers.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_falkordb_helpers.py
@@ -1,0 +1,100 @@
+"""Unit tests for the helpers that do not require a running FalkorDB."""
+
+import pytest
+
+from llama_index.graph_stores.falkordb.falkordb_property_graph import (
+    FalkorDBPropertyGraphStore,
+    _batched,
+    convert_operator,
+    escape_identifier,
+    remove_empty_values,
+    sample_value_type,
+    to_plain_value,
+)
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("PERSON", "`PERSON`"),
+        ("Business Unit", "`Business Unit`"),
+        ("A` REMOVE e:`__Entity__", "`A REMOVE e:__Entity__`"),
+        ("`", "``"),
+    ],
+)
+def test_escape_identifier(identifier: str, expected: str) -> None:
+    assert escape_identifier(identifier) == expected
+
+
+@pytest.mark.parametrize(
+    ("operator", "expected"),
+    [
+        ("==", "="),
+        ("!=", "<>"),
+        ("in", "IN"),
+        ("nin", "IN"),
+        ("contains", "CONTAINS"),
+        (">=", ">="),
+        ("<", "<"),
+    ],
+)
+def test_convert_operator(operator: str, expected: str) -> None:
+    assert convert_operator(operator) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, "BOOLEAN"),
+        (3, "INTEGER"),
+        (1.5, "FLOAT"),
+        ("text", "STRING"),
+        ([1, 2], "LIST"),
+        ({"a": 1}, "MAP"),
+        (None, "UNKNOWN"),
+    ],
+)
+def test_sample_value_type(value: object, expected: str) -> None:
+    assert sample_value_type(value) == expected
+
+
+def test_to_plain_value_recurses() -> None:
+    assert to_plain_value({"a": [1, {"b": 2}]}) == {"a": [1, {"b": 2}]}
+    assert to_plain_value((1, 2)) == [1, 2]
+    assert to_plain_value("text") == "text"
+
+
+def test_to_plain_value_converts_driver_objects() -> None:
+    from falkordb import Edge, Node
+
+    node = Node(node_id=1, alias="n", labels="PERSON", properties={"name": "Alice"})
+    edge = Edge(src_node=1, relation="KNOWS", dest_node=2, properties={"since": 2023})
+
+    assert to_plain_value(node) == {"name": "Alice"}
+    assert to_plain_value(edge) == {"since": 2023}
+    assert to_plain_value([node, edge]) == [{"name": "Alice"}, {"since": 2023}]
+
+
+def test_batched() -> None:
+    rows = [{"i": i} for i in range(5)]
+    assert list(_batched(rows, size=2)) == [
+        [{"i": 0}, {"i": 1}],
+        [{"i": 2}, {"i": 3}],
+        [{"i": 4}],
+    ]
+    assert list(_batched([], size=2)) == []
+
+
+def test_remove_empty_values() -> None:
+    assert remove_empty_values({"a": 1, "b": None, "c": "", "d": []}) == {"a": 1}
+
+
+def test_format_properties_handles_both_schema_shapes() -> None:
+    formatted = FalkorDBPropertyGraphStore._format_properties(
+        [{"property": "age", "sample": 30}, "name"]
+    )
+    assert formatted == [
+        {"property": "age", "type": "INTEGER"},
+        {"property": "name", "type": "UNKNOWN"},
+    ]
+    assert FalkorDBPropertyGraphStore._format_properties(None) == []

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_graph_stores_falkordb.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_graph_stores_falkordb.py
@@ -1,64 +1,66 @@
-import time
-import docker
-import unittest
-from llama_index.graph_stores.falkordb.base import FalkorDBGraphStore
+from typing import Iterator
 
-# Set up Docker client
-docker_client = docker.from_env()
+import pytest
 
-
-class TestFalkorDBGraphStore(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """Setup method called once for the entire test class."""
-        # Start FalkorDB container
-        try:
-            cls.container = docker_client.containers.run(
-                "falkordb/falkordb:latest",
-                detach=True,
-                name="falkordb_test_instance",
-                ports={"6379/tcp": 6379},
-            )
-            time.sleep(2)  # Allow time for the container to initialize
-        except Exception as e:
-            print(f"Error starting FalkorDB container: {e}")
-            raise
-
-        # Set up the FalkorDB Graph store
-        cls.graph_store = FalkorDBGraphStore(url="redis://localhost:6379")
-
-    @classmethod
-    def tearDownClass(cls):
-        """Teardown method called once after all tests are done."""
-        try:
-            cls.container.stop()
-            cls.container.remove()
-        except Exception as e:
-            print(f"Error stopping/removing container: {e}")
-
-    def test_base_graph(self):
-        self.graph_store.upsert_triplet("node1", "related_to", "node2")
-
-        # Check if the data has been inserted correctly
-        result = self.graph_store.get("node1")
-        expected_result = [
-            "RELATED_TO",
-            "node2",
-        ]  # Expected data
-        self.assertIn(expected_result, result)
-
-        result = self.graph_store.get_rel_map(["node1"], 1)
-        self.assertIn(expected_result, result["node1"])
-
-        self.graph_store.delete("node1", "related_to", "node2")
-
-        result = self.graph_store.get("node1")
-        expected_result = []  # Expected data
-        self.assertEqual(expected_result, result)
-
-        self.graph_store.switch_graph("new_graph")
-        self.graph_store.refresh_schema()
+from llama_index.core.graph_stores.types import GraphStore
+from llama_index.graph_stores.falkordb import FalkorDBGraphStore
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_class() -> None:
+    names_of_base_classes = [b.__name__ for b in FalkorDBGraphStore.__mro__]
+    assert GraphStore.__name__ in names_of_base_classes
+
+
+@pytest.fixture()
+def graph_store(falkordb_url: str, graph_name: str) -> Iterator[FalkorDBGraphStore]:
+    store = FalkorDBGraphStore(url=falkordb_url, database=graph_name)
+    store.query("MATCH (n) DETACH DELETE n")
+    yield store
+    store.close()
+
+
+def test_upsert_and_get(graph_store: FalkorDBGraphStore) -> None:
+    graph_store.upsert_triplet("node1", "related_to", "node2")
+
+    assert ["RELATED_TO", "node2"] in graph_store.get("node1")
+    assert ["RELATED_TO", "node2"] in graph_store.get_rel_map(["node1"], 1)["node1"]
+
+
+def test_delete_removes_orphaned_entities(graph_store: FalkorDBGraphStore) -> None:
+    """Regression: `check_edges` used to be truthy for a count of 0."""
+    graph_store.upsert_triplet("node1", "related_to", "node2")
+    graph_store.delete("node1", "related_to", "node2")
+
+    assert graph_store.get("node1") == []
+    assert graph_store.query("MATCH (n) RETURN count(n)")[0][0] == 0
+
+
+def test_delete_keeps_entities_with_remaining_edges(
+    graph_store: FalkorDBGraphStore,
+) -> None:
+    graph_store.upsert_triplet("node1", "related_to", "node2")
+    graph_store.upsert_triplet("node1", "knows", "node3")
+    graph_store.delete("node1", "related_to", "node2")
+
+    # node1 still has the `knows` edge, node2 is now orphaned
+    ids = {row[0] for row in graph_store.query("MATCH (n) RETURN n.id")}
+    assert ids == {"node1", "node3"}
+
+
+def test_index_is_created(graph_store: FalkorDBGraphStore) -> None:
+    indexes = graph_store.query("CALL db.indexes()")
+    assert any(row[0] == "Entity" for row in indexes)
+
+
+def test_switch_graph_creates_index(
+    graph_store: FalkorDBGraphStore, graph_name: str
+) -> None:
+    graph_store.switch_graph(f"{graph_name}_switched")
+    indexes = graph_store.query("CALL db.indexes()")
+    assert any(row[0] == "Entity" for row in indexes)
+
+
+def test_refresh_schema(graph_store: FalkorDBGraphStore) -> None:
+    graph_store.upsert_triplet("node1", "related_to", "node2")
+    schema = graph_store.get_schema(refresh=True)
+    assert "RELATED_TO" in schema

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_pg_stores_falkordb.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_pg_stores_falkordb.py
@@ -1,159 +1,566 @@
-import time
-import unittest
-import docker
-from llama_index.graph_stores.falkordb import FalkorDBPropertyGraphStore
-from llama_index.core.graph_stores.types import Relation, EntityNode
+from typing import Iterator
+
+import pytest
+
+from llama_index.core.graph_stores.types import (
+    ChunkNode,
+    EntityNode,
+    PropertyGraphStore,
+    Relation,
+)
 from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import (
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+    VectorStoreQuery,
+)
+from llama_index.graph_stores.falkordb import (
+    FalkorDBPGStore,
+    FalkorDBPropertyGraphStore,
+)
+from llama_index.graph_stores.falkordb import falkordb_property_graph
 
-# Set up Docker client
-docker_client = docker.from_env()
+
+def test_class() -> None:
+    names_of_base_classes = [b.__name__ for b in FalkorDBPropertyGraphStore.__mro__]
+    assert PropertyGraphStore.__name__ in names_of_base_classes
+    assert FalkorDBPGStore is FalkorDBPropertyGraphStore
 
 
-class TestFalkorDBPropertyGraphStore(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """Setup method called once for the entire test class."""
-        # Start FalkorDB container
-        try:
-            cls.container = docker_client.containers.run(
-                "falkordb/falkordb:latest",
-                detach=True,
-                name="falkordb_test_instance_pg",
-                ports={"6379/tcp": 6380},
+@pytest.fixture()
+def pg_store(
+    falkordb_url: str, graph_name: str
+) -> Iterator[FalkorDBPropertyGraphStore]:
+    store = FalkorDBPropertyGraphStore(url=falkordb_url, database=graph_name)
+    store.structured_query("MATCH (n) DETACH DELETE n")
+    yield store
+    store.close()
+
+
+def test_upsert_nodes_and_get(pg_store: FalkorDBPropertyGraphStore) -> None:
+    entity = EntityNode(label="PERSON", name="Alice", properties={"age": 30})
+    chunk = ChunkNode(text="Alice is a software engineer.")
+    pg_store.upsert_nodes([entity, chunk])
+
+    retrieved_entities = pg_store.get(ids=[entity.id])
+    assert len(retrieved_entities) == 1
+    assert isinstance(retrieved_entities[0], EntityNode)
+    assert retrieved_entities[0].name == "Alice"
+    assert retrieved_entities[0].label == "PERSON"
+
+    retrieved_chunks = pg_store.get(ids=[chunk.id])
+    assert len(retrieved_chunks) == 1
+    assert isinstance(retrieved_chunks[0], ChunkNode)
+    assert retrieved_chunks[0].text == "Alice is a software engineer."
+
+    retrieved_by_prop = pg_store.get(properties={"age": 30})
+    assert [node.id for node in retrieved_by_prop] == [entity.id]
+
+    assert pg_store.get(properties={"non_existent_prop": "foo"}) == []
+
+
+def test_get_with_ids_and_properties(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: combining `ids` and `properties` produced invalid Cypher."""
+    alice = EntityNode(label="PERSON", name="Alice", properties={"age": 30})
+    bob = EntityNode(label="PERSON", name="Bob", properties={"age": 40})
+    pg_store.upsert_nodes([alice, bob])
+
+    assert [n.name for n in pg_store.get(ids=[alice.id], properties={"age": 30})] == [
+        "Alice"
+    ]
+    assert pg_store.get(ids=[alice.id], properties={"age": 40}) == []
+
+
+def test_get_triplets_with_entity_names_and_ids(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Regression: combining `entity_names` and `ids` produced invalid Cypher."""
+    alice = EntityNode(label="PERSON", name="Alice")
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    pg_store.upsert_relations(
+        [Relation(label="WORKS_FOR", source_id=alice.id, target_id=acme.id)]
+    )
+
+    triplets = pg_store.get_triplets(entity_names=["Alice"], ids=[alice.id])
+    assert [t[1].label for t in triplets] == ["WORKS_FOR"]
+
+
+def test_upsert_relations_is_idempotent(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: relations were CREATEd, duplicating on every re-ingest."""
+    alice = EntityNode(label="PERSON", name="Alice")
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    relation = Relation(
+        label="WORKS_FOR",
+        source_id=alice.id,
+        target_id=acme.id,
+        properties={"since": 2023},
+    )
+
+    for _ in range(3):
+        pg_store.upsert_relations([relation])
+
+    count = pg_store.structured_query(
+        "MATCH ()-[r:WORKS_FOR]->() RETURN count(r) AS count"
+    )
+    assert count[0]["count"] == 1
+
+
+def test_labels_with_special_characters(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: labels were interpolated unquoted, breaking on spaces."""
+    node = EntityNode(label="Business Unit", name="Sales")
+    pg_store.upsert_nodes([node])
+
+    assert [n.label for n in pg_store.get(ids=[node.id])] == ["Business Unit"]
+
+
+def test_label_injection_is_neutralised(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """A backtick in an (LLM generated) label must not escape the identifier."""
+    node = EntityNode(label="A` REMOVE e:`__Entity__", name="Injected")
+    pg_store.upsert_nodes([node])
+
+    labels = pg_store.structured_query(
+        "MATCH (n) WHERE n.id = 'Injected' RETURN labels(n) AS labels"
+    )[0]["labels"]
+    assert "__Entity__" in labels
+
+
+def test_relation_labels_with_special_characters(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    alice = EntityNode(label="PERSON", name="Alice")
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    pg_store.upsert_relations(
+        [Relation(label="WORKS FOR", source_id=alice.id, target_id=acme.id)]
+    )
+
+    triplets = pg_store.get_triplets(entity_names=["Alice"])
+    assert [t[1].label for t in triplets] == ["WORKS FOR"]
+
+
+def test_get_schema_str(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: `get_schema_str` raised TypeError on a non-empty graph."""
+    alice = EntityNode(label="PERSON", name="Alice", properties={"age": 30})
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    pg_store.upsert_relations(
+        [Relation(label="WORKS_FOR", source_id=alice.id, target_id=acme.id)]
+    )
+
+    schema_str = pg_store.get_schema_str(refresh=True)
+    assert "PERSON {" in schema_str
+    assert "age: INTEGER" in schema_str
+    assert "WORKS_FOR" in schema_str
+    # embeddings must never be advertised to the LLM
+    assert "embedding" not in schema_str
+
+    node_props = pg_store.get_schema()["node_props"]["PERSON"]
+    assert {"property": "age", "type": "INTEGER"} in node_props
+
+
+def test_vector_query_returns_similarity(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: a distance was returned, inverting the retriever ranking."""
+    match = EntityNode(label="PERSON", name="Match", embedding=[1.0, 0.0, 0.0])
+    other = EntityNode(label="PERSON", name="Other", embedding=[0.0, 1.0, 0.0])
+    pg_store.upsert_nodes([match, other])
+
+    nodes, scores = pg_store.vector_query(
+        VectorStoreQuery(query_embedding=[1.0, 0.0, 0.0], similarity_top_k=2)
+    )
+
+    assert [node.name for node in nodes] == ["Match", "Other"]
+    assert scores == sorted(scores, reverse=True)
+    assert scores[0] == pytest.approx(1.0, abs=1e-4)
+
+
+def test_vector_index_is_created(pg_store: FalkorDBPropertyGraphStore) -> None:
+    pg_store.upsert_nodes(
+        [EntityNode(label="PERSON", name="Alice", embedding=[1.0, 0.0, 0.0])]
+    )
+    assert pg_store._vector_index_dimensions == {"__Entity__": 3}
+
+
+def test_vector_query_with_filters(pg_store: FalkorDBPropertyGraphStore) -> None:
+    """Regression: filter values were interpolated instead of parameterised."""
+    alice = EntityNode(label="PERSON", name="Alice", embedding=[1.0, 0.0, 0.0])
+    bob = EntityNode(label="PERSON", name="Bob", embedding=[0.9, 0.1, 0.0])
+    pg_store.upsert_nodes([alice, bob])
+
+    nodes, _ = pg_store.vector_query(
+        VectorStoreQuery(
+            query_embedding=[1.0, 0.0, 0.0],
+            similarity_top_k=2,
+            filters=MetadataFilters(
+                filters=[
+                    MetadataFilter(key="name", value="Bob", operator=FilterOperator.EQ)
+                ]
+            ),
+        )
+    )
+    assert [node.name for node in nodes] == ["Bob"]
+
+
+def test_vector_query_filter_value_is_not_executed(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """A malicious filter value must be treated as data, not as Cypher."""
+    pg_store.upsert_nodes(
+        [EntityNode(label="PERSON", name="Alice", embedding=[1.0, 0.0, 0.0])]
+    )
+
+    nodes, _ = pg_store.vector_query(
+        VectorStoreQuery(
+            query_embedding=[1.0, 0.0, 0.0],
+            similarity_top_k=2,
+            filters=MetadataFilters(
+                filters=[
+                    MetadataFilter(
+                        key="name",
+                        value="' OR true RETURN 1 //",
+                        operator=FilterOperator.EQ,
+                    )
+                ]
+            ),
+        )
+    )
+    assert nodes == []
+    assert (
+        pg_store.structured_query("MATCH (n) RETURN count(n) AS count")[0]["count"] == 1
+    )
+
+
+def test_structured_query_returns_plain_values(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Regression: raw driver objects leaked into the LLM context."""
+    pg_store.upsert_nodes([EntityNode(label="PERSON", name="Alice")])
+
+    row = pg_store.structured_query("MATCH (n) RETURN n")[0]["n"]
+    assert isinstance(row, dict)
+    assert row["name"] == "Alice"
+
+    path = pg_store.structured_query("MATCH (n) RETURN [n] AS nodes")[0]["nodes"]
+    assert isinstance(path, list)
+    assert isinstance(path[0], dict)
+
+
+def test_structured_query_sanitizes_embeddings(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Regression: `sanitize_query_output` never applied to node objects."""
+    pg_store.upsert_nodes(
+        [EntityNode(label="PERSON", name="Alice", embedding=[0.1] * 256)]
+    )
+
+    row = pg_store.structured_query("MATCH (n) RETURN n")[0]["n"]
+    assert "embedding" not in row
+
+
+def test_range_indexes_are_created(pg_store: FalkorDBPropertyGraphStore) -> None:
+    labels = {
+        index["label"] for index in pg_store.structured_query("CALL db.indexes()")
+    }
+    assert {"__Entity__", "Chunk"} <= labels
+
+
+def test_create_indexes_can_be_disabled(falkordb_url: str, graph_name: str) -> None:
+    store = FalkorDBPropertyGraphStore(
+        url=falkordb_url, database=graph_name, create_indexes=False
+    )
+    try:
+        assert store.structured_query("CALL db.indexes()") == []
+    finally:
+        store.close()
+
+
+def test_upsert_preserves_existing_embedding(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    pg_store.upsert_nodes(
+        [EntityNode(label="PERSON", name="Alice", embedding=[1.0, 0.0, 0.0])]
+    )
+    pg_store.upsert_nodes(
+        [EntityNode(label="PERSON", name="Alice", properties={"age": 30})]
+    )
+
+    has_embedding = pg_store.structured_query(
+        "MATCH (n) WHERE n.id = 'Alice' RETURN n.embedding IS NOT NULL AS has_embedding"
+    )[0]["has_embedding"]
+    assert has_embedding
+
+
+def test_get_rel_map(pg_store: FalkorDBPropertyGraphStore) -> None:
+    alice = EntityNode(label="PERSON", name="Alice")
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    pg_store.upsert_relations(
+        [
+            Relation(
+                label="WORKS_FOR",
+                source_id=alice.id,
+                target_id=acme.id,
+                properties={"since": 2023},
             )
-            time.sleep(2)  # Allow time for the container to initialize
-        except Exception as e:
-            print(f"Error starting FalkorDB container: {e}")
-            raise
-
-        # Set up the property graph store and clear database
-        cls.pg_store = FalkorDBPropertyGraphStore(url="redis://localhost:6380")
-        cls.pg_store.structured_query("MATCH (n) DETACH DELETE n")  # Clear the database
-
-    @classmethod
-    def tearDownClass(cls):
-        """Teardown method called once after all tests are done."""
-        try:
-            cls.container.stop()
-            cls.container.remove()
-        except Exception as e:
-            print(f"Error stopping/removing container: {e}")
-
-    def test_pg_graph(self):
-        # Create two entity nodes
-        entity1 = EntityNode(label="PERSON", name="Logan", properties={"age": 28})
-        entity2 = EntityNode(label="ORGANIZATION", name="LlamaIndex")
-
-        # Create a relation
-        relation = Relation(
-            label="WORKS_FOR",
-            source_id=entity1.id,
-            target_id=entity2.id,
-            properties={"since": 2023},
-        )
-
-        self.pg_store.upsert_nodes([entity1, entity2])
-        self.pg_store.upsert_relations([relation])
-
-        source_node = TextNode(text="Logan (age 28), works for LlamaIndex since 2023.")
-        relations = [
-            Relation(
-                label="MENTIONS",
-                target_id=entity1.id,
-                source_id=source_node.node_id,
-            ),
-            Relation(
-                label="MENTIONS",
-                target_id=entity2.id,
-                source_id=source_node.node_id,
-            ),
         ]
+    )
 
-        self.pg_store.upsert_llama_nodes([source_node])
-        self.pg_store.upsert_relations(relations)
+    paths = pg_store.get_rel_map(pg_store.get(ids=[alice.id]), depth=1)
+    assert len(paths) == 1
+    source, relation, target = paths[0]
+    assert source.id == alice.id
+    assert target.id == acme.id
+    # relationship properties used to be dropped
+    assert relation.properties == {"since": 2023}
 
-        kg_nodes = self.pg_store.get(ids=[entity1.id])
-        self.assertEqual(len(kg_nodes), 1)
-        self.assertEqual(kg_nodes[0].label, "PERSON")
-        self.assertEqual(kg_nodes[0].name, "Logan")
-
-        kg_nodes = self.pg_store.get(properties={"age": 28})
-        self.assertEqual(len(kg_nodes), 1)
-        self.assertEqual(kg_nodes[0].label, "PERSON")
-        self.assertEqual(kg_nodes[0].name, "Logan")
-
-        # Get paths from a node
-        paths = self.pg_store.get_rel_map(kg_nodes, depth=1)
-        for path in paths:
-            self.assertEqual(path[0].id, entity1.id)
-            self.assertEqual(path[2].id, entity2.id)
-            self.assertEqual(path[1].id, relation.id)
-
-        query = "MATCH (n:`__Entity__`) RETURN n"
-        result = self.pg_store.structured_query(query)
-        self.assertEqual(len(result), 2)
-
-        # Get the original text node back
-        llama_nodes = self.pg_store.get_llama_nodes([source_node.node_id])
-        self.assertEqual(len(llama_nodes), 1)
-        self.assertEqual(llama_nodes[0].text, source_node.text)
-
-        # Upsert a new node
-        new_node = EntityNode(
-            label="PERSON", name="Logan", properties={"age": 28, "location": "Canada"}
+    assert (
+        pg_store.get_rel_map(
+            pg_store.get(ids=[alice.id]), depth=1, ignore_rels=["WORKS_FOR"]
         )
-        self.pg_store.upsert_nodes([new_node])
-        kg_nodes = self.pg_store.get(properties={"age": 28})
-        self.assertEqual(len(kg_nodes), 1)
-        self.assertEqual(kg_nodes[0].label, "PERSON")
-        self.assertEqual(kg_nodes[0].name, "Logan")
-        self.assertEqual(kg_nodes[0].properties["location"], "Canada")
+        == []
+    )
 
-        # Deleting
-        # Delete our entities
-        self.pg_store.delete(ids=[entity1.id, entity2.id])
 
-        # Delete our text nodes
-        self.pg_store.delete(ids=[source_node.node_id])
+def test_llama_nodes_round_trip(pg_store: FalkorDBPropertyGraphStore) -> None:
+    source_node = TextNode(text="Alice works for Acme since 2023.")
+    entity = EntityNode(label="PERSON", name="Alice")
+    pg_store.upsert_llama_nodes([source_node])
+    pg_store.upsert_nodes([entity])
+    pg_store.upsert_relations(
+        [Relation(label="MENTIONS", source_id=source_node.node_id, target_id=entity.id)]
+    )
 
-        nodes = self.pg_store.get(ids=[entity1.id, entity2.id])
-        self.assertEqual(len(nodes), 0)
+    llama_nodes = pg_store.get_llama_nodes([source_node.node_id])
+    assert [node.text for node in llama_nodes] == [source_node.text]
 
-        text_nodes = self.pg_store.get_llama_nodes([source_node.node_id])
-        self.assertEqual(len(text_nodes), 0)
+    pg_store.delete_llama_nodes(node_ids=[source_node.node_id])
+    assert pg_store.get_llama_nodes([source_node.node_id]) == []
 
-        self.pg_store.switch_graph("new_graph")
-        self.pg_store.refresh_schema()
 
-    def test_mentions_relationship_with_triplet_source_id(self):
-        """Test that MENTIONS relationships are created when entities have triplet_source_id."""
-        # Create a chunk node first
-        from llama_index.core.graph_stores.types import ChunkNode
+def test_mentions_relationship_from_triplet_source_id(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    pg_store.upsert_nodes([ChunkNode(id_="chunk_1", text="Test chunk with entities")])
+    pg_store.upsert_nodes(
+        [
+            EntityNode(
+                label="PERSON",
+                name="TestEntity",
+                properties={"triplet_source_id": "chunk_1"},
+            )
+        ]
+    )
 
-        chunk = ChunkNode(id_="chunk_1", text="Test chunk with entities", properties={})
-        self.pg_store.upsert_nodes([chunk])
-
-        # Create entity with triplet_source_id
-        entity = EntityNode(
-            label="PERSON",
-            name="TestEntity",
-            properties={"triplet_source_id": "chunk_1"},
-        )
-
-        self.pg_store.upsert_nodes([entity])
-
-        # Verify MENTIONS relationship exists
-        mentions_query = """
-            MATCH (c:Chunk {id: 'chunk_1'})-[r:MENTIONS]->(e:__Entity__ {name: 'TestEntity'})
-            RETURN count(r) AS mention_count
+    result = pg_store.structured_query(
         """
-        result = self.pg_store.structured_query(mentions_query)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["mention_count"], 1)
+        MATCH (c:Chunk {id: 'chunk_1'})-[r:MENTIONS]->(e:__Entity__ {name: 'TestEntity'})
+        RETURN count(r) AS mention_count
+        """
+    )
+    assert result[0]["mention_count"] == 1
 
-        # Clean up
-        self.pg_store.delete(ids=[entity.id, chunk.id_])
+
+def test_delete(pg_store: FalkorDBPropertyGraphStore) -> None:
+    alice = EntityNode(label="PERSON", name="Alice", properties={"age": 30})
+    acme = EntityNode(label="ORGANIZATION", name="Acme")
+    pg_store.upsert_nodes([alice, acme])
+    pg_store.upsert_relations(
+        [Relation(label="WORKS_FOR", source_id=alice.id, target_id=acme.id)]
+    )
+
+    pg_store.delete(relation_names=["WORKS_FOR"])
+    assert pg_store.get_triplets(entity_names=["Alice"]) == []
+
+    pg_store.delete(properties={"age": 30})
+    assert pg_store.get(ids=[alice.id]) == []
+
+    pg_store.delete(entity_names=["Acme"])
+    assert pg_store.get(ids=[acme.id]) == []
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_switch_graph(pg_store: FalkorDBPropertyGraphStore, graph_name: str) -> None:
+    pg_store.upsert_nodes([EntityNode(label="PERSON", name="Alice")])
+    pg_store.switch_graph(f"{graph_name}_other")
+
+    assert pg_store.get(ids=["Alice"]) == []
+    labels = {
+        index["label"] for index in pg_store.structured_query("CALL db.indexes()")
+    }
+    assert "__Entity__" in labels
+
+
+def test_context_manager_closes_connection(falkordb_url: str, graph_name: str) -> None:
+    with FalkorDBPropertyGraphStore(url=falkordb_url, database=graph_name) as store:
+        store.upsert_nodes([EntityNode(label="PERSON", name="Alice")])
+    assert not hasattr(store, "_driver")
+
+
+def test_client_kwargs_are_forwarded(falkordb_url: str, graph_name: str) -> None:
+    store = FalkorDBPropertyGraphStore(
+        url=falkordb_url, database=graph_name, socket_timeout=30
+    )
+    try:
+        assert store.structured_query("RETURN 1 AS one")[0]["one"] == 1
+    finally:
+        store.close()
+
+
+def test_batched_upserts(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Force several batches per label so the batching loops (and the per-label
+    # grouping inside them) are actually exercised.
+    monkeypatch.setattr(falkordb_property_graph, "CHUNK_SIZE", 10)
+
+    entities = [
+        EntityNode(
+            label="PERSON" if i % 2 else "ORG",
+            name=f"person_{i}",
+            properties={"triplet_source_id": f"chunk_{i}"},
+        )
+        for i in range(105)
+    ]
+    relations = [
+        Relation(label="KNOWS", source_id=f"person_{i}", target_id=f"person_{i + 1}")
+        for i in range(104)
+    ]
+    pg_store.upsert_nodes(entities)
+    pg_store.upsert_relations(relations)
+
+    counts = pg_store.structured_query(
+        "MATCH (n:`__Entity__`) RETURN count(n) AS nodes"
+    )
+    assert counts[0]["nodes"] == 105
+    for label, expected in (("PERSON", 52), ("ORG", 53)):
+        rows = pg_store.structured_query(
+            f"MATCH (n:`{label}`) RETURN count(n) AS nodes"
+        )
+        assert rows[0]["nodes"] == expected
+    rels = pg_store.structured_query("MATCH ()-[r:KNOWS]->() RETURN count(r) AS rels")
+    assert rels[0]["rels"] == 104
+    # MENTIONS is batched separately and must survive the batch boundary too.
+    mentions = pg_store.structured_query(
+        "MATCH (:Chunk)-[r:MENTIONS]->(:`__Entity__`) RETURN count(r) AS rels"
+    )
+    assert mentions[0]["rels"] == 105
+
+
+def test_upsert_relations_before_nodes_does_not_duplicate(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Relation endpoints must be reused by a later upsert_nodes, not duplicated."""
+    pg_store.upsert_relations(
+        [Relation(label="WORKS_FOR", source_id="Alice", target_id="Acme")]
+    )
+    pg_store.upsert_nodes(
+        [
+            EntityNode(label="PERSON", name="Alice", properties={"age": 30}),
+            EntityNode(label="ORG", name="Acme"),
+        ]
+    )
+
+    counts = pg_store.structured_query(
+        "MATCH (n {id: 'Alice'}) RETURN count(n) AS nodes"
+    )
+    assert counts[0]["nodes"] == 1
+
+    nodes = pg_store.get(ids=["Alice"])
+    assert len(nodes) == 1
+    assert nodes[0].properties["age"] == 30
+
+    # The relation must still hang off that same node.
+    triplets = pg_store.get_triplets(entity_names=["Alice"])
+    assert len(triplets) == 1
+    assert triplets[0][1].label == "WORKS_FOR"
+
+
+def test_upsert_relations_uses_indexed_merge(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The MERGE must be label-scoped so FalkorDB can use the `id` index."""
+    pg_store.upsert_nodes([EntityNode(label="PERSON", name="Alice")])
+
+    captured = []
+    original = pg_store.structured_query
+
+    def spy(query, param_map=None):
+        captured.append((query, param_map))
+        return original(query, param_map)
+
+    monkeypatch.setattr(pg_store, "structured_query", spy)
+    pg_store.upsert_relations(
+        [Relation(label="KNOWS", source_id="Alice", target_id="Bob")]
+    )
+
+    merges = [(q, p) for q, p in captured if "MERGE (source" in q]
+    assert merges, "upsert_relations issued no MERGE statement"
+    for query, param_map in merges:
+        plan = str(pg_store._graph.explain(query, params=param_map))
+        assert "All Node Scan" not in plan, plan
+
+
+def test_get_triplets_returns_correct_properties_for_incoming_rels(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Traversing an incoming edge must not swap the two nodes' property bags."""
+    pg_store.upsert_nodes(
+        [
+            EntityNode(label="PERSON", name="Alice", properties={"city": "NYC"}),
+            EntityNode(label="ORG", name="Acme", properties={"industry": "tech"}),
+        ]
+    )
+    pg_store.upsert_relations(
+        [
+            Relation(
+                label="WORKS_FOR",
+                source_id="Alice",
+                target_id="Acme",
+                properties={"since": 2020},
+            )
+        ]
+    )
+
+    # Anchored on the *target*, so the store has to walk the edge backwards.
+    triplets = pg_store.get_triplets(entity_names=["Acme"])
+    assert len(triplets) == 1
+    source, relation, target = triplets[0]
+
+    assert source.name == "Alice"
+    assert source.properties["city"] == "NYC"
+    assert source.properties["id"] == "Alice"
+    assert target.name == "Acme"
+    assert target.properties["industry"] == "tech"
+    assert target.properties["id"] == "Acme"
+    assert relation.properties["since"] == 2020
+
+    # The forward direction must agree with the reverse one.
+    forward = pg_store.get_triplets(entity_names=["Alice"])
+    assert [n.properties for n in (forward[0][0], forward[0][2])] == [
+        source.properties,
+        target.properties,
+    ]
+
+
+def test_refresh_schema_includes_rare_labels(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A label outside the sampling window must still appear in the schema."""
+    monkeypatch.setattr(falkordb_property_graph, "SCHEMA_SAMPLE_SIZE", 5)
+
+    pg_store.upsert_nodes(
+        [EntityNode(label="BULK", name=f"bulk_{i}") for i in range(50)]
+        + [EntityNode(label="RARE", name="rare_1", properties={"rare_prop": "x"})]
+    )
+
+    pg_store.refresh_schema()
+    node_props = pg_store.structured_schema["node_props"]
+    assert {"BULK", "RARE"} <= set(node_props)
+
+    rare_props = {prop["property"] for prop in node_props["RARE"]}
+    assert "rare_prop" in rare_props
+    assert "embedding" not in rare_props
+
+    # ...and the rendered schema the LLM sees must mention it too.
+    assert "RARE" in pg_store.get_schema_str()

--- a/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_pg_stores_falkordb.py
+++ b/llama-index-integrations/graph_stores/llama-index-graph-stores-falkordb/tests/test_pg_stores_falkordb.py
@@ -564,3 +564,151 @@ def test_refresh_schema_includes_rare_labels(
 
     # ...and the rendered schema the LLM sees must mention it too.
     assert "RARE" in pg_store.get_schema_str()
+
+
+def _capture_queries(
+    store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> list:
+    """Record every Cypher statement a store method issues."""
+    captured: list = []
+    original = store.structured_query
+
+    def spy(query, param_map=None):
+        captured.append((query, param_map))
+        return original(query, param_map)
+
+    monkeypatch.setattr(store, "structured_query", spy)
+    return captured
+
+
+def _plans(store: FalkorDBPropertyGraphStore, captured: list) -> list:
+    plans = []
+    for query, params in captured:
+        try:
+            plans.append((query, str(store._graph.explain(query, params=params))))
+        except Exception:
+            # Procedure calls such as `CALL db.labels()` cannot be explained.
+            continue
+    return plans
+
+
+def _seed_graph(store: FalkorDBPropertyGraphStore) -> None:
+    store.upsert_nodes(
+        [
+            EntityNode(label="PERSON", name="Alice", properties={"city": "NYC"}),
+            EntityNode(label="ORG", name="Acme"),
+            ChunkNode(text="some chunk text", id_="chunk_1"),
+        ]
+    )
+    store.upsert_relations(
+        [Relation(label="WORKS_FOR", source_id="Alice", target_id="Acme")]
+    )
+
+
+def test_get_uses_indexes_instead_of_scanning_the_graph(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`get()` runs twice per ingestion batch to dedup - it must not full-scan."""
+    _seed_graph(pg_store)
+
+    captured = _capture_queries(pg_store, monkeypatch)
+    pg_store.get(ids=["Alice", "chunk_1"])
+
+    plans = _plans(pg_store, captured)
+    assert plans, "get() issued no explainable query"
+    for query, plan in plans:
+        assert "All Node Scan" not in plan, f"{query}\n{plan}"
+        assert "Node By Index Scan" in plan, f"{query}\n{plan}"
+
+
+def test_get_still_returns_entities_and_chunks(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    """Splitting the lookup per label must not change what `get()` returns."""
+    _seed_graph(pg_store)
+
+    by_id = {node.id: node for node in pg_store.get(ids=["Alice", "chunk_1"])}
+    assert set(by_id) == {"Alice", "chunk_1"}
+    assert isinstance(by_id["Alice"], EntityNode)
+    assert by_id["Alice"].properties["city"] == "NYC"
+    assert isinstance(by_id["chunk_1"], ChunkNode)
+    assert by_id["chunk_1"].text == "some chunk text"
+
+    # No filters must still return every node the store manages, exactly once.
+    all_ids = [node.id for node in pg_store.get()]
+    assert sorted(all_ids) == ["Acme", "Alice", "chunk_1"]
+
+    # Property filters keep working across both labels.
+    assert [n.id for n in pg_store.get(properties={"city": "NYC"})] == ["Alice"]
+
+
+def test_get_deduplicates_nodes_carrying_both_labels(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    _seed_graph(pg_store)
+    pg_store.structured_query("MATCH (n {id: 'Alice'}) SET n:Chunk")
+
+    assert [node.id for node in pg_store.get(ids=["Alice"])] == ["Alice"]
+
+
+def test_refresh_schema_does_not_traverse_every_relationship(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PropertyGraphIndex refreshes the schema after every ingestion batch."""
+    _seed_graph(pg_store)
+
+    captured = _capture_queries(pg_store, monkeypatch)
+    pg_store.refresh_schema()
+
+    traversals = [
+        (query, plan)
+        for query, plan in _plans(pg_store, captured)
+        if "Conditional Traverse" in plan
+    ]
+    assert traversals, "expected refresh_schema to inspect relationships"
+    for query, plan in traversals:
+        assert "Limit" in plan, f"unbounded relationship traversal:\n{query}\n{plan}"
+
+
+def test_refresh_schema_still_reports_relationships(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    _seed_graph(pg_store)
+    pg_store.refresh_schema()
+
+    triples = {
+        (rel["start"], rel["type"], rel["end"])
+        for rel in pg_store.structured_schema["relationships"]
+    }
+    assert ("PERSON", "WORKS_FOR", "ORG") in triples
+    assert ("Chunk", "MENTIONS", "PERSON") not in triples  # no source id seeded
+    assert "(:PERSON)-[:WORKS_FOR]->(:ORG)" in pg_store.get_schema_str()
+
+
+def test_delete_uses_indexes_instead_of_scanning_the_graph(
+    pg_store: FalkorDBPropertyGraphStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_graph(pg_store)
+
+    captured = _capture_queries(pg_store, monkeypatch)
+    pg_store.delete(ids=["chunk_1"])
+
+    plans = _plans(pg_store, captured)
+    assert plans, "delete() issued no explainable query"
+    for query, plan in plans:
+        assert "All Node Scan" not in plan, f"{query}\n{plan}"
+
+    assert [n.id for n in pg_store.get(ids=["chunk_1"])] == []
+    assert sorted(n.id for n in pg_store.get()) == ["Acme", "Alice"]
+
+
+def test_delete_by_entity_names_and_properties_still_works(
+    pg_store: FalkorDBPropertyGraphStore,
+) -> None:
+    _seed_graph(pg_store)
+
+    pg_store.delete(entity_names=["Acme"])
+    assert sorted(n.id for n in pg_store.get()) == ["Alice", "chunk_1"]
+
+    pg_store.delete(properties={"city": "NYC"})
+    assert sorted(n.id for n in pg_store.get()) == ["chunk_1"]


### PR DESCRIPTION
## Summary

The FalkorDB property graph store had a number of defects that made
`TextToCypherRetriever` and `VectorContextRetriever` unusable, silently returned
incorrect data, and left the store open to Cypher injection. This PR fixes them,
adds index-backed batched writes, and replaces the test module with a suite that
runs against a live FalkorDB.

Every issue below was reproduced against a real `falkordb/falkordb:latest`
container before fixing, and each has a regression test that was verified to fail
when the fix is reverted.

## Changes

**Correctness**

- `refresh_schema()` returned raw sampled values where `get_schema_str()` expects
  `{"property", "type"}` dicts, so **every text-to-Cypher query raised**
  `TypeError`. It now infers type names, and excludes `embedding` so a vector is
  never rendered into the LLM prompt.
- `refresh_schema()` also enumerates labels and relationship types exhaustively
  (`CALL db.labels()` / `db.relationshipTypes()`) and only samples property
  *values*. Previously a `LIMIT` was applied before `UNWIND labels(n)`, so any
  label outside the first 1000 scanned nodes vanished from the schema while
  still being advertised in the relationship section.
- `vector_query()` returned a cosine **distance** ordered `ASC`. Because
  `VectorContextRetriever` sorts descending and filters `score >= similarity_score`,
  ranking was inverted and thresholds were meaningless. It now returns
  `1 - distance` ordered `DESC`.
- `get()` and `get_triplets()` concatenated their `WHERE` conditions **without
  `AND`**, so any call combining two filters (e.g. `ids` + `properties`) was a
  syntax error.
- `get_triplets()` swapped the source/target property bags when a triplet was
  reached by traversing an **incoming** edge, so `node.properties["id"]`
  identified the wrong entity. Relationship properties were also dropped.
- `upsert_relations()` merged endpoints on an unlabelled pattern and stamped
  missing ones as `Chunk`. A later `upsert_nodes()` merges on `__Entity__`, so it
  could not match that stub and inserted a **second node with the same `id`**,
  leaving the relationship attached to the orphan. Endpoints are now created with
  the label `upsert_nodes` uses; endpoints that already exist as chunks keep theirs.
- `FalkorDBGraphStore.check_edges()` tested the row count of a `RETURN count(*)`,
  which is always exactly 1, so it never reported "no remaining edges".
  `switch_graph()` also left `self._database` stale and did not index the new graph.

**Security**

- Labels, relationship types and property keys are backtick-quoted through a new
  `escape_identifier()` before interpolation (FalkorDB has no APOC, so these
  cannot be parameterized). Since labels are typically LLM-generated, a label such
  as ``` `) MATCH (x) DETACH DELETE (x) // ``` previously executed.
- Vector-filter values are now bound as parameters instead of interpolated.

**Performance**

- Every read is scoped to `__Entity__` / `Chunk` so FalkorDB's **label-scoped**
  range indexes apply. `PropertyGraphIndex._insert_nodes` deduplicates each batch
  with two `get()` calls and then refreshes the schema, so all three ran once per
  ingestion batch — and all three previously traversed the **entire graph**,
  making ingestion cost grow with the size of the graph rather than the batch.
  `get()` now matches once per store label and merges the results; `delete()` is
  scoped the same way; `get_llama_nodes()` inherits the fix.
- `refresh_schema()` derived relationship endpoint labels with
  `MATCH (n)-[r]->(m)`, traversing every relationship in the graph on every
  batch. It now enumerates relationship types and samples up to 1000
  relationships per type, matching how node properties were already sampled.
- Writes are batched with `UNWIND` (1000 rows/statement) grouped by label, instead
  of one round trip per node/relation.
- Range indexes on `__Entity__.id` and `Chunk.id` are created on init, and the
  relation `MERGE` is label-scoped so those indexes are actually usable — an
  unlabelled `MERGE` forced an `All Node Scan` per row.

**Other**

- `**falkordb_kwargs` (auth/TLS) and a `timeout` are forwarded to the client.
- `close()`, context-manager and `__del__` support on both stores.
- `Node`/`Edge`/`Path` results are converted to plain dicts, so `value_sanitize`
  can actually strip embeddings and results no longer render as
  `<falkordb.node.Node object at 0x...>` in a text-to-Cypher prompt.
- Vector index on `__Entity__.embedding` created lazily at the first embedding's
  dimension; a dimension mismatch warns and falls back to an exact scan.
- README rewritten to document configuration, indexing and schema behaviour.

## Testing

`tests/` was rewritten as pytest and runs against a real FalkorDB. Set
`FALKORDB_TEST_URL` to reuse an instance, otherwise a container is started
automatically on a free port; if neither Docker nor a server is available the
tests skip rather than fail. Each test gets its own uuid-named graph.

```
$ FALKORDB_TEST_URL=redis://localhost:6399 pytest tests -q
67 passed
$ pytest tests -q          # auto-starts a container
67 passed
$ ruff check llama_index tests && ruff format --check llama_index tests
All checks passed!
```

There is one regression test per fixed defect, and I confirmed each fails when its
fix is reverted (rather than passing vacuously) — including the Cypher-injection,
duplicate-node, swapped-properties, rare-label and index-usage tests.

## Memory / Performance Impact

**Ingestion no longer scans the whole graph.** Measured on a 220k node / 100k
relationship graph, per `PropertyGraphIndex` ingestion batch:

| Per-batch operation | Before | After | Speedup |
| --- | --- | --- | --- |
| `get()` x2 (dedup) | 99.6 ms | 3.2 ms | 31x |
| `refresh_schema()` | 809.2 ms | 13.3 ms | 61x |
| **total per batch** | **908.8 ms** | **16.6 ms** | **55x** |

The before-numbers grow linearly with graph size (`get()` alone went 3.5 ms ->
40 ms as the graph grew 10k -> 200k nodes), so ingesting N batches was quadratic;
the after-numbers are bounded by the batch and the sample size. Results are
byte-identical before and after.

**Writes.** Measured against `falkordb/falkordb:latest`, 500 entities + 500 relations:

| Operation | Before | After | Speedup |
| --- | --- | --- | --- |
| `upsert_nodes` | 550 ms | 28 ms | 19.7x |
| `upsert_relations` | 325 ms | 16 ms | 19.9x |
| **ingest total** | **875 ms** | **44 ms** | **19.7x** |

Memory impact is limited to the new indexes (range indexes on two `id` properties,
plus the vector index that vector search already required) and a bounded 1000-row
batch buffer per write statement.

Trade-off: relationship endpoint labels are now sampled rather than exhaustive, so
a `(:Start)-[:REL]->(:End)` combination occurring in fewer than 1 in 1000
relationships of its type may be missed from the schema. This is the same
trade-off already accepted for node property types, and is documented in the README.


## Related Issues

None filed — found while reviewing the integration.

## Follow-ups (deliberately not in this PR)

- Real async via `falkordb.asyncio`; the `a*` methods still delegate to the sync
  implementations, which is correct but not concurrent.
- `ro_query` for read-only replica routing.
- Full-text index to support hybrid retrieval.

