### PR TITLE
fix: close file handles and http connections in reader integrations

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/llama_index/readers/alibabacloud_aisearch/base.py
@@ -39,6 +39,12 @@ except ImportError:
 FilePath = Union[str, Path]
 
 
+def _read_file_bytes(file_path: FilePath) -> bytes:
+    """Read the full contents of a file, closing the handle when done."""
+    with open(file_path, "rb") as f:
+        return f.read()
+
+
 def retry_decorator(func, wait_seconds: int = 1):
     def wrap(*args, **kwargs):
         while True:
@@ -124,7 +130,7 @@ class AlibabaCloudAISearchDocumentReader(BasePydanticReader):
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
             document = CreateDocumentAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=base64.b64encode(_read_file_bytes(file_path)).decode(),
                 file_name=file_name,
                 file_type=file_type,
             )
@@ -262,7 +268,7 @@ class AlibabaCloudAISearchImageReader(AlibabaCloudAISearchDocumentReader):
             if not file_type:
                 file_type = os.path.splitext(file_name)[1][1:]
             document = CreateImageAnalyzeTaskRequestDocument(
-                content=base64.b64encode(open(file_path, "rb").read()).decode(),
+                content=base64.b64encode(_read_file_bytes(file_path)).decode(),
                 file_name=file_name,
                 file_type=file_type,
             )

--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-alibabacloud-aisearch"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index readers alibabacloud_aisearch integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/tests/test_readers_alibabacloud_aisearch.py
+++ b/llama-index-integrations/readers/llama-index-readers-alibabacloud-aisearch/tests/test_readers_alibabacloud_aisearch.py
@@ -2,6 +2,7 @@ from llama_index.readers.alibabacloud_aisearch import (
     AlibabaCloudAISearchDocumentReader,
     AlibabaCloudAISearchImageReader,
 )
+from llama_index.readers.alibabacloud_aisearch.base import _read_file_bytes
 from llama_index.core.readers.base import BasePydanticReader
 
 
@@ -14,3 +15,10 @@ def test_class():
         b.__name__ for b in AlibabaCloudAISearchImageReader.__mro__
     ]
     assert BasePydanticReader.__name__ in names_of_base_classes
+
+
+def test_read_file_bytes(tmp_path):
+    file_path = tmp_path / "example.bin"
+    file_path.write_bytes(b"hello world")
+
+    assert _read_file_bytes(file_path) == b"hello world"

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/llama_index/readers/huggingface_fs/base.py
@@ -40,8 +40,8 @@ class HuggingFaceFSReader(BaseReader):
                 with open(tmp / "tmp.jsonl.gz", "wb") as fp:
                     fp.write(test_data)
 
-                f = gzip.open(tmp / "tmp.jsonl.gz", "rb")
-                raw = f.read()
+                with gzip.open(tmp / "tmp.jsonl.gz", "rb") as f:
+                    raw = f.read()
                 data = raw.decode()
         else:
             data = test_data.decode()

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-huggingface-fs"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers huggingface fs integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-huggingface-fs/tests/test_readers_huggingface.py
+++ b/llama-index-integrations/readers/llama-index-readers-huggingface-fs/tests/test_readers_huggingface.py
@@ -1,3 +1,7 @@
+import gzip
+import json
+from unittest.mock import MagicMock
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.huggingface_fs import HuggingFaceFSReader
 
@@ -5,3 +9,14 @@ from llama_index.readers.huggingface_fs import HuggingFaceFSReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in HuggingFaceFSReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_load_dicts_from_gzipped_file():
+    reader = HuggingFaceFSReader()
+    reader.fs = MagicMock()
+    lines = "\n".join([json.dumps({"a": 1}), json.dumps({"a": 2})]).encode()
+    reader.fs.read_bytes.return_value = gzip.compress(lines)
+
+    result = reader.load_dicts("hf://datasets/example/file.jsonl.gz")
+
+    assert result == [{"a": 1}, {"a": 2}]

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/api/section.py
@@ -305,7 +305,8 @@ def ungz_file(file: UploadFile, gz_uncompressed_content_type=None) -> UploadFile
     if filename.endswith(".gz"):
         filename = filename[:-3]
 
-    gzip_file = gzip.open(file.file).read()
+    with gzip.open(file.file) as gz:
+        gzip_file = gz.read()
     return UploadFile(
         file=io.BytesIO(gzip_file),
         size=len(gzip_file),

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-sec-filings"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers sec_filings integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/llama_index/readers/stripe_docs/base.py
@@ -30,7 +30,8 @@ class StripeDocsReader(BaseReader):
         self._limit = limit
 
     def _load_url(self, url: str) -> str:
-        return urllib.request.urlopen(url).read()
+        with urllib.request.urlopen(url) as response:
+            return response.read()
 
     def _load_sitemap(self) -> str:
         return self._load_url(STRIPE_SITEMAP_URL)

--- a/llama-index-integrations/readers/llama-index-readers-stripe-docs/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-stripe-docs/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-stripe-docs"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers stripe_docs integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/llama_index/retrievers/galaxia/base.py
@@ -64,37 +64,39 @@ class GalaxiaClient:
         query: str,
     ) -> Union[dict, None]:
         conn = http.client.HTTPSConnection(self.api_url)
+        try:
+            flag_init = False
+            for i in range(self.n_retries):
+                init_res = self.initialize(conn, query)
 
-        flag_init = False
-        for i in range(self.n_retries):
-            init_res = self.initialize(conn, query)
+                if "operationId" in init_res:
+                    flag_init = True
+                    break
 
-            if "operationId" in init_res:
-                flag_init = True
-                break
+                time.sleep(self.wait_time * i)
 
-            time.sleep(self.wait_time * i)
+            if not flag_init:
+                # failed to init
+                return None
 
-        if not flag_init:
-            # failed to init
-            return None
+            flag_proc = False
+            for i in range(1, self.n_retries + 1):
+                time.sleep(self.wait_time * i)
+                status = self.check_status(conn, init_res)
 
-        flag_proc = False
-        for i in range(1, self.n_retries + 1):
-            time.sleep(self.wait_time * i)
-            status = self.check_status(conn, init_res)
+                if status["status"] == "processed":
+                    flag_proc = True
+                    break
 
-            if status["status"] == "processed":
-                flag_proc = True
-                break
+            if flag_proc:
+                res = self.get_result(conn, init_res)
+                return res["result"]["resultItems"]
 
-        if flag_proc:
-            res = self.get_result(conn, init_res)
-            return res["result"]["resultItems"]
-
-        else:
-            # failed to process
-            return None
+            else:
+                # failed to process
+                return None
+        finally:
+            conn.close()
 
 
 class GalaxiaRetriever(BaseRetriever):

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-retrievers-galaxia"
-version = "0.2.1"
+version = "0.2.2"
 description = "llama-index retrievers galaxia integration"
 authors = [{name = "Robert Rozanski"}]
 requires-python = ">=3.8.1,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/tests/test_retrievers_galaxia.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-galaxia/tests/test_retrievers_galaxia.py
@@ -1,6 +1,14 @@
-from unittest.mock import MagicMock
+import json
+from unittest.mock import MagicMock, patch
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.retrievers.galaxia import GalaxiaRetriever
+from llama_index.retrievers.galaxia.base import GalaxiaClient
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    return response
 
 
 def test_retrieve():
@@ -51,3 +59,56 @@ def test_retrieve():
     assert result[0].text == expected_result[0].text
     assert result[0].score == expected_result[0].score
     assert result[0].metadata == expected_result[0].metadata
+
+
+@patch("llama_index.retrievers.galaxia.base.http.client.HTTPSConnection")
+def test_galaxia_client_retrieve_success_closes_connection(mock_https_connection):
+    mock_conn = MagicMock()
+    mock_https_connection.return_value = mock_conn
+    # first init attempt fails (no operationId, exercises the retry/sleep
+    # branch), second attempt succeeds; status is processed on first check
+    mock_conn.getresponse.side_effect = [
+        _mock_response({}),
+        _mock_response({"operationId": "op-1"}),
+        _mock_response({"status": "processed"}),
+        _mock_response({"result": {"resultItems": ["item-1"]}}),
+    ]
+
+    client = GalaxiaClient("api.example.com", "key", "kb-1", n_retries=2, wait_time=0)
+    result = client.retrieve("question")
+
+    assert result == ["item-1"]
+    mock_conn.close.assert_called_once()
+
+
+@patch("llama_index.retrievers.galaxia.base.http.client.HTTPSConnection")
+def test_galaxia_client_retrieve_closes_connection_on_failed_init(
+    mock_https_connection,
+):
+    mock_conn = MagicMock()
+    mock_https_connection.return_value = mock_conn
+    mock_conn.getresponse.return_value = _mock_response({})
+
+    client = GalaxiaClient("api.example.com", "key", "kb-1", n_retries=1, wait_time=0)
+    result = client.retrieve("question")
+
+    assert result is None
+    mock_conn.close.assert_called_once()
+
+
+@patch("llama_index.retrievers.galaxia.base.http.client.HTTPSConnection")
+def test_galaxia_client_retrieve_closes_connection_on_failed_processing(
+    mock_https_connection,
+):
+    mock_conn = MagicMock()
+    mock_https_connection.return_value = mock_conn
+    mock_conn.getresponse.side_effect = [
+        _mock_response({"operationId": "op-1"}),
+        _mock_response({"status": "pending"}),
+    ]
+
+    client = GalaxiaClient("api.example.com", "key", "kb-1", n_retries=1, wait_time=0)
+    result = client.retrieve("question")
+
+    assert result is None
+    mock_conn.close.assert_called_once()


### PR DESCRIPTION
A few readers/retrievers open files or http connections but never close
them (gzip.open, open(), urlopen(), HTTPSConnection). Over a long-running
process this leaks file descriptors until you hit "Too many open files".

Wrapped these in `with` blocks / try-finally so they always close:
- llama-index-readers-huggingface-fs
- llama-index-readers-alibabacloud-aisearch
- llama-index-readers-stripe-docs
- llama-index-readers-sec-filings
- llama-index-retrievers-galaxia

Fixes #22026

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods