### PR TITLE
fix: don't hardcode verify=False for S3 TLS in BotoMinioReader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/llama_index/readers/minio/boto3_client/base.py
@@ -36,6 +36,7 @@ class BotoMinioReader(BaseReader):
         aws_access_secret: Optional[str] = None,
         aws_session_token: Optional[str] = None,
         s3_endpoint_url: Optional[str] = "https://s3.amazonaws.com",
+        verify: Union[bool, str] = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -62,6 +63,11 @@ class BotoMinioReader(BaseReader):
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.
         s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
+        verify (Union[bool, str]): whether to verify TLS certificates on the S3
+            connection, or a path to a CA bundle to use instead of the default.
+            Defaults to True. Only disable this if you understand the risk of
+            man-in-the-middle attacks (e.g. trusted internal network with a
+            self-signed certificate).
 
         """
         super().__init__(*args, **kwargs)
@@ -80,6 +86,7 @@ class BotoMinioReader(BaseReader):
         self.aws_access_secret = aws_access_secret
         self.aws_session_token = aws_session_token
         self.s3_endpoint_url = s3_endpoint_url
+        self.verify = verify
 
     def load_data(self) -> List[Document]:
         """Load file(s) from S3."""
@@ -92,7 +99,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify,
         )
         s3 = boto3.resource(
             "s3",
@@ -101,7 +108,7 @@ class BotoMinioReader(BaseReader):
             aws_secret_access_key=self.aws_access_secret,
             aws_session_token=self.aws_session_token,
             config=boto3.session.Config(signature_version="s3v4"),
-            verify=False,
+            verify=self.verify,
         )
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-minio/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-minio"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers minio integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
+++ b/llama-index-integrations/readers/llama-index-readers-minio/tests/test_readers_minio.py
@@ -8,3 +8,13 @@ def test_class():
 
     names_of_base_classes = [b.__name__ for b in MinioReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+def test_verify_defaults_to_true():
+    reader = BotoMinioReader(bucket="test-bucket")
+    assert reader.verify is True
+
+
+def test_verify_can_be_disabled_explicitly():
+    reader = BotoMinioReader(bucket="test-bucket", verify=False)
+    assert reader.verify is False


### PR DESCRIPTION
BotoMinioReader hardcoded verify=False on both the boto3 client and
resource, so TLS certificate verification was disabled for every
user of this reader, no way to turn it back on. That means AWS creds
and file contents could be intercepted by anyone in the network path.

Added a verify param, defaults to True. If someone genuinely needs
to skip verification (self-signed cert on an internal MinIO), they
can pass verify=False explicitly instead of it being forced on them.

Fixes #21978

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods