### PR TITLE
feat(bedrock-converse): Support thinking type 'disabled'

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/llama_index/llms/bedrock_converse/utils.py
@@ -1066,5 +1066,5 @@ def join_two_dicts(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Dict[str, An
 
 
 class ThinkingDict(TypedDict):
-    type: Literal["enabled", "adaptive"]
+    type: Literal["enabled", "adaptive", "disabled"]
     budget_tokens: NotRequired[int]

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.17"
+version = "0.14.18"
 description = "llama-index llms bedrock converse integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/tests/test_bedrock_converse_utils.py
@@ -925,3 +925,9 @@ def test_thinking_dict_adaptive_no_budget():
     td: ThinkingDict = {"type": "adaptive"}
     assert td["type"] == "adaptive"
     assert "budget_tokens" not in td
+
+
+def test_thinking_dict_disabled_no_budget():
+    td: ThinkingDict = {"type": "disabled"}
+    assert td["type"] == "disabled"
+    assert "budget_tokens" not in td

--- a/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-bedrock-converse/uv.lock
@@ -1935,12 +1935,16 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-bedrock-converse"
-version = "0.14.17"
+version = "0.14.18"
 source = { editable = "." }
 dependencies = [
-    { name = "aioboto3" },
     { name = "boto3" },
     { name = "llama-index-core" },
+]
+
+[package.optional-dependencies]
+async = [
+    { name = "aioboto3" },
 ]
 
 [package.dev-dependencies]
@@ -1970,10 +1974,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=15.0.0,<16" },
+    { name = "aioboto3", marker = "extra == 'async'", specifier = ">=13.0.0" },
     { name = "boto3", specifier = ">=1.38.27,<2" },
     { name = "llama-index-core", specifier = ">=0.14.5,<0.15" },
 ]
+provides-extras = ["async"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

Newer Claude models, like Sonnet 5 and Opus 5, have thinking enabled by default.
- https://platform.claude.com/docs/en/build-with-claude/thinking#configuring-thinking

> On current models, thinking is on by default or one parameter away. [...]

> On Claude Opus 5, Claude Sonnet 5, Claude Fable 5, Claude Mythos 5, and Claude Mythos Preview, thinking is already on: no configuration needed. The first thing most developers need on these models is to see the thinking text, since display defaults to "omitted" there [...]

As a result, if a thinking configuration is _not_ provided (i.e., `thinking=None` (default) when initializing an instance of `BedrockConverse`) and you're using a new Claude model, thinking continues to be on.

To turn thinking off, `thinking: {type: "disabled"}` must be provided.
- https://platform.claude.com/docs/en/build-with-claude/thinking#turning-thinking-off

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
