### PR TITLE
feat(tools-mcp): support MCP Python SDK 2.x alongside 1.x

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## [0.5.0] - 2026-08-01
+
+- Support the MCP Python SDK 2.x line alongside 1.x (widened the pin to `mcp>=1.24.0,<3`).
+- Added an internal `_compat` layer isolating the 1.x/2.x differences: relocated
+  `ProgressFnT`, the `httpx` -> `httpx2` HTTP stack, the `FastMCP` -> `MCPServer`
+  high-level server, `read_timeout_seconds` (timedelta vs float), the
+  `streamable_http_client` 3- vs 2-tuple yield, `Context.log`'s renamed argument,
+  and the camelCase -> snake_case protocol-model field renames.
+- Fixed a silent regression where resource templates were dropped under mcp 2.x
+  (`resourceTemplates` -> `resource_templates`).
+
 ## [0.4.0] - 2025-08-06
 
 - Reworked function `create_model_from_json_schema` in `llama_index.tools.mcp.base`.

--- a/llama-index-integrations/tools/llama-index-tools-mcp/examples/mcp_server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/examples/mcp_server.py
@@ -1,5 +1,5 @@
 import argparse
-from mcp.server.fastmcp import FastMCP
+from llama_index.tools.mcp._compat import MCPServerApp as FastMCP
 from pydantic import BaseModel, IPvAnyAddress
 import ipinfo
 import os

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/_compat.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/_compat.py
@@ -1,0 +1,95 @@
+"""
+Compatibility shims for MCP Python SDK 1.x and 2.x.
+
+The MCP Python SDK 2.0 release (2026-07-28) made several breaking changes that
+touch this integration. Everything version-specific is isolated here so the
+rest of the package can be written once and run under either SDK major:
+
+* ``ProgressFnT`` moved from ``mcp.shared.session`` to ``mcp.client.session``.
+* the HTTP stack moved from ``httpx`` to ``httpx2``.
+* the high-level server class moved from ``mcp.server.fastmcp.FastMCP`` to
+  ``mcp.server.mcpserver.MCPServer`` (the decorator API is otherwise the same).
+* ``ClientSession(read_timeout_seconds=...)`` takes a ``float`` of seconds
+  instead of a ``datetime.timedelta``.
+* ``streamable_http_client`` yields a 2-tuple instead of a 3-tuple.
+* ``Context.log(...)`` renamed its second parameter ``message`` -> ``data``
+  (call it positionally to stay compatible).
+* several protocol-model fields were renamed camelCase -> snake_case
+  (``Tool.inputSchema`` -> ``input_schema``, ``*.mimeType`` -> ``mime_type``,
+  ``ListResourceTemplatesResult.resourceTemplates`` -> ``resource_templates``).
+"""
+
+from datetime import timedelta
+from importlib.metadata import version as _dist_version
+from typing import Any, Union
+
+# ``mcp`` is always installed; the major version drives every branch below.
+MCP_MAJOR = int(_dist_version("mcp").split(".", 1)[0])
+IS_MCP_V2 = MCP_MAJOR >= 2
+
+# --- ProgressFnT relocation ------------------------------------------------
+try:  # mcp 1.x
+    from mcp.shared.session import ProgressFnT
+except ModuleNotFoundError:  # mcp >= 2.0
+    from mcp.client.session import ProgressFnT
+
+# --- httpx (1.x) vs httpx2 (2.x) -------------------------------------------
+if IS_MCP_V2:
+    from httpx2 import AsyncClient, Timeout
+else:
+    from httpx import AsyncClient, Timeout
+
+# --- high-level server class + prompt helpers ------------------------------
+if IS_MCP_V2:
+    from mcp.server.mcpserver import MCPServer as MCPServerApp, Context, Image
+    from mcp.server.mcpserver import prompts as _server_prompts
+else:
+    from mcp.server.fastmcp import FastMCP as MCPServerApp, Context, Image
+    from mcp.server.fastmcp import prompts as _server_prompts
+
+prompt_base = _server_prompts.base
+
+__all__ = [
+    "IS_MCP_V2",
+    "MCP_MAJOR",
+    "ProgressFnT",
+    "AsyncClient",
+    "Timeout",
+    "MCPServerApp",
+    "Context",
+    "Image",
+    "prompt_base",
+    "read_timeout_seconds",
+    "compat_getattr",
+]
+
+_MISSING = object()
+
+
+def read_timeout_seconds(seconds: float) -> Union[float, timedelta]:
+    """
+    Build the value ``ClientSession(read_timeout_seconds=...)`` expects.
+
+    mcp 2.0 takes a plain float of seconds; mcp 1.x wants a ``timedelta``.
+    """
+    return seconds if IS_MCP_V2 else timedelta(seconds=seconds)
+
+
+def compat_getattr(obj: Any, snake: str, camel: str, default: Any = _MISSING) -> Any:
+    """
+    Read a protocol-model field that was renamed camelCase -> snake_case in
+    mcp 2.0, trying the 2.x name first and falling back to the 1.x name.
+
+    If neither attribute exists and a ``default`` is supplied it is returned,
+    otherwise ``AttributeError`` is raised.
+    """
+    value = getattr(obj, snake, _MISSING)
+    if value is _MISSING:
+        value = getattr(obj, camel, _MISSING)
+    if value is _MISSING:
+        if default is _MISSING:
+            raise AttributeError(
+                f"{type(obj).__name__} has neither {snake!r} nor {camel!r}"
+            )
+        return default
+    return value

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, create_model
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.core.tools.types import ToolMetadata
+from llama_index.tools.mcp._compat import compat_getattr
 from llama_index.tools.mcp.tool_spec_mixins import (
     TypeResolutionMixin,
     TypeCreationMixin,
@@ -82,10 +83,10 @@ class McpToolSpec(
         static_resources = (
             static_response.resources if hasattr(static_response, "resources") else []
         )
-        dynamic_resources = (
-            dynamic_response.resourceTemplates
-            if hasattr(dynamic_response, "resourceTemplates")
-            else []
+        # mcp 2.0 renamed this field resourceTemplates -> resource_templates;
+        # read whichever exists so template resources are not silently dropped.
+        dynamic_resources = compat_getattr(
+            dynamic_response, "resource_templates", "resourceTemplates", default=[]
         )
         resources = static_resources + dynamic_resources
         if self.allowed_tools is None:
@@ -135,9 +136,11 @@ class McpToolSpec(
         function_tool_list: List[FunctionTool] = []
         for tool in tools_list:
             fn = self._create_tool_fn(tool.name)
-            # Create a Pydantic model based on the tool inputSchema
+            # Create a Pydantic model based on the tool input schema
+            # (mcp 2.0 renamed Tool.inputSchema -> input_schema).
             model_schema = self.create_model_from_json_schema(
-                tool.inputSchema, model_name=f"{tool.name}_Schema"
+                compat_getattr(tool, "input_schema", "inputSchema"),
+                model_name=f"{tool.name}_Schema",
             )
             # Set up global partial params as default
             tool_partial_params = dict(self.global_partial_params or {})

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -3,7 +3,6 @@ import logging
 import io
 
 from contextlib import asynccontextmanager
-from datetime import timedelta
 from typing import (
     Optional,
     List,
@@ -15,10 +14,8 @@ from typing import (
     Any,
 )
 from urllib.parse import urlparse, parse_qs
-from httpx import AsyncClient, Timeout
 from mcp.client.session import ClientSession
 from mcp.shared._httpx_utils import create_mcp_http_client
-from mcp.shared.session import ProgressFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.streamable_http import streamable_http_client
@@ -28,6 +25,13 @@ from mcp import types
 from pydantic import AnyUrl
 
 from llama_index.core.llms import ChatMessage, TextBlock, ImageBlock
+from llama_index.tools.mcp._compat import (
+    AsyncClient,
+    Timeout,
+    ProgressFnT,
+    compat_getattr,
+    read_timeout_seconds,
+)
 
 
 class StreamingHandler(logging.Handler):
@@ -242,7 +246,7 @@ class BasicMCPClient(ClientSession):
                 ) as streams:
                     async with ClientSession(
                         *streams,
-                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        read_timeout_seconds=read_timeout_seconds(self.timeout),
                         sampling_callback=self.sampling_callback,
                     ) as session:
                         await session.initialize()
@@ -252,11 +256,14 @@ class BasicMCPClient(ClientSession):
                 async with streamable_http_client(
                     url=self.command_or_url,
                     http_client=self.http_client,
-                ) as (read, write, _):
+                ) as streams:
+                    # mcp 1.x yields (read, write, get_session_id); 2.0 yields
+                    # (read, write). Take the first two either way.
+                    read, write = streams[0], streams[1]
                     async with ClientSession(
                         read,
                         write,
-                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        read_timeout_seconds=read_timeout_seconds(self.timeout),
                         sampling_callback=self.sampling_callback,
                     ) as session:
                         await session.initialize()
@@ -269,7 +276,7 @@ class BasicMCPClient(ClientSession):
             async with stdio_client(server_parameters) as streams:
                 async with ClientSession(
                     *streams,
-                    read_timeout_seconds=timedelta(seconds=self.timeout),
+                    read_timeout_seconds=read_timeout_seconds(self.timeout),
                     sampling_callback=self.sampling_callback,
                 ) as session:
                     await session.initialize()
@@ -393,7 +400,9 @@ class BasicMCPClient(ClientSession):
                             blocks=[
                                 ImageBlock(
                                     image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
+                                    image_mimetype=compat_getattr(
+                                        message.content, "mime_type", "mimeType"
+                                    ),
                                 )
                             ],
                         )

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, List, Optional
 
 from mcp.client.session import ClientSession
-from mcp.server.fastmcp import FastMCP, Context
 from pydantic import BaseModel
 
 from llama_index.core.tools import FunctionTool
 from llama_index.core.workflow import Event, StartEvent, StopEvent, Workflow
+from llama_index.tools.mcp._compat import MCPServerApp, Context
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
 
@@ -80,7 +80,7 @@ def workflow_as_mcp(
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
     **fastmcp_init_kwargs: Any,
-) -> FastMCP:
+) -> MCPServerApp:
     """
     Convert a workflow to an MCP app.
 
@@ -98,13 +98,16 @@ def workflow_as_mcp(
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
         **fastmcp_init_kwargs:
-            Additional keyword arguments to pass to the FastMCP constructor.
+            Additional keyword arguments to pass to the MCP server constructor.
+            Note: under mcp 2.0 the high-level server is ``MCPServer`` and no
+            longer accepts ``host``/``port`` here — pass those to ``app.run(...)``
+            instead.
 
     Returns:
         The MCP app object.
 
     """
-    app = FastMCP(**fastmcp_init_kwargs)
+    app = MCPServerApp(**fastmcp_init_kwargs)
 
     # Dynamically get the start event class -- this is a bit of a hack
     StartEventCLS = start_event_model or workflow._start_event_class
@@ -134,7 +137,9 @@ def workflow_as_mcp(
 
         async for event in handler.stream_events():
             if not isinstance(event, StopEvent):
-                await context.log("info", message=event.model_dump_json())
+                # Second arg passed positionally: mcp 1.x names it ``message``,
+                # 2.0 renamed it to ``data``.
+                await context.log("info", event.model_dump_json())
 
         return await handler
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.5.0"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"
@@ -41,7 +41,7 @@ keywords = [
     "tools",
 ]
 dependencies = [
-    "mcp>=1.24.0,<2",
+    "mcp>=1.24.0,<3",
     "llama-index-core>=0.13.0,<0.15",
     "pydantic>=2.0.0,<3",
 ]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
@@ -6,8 +6,12 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Dict, Optional
 
-from mcp.server.fastmcp import FastMCP, Context, Image
-from mcp.server.fastmcp.prompts import base
+from llama_index.tools.mcp._compat import (
+    MCPServerApp as FastMCP,
+    Context,
+    Image,
+    prompt_base as base,
+)
 from PIL import Image as PILImage
 import numpy as np
 import io

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,9 +1,9 @@
 import os
-from httpx import AsyncClient
 import pytest
 
 from llama_index.tools.mcp import BasicMCPClient
 from llama_index.tools.mcp.client import enable_sse
+from llama_index.tools.mcp._compat import AsyncClient, compat_getattr
 from mcp import types
 
 
@@ -73,7 +73,8 @@ async def test_read_resources(client: BasicMCPClient):
     # Test static resource
     resource = await client.read_resource("config://app")
     assert isinstance(resource, types.ReadResourceResult)
-    assert resource.contents[0].mimeType == "text/plain"
+    # mcp 2.0 renamed mimeType -> mime_type on resource contents.
+    assert compat_getattr(resource.contents[0], "mime_type", "mimeType") == "text/plain"
     config_text = resource.contents[0].text
     assert "app_name" in config_text
     assert "MCP Test Server" in config_text


### PR DESCRIPTION
## Description

`llama-index-tools-mcp` was pinned to `mcp<2` and fails to import under the MCP Python SDK 2.0 (released 2026-07-28). This PR adds support for the 2.x line **without dropping 1.x**, widening the pin to `mcp>=1.24.0,<3`.

Rather than a hard bump, all version-specific differences are isolated in a new internal `llama_index/tools/mcp/_compat.py`, so the rest of the package is single-sourced across both SDK majors. mcp 2.0's raised floors (pydantic ≥ 2.12, anyio ≥ 4.9) make dropping 1.x costly for downstream users, so dual support is the safer default; if a hard `>=2,<3` bump is preferred, the compat layer collapses to a couple of imports — happy to switch.

### Breaking changes bridged

| Concern | mcp 1.x | mcp 2.0 |
|---|---|---|
| `ProgressFnT` | `mcp.shared.session` | `mcp.client.session` |
| HTTP stack | `httpx` | `httpx2` |
| High-level server | `mcp.server.fastmcp.FastMCP` | `mcp.server.mcpserver.MCPServer` |
| `ClientSession(read_timeout_seconds=…)` | `timedelta` | `float` seconds |
| `streamable_http_client` yield | 3-tuple | 2-tuple |
| `Context.log(level, …)` 2nd arg | `message=` | `data=` (now passed positionally) |
| `Tool.inputSchema` | camelCase | `input_schema` |
| `*.mimeType` | camelCase | `mime_type` |
| `ListResourceTemplatesResult.resourceTemplates` | camelCase | `resource_templates` |

The last row also fixes a **silent regression**: under 2.0 the old `hasattr(resp, "resourceTemplates")` guard evaluated to `False`, so `McpToolSpec.fetch_resources()` quietly dropped all template resources (undoing #19307) rather than failing. `_compat.compat_getattr` reads whichever name exists.

## How Has This Been Tested?

- Ran the full package test suite under **mcp 1.29.0** and **mcp 2.0.0** in isolated venvs: **51 passed** on each. (`tests/server.py`, the FastMCP-based fixture, was ported to the compat server class so it runs on both.)
- Confirmed `import llama_index.tools.mcp` succeeds on 2.0 (previously failed at `client.py` import time).
- `ruff check` / `ruff format --check` clean on all changed package files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Version Bump?

- [x] Yes — `0.4.8` → `0.5.0`, CHANGELOG updated.

## Note for reviewers

Under mcp 2.0, `MCPServer` no longer accepts `host`/`port` in its constructor (they moved to `run_*_async`), so `workflow_as_mcp(**init_kwargs)` callers should pass those to `app.run(...)` instead. Documented in the `workflow_as_mcp` docstring.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)