### PR TITLE
feat(tools-mcp): expose JSON Schema → Pydantic conversion without a client

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [0.5.0] - 2026-08-01
+
+- Extracted the JSON Schema → Pydantic conversion into a standalone public
+  `JsonSchemaToPydantic` class (exported from `llama_index.tools.mcp`) that works
+  without an MCP client. `McpToolSpec` now delegates to it, so existing callers and
+  `to_tool_list_async` are unchanged and produce identical models.
+
 ## [0.4.0] - 2025-08-06
 
 - Reworked function `create_model_from_json_schema` in `llama_index.tools.mcp.base`.

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
@@ -1,5 +1,6 @@
 from llama_index.tools.mcp.base import McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
+from llama_index.tools.mcp.tool_spec_mixins import JsonSchemaToPydantic
 from llama_index.tools.mcp.utils import (
     workflow_as_mcp,
     get_tools_from_mcp_url,
@@ -9,6 +10,7 @@ from llama_index.tools.mcp.utils import (
 __all__ = [
     "McpToolSpec",
     "BasicMCPClient",
+    "JsonSchemaToPydantic",
     "workflow_as_mcp",
     "get_tools_from_mcp_url",
     "aget_tools_from_mcp_url",

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -4,21 +4,15 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 from mcp.client.session import ClientSession
 from mcp.types import Resource
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel
 
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.core.tools.types import ToolMetadata
-from llama_index.tools.mcp.tool_spec_mixins import (
-    TypeResolutionMixin,
-    TypeCreationMixin,
-    FieldExtractionMixin,
-)
+from llama_index.tools.mcp.tool_spec_mixins import JsonSchemaToPydantic
 
 
-class McpToolSpec(
-    BaseToolSpec, TypeResolutionMixin, TypeCreationMixin, FieldExtractionMixin
-):
+class McpToolSpec(BaseToolSpec):
     """
     MCPToolSpec will get the tools from MCP Client (only need to implement ClientSession) and convert them to LlamaIndex's FunctionTool objects.
 
@@ -48,7 +42,12 @@ class McpToolSpec(
         self.global_partial_params = global_partial_params
         self.partial_params_by_tool = partial_params_by_tool
         self.include_resources = include_resources
-        self.properties_cache = {}
+        self._schema_converter = JsonSchemaToPydantic()
+
+    @property
+    def properties_cache(self) -> Dict[str, type[BaseModel]]:
+        """Cache of Pydantic models built from tool schemas (owned by the converter)."""
+        return self._schema_converter.properties_cache
 
     async def fetch_tools(self) -> List[Any]:
         """
@@ -207,6 +206,9 @@ class McpToolSpec(
         """
         To create a Pydantic model from the JSON Schema of MCP tools.
 
+        Delegates to :class:`~llama_index.tools.mcp.tool_spec_mixins.JsonSchemaToPydantic`,
+        which can also be used directly without an MCP client.
+
         Args:
             schema: A JSON Schema dictionary containing properties and required fields.
             model_name: The name of the model.
@@ -215,32 +217,9 @@ class McpToolSpec(
             A Pydantic model class.
 
         """
-        defs = schema.get("$defs", {})
-
-        # Process all type definitions
-        for cls_name, cls_schema in defs.items():
-            self.properties_cache[cls_name] = self._create_model(
-                cls_schema,
-                cls_name,
-                defs,
-            )
-
-        return self._create_model(schema, model_name)
-
-    def _create_model(
-        self,
-        schema: dict,
-        model_name: str,
-        defs: dict = {},
-    ) -> type[BaseModel]:
-        """Create a Pydantic model from a schema."""
-        if model_name in self.properties_cache:
-            return self.properties_cache[model_name]
-
-        fields = self._extract_fields(schema, defs)
-        model = create_model(model_name, **fields)
-        self.properties_cache[model_name] = model
-        return model
+        return self._schema_converter.create_model_from_json_schema(
+            schema, model_name=model_name
+        )
 
     def remove_model_fields(
         self,
@@ -248,15 +227,10 @@ class McpToolSpec(
         fields_to_remove: Set[str],
         model_name: str,
     ) -> type[BaseModel]:
-        fields = {
-            name: (
-                field.annotation,
-                field.default if field.is_required() else field.default,
-            )
-            for name, field in model.model_fields.items()
-            if name not in fields_to_remove
-        }
-        return create_model(model_name, **fields)
+        """Return a copy of ``model`` with ``fields_to_remove`` dropped."""
+        return self._schema_converter.remove_model_fields(
+            model, fields_to_remove, model_name
+        )
 
 
 def patch_sync(func_async: Callable) -> Callable:

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -1,8 +1,5 @@
-from typing import Any, Dict, List, Union, Literal, Type, TYPE_CHECKING
-from pydantic import Field
-
-if TYPE_CHECKING:
-    from llama_index.tools.mcp.base import McpToolSpec
+from typing import Any, Dict, List, Set, Union, Literal, Type
+from pydantic import BaseModel, Field, create_model
 
 # Map JSON Schema types to Python types
 json_type_mapping: Dict[str, Type] = {
@@ -17,7 +14,7 @@ json_type_mapping: Dict[str, Type] = {
 
 class TypeResolutionMixin:
     def _resolve_field_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         field_schema: dict,
         defs: dict,
     ) -> Any:
@@ -31,7 +28,7 @@ class TypeResolutionMixin:
         return self._resolve_basic_type(field_schema, defs)
 
     def _resolve_reference(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         field_schema: dict,
         defs: dict,
     ) -> Any:
@@ -56,7 +53,7 @@ class TypeResolutionMixin:
         )
 
     def _resolve_union_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         schema: dict,
         defs: dict,
     ) -> Any:
@@ -67,7 +64,7 @@ class TypeResolutionMixin:
         return Union[tuple(union_types)] if len(union_types) > 1 else union_types[0]
 
     def _resolve_union_option(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         option: dict,
         defs: dict,
     ) -> Any:
@@ -81,7 +78,7 @@ class TypeResolutionMixin:
         return self._resolve_basic_type(option, defs)
 
     def _resolve_basic_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         schema: dict,
         defs: dict,
     ) -> Any:
@@ -97,12 +94,16 @@ class TypeResolutionMixin:
 
 
 class TypeCreationMixin:
-    def _create_list_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+    def _create_list_type(
+        self: "JsonSchemaToPydantic", schema: dict, defs: dict
+    ) -> type:
         """Create a List type from schema."""
         item_type = self._resolve_field_type(schema["items"], defs)
         return List[item_type]
 
-    def _create_dict_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+    def _create_dict_type(
+        self: "JsonSchemaToPydantic", schema: dict, defs: dict
+    ) -> type:
         """Create a Dict type from schema."""
         additional_props = schema.get("additionalProperties")
 
@@ -115,11 +116,11 @@ class TypeCreationMixin:
 
         return Dict[str, Any]
 
-    def _is_simple_array(self: "McpToolSpec", schema: dict) -> bool:
+    def _is_simple_array(self: "JsonSchemaToPydantic", schema: dict) -> bool:
         """Check if schema is a simple array type."""
         return schema.get("type") == "array" and "items" in schema
 
-    def _is_simple_object(self: "McpToolSpec", schema: dict) -> bool:
+    def _is_simple_object(self: "JsonSchemaToPydantic", schema: dict) -> bool:
         """Check if schema is a simple object type."""
         additional_props = schema.get("additionalProperties")
         return (
@@ -129,13 +130,13 @@ class TypeCreationMixin:
             and isinstance(additional_props, dict)
         )
 
-    def _extract_ref_name(self: "McpToolSpec", ref_path: str) -> str:
+    def _extract_ref_name(self: "JsonSchemaToPydantic", ref_path: str) -> str:
         """Extract reference name from $ref path."""
         return ref_path.split("#/$defs/")[-1]
 
 
 class FieldExtractionMixin:
-    def _extract_fields(self: "McpToolSpec", schema: dict, defs: dict) -> dict:
+    def _extract_fields(self: "JsonSchemaToPydantic", schema: dict, defs: dict) -> dict:
         """Extract Pydantic fields from schema."""
         properties = self._get_properties(schema)
         required_fields = set(schema.get("required", []))
@@ -161,7 +162,7 @@ class FieldExtractionMixin:
 
         return fields
 
-    def _get_properties(self: "McpToolSpec", schema: dict) -> dict:
+    def _get_properties(self: "JsonSchemaToPydantic", schema: dict) -> dict:
         """Get properties from schema, handling enum types."""
         if "enum" in schema:
             # For enum types, create a property with the schema name as the key
@@ -183,3 +184,89 @@ class FieldExtractionMixin:
         if default_value is None:
             ftype = ftype | type(None)
         return default_value, ftype
+
+
+class JsonSchemaToPydantic(
+    TypeResolutionMixin, TypeCreationMixin, FieldExtractionMixin
+):
+    """
+    Convert the JSON Schema of an MCP tool into a Pydantic model.
+
+    This is the schema-conversion half of :class:`~llama_index.tools.mcp.base.McpToolSpec`,
+    extracted so it can be used without an MCP client. It depends only on its own
+    ``properties_cache`` and never touches a ``ClientSession``, so callers that already
+    hold ``mcp.types.Tool`` definitions can convert a tool's ``inputSchema`` directly::
+
+        from llama_index.tools.mcp import JsonSchemaToPydantic
+
+        converter = JsonSchemaToPydantic()
+        fn_schema = converter.create_model_from_json_schema(
+            tool.inputSchema, model_name=f"{tool.name}_Schema"
+        )
+
+    ``McpToolSpec`` delegates to an instance of this class, so the models it produces
+    are identical to the ones ``to_tool_list_async`` builds.
+    """
+
+    def __init__(self) -> None:
+        self.properties_cache: Dict[str, Type[BaseModel]] = {}
+
+    def create_model_from_json_schema(
+        self,
+        schema: dict[str, Any],
+        model_name: str = "DynamicModel",
+    ) -> type[BaseModel]:
+        """
+        Create a Pydantic model from the JSON Schema of an MCP tool.
+
+        Args:
+            schema: A JSON Schema dictionary containing properties and required fields.
+            model_name: The name of the model.
+
+        Returns:
+            A Pydantic model class.
+
+        """
+        defs = schema.get("$defs", {})
+
+        # Process all type definitions
+        for cls_name, cls_schema in defs.items():
+            self.properties_cache[cls_name] = self._create_model(
+                cls_schema,
+                cls_name,
+                defs,
+            )
+
+        return self._create_model(schema, model_name)
+
+    def _create_model(
+        self,
+        schema: dict,
+        model_name: str,
+        defs: dict = {},
+    ) -> type[BaseModel]:
+        """Create a Pydantic model from a schema."""
+        if model_name in self.properties_cache:
+            return self.properties_cache[model_name]
+
+        fields = self._extract_fields(schema, defs)
+        model = create_model(model_name, **fields)
+        self.properties_cache[model_name] = model
+        return model
+
+    def remove_model_fields(
+        self,
+        model: type[BaseModel],
+        fields_to_remove: Set[str],
+        model_name: str,
+    ) -> type[BaseModel]:
+        """Return a copy of ``model`` with ``fields_to_remove`` dropped."""
+        fields = {
+            name: (
+                field.annotation,
+                field.default if field.is_required() else field.default,
+            )
+            for name, field in model.model_fields.items()
+            if name not in fields_to_remove
+        }
+        return create_model(model_name, **fields)

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.5.0"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_schema_converter.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_schema_converter.py
@@ -1,0 +1,104 @@
+"""
+Tests for JsonSchemaToPydantic — the schema converter used without an MCP client.
+
+These deliberately never construct a ``ClientSession`` (or mock one), which is the
+whole point of https://github.com/run-llama/llama_index/issues/22510.
+"""
+
+from typing import get_args
+
+from pydantic import BaseModel
+
+from llama_index.tools.mcp import JsonSchemaToPydantic, McpToolSpec
+
+# A schema shaped like a real MCP tool inputSchema: a $ref to a nested model,
+# an array, an enum, and an optional (anyOf + null) field.
+TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"$ref": "#/$defs/PersonName"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "color": {"enum": ["red", "green", "blue"]},
+        "note": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+    },
+    "required": ["name", "color"],
+    "$defs": {
+        "PersonName": {
+            "type": "object",
+            "properties": {
+                "first": {"type": "string"},
+                "last": {"type": "string"},
+            },
+            "required": ["first"],
+        }
+    },
+}
+
+
+def test_convert_without_a_client():
+    """The converter builds a model from a tool schema with no client at all."""
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+
+    assert issubclass(model, BaseModel)
+    assert set(model.model_fields) == {"name", "tags", "color", "note"}
+
+    # required vs optional
+    assert model.model_fields["name"].is_required()
+    assert model.model_fields["color"].is_required()
+    assert not model.model_fields["note"].is_required()
+
+
+def test_nested_ref_resolves_to_a_submodel():
+    """A $ref to a $defs entry becomes a nested Pydantic model."""
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+
+    name_type = model.model_fields["name"].annotation
+    assert isinstance(name_type, type) and issubclass(name_type, BaseModel)
+    assert set(name_type.model_fields) == {"first", "last"}
+    # The submodel is also cached under its $defs name.
+    assert "PersonName" in converter.properties_cache
+
+
+def test_enum_resolves_to_literal():
+    converter = JsonSchemaToPydantic()
+    resolved = converter._resolve_field_type({"enum": ["red", "green", "blue"]}, {})
+    from typing import Literal
+
+    assert resolved == Literal["red", "green", "blue"]
+
+
+def test_array_items_are_typed():
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+    # tags isn't required, so its annotation is Optional[List[str]]; unwrap the
+    # Optional and check the list item type is str.
+    tags_type = model.model_fields["tags"].annotation
+    list_type = next(a for a in get_args(tags_type) if a is not type(None))
+    assert get_args(list_type) == (str,)
+
+
+def test_remove_model_fields_standalone():
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+    trimmed = converter.remove_model_fields(model, {"note", "tags"}, "Tool_Schema")
+    assert set(trimmed.model_fields) == {"name", "color"}
+
+
+def test_mcptoolspec_delegates_and_matches():
+    """
+    McpToolSpec produces the same model as the standalone converter, and never
+    touches the client during conversion (a dummy object is enough here).
+    """
+    dummy_client = object()  # conversion must not read the client
+    spec = McpToolSpec(dummy_client)
+
+    from_spec = spec.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+    from_converter = JsonSchemaToPydantic().create_model_from_json_schema(
+        TOOL_SCHEMA, "Tool_Schema"
+    )
+
+    assert from_spec.model_json_schema() == from_converter.model_json_schema()
+    # The spec's properties_cache is the converter's cache.
+    assert spec.properties_cache is spec._schema_converter.properties_cache

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -7,6 +7,7 @@ from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.mcp import (
     BasicMCPClient,
     McpToolSpec,
+    JsonSchemaToPydantic,
     get_tools_from_mcp_url,
     aget_tools_from_mcp_url,
 )
@@ -136,24 +137,24 @@ def test_schema_structure_exact_match(client: BasicMCPClient):
     assert set(json_schema["required"]) == {"name", "method", "lst"}
 
 
-def test_resolve_union_option_with_enum(client: BasicMCPClient):
+def test_resolve_union_option_with_enum():
     """
     Regression test for https://github.com/run-llama/llama_index/issues/20109
 
     _resolve_union_option should handle enum entries in anyOf schemas,
     resolving them to Literal types instead of falling through to str.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
-    result = tool_spec._resolve_union_option({"enum": ["red", "green", "blue"]}, {})
+    result = converter._resolve_union_option({"enum": ["red", "green", "blue"]}, {})
     assert result == Literal["red", "green", "blue"]
 
 
-def test_resolve_union_type_multiple_enums(client: BasicMCPClient):
+def test_resolve_union_type_multiple_enums():
     """
     Test that anyOf with multiple enum entries resolves to a Union of Literals.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -161,18 +162,18 @@ def test_resolve_union_type_multiple_enums(client: BasicMCPClient):
             {"enum": ["cyan", "magenta", "yellow"]},
         ]
     }
-    resolved = tool_spec._resolve_union_type(schema, {})
+    resolved = converter._resolve_union_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert Literal["red", "green", "blue"] in args
     assert Literal["cyan", "magenta", "yellow"] in args
 
 
-def test_resolve_optional_literal(client: BasicMCPClient):
+def test_resolve_optional_literal():
     """
     Test that anyOf with enum + null resolves to Optional[Literal[...]].
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -180,18 +181,18 @@ def test_resolve_optional_literal(client: BasicMCPClient):
             {"type": "null"},
         ]
     }
-    resolved = tool_spec._resolve_union_type(schema, {})
+    resolved = converter._resolve_union_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert type(None) in args
     assert Literal["a", "b", "c"] in args
 
 
-def test_resolve_field_type_delegates_anyof_enums(client: BasicMCPClient):
+def test_resolve_field_type_delegates_anyof_enums():
     """
     Test that _resolve_field_type correctly delegates anyOf with enum entries.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -199,34 +200,34 @@ def test_resolve_field_type_delegates_anyof_enums(client: BasicMCPClient):
             {"enum": ["z"]},
         ]
     }
-    resolved = tool_spec._resolve_field_type(schema, {})
+    resolved = converter._resolve_field_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert Literal["x", "y"] in args
     assert Literal["z"] in args
 
 
-def test_additional_properties_false_parsing(client: BasicMCPClient):
+def test_additional_properties_false_parsing():
     """Test that schemas with additionalProperties: false are parsed correctly."""
     from typing import Dict, Any
 
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     # Test case 1: additionalProperties is False
     schema_false = {"type": "object", "additionalProperties": False}
-    assert not tool_spec._is_simple_object(schema_false)
-    result_type = tool_spec._create_dict_type(schema_false, {})
+    assert not converter._is_simple_object(schema_false)
+    result_type = converter._create_dict_type(schema_false, {})
     assert result_type == Dict[str, Any]
 
     # Test case 2: additionalProperties is None
     schema_none = {"type": "object", "additionalProperties": None}
-    result_type = tool_spec._create_dict_type(schema_none, {})
+    result_type = converter._create_dict_type(schema_none, {})
     assert result_type == Dict[str, Any]
 
     # Test case 3: additionalProperties is a dict (should be treated as simple object)
     schema_dict = {"type": "object", "additionalProperties": {"type": "string"}}
-    assert tool_spec._is_simple_object(schema_dict)
-    result_type = tool_spec._create_dict_type(schema_dict, {})
+    assert converter._is_simple_object(schema_dict)
+    result_type = converter._create_dict_type(schema_dict, {})
     assert result_type == Dict[str, str]
 
 


### PR DESCRIPTION
## Description

`McpToolSpec` mixes two concerns: talking to an MCP server, and converting a tool's JSON Schema into a Pydantic model (`create_model_from_json_schema`, `remove_model_fields`, and the three mixins in `tool_spec_mixins.py`). The conversion depends only on `self.properties_cache` and never reads `self.client`, but it's only reachable by constructing an `McpToolSpec`, whose `__init__` requires a `ClientSession`. Anyone who already holds `mcp.types.Tool` definitions and wants only the conversion has to build a spec that's then never used — or copy the converter into their own code and drift from upstream.

This PR extracts the conversion into a standalone public `JsonSchemaToPydantic` class (exported from `llama_index.tools.mcp`), exactly as sketched in the issue:

```python
from llama_index.tools.mcp import JsonSchemaToPydantic

converter = JsonSchemaToPydantic()
fn_schema = converter.create_model_from_json_schema(
    tool.inputSchema, model_name=f"{tool.name}_Schema"
)
```

`McpToolSpec` now holds a `JsonSchemaToPydantic` instance and delegates `create_model_from_json_schema` / `remove_model_fields` to it (with `properties_cache` exposed as a property for backwards compatibility). Existing callers and `to_tool_list_async` are untouched and produce identical models. Server communication and schema conversion now each have a single responsibility, and the converter is testable and fixable on its own — no client, no mocking.

## How Has This Been Tested?

- New `tests/test_schema_converter.py` builds models with **no client at all**, covering `$ref`/nested models, `anyOf`, `enum`, arrays, `remove_model_fields`, and asserting `McpToolSpec`'s output matches the standalone converter's.
- The existing internal-helper tests (`_resolve_*`, `_is_simple_object`, `_create_dict_type`) were repointed to `JsonSchemaToPydantic`, which is their new home.
- Full package suite: **57 passed** (mcp 1.29.0). `ruff check` / `ruff format --check` clean.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Version Bump?

- [x] Yes — `0.4.8` → `0.5.0`, CHANGELOG updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)