### PR TITLE
fix(core): give each CitationQueryEngine citation node its own id and offsets

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/citation_query_engine.py
@@ -330,11 +330,20 @@ class CitationQueryEngine(BaseQueryEngine):
                 node.node.get_content(metadata_mode=self._metadata_mode)
             )
 
+            # Each citation node holds a single chunk, so the source node's id and
+            # character offsets no longer describe it: copying the id would give
+            # every chunk of a source the same one, and the offsets would span the
+            # whole source. _create_multimodal_citation_nodes already omits both.
+            source_data = node.node.model_dump()
+            source_data.pop("id_", None)
+            source_data["start_char_idx"] = None
+            source_data["end_char_idx"] = None
+
             for text_chunk in text_chunks:
                 text = f"Source {len(new_nodes) + 1}:\n{text_chunk}\n"
 
                 new_node = NodeWithScore(
-                    node=TextNode.model_validate(node.node.model_dump()),
+                    node=TextNode.model_validate(source_data),
                     score=node.score,
                 )
                 new_node.node.set_content(text)

--- a/llama-index-core/tests/query_engine/test_citation_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_citation_query_engine.py
@@ -17,7 +17,9 @@ from llama_index.core.schema import (
     MediaResource,
     MetadataMode,
     Node,
+    NodeRelationship,
     NodeWithScore,
+    RelatedNodeInfo,
     TextNode,
 )
 
@@ -61,6 +63,71 @@ def test_create_citation_nodes_text__prefixes_each_chunk_with_source_label():
     assert len(nodes) >= 2  # got chunked
     for i, nws in enumerate(nodes, start=1):
         assert nws.node.get_content().startswith(f"Source {i}:\n")
+
+
+def _text_citation_query_engine() -> CitationQueryEngine:
+    return CitationQueryEngine(
+        retriever=MagicMock(),
+        llm=MockLLM(),
+        multimodal=False,
+        citation_chunk_size=32,
+        citation_chunk_overlap=0,
+        text_splitter=SentenceSplitter(chunk_size=32, chunk_overlap=0),
+    )
+
+
+def test_create_citation_nodes_text__gives_each_chunk_its_own_id():
+    query_engine = _text_citation_query_engine()
+    src = NodeWithScore(node=TextNode(id_="src-1", text="A. " * 200), score=0.5)
+
+    nodes = query_engine._create_citation_nodes([src])
+
+    assert len(nodes) >= 2  # got chunked
+    ids = [nws.node.node_id for nws in nodes]
+    assert len(set(ids)) == len(ids)
+    assert "src-1" not in ids
+
+
+def test_create_citation_nodes_text__drops_source_char_offsets():
+    query_engine = _text_citation_query_engine()
+    text = "A. " * 200
+    src = NodeWithScore(
+        node=TextNode(text=text, start_char_idx=0, end_char_idx=len(text)),
+        score=0.5,
+    )
+
+    nodes = query_engine._create_citation_nodes([src])
+
+    assert len(nodes) >= 2  # got chunked
+    for nws in nodes:
+        # the chunk is not the span the source offsets describe
+        assert nws.node.start_char_idx is None
+        assert nws.node.end_char_idx is None
+
+
+def test_create_citation_nodes_text__preserves_source_node_metadata():
+    query_engine = _text_citation_query_engine()
+    src = NodeWithScore(
+        node=TextNode(
+            text="A. " * 200,
+            metadata={"file": "doc1.txt"},
+            relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="doc-1")},
+        ),
+        score=0.42,
+    )
+
+    nodes = query_engine._create_citation_nodes([src])
+
+    assert len(nodes) >= 2  # got chunked
+    for nws in nodes:
+        assert nws.node.metadata == {"file": "doc1.txt"}
+        assert nws.node.ref_doc_id == "doc-1"
+        assert nws.score == 0.42
+
+    # each chunk owns its metadata, so editing one does not touch the others
+    nodes[0].node.metadata["file"] = "other.txt"
+    assert nodes[1].node.metadata == {"file": "doc1.txt"}
+    assert src.node.metadata == {"file": "doc1.txt"}
 
 
 def test_create_multimodal_citation_nodes__text_only_chunks_with_source_labels():


### PR DESCRIPTION
# Description

`CitationQueryEngine._create_citation_nodes` splits each retrieved node into per-source citation chunks by round-tripping the whole source node:

```python
new_node = NodeWithScore(
    node=TextNode.model_validate(node.node.model_dump()),
    score=node.score,
)
new_node.node.set_content(text)
```

The full `model_dump()` carries over two fields that describe the *source* node and no longer describe the chunk that replaces its content:

- **`id_`** — every chunk cut from one retrieved node gets that node's id, so all the citation nodes surfaced in `response.source_nodes` share a single id. There is no way to map `[3]` in the answer back to a specific source node, and any consumer that keys or de-duplicates by `node_id` collapses them into one.
- **`start_char_idx` / `end_char_idx`** — the offsets still span the entire source node while the node's content is now a single chunk, so they point at the wrong span. Consumers that use the offsets for highlighting or for locating a citation in the original document get the whole document back.

The multimodal sibling, `_create_multimodal_citation_nodes`, already builds each citation node from an explicit field whitelist (`embedding`, `metadata`, excluded-key lists, `relationships`) and therefore carries neither field — so the two branches of the same method disagree today. This makes the text branch match.

Reproducer on `main` — one retrieved node, 14 citation chunks:

```python
long_text = ". ".join(f"sentence number {i} with some filler words" for i in range(80))
src = TextNode(text=long_text, start_char_idx=0, end_char_idx=len(long_text))

qe = CitationQueryEngine(retriever=..., citation_chunk_size=64, citation_chunk_overlap=0)
cn = qe._create_citation_nodes([NodeWithScore(node=src, score=0.9)])

len(cn)                                   # 14
len({n.node.node_id for n in cn})         # 1      -> expected 14
cn[0].node.start_char_idx, cn[0].node.end_char_idx   # (0, 3428), content is 262 chars
```

After the change: 14 unique ids, and offsets are `None`.

## Fix

Drop `id_` (so each chunk gets a fresh uuid from the `TextNode` default) and null the two character offsets before validating. `metadata`, `embedding`, excluded-metadata keys, `relationships` — including `SOURCE`, so tracing a citation back to its document still works — and the `score` are all unchanged.

The dump is also hoisted out of the inner loop, since it was being recomputed for every chunk of the same source node.

## New Tests

Three tests in `tests/query_engine/test_citation_query_engine.py`, mirroring the naming and structure of the existing `_create_multimodal_citation_nodes` tests:

- `test_create_citation_nodes_text__gives_each_chunk_its_own_id`
- `test_create_citation_nodes_text__drops_source_char_offsets`
- `test_create_citation_nodes_text__preserves_source_node_metadata` — a regression guard that the fix does not strip too much (metadata, `ref_doc_id`, `score` survive, and the chunks do not share a metadata dict with each other or with the source node)

The first two fail on `main` (`assert 1 == 13`, `assert 0 is None`) and pass with the change; the third passes either way by design.

## Version Bump?

No — bug fix, no public API change.

## Suggested Checklist

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests
