### PR TITLE
fix(core): persist SimpleChatStore without escaping non-ascii

### DIFF
--- a/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
@@ -91,7 +91,9 @@ class SimpleChatStore(BaseChatStore):
             fs.makedirs(dirpath)
 
         with fs.open(persist_path, "w", encoding="utf-8") as f:
-            f.write(self.json())
+            # model_dump_json writes non-ascii characters as-is, while BaseComponent.json()
+            # escapes them to \uXXXX sequences (json.dumps default).
+            f.write(self.model_dump_json())
 
     @classmethod
     def from_persist_path(

--- a/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
+++ b/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from llama_index.core.llms import ChatMessage
 from llama_index.core.storage.chat_store import SimpleChatStore
 
@@ -73,4 +75,19 @@ def test_delete_chat_message_idx() -> None:
 
     assert chat_store.get_messages("user1") == [
         ChatMessage(role="user", content="world"),
+    ]
+
+
+def test_persist_non_ascii_unescaped(tmp_path: Path) -> None:
+    """Test that non-ascii content is persisted as-is, not as unicode escapes."""
+    chat_store = SimpleChatStore()
+
+    chat_store.add_message("user1", ChatMessage(role="user", content="ハロー héllo"))
+
+    persist_path = str(tmp_path / "chat_store.json")
+    chat_store.persist(persist_path)
+
+    assert "ハロー héllo" in (tmp_path / "chat_store.json").read_text(encoding="utf-8")
+    assert SimpleChatStore.from_persist_path(persist_path).get_messages("user1") == [
+        ChatMessage(role="user", content="ハロー héllo"),
     ]


### PR DESCRIPTION
# Description

`SimpleChatStore.persist()` writes every non-ascii character as a `\uXXXX` escape, so persisted chat stores containing CJK, Cyrillic or accented text are unreadable on disk and several times larger than necessary.

The file is already opened with `encoding="utf-8"` (#21111), but the payload itself is produced by `BaseComponent.json()`, which routes through `json.dumps()` and inherits its `ensure_ascii=True` default. The encoding on the file handle never gets a chance to matter.

Reproduction on `main`:

```python
from llama_index.core.storage.chat_store import SimpleChatStore
from llama_index.core.llms import ChatMessage

s = SimpleChatStore()
s.add_message("u", ChatMessage(role="user", content="ハローワールド 안녕 héllo"))
s.persist("chat_store.json")
```

Current output — every non-ascii character escaped:

```json
{"store": {"u": [{"role": "user", "additional_kwargs": {}, "blocks": [{"block_type": "text", "text": "\u30cf\u30ed\u30fc\u30ef\u30fc\u30eb\u30c9 \uc548\ub155 h\u00e9llo"}]}]}, "class_name": "SimpleChatStore"}
```

With this change:

```json
{"store":{"u":[{"role":"user","additional_kwargs":{},"blocks":[{"block_type":"text","text":"ハローワールド 안녕 héllo"}]}]},"class_name":"SimpleChatStore"}
```

Switching to pydantic's `model_dump_json()` emits the identical payload as raw UTF-8. It goes through the same `WrapSerializer` on `ChatMessage`, still includes `class_name`, and round-trips through the existing `from_persist_path()` unchanged, so persisted files stay backward and forward compatible.

Fixes #15055

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core` is exempt)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_persist_non_ascii_unescaped` asserts the raw file contains the literal characters and that the store round-trips. It fails on `main` and passes with this change:

```
$ uv run pytest tests/storage/chat_store/test_simple_chat_store.py -q
5 passed in 0.02s
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
