### PR TITLE
fix(llama-cpp): report the model's effective context window

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/llama_index/llms/llama_cpp/base.py
@@ -184,7 +184,10 @@ class LlamaCPP(CustomLLM):
             model_path=model_path,
             model_url=model_url,
             temperature=temperature,
-            context_window=context_window,
+            # llama.cpp resolves the effective context (model default when n_ctx is 0,
+            # clamped to what the model supports), so read it back off the loaded model
+            # instead of trusting the requested value.
+            context_window=model.n_ctx(),
             max_new_tokens=max_new_tokens,
             callback_manager=callback_manager,
             generate_kwargs=generate_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-llama-cpp"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index llms llama cpp integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/tests/test_llms_llama_cpp.py
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/tests/test_llms_llama_cpp.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+from llama_index.llms.llama_cpp import base as llama_cpp_base
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.llms.llama_cpp import LlamaCPP
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
@@ -48,3 +51,26 @@ def test_messages_to_prompt_v3_instruct():
         "<|start_header_id|>assistant<|end_header_id|>\n\n"
     )
     assert messages_to_prompt_v3_instruct(messages, "SYSTEM PROMPT") == output
+
+
+def test_context_window_read_back_from_model(tmp_path, monkeypatch):
+    """Requesting n_ctx=0 (model default) should report the model's real context."""
+
+    class FakeLlama:
+        def __init__(self, model_path, **kwargs):
+            self.requested_n_ctx = kwargs.get("n_ctx")
+            self.context_params = SimpleNamespace(n_ctx=4096)
+
+        def n_ctx(self):
+            return 4096
+
+    monkeypatch.setattr(llama_cpp_base, "Llama", FakeLlama)
+
+    model_path = tmp_path / "model.gguf"
+    model_path.write_bytes(b"")
+
+    llm = LlamaCPP(model_path=str(model_path), context_window=0)
+
+    assert llm._model.requested_n_ctx == 0
+    assert llm.context_window == 4096
+    assert llm.metadata.context_window == 4096

--- a/llama-index-integrations/llms/llama-index-llms-llama-cpp/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-llama-cpp/uv.lock
@@ -1846,7 +1846,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-llama-cpp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-cpp-python" },


### PR DESCRIPTION
# Description

`LlamaCPP` stored the *requested* `context_window` rather than the one llama.cpp actually resolved, which breaks two cases:

1. **`context_window=0` is rejected outright.** `0` is llama.cpp's documented "use the model's own trained context" flag, but it is passed straight to the pydantic field, which declares `gt=0`:

   ```
   pydantic_core._pydantic_core.ValidationError: 1 validation error for LlamaCPP
   context_window
     Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]
   ```

2. **Clamped values are reported inaccurately.** When the runtime narrows `n_ctx` to what the model supports, `llm.context_window` keeps the larger requested number, so token budgeting downstream over-estimates the real window.

The loaded model already knows the answer, and `LlamaCPP.metadata` was reading it correctly all along via `self._model.context_params.n_ctx` — only the field itself was stale. Reading it back with `Llama.n_ctx()` before `super().__init__()` makes the field agree with `metadata.context_window`, and the value is always positive so the existing `gt=0` constraint still holds.

Fixes #14727

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.6.0 → 0.6.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_context_window_read_back_from_model` monkeypatches `Llama` with a stub that reports a different context than requested, then asserts the requested `n_ctx=0` reaches llama.cpp while `context_window` and `metadata.context_window` both report the resolved size. It fails on `main` with the ValidationError above and passes with this change:

```
$ uv run pytest tests/test_llms_llama_cpp.py -q
4 passed in 3.96s
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
