### PR TITLE
fix(weaviate): return real properties as node metadata for pre-existing collections

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/utils.py
@@ -7,6 +7,7 @@ Contain conversion to and from dataclasses that LlamaIndex uses.
 
 import logging
 from typing import Any, Dict, List, cast
+from uuid import uuid4
 
 
 from llama_index.core.schema import BaseNode, MetadataMode, TextNode
@@ -142,11 +143,18 @@ def to_node(entry: Dict, text_key: str = DEFAULT_TEXT_KEY) -> TextNode:
         node.embedding = embedding
     except Exception as e:
         _logger.debug("Failed to parse Node metadata, fallback to legacy logic. %s", e)
-        metadata, node_info, relationships = legacy_metadata_dict_to_node(entry)
+        # Only the properties are node metadata -- passing the whole entry would
+        # surface the Weaviate object wrapper (uuid/vector/collection/...) as the
+        # node's metadata and hide the real properties one level down.
+        metadata, node_info, relationships = legacy_metadata_dict_to_node(
+            entry["properties"]
+        )
+
+        node_id = additional.get("id") or entry.get("uuid")
 
         node = TextNode(
             text=text,
-            id_=additional.get("id", str(metadata.get("uuid"))),
+            id_=str(node_id) if node_id is not None else str(uuid4()),
             metadata=metadata,
             start_char_idx=node_info.get("start", None),
             end_char_idx=node_info.get("end", None),

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-weaviate"
-version = "1.6.1"
+version = "1.6.2"
 description = "llama-index vector_stores weaviate integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_utils.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for the Weaviate <-> LlamaIndex serializers.
+
+These do not need a running Weaviate instance: ``to_node`` is a pure function
+over the ``__dict__`` of a ``weaviate.outputs.query.Object``, which is exactly
+what ``WeaviateVectorStore.parse_query_result`` passes it.
+"""
+
+import json
+from uuid import UUID
+
+from llama_index.core.schema import NodeRelationship, TextNode
+from llama_index.core.vector_stores.utils import node_to_metadata_dict
+from llama_index.vector_stores.weaviate.utils import to_node
+
+from weaviate.outputs.query import MetadataReturn, Object
+
+TEST_UUID = UUID("11111111-2222-3333-4444-555555555555")
+
+
+def make_entry(properties: dict) -> dict:
+    """Build the dict that ``parse_query_result`` hands to ``to_node``."""
+    return Object(
+        uuid=TEST_UUID,
+        metadata=MetadataReturn(score=0.5),
+        properties=properties,
+        references=None,
+        vector={"default": [0.1, 0.2, 0.3]},
+        collection="TestCollection",
+    ).__dict__
+
+
+def test_to_node_llama_index_collection():
+    """A collection written by llama-index takes the non-legacy path."""
+    node = TextNode(
+        text="Hello world.",
+        id_=str(TEST_UUID),
+        metadata={"title": "Paper A"},
+    )
+    properties = {"text": node.text}
+    properties.update(
+        node_to_metadata_dict(node, remove_text=True, flat_metadata=False)
+    )
+
+    parsed = to_node(make_entry(properties), text_key="text")
+
+    assert parsed.node_id == str(TEST_UUID)
+    assert parsed.text == "Hello world."
+    assert parsed.metadata == {"title": "Paper A"}
+    assert parsed.embedding == [0.1, 0.2, 0.3]
+
+
+def test_to_node_pre_existing_collection():
+    """
+    A collection not written by llama-index has no ``_node_content``.
+
+    Regression test for #14857: the legacy fallback used to be handed the whole
+    Weaviate object wrapper, so every node came back with
+    ``{'collection', 'metadata', 'properties', 'references', 'uuid', 'vector'}``
+    as its metadata while the real properties were buried one level down.
+    """
+    entry = make_entry({"text": "Paper A body", "title": "Paper A", "year": 2020})
+
+    node = to_node(entry, text_key="text")
+
+    assert node.metadata == {"title": "Paper A", "year": 2020}
+    assert node.node_id == str(TEST_UUID)
+    assert node.text == "Paper A body"
+    assert node.embedding == [0.1, 0.2, 0.3]
+
+
+def test_to_node_legacy_llama_index_collection():
+    """Legacy llama-index properties are still unpacked, not returned as metadata."""
+    entry = make_entry(
+        {
+            "text": "Paper A body",
+            "title": "Paper A",
+            "node_info": json.dumps({"start": 0, "end": 12}),
+            "relationships": json.dumps(
+                {NodeRelationship.PARENT.value: "parent-doc-id"}
+            ),
+            "doc_id": "parent-doc-id",
+        }
+    )
+
+    node = to_node(entry, text_key="text")
+
+    assert node.metadata == {"title": "Paper A"}
+    assert node.start_char_idx == 0
+    assert node.end_char_idx == 12
+    assert node.relationships[NodeRelationship.PARENT].node_id == "parent-doc-id"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/uv.lock
@@ -1910,7 +1910,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-weaviate"
-version = "1.6.0"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`WeaviateVectorStore` returns garbage `node.metadata` for collections that were not created by llama-index.

**Note on scoping:** the title of #14857 names a `KeyError: 'id'`. That half is already fixed — `utils.py:149` uses `.get` today. This PR fixes the *other* half of the same report, which is still present at `main`: the existing-data retrieval path returns the wrong metadata.

## Root cause

When a collection has no `_node_content` property (i.e. it was written by something other than llama-index), `metadata_dict_to_node()` raises and `to_node()` falls back to the legacy branch. That branch was handed the **whole weaviate v4 `Object.__dict__`**:

```python
# base.py:665
entry_as_dict = entry.__dict__          # {uuid, metadata, properties, references, vector, collection}
nodes.append(to_node(entry_as_dict, text_key=self.text_key))

# utils.py:145 (before)
metadata, node_info, relationships = legacy_metadata_dict_to_node(entry)
```

`legacy_metadata_dict_to_node` only pops `node_info` / `relationships` / `text_key` / `id` / `document_id` / `doc_id` / `ref_doc_id`, so everything else it is given is returned verbatim as the node's metadata. For the wrapper dict, that is the wrapper itself — including live, unserializable weaviate handles — while the real properties sit one level down and are never surfaced.

## Reproduction

`to_node` is a pure function over exactly the dict `parse_query_result` builds, so this replays without a live Weaviate:

```python
entry = Object(
    uuid=UUID("11111111-2222-3333-4444-555555555555"),
    metadata=MetadataReturn(score=0.5),
    properties={"text": "Paper A body", "title": "Paper A", "year": 2020},
    references=None,
    vector={"default": [0.1, 0.2, 0.3]},
    collection="Papers",
)
node = to_node(entry.__dict__, text_key="text")
```

**Before:**

```
node.id_      : 11111111-2222-3333-4444-555555555555
node.text     : 'Paper A body'
metadata keys : ['collection', 'metadata', 'properties', 'references', 'uuid', 'vector']
metadata      : {'uuid': UUID('11111111-...'), 'metadata': MetadataReturn(...), 'properties': {'title': 'Paper A', 'year': 2020}, 'references': None, 'vector': {}, 'collection': 'Papers'}
```

**After:**

```
node.id_      : 11111111-2222-3333-4444-555555555555
node.text     : 'Paper A body'
metadata keys : ['title', 'year']
metadata      : {'title': 'Paper A', 'year': 2020}
```

This matches the documented intent in `docs/examples/vector_stores/existing_data/weaviate_existing_data.ipynb` — *"The remaining fields should be loaded as metadata"* — so no design decision is needed here.

## The fix (+10/-2 in source)

1. Pass `entry["properties"]` to `legacy_metadata_dict_to_node` instead of the whole entry.
2. Source the node id from the object: `additional.get("id") or entry.get("uuid")`. This is required, not cosmetic — the previous `str(metadata.get("uuid"))` only worked *because* the wrapper was being passed, and would silently become the string `"None"` once the properties are used.

Behaviour for collections written by llama-index is untouched: those take the non-legacy `metadata_dict_to_node` path and never reach this branch.

Blast radius: `to_node` has exactly one non-test caller, `WeaviateVectorStore.parse_query_result` (`base.py:667`).

Fixes #14857

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (`1.6.1` -> `1.6.2`)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

New `tests/test_utils.py` — no live Weaviate needed, so it runs in CI:

| test | covers |
|---|---|
| `test_to_node_pre_existing_collection` | the regression: properties become metadata, uuid becomes the node id |
| `test_to_node_llama_index_collection` | non-regression on the normal `_node_content` path |
| `test_to_node_legacy_llama_index_collection` | legacy `node_info` / `relationships` / `doc_id` properties are still unpacked, not dumped into metadata |

Run locally against this package:

```
# RED, new tests on unmodified source
$ uv run -- pytest tests/test_utils.py -q
2 failed, 1 passed in 1.13s

# GREEN, with the fix
$ uv run -- pytest tests/test_utils.py -q
3 passed in 1.04s

# whole package, incl. the embedded-Weaviate suite
$ uv run -- pytest -q
52 passed, 1 skipped, 3 warnings in 24.48s

# diff coverage gate
$ uv run -- diff-cover coverage.xml --fail-under=50 --compare-branch=main
Total:   3 lines
Missing: 0 lines
Coverage: 100%

$ uv run -- pre-commit run --files <the 4 changed files>
ruff ... Passed   ruff-format ... Passed   mypy ... Passed   codespell ... Passed
```

The 3 warnings are pre-existing on `main` (event-loop deprecation and asyncio-marker warnings in `test_vector_stores_weaviate.py`), not introduced here.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
