### PR TITLE
feat(core): allow Memory to accept any AsyncDBChatStore

### DIFF
--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -268,6 +268,32 @@ memory = Memory.from_defaults(
 )
 ```
 
+### Custom Chat Store
+
+If SQLAlchemy isn't a fit for your infrastructure, implement the `AsyncDBChatStore` interface and pass it as `chat_store`. The SQL-specific arguments (`table_name`, `async_database_uri`, `async_engine`, `db_schema`) are ignored when a `chat_store` is given.
+
+```python
+from llama_index.core.memory import Memory
+from llama_index.core.storage.chat_store.base_db import (
+    AsyncDBChatStore,
+    MessageStatus,
+)
+
+
+class MyChatStore(AsyncDBChatStore):
+    # implement get_messages, add_message(s), set_messages,
+    # delete_message(s), delete_oldest_messages,
+    # archive_oldest_messages, count_messages and get_keys
+    ...
+
+
+memory = Memory.from_defaults(
+    session_id="my_session",
+    token_limit=40000,
+    chat_store=MyChatStore(),
+)
+```
+
 ## Memory vs. Workflow Context
 
 At this point in the documentation, you may have encountered cases where you are using a Workflow and are serializing a `Context` object to save and resume a specific workflow state. The workflow `Context` is a complex object that holds runtime information about the workflow, as well as key/value pairs that are shared across workflow steps.

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -39,6 +39,7 @@ from llama_index.core.bridge.pydantic import (
 )
 from llama_index.core.memory.types import BaseMemory
 from llama_index.core.prompts import RichPromptTemplate
+from llama_index.core.storage.chat_store.base_db import AsyncDBChatStore
 from llama_index.core.storage.chat_store.sql import SQLAlchemyChatStore, MessageStatus
 from llama_index.core.utils import get_tokenizer
 
@@ -246,7 +247,7 @@ class Memory(BaseMemory):
         exclude=True,
         description="The tokenizer function to use for token counting.",
     )
-    sql_store: SQLAlchemyChatStore = Field(
+    sql_store: AsyncDBChatStore = Field(
         default_factory=get_default_chat_store,
         exclude=True,
         description="The chat store to use for storing messages.",
@@ -299,6 +300,9 @@ class Memory(BaseMemory):
         image_token_size_estimate: int = 256,
         audio_token_size_estimate: int = 256,
         video_token_size_estimate: int = 256,
+        # Any AsyncDBChatStore implementation. Takes precedence over the
+        # SQLAlchemyChatStore parameters below, which are then ignored.
+        chat_store: Optional[AsyncDBChatStore] = None,
         # SQLAlchemyChatStore parameters
         table_name: str = "llama_index_memory",
         async_database_uri: Optional[str] = None,
@@ -308,8 +312,7 @@ class Memory(BaseMemory):
         """Initialize Memory."""
         session_id = session_id or generate_chat_store_key()
 
-        # If not using the SQLAlchemyChatStore, provide an error
-        sql_store = SQLAlchemyChatStore(
+        sql_store = chat_store or SQLAlchemyChatStore(
             table_name=table_name,
             async_database_uri=async_database_uri,
             async_engine=async_engine,

--- a/llama-index-core/tests/memory/test_memory_custom_chat_store.py
+++ b/llama-index-core/tests/memory/test_memory_custom_chat_store.py
@@ -1,0 +1,172 @@
+"""Tests that Memory works with any AsyncDBChatStore implementation."""
+
+from typing import Dict, List, Optional
+
+import pytest
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.memory.memory import Memory
+from llama_index.core.storage.chat_store.base_db import (
+    AsyncDBChatStore,
+    MessageStatus,
+)
+
+
+class InMemoryChatStore(AsyncDBChatStore):
+    """A minimal non-SQL AsyncDBChatStore, as a custom backend would implement it."""
+
+    active: Dict[str, List[ChatMessage]] = Field(default_factory=dict)
+    archived: Dict[str, List[ChatMessage]] = Field(default_factory=dict)
+
+    def _bucket(self, key: str, status: MessageStatus) -> List[ChatMessage]:
+        bucket = self.active if status == MessageStatus.ACTIVE else self.archived
+        return bucket.setdefault(key, [])
+
+    async def get_messages(
+        self,
+        key: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[ChatMessage]:
+        if status is None:
+            messages = self._bucket(key, MessageStatus.ACTIVE) + self._bucket(
+                key, MessageStatus.ARCHIVED
+            )
+        else:
+            messages = list(self._bucket(key, status))
+
+        messages = messages[offset or 0 :]
+        if limit is not None:
+            messages = messages[:limit]
+        return messages
+
+    async def count_messages(
+        self, key: str, status: Optional[MessageStatus] = MessageStatus.ACTIVE
+    ) -> int:
+        return len(await self.get_messages(key, status=status))
+
+    async def add_message(
+        self,
+        key: str,
+        message: ChatMessage,
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        self._bucket(key, status).append(message)
+
+    async def add_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        self._bucket(key, status).extend(messages)
+
+    async def set_messages(
+        self,
+        key: str,
+        messages: List[ChatMessage],
+        status: MessageStatus = MessageStatus.ACTIVE,
+    ) -> None:
+        self._bucket(key, status)[:] = messages
+
+    async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
+        messages = self._bucket(key, MessageStatus.ACTIVE)
+        if idx >= len(messages):
+            return None
+        return messages.pop(idx)
+
+    async def delete_messages(
+        self, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        statuses = [status] if status is not None else list(MessageStatus)
+        for message_status in statuses:
+            self._bucket(key, message_status).clear()
+
+    async def delete_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        messages = self._bucket(key, MessageStatus.ACTIVE)
+        oldest = messages[:n]
+        del messages[:n]
+        return oldest
+
+    async def archive_oldest_messages(self, key: str, n: int) -> List[ChatMessage]:
+        oldest = await self.delete_oldest_messages(key, n)
+        self._bucket(key, MessageStatus.ARCHIVED).extend(oldest)
+        return oldest
+
+    async def get_keys(self) -> List[str]:
+        return list({*self.active, *self.archived})
+
+
+@pytest.fixture()
+def chat_store():
+    return InMemoryChatStore()
+
+
+@pytest.mark.asyncio
+async def test_memory_accepts_custom_chat_store(chat_store):
+    """Memory should accept any AsyncDBChatStore, not just SQLAlchemyChatStore."""
+    memory = Memory(token_limit=1000, session_id="test_user", sql_store=chat_store)
+
+    await memory.aput_messages(
+        [
+            ChatMessage(role="user", content="Message 1"),
+            ChatMessage(role="assistant", content="Response 1"),
+        ]
+    )
+
+    messages = await memory.aget()
+    assert [message.content for message in messages] == ["Message 1", "Response 1"]
+    assert memory.sql_store is chat_store
+    assert len(chat_store.active["test_user"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_from_defaults_with_custom_chat_store(chat_store):
+    """from_defaults should use the given chat store instead of building a SQL one."""
+    memory = Memory.from_defaults(
+        session_id="test_user",
+        token_limit=1000,
+        chat_history=[ChatMessage(role="user", content="Seeded")],
+        chat_store=chat_store,
+    )
+
+    assert memory.sql_store is chat_store
+    messages = await memory.aget()
+    assert [message.content for message in messages] == ["Seeded"]
+
+
+def test_from_defaults_without_chat_store_still_uses_sql_store():
+    """The default backend is unchanged when no chat store is passed."""
+    from llama_index.core.storage.chat_store.sql import SQLAlchemyChatStore
+
+    memory = Memory.from_defaults(token_limit=1000, table_name="test_memory")
+
+    assert isinstance(memory.sql_store, SQLAlchemyChatStore)
+    assert memory.sql_store.table_name == "test_memory"
+
+
+@pytest.mark.asyncio
+async def test_waterfall_archives_into_custom_chat_store(chat_store):
+    """Flushed messages are archived through the custom store."""
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        session_id="test_user",
+        sql_store=chat_store,
+    )
+
+    await memory.aput_messages(
+        [
+            ChatMessage(role="user", content="x " * 500),
+            ChatMessage(role="assistant", content="y " * 500),
+            ChatMessage(role="user", content="z " * 500),
+        ]
+    )
+
+    messages = await memory.aget()
+    assert len(messages) == 1
+    assert "z " in messages[0].content
+    assert len(chat_store.archived["test_user"]) == 2


### PR DESCRIPTION
# Description

`Memory.sql_store` was typed as `SQLAlchemyChatStore`, so a custom chat store that already implements the `AsyncDBChatStore` interface was rejected at construction:

```
Memory(token_limit=1000, sql_store=MyStore())
ValidationError: Input should be a valid dictionary or instance of SQLAlchemyChatStore
```

Every store method `Memory` actually calls — `get_messages`, `add_message`, `add_messages`, `set_messages`, `archive_oldest_messages`, `delete_messages` — is already an `@abstractmethod` on `AsyncDBChatStore`, so nothing SQLAlchemy-specific is used. This widens the field to the interface and adds an optional `chat_store` argument to `Memory.from_defaults` (which also replaces the leftover `# If not using the SQLAlchemyChatStore, provide an error` placeholder).

Backward compatible:

- field keeps the name `sql_store`, so `memory.sql_store` and existing tests are untouched
- `from_defaults` still builds the same `SQLAlchemyChatStore` when no `chat_store` is passed
- when `chat_store` is passed, the SQL-only arguments (`table_name`, `async_database_uri`, `async_engine`, `db_schema`) are ignored, documented in the signature and docs

Two open points for the reviewer, happy to change either way:

1. Field name: left as `sql_store` to avoid breaking users and tests. Rename to `chat_store` with a deprecated alias if you prefer.
2. Passing `chat_store` together with the SQL-only arguments is silently ignored rather than raising `ValueError`. Can raise instead.

Fixes #19763

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

New `llama-index-core/tests/memory/test_memory_custom_chat_store.py` defines a minimal non-SQL `InMemoryChatStore(AsyncDBChatStore)` and covers: construction with a custom store, `from_defaults(chat_store=...)` including `chat_history` seeding, the unchanged SQL default, and the waterfall path archiving through the custom store.

```
$ uv run pytest tests/memory tests/agent -q
174 passed
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods