### PR TITLE
fix(lancedb): repair image ingestion crash, embedding_model typo, and…

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/llama_index/indices/managed/lancedb/base.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/llama_index/indices/managed/lancedb/base.py
@@ -168,7 +168,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
             class TextSchema(LanceModel):
                 id: str
                 metadata: str = Field(default=json.dumps({}))
-                text: str = self._embedding_model.embedding_modxel.SourceField()
+                text: str = self._embedding_model.embedding_model.SourceField()
                 vector: Vector(self._embedding_model.embedding_model.ndims()) = (
                     self._embedding_model.embedding_model.VectorField()
                 )
@@ -387,7 +387,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
         else:
             assert all(isinstance(document, ImageDocument) for document in documents)
             for document in documents:
-                label = json.dumps(document.metadata).get("image_label", None) or ""
+                label = document.metadata.get("image_label") or ""
                 if document.image:
                     data.append(
                         {
@@ -546,7 +546,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
         else:
             assert all(isinstance(document, ImageDocument) for document in documents)
             for document in documents:
-                label = json.dumps(document.metadata).get("image_label", None) or ""
+                label = document.metadata.get("image_label") or ""
                 if document.image:
                     data.append(
                         {
@@ -616,7 +616,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
         else:
             assert all(isinstance(document, ImageDocument) for document in documents)
             for document in documents:
-                label = json.dumps(document.metadata).get("image_label", None) or ""
+                label = document.metadata.get("image_label") or ""
                 if document.image:
                     data.append(
                         {
@@ -694,7 +694,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
     def delete_ref_doc(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         if not self.connection_config.use_async:
             self._table = cast(Table, self._table)
-            self._table.delete(where="id = '" + ref_doc_id + "'")
+            self._table.delete(where="id = '" + ref_doc_id.replace("'", "''") + "'")
         else:
             raise ValueError(
                 "Attempting to delete data synchronously with an asynchronous connection!"
@@ -703,7 +703,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
     async def adelete_ref_doc(self, ref_doc_id: str, **delete_kwargs):
         if self.connection_config.use_async:
             self._table = cast(AsyncTable, self._table)
-            await self._table.delete(where="id = '" + ref_doc_id + "'")
+            await self._table.delete(where="id = '" + ref_doc_id.replace("'", "''") + "'")
         else:
             raise ValueError(
                 "Attempting to delete data asynchronously with a synchronous connection!"
@@ -712,7 +712,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
     def delete_nodes(self, ref_doc_ids: List[str]) -> None:
         if not self.connection_config.use_async:
             self._table = cast(Table, self._table)
-            delete_where = "id IN ('" + "', '".join(ref_doc_ids) + "')"
+            delete_where = "id IN ('" + "', '".join(i.replace("'", "''") for i in ref_doc_ids) + "')"
             self._table.delete(where=delete_where)
         else:
             raise ValueError(
@@ -722,7 +722,7 @@ class LanceDBMultiModalIndex(BaseManagedIndex):
     async def adelete_nodes(self, ref_doc_ids: List[str]) -> None:
         if self.connection_config.use_async:
             self._table = cast(AsyncTable, self._table)
-            delete_where = "id IN ('" + "', '".join(ref_doc_ids) + "')"
+            delete_where = "id IN ('" + "', '".join(i.replace("'", "''") for i in ref_doc_ids) + "')"
             await self._table.delete(where=delete_where)
         else:
             raise ValueError(

--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-indices-managed-lancedb"
-version = "0.3.1"
+version = "0.3.2"
 description = "LlamaIndex x LanceDB MultiModal AI Lakehouse"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
Fixes #22542 (crashes) and #22543 (delete-filter escaping).

`llama-index-indices-managed-lancedb` had three defects in one file, all in paths that appear to lack end-to-end test coverage:

1. **Image ingestion crashed unconditionally.** `from_documents`, `insert_nodes`, and `ainsert_nodes` computed `label` via `json.dumps(document.metadata).get("image_label", ...)`. `json.dumps` returns `str`, which has no `.get`, so every ImageDocument raised `AttributeError`. Now reads `document.metadata.get("image_label")`.
2. **Sync text `create_index` crashed on a typo.** `embedding_modxel` -> `embedding_model` (the async twin was already correct).
3. **`delete_*` built filter predicates by unescaped string concatenation** of document ids. A single quote in an id breaks or widens the predicate (same class as #22475). All four delete methods now escape single quotes by doubling them.
No behavior change for valid inputs; only the crashing / injection-prone paths are affected. Happy to add regression tests if the maintainers prefer.

**AI assistance:** I used AI assistance to help locate these issues and draft the fix. I reviewed every change, reproduced the crash and the injection behavior, and confirmed the diff contains only the intended 8 line changes.