### PR TITLE
fix(vertex): surface usage_metadata token counts in Vertex Gemini chat responses

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py
@@ -227,6 +227,28 @@ class Vertex(FunctionCallingLLM):
             content = ""
         return content, tool_calls
 
+    def _extract_usage_metadata(self, response: Any) -> Dict[str, Any]:
+        """Extract token usage from a Vertex Gemini response usage_metadata.
+
+        Only Gemini models return usage_metadata; legacy text/chat-bison models
+        do not expose token counts, so an empty dict is returned for them.
+        """
+        if not self._is_gemini:
+            return {}
+        um = getattr(response, "usage_metadata", None)
+        if um is None:
+            return {}
+        usage: Dict[str, Any] = {}
+        if getattr(um, "prompt_token_count", None) is not None:
+            usage["prompt_tokens"] = um.prompt_token_count
+        if getattr(um, "candidates_token_count", None) is not None:
+            usage["completion_tokens"] = um.candidates_token_count
+        if getattr(um, "total_token_count", None) is not None:
+            usage["total_tokens"] = um.total_token_count
+        if getattr(um, "cached_content_token_count", None):
+            usage["cached_content_token_count"] = um.cached_content_token_count
+        return usage
+
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
         merged_messages = (
@@ -266,12 +288,16 @@ class Vertex(FunctionCallingLLM):
         )
 
         content, tool_calls = self._get_content_and_tool_calls(generation)
+        additional_kwargs: Dict[str, Any] = {
+            "tool_calls": tool_calls,
+            **self._extract_usage_metadata(generation),
+        }
 
         return ChatResponse(
             message=ChatMessage(
                 role=MessageRole.ASSISTANT,
                 content=content,
-                additional_kwargs={"tool_calls": tool_calls},
+                additional_kwargs=additional_kwargs,
             ),
             raw=generation.__dict__,
         )
@@ -411,11 +437,15 @@ class Vertex(FunctionCallingLLM):
             generation = await generation
 
         content, tool_calls = self._get_content_and_tool_calls(generation)
+        additional_kwargs: Dict[str, Any] = {
+            "tool_calls": tool_calls,
+            **self._extract_usage_metadata(generation),
+        }
         return ChatResponse(
             message=ChatMessage(
                 role=MessageRole.ASSISTANT,
                 content=content,
-                additional_kwargs={"tool_calls": tool_calls},
+                additional_kwargs=additional_kwargs,
             ),
             raw=generation.__dict__,
         )

--- a/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_llms_vertex.py
+++ b/llama-index-integrations/llms/llama-index-llms-vertex/tests/test_llms_vertex.py
@@ -1,4 +1,30 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
 from llama_index.llms.vertex import Vertex
+
+
+def _make_mock_gemini_response(
+    prompt_tokens: int = 50,
+    completion_tokens: int = 20,
+    total_tokens: int = 70,
+    cached_tokens: int = 0,
+    text: str = "Hello world",
+) -> Mock:
+    """Build a mock Vertex Gemini GenerateContentResponse."""
+    mock_usage = Mock()
+    mock_usage.prompt_token_count = prompt_tokens
+    mock_usage.candidates_token_count = completion_tokens
+    mock_usage.total_token_count = total_tokens
+    mock_usage.cached_content_token_count = cached_tokens
+
+    mock_response = Mock()
+    mock_response.usage_metadata = mock_usage
+    mock_response.candidates = [Mock(function_calls=[])]
+    mock_response.text = text
+    mock_response.__dict__ = {"text": text}
+    return mock_response
 
 
 def test_vertex_metadata_function_calling():
@@ -37,3 +63,104 @@ def test_vertex_metadata_non_function_calling():
         assert metadata.is_function_calling_model is False
         assert metadata.model_name == "chat-bison"
         assert metadata.is_chat_model is True
+
+
+def test_extract_usage_metadata_with_tokens():
+    """_extract_usage_metadata populates prompt/completion/total tokens for Gemini."""
+    with patch(
+        "llama_index.llms.vertex.gemini_utils.create_gemini_client"
+    ) as mock_create_client:
+        mock_create_client.return_value = Mock()
+        llm = Vertex(model="gemini-2.0-flash", project="test-project")
+
+    mock_response = _make_mock_gemini_response(
+        prompt_tokens=100, completion_tokens=30, total_tokens=130
+    )
+    usage = llm._extract_usage_metadata(mock_response)
+
+    assert usage["prompt_tokens"] == 100
+    assert usage["completion_tokens"] == 30
+    assert usage["total_tokens"] == 130
+    assert "cached_content_token_count" not in usage
+
+
+def test_extract_usage_metadata_with_cache_hits():
+    """_extract_usage_metadata includes cached_content_token_count when non-zero."""
+    with patch(
+        "llama_index.llms.vertex.gemini_utils.create_gemini_client"
+    ) as mock_create_client:
+        mock_create_client.return_value = Mock()
+        llm = Vertex(model="gemini-2.0-flash", project="test-project")
+
+    mock_response = _make_mock_gemini_response(
+        prompt_tokens=200, completion_tokens=40, total_tokens=240, cached_tokens=150
+    )
+    usage = llm._extract_usage_metadata(mock_response)
+
+    assert usage["prompt_tokens"] == 200
+    assert usage["completion_tokens"] == 40
+    assert usage["total_tokens"] == 240
+    assert usage["cached_content_token_count"] == 150
+
+
+def test_extract_usage_metadata_non_gemini_model():
+    """_extract_usage_metadata returns empty dict for legacy text/chat-bison models."""
+    with patch("vertexai.language_models.ChatModel.from_pretrained") as mock_fp:
+        mock_fp.return_value = Mock()
+        llm = Vertex(model="chat-bison")
+
+    mock_response = Mock()
+    usage = llm._extract_usage_metadata(mock_response)
+
+    assert usage == {}
+
+
+def test_chat_includes_usage_in_additional_kwargs():
+    """chat() propagates token counts into ChatMessage.additional_kwargs."""
+    with patch(
+        "llama_index.llms.vertex.gemini_utils.create_gemini_client"
+    ) as mock_create_client:
+        mock_chat_session = Mock()
+        mock_client = Mock()
+        mock_client.start_chat.return_value = mock_chat_session
+        mock_create_client.return_value = mock_client
+
+        mock_response = _make_mock_gemini_response(
+            prompt_tokens=50, completion_tokens=20, total_tokens=70
+        )
+        mock_chat_session.send_message.return_value = mock_response
+
+        llm = Vertex(model="gemini-2.0-flash", project="test-project")
+        from llama_index.core.llms import ChatMessage
+
+        response = llm.chat([ChatMessage(role="user", content="Hello")])
+
+    assert response.message.additional_kwargs["prompt_tokens"] == 50
+    assert response.message.additional_kwargs["completion_tokens"] == 20
+    assert response.message.additional_kwargs["total_tokens"] == 70
+
+
+def test_chat_includes_cache_tokens_in_additional_kwargs():
+    """chat() includes cached_content_token_count when context cache is hit."""
+    with patch(
+        "llama_index.llms.vertex.gemini_utils.create_gemini_client"
+    ) as mock_create_client:
+        mock_chat_session = Mock()
+        mock_client = Mock()
+        mock_client.start_chat.return_value = mock_chat_session
+        mock_create_client.return_value = mock_client
+
+        mock_response = _make_mock_gemini_response(
+            prompt_tokens=300, completion_tokens=50, total_tokens=350, cached_tokens=250
+        )
+        mock_chat_session.send_message.return_value = mock_response
+
+        llm = Vertex(model="gemini-2.0-flash", project="test-project")
+        from llama_index.core.llms import ChatMessage
+
+        response = llm.chat([ChatMessage(role="user", content="Summarize")])
+
+    assert response.message.additional_kwargs["prompt_tokens"] == 300
+    assert response.message.additional_kwargs["completion_tokens"] == 50
+    assert response.message.additional_kwargs["total_tokens"] == 350
+    assert response.message.additional_kwargs["cached_content_token_count"] == 250


### PR DESCRIPTION
## Summary

Vertex Gemini responses carry a `usage_metadata` object with `prompt_token_count`, `candidates_token_count`, `total_token_count`, and `cached_content_token_count`, but `chat()` and `achat()` in `llama-index-llms-vertex` only put `tool_calls` in `additional_kwargs`, silently dropping all token-count information. The Google GenAI integration already extracts these same fields; this PR brings parity to the Vertex integration.

## Root Cause / Motivation

In `base.py`, the `chat()` return statement hard-codes `additional_kwargs={"tool_calls": tool_calls}` after extracting the generation response. The `usage_metadata` attribute on the `GenerateContentResponse` object is never read. Users and frameworks (e.g. MLflow Tracing, LangSmith) that inspect `additional_kwargs` for token cost estimation receive no data for Vertex Gemini calls, even when the model returns full usage statistics.

The Google GenAI integration (`llama-index-llms-google-genai/utils.py`) already reads these fields as `prompt_tokens`, `completion_tokens`, and `total_tokens`. This PR adopts the same field names so downstream consumers see a consistent interface.

## Design Decisions

- **Helper method `_extract_usage_metadata(response)`**: isolates the extraction logic so it can be tested independently and called from both `chat()` and `achat()` without duplication.
- **Guard on `self._is_gemini`**: legacy text/chat-bison models do not have `usage_metadata`; returning `{}` for them is safe and keeps the dict merge in callers simple.
- **`getattr` defensively**: each sub-field read uses `getattr(..., None)` so partial responses (where only some fields are present) are handled without `AttributeError`.
- **Cache tokens only when non-zero**: `cached_content_token_count` is included only when the value is truthy, matching the convention used in the Google GenAI integration (PR #22516).

## Changes

| File | What changed |
|------|-------------|
| `llama-index-integrations/llms/llama-index-llms-vertex/llama_index/llms/vertex/base.py` | Add `_extract_usage_metadata()` helper; update `chat()` and `achat()` to merge usage into `additional_kwargs` |
| `llama-index-integrations/llms/llama-index-llms-vertex/tests/test_llms_vertex.py` | 5 new unit tests covering the helper and end-to-end `chat()` paths |

## Testing

- [x] Existing tests pass (`test_vertex_metadata_function_calling`, `test_vertex_metadata_non_function_calling`)
- [x] New tests:
  - `test_extract_usage_metadata_with_tokens` — verifies prompt/completion/total populated
  - `test_extract_usage_metadata_with_cache_hits` — verifies `cached_content_token_count` included when non-zero
  - `test_extract_usage_metadata_non_gemini_model` — verifies empty dict for chat-bison
  - `test_chat_includes_usage_in_additional_kwargs` — end-to-end `chat()` with mocked client
  - `test_chat_includes_cache_tokens_in_additional_kwargs` — end-to-end `chat()` with context cache hit

## Impact

Users of `llama-index-llms-vertex` with Gemini models now get token counts in `ChatResponse.message.additional_kwargs`, enabling accurate cost tracking, prompt-cache hit monitoring, and compatibility with tracing frameworks that rely on these fields.