### PR TITLE
fix(callbacks): count Anthropic cached prompt tokens in TokenCountingHandler

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -67,6 +67,21 @@ def get_tokens_from_response(
             prompt_tokens = usage[input_key]
             break
 
+    # Anthropic reports `input_tokens` NET of the prompt cache and puts the cached
+    # tokens in their own fields, so reading `input_tokens` alone drops every token
+    # served from cache. All three are billed. With a warm cache `input_tokens` can be
+    # single digits while `cache_read_input_tokens` is tens of thousands.
+    #
+    # This is deliberately narrow. OpenAI's `prompt_tokens` and Gemini's
+    # `prompt_token_count` ALREADY include their cached tokens
+    # (`prompt_tokens_details.cached_tokens`, `cached_content_token_count`), so adding
+    # a cache count for those providers would double-count. Only the Anthropic-shaped
+    # keys are summed, and only when they are actually present.
+    prompt_tokens += sum(
+        usage.get(cache_key) or 0
+        for cache_key in ("cache_read_input_tokens", "cache_creation_input_tokens")
+    )
+
     completion_tokens = 0
     for output_key in possible_output_keys:
         if output_key in usage:

--- a/llama-index-core/tests/callbacks/test_token_counter_cache_tokens.py
+++ b/llama-index-core/tests/callbacks/test_token_counter_cache_tokens.py
@@ -1,0 +1,121 @@
+"""Cached prompt tokens are billed and must be counted.
+
+Anthropic reports `input_tokens` NET of the prompt cache, with the cached tokens in
+`cache_read_input_tokens` and `cache_creation_input_tokens`. Reading `input_tokens`
+alone therefore drops every token served from cache. With a warm cache that is not a
+rounding error: `input_tokens` can be single digits while `cache_read_input_tokens` is
+tens of thousands, so `TokenCountingHandler` reported 3 tokens for a call that billed
+21,503.
+
+That number feeds the `token_budget` guard, so a budget silently fails to fire.
+
+OpenAI and Gemini already include their cached tokens in `prompt_tokens` /
+`prompt_token_count`, so those must NOT be adjusted. The last two tests pin that,
+because the obvious fix double-counts them.
+"""
+
+from types import SimpleNamespace
+
+from llama_index.core.callbacks.token_counting import get_tokens_from_response
+
+
+def _response(usage):
+    """Minimal stand-in for a ChatResponse carrying a provider usage blob."""
+    return SimpleNamespace(raw={"usage": usage}, additional_kwargs={})
+
+
+class TestAnthropicCacheTokens:
+    def test_cache_read_tokens_are_counted(self):
+        """A warm cache: 3 uncached tokens, 20000 served from cache. All billed."""
+        prompt, completion = get_tokens_from_response(
+            _response(
+                {
+                    "input_tokens": 3,
+                    "output_tokens": 120,
+                    "cache_read_input_tokens": 20000,
+                }
+            )
+        )
+        assert prompt == 20003
+        assert completion == 120
+
+    def test_cache_creation_tokens_are_counted(self):
+        """Writing the cache is billed too, at a premium."""
+        prompt, _ = get_tokens_from_response(
+            _response(
+                {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 1500,
+                }
+            )
+        )
+        assert prompt == 1510
+
+    def test_both_cache_fields_are_counted(self):
+        """The case that motivated this: 3 reported against 21503 billed."""
+        prompt, _ = get_tokens_from_response(
+            _response(
+                {
+                    "input_tokens": 3,
+                    "output_tokens": 120,
+                    "cache_read_input_tokens": 20000,
+                    "cache_creation_input_tokens": 1500,
+                }
+            )
+        )
+        assert prompt == 21503
+
+    def test_null_cache_fields_are_treated_as_zero(self):
+        """Anthropic may send the keys explicitly set to null rather than omitting."""
+        prompt, _ = get_tokens_from_response(
+            _response(
+                {
+                    "input_tokens": 42,
+                    "output_tokens": 7,
+                    "cache_read_input_tokens": None,
+                    "cache_creation_input_tokens": None,
+                }
+            )
+        )
+        assert prompt == 42
+
+    def test_uncached_anthropic_call_is_unchanged(self):
+        """With no cache in play the previous arithmetic was already right."""
+        prompt, completion = get_tokens_from_response(
+            _response({"input_tokens": 100, "output_tokens": 50})
+        )
+        assert prompt == 100
+        assert completion == 50
+
+
+class TestProvidersThatAlreadyIncludeCache:
+    """These pin the boundary. A fix that just adds any cache count breaks them."""
+
+    def test_openai_prompt_tokens_are_not_adjusted(self):
+        """OpenAI's prompt_tokens ALREADY includes prompt_tokens_details.cached_tokens."""
+        prompt, completion = get_tokens_from_response(
+            _response(
+                {
+                    "prompt_tokens": 5000,
+                    "completion_tokens": 200,
+                    "prompt_tokens_details": {"cached_tokens": 4864},
+                }
+            )
+        )
+        assert prompt == 5000, "adding the cached tokens here would double-count"
+        assert completion == 200
+
+    def test_gemini_prompt_token_count_is_not_adjusted(self):
+        """Gemini's prompt_token_count ALREADY includes cached_content_token_count."""
+        prompt, completion = get_tokens_from_response(
+            _response(
+                {
+                    "prompt_token_count": 8000,
+                    "candidates_token_count": 300,
+                    "cached_content_token_count": 7500,
+                }
+            )
+        )
+        assert prompt == 8000, "adding the cached tokens here would double-count"
+        assert completion == 300

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -652,6 +652,15 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.message.usage.input_tokens,
                             "output_tokens": r.message.usage.output_tokens,
+                            # Anthropic reports input_tokens NET of the prompt
+                            # cache. Carry the cache counts through so token
+                            # counting can add them back in; all three are billed.
+                            "cache_read_input_tokens": getattr(
+                                r.message.usage, "cache_read_input_tokens", None
+                            ),
+                            "cache_creation_input_tokens": getattr(
+                                r.message.usage, "cache_creation_input_tokens", None
+                            ),
                         }
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
@@ -661,6 +670,15 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.usage.input_tokens,
                             "output_tokens": r.usage.output_tokens,
+                            # Anthropic reports input_tokens NET of the prompt
+                            # cache. Carry the cache counts through so token
+                            # counting can add them back in; all three are billed.
+                            "cache_read_input_tokens": getattr(
+                                r.usage, "cache_read_input_tokens", None
+                            ),
+                            "cache_creation_input_tokens": getattr(
+                                r.usage, "cache_creation_input_tokens", None
+                            ),
                         }
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason
@@ -909,6 +927,15 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.message.usage.input_tokens,
                             "output_tokens": r.message.usage.output_tokens,
+                            # Anthropic reports input_tokens NET of the prompt
+                            # cache. Carry the cache counts through so token
+                            # counting can add them back in; all three are billed.
+                            "cache_read_input_tokens": getattr(
+                                r.message.usage, "cache_read_input_tokens", None
+                            ),
+                            "cache_creation_input_tokens": getattr(
+                                r.message.usage, "cache_creation_input_tokens", None
+                            ),
                         }
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
@@ -918,6 +945,15 @@ class Anthropic(FunctionCallingLLM):
                         usage_metadata = {
                             "input_tokens": r.usage.input_tokens,
                             "output_tokens": r.usage.output_tokens,
+                            # Anthropic reports input_tokens NET of the prompt
+                            # cache. Carry the cache counts through so token
+                            # counting can add them back in; all three are billed.
+                            "cache_read_input_tokens": getattr(
+                                r.usage, "cache_read_input_tokens", None
+                            ),
+                            "cache_creation_input_tokens": getattr(
+                                r.usage, "cache_creation_input_tokens", None
+                            ),
                         }
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason


### PR DESCRIPTION
## The bug

Anthropic reports `input_tokens` **net of the prompt cache**, with the cached tokens in `cache_read_input_tokens` and `cache_creation_input_tokens`. `get_tokens_from_response` reads `input_tokens` alone:

```python
possible_input_keys = ("prompt_tokens", "input_tokens", "prompt_token_count")
for input_key in possible_input_keys:
    if input_key in usage:
        prompt_tokens = usage[input_key]
        break
```

So every token served from cache is dropped. With a warm cache that is not a rounding error, because `input_tokens` is exactly the part that *wasn't* cached:

```
input_tokens                   3
cache_read_input_tokens        20000
cache_creation_input_tokens    1500

reported prompt tokens         3
actually billed                21503
```

Reproduced against `llama-index-core 0.14.23`:

```python
from types import SimpleNamespace
from llama_index.core.callbacks.token_counting import get_tokens_from_response

usage = {"input_tokens": 3, "output_tokens": 120,
         "cache_read_input_tokens": 20000, "cache_creation_input_tokens": 1500}
print(get_tokens_from_response(SimpleNamespace(raw={"usage": usage},
                                               additional_kwargs={})))
# (3, 120)
```

## Why it matters beyond the number

`TokenCountingHandler` is what the [cost analysis guide](https://docs.llamaindex.ai/en/stable/understanding/evaluating/cost_analysis/) is built on, so this under-reports spend by the entire cached portion of every prompt. Prompt caching is most valuable on large, stable system prompts, which is precisely when the dropped figure is largest.

It also feeds `token_budget`, which raises `ValueError` when exceeded. Computed from a count that omits cache reads, **a budget silently fails to fire** on any cached Anthropic workload. That is the part that seemed worth fixing rather than just documenting: nothing raises, and the guard that exists to raise is the thing being fooled.

## The streaming path was worse

`llama-index-llms-anthropic` built its `usage_metadata` as:

```python
usage_metadata = {
    "input_tokens": r.message.usage.input_tokens,
    "output_tokens": r.message.usage.output_tokens,
}
```

The cache fields were discarded **at the source**, so nothing downstream could recover them even in principle. Four sites, sync and async, now carry them through.

## The fix is deliberately narrow

This is the part I would most like reviewed. The obvious fix, "add any cache count you find", is wrong:

- **OpenAI**'s `prompt_tokens` already includes `prompt_tokens_details.cached_tokens`
- **Gemini**'s `prompt_token_count` already includes `cached_content_token_count`

Adding a cache count for those providers would double-count. Only the Anthropic-shaped keys are summed, and only when present. `or 0` rather than a default in `.get`, because Anthropic may send the keys explicitly set to `null` rather than omitting them, and `None` would propagate into the sum.

## Tests

Seven tests in `llama-index-core/tests/callbacks/test_token_counter_cache_tokens.py`.

**Three fail on `main`:**

```
FAILED TestAnthropicCacheTokens::test_cache_read_tokens_are_counted
FAILED TestAnthropicCacheTokens::test_cache_creation_tokens_are_counted
FAILED TestAnthropicCacheTokens::test_both_cache_fields_are_counted
3 failed, 4 passed
```

**Four pass on both, and that is the point.** The uncached case, null cache fields, and the two boundary tests pinning OpenAI and Gemini as unchanged. If someone later "simplifies" this into a generic cache sum, those two boundary tests fail.

The existing `test_token_counter.py` and `test_token_budget.py` still pass.

## Related

The same defect, same place, in two other frameworks, both fixed and merged: [`pipecat-ai/pipecat#5163`](https://github.com/pipecat-ai/pipecat/pull/5163) and [`livekit/agents#6663`](https://github.com/livekit/agents/pull/6663). Three independent implementations treating Anthropic's `input_tokens` as the whole input. The shape of the mistake seems easier to make than to notice, which is why the tests here are written around the boundary rather than just the happy path.
