### PR TITLE
feat(tools-mcp): expose JSON Schema → Pydantic conversion without a client

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [0.5.0] - 2026-08-02
+
+### Added
+- Exposed `JsonSchemaToPydantic` as a standalone public class (importable from `llama_index.tools.mcp`). Converts an MCP tool's JSON Schema into a Pydantic model without requiring an MCP `ClientSession`.
+
+### Changed
+- `McpToolSpec` now delegates schema conversion to an internal `JsonSchemaToPydantic` instance. Public API (`create_model_from_json_schema`, `remove_model_fields`, `properties_cache`, `to_tool_list_async`) is unchanged and produces identical models.
+
 ## [0.4.0] - 2025-08-06
 
 - Reworked function `create_model_from_json_schema` in `llama_index.tools.mcp.base`.

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/__init__.py
@@ -1,4 +1,4 @@
-from llama_index.tools.mcp.base import McpToolSpec
+from llama_index.tools.mcp.base import JsonSchemaToPydantic, McpToolSpec
 from llama_index.tools.mcp.client import BasicMCPClient
 from llama_index.tools.mcp.utils import (
     workflow_as_mcp,
@@ -8,6 +8,7 @@ from llama_index.tools.mcp.utils import (
 
 __all__ = [
     "McpToolSpec",
+    "JsonSchemaToPydantic",
     "BasicMCPClient",
     "workflow_as_mcp",
     "get_tools_from_mcp_url",

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -16,9 +16,82 @@ from llama_index.tools.mcp.tool_spec_mixins import (
 )
 
 
-class McpToolSpec(
-    BaseToolSpec, TypeResolutionMixin, TypeCreationMixin, FieldExtractionMixin
+class JsonSchemaToPydantic(
+    TypeResolutionMixin, TypeCreationMixin, FieldExtractionMixin
 ):
+    """
+    Converts the JSON Schema of an MCP tool into a Pydantic model.
+
+    This class is client-free: it does not require an MCP ``ClientSession``
+    and can be used standalone whenever you already hold an
+    ``mcp.types.Tool`` (or any JSON Schema dict) and just need the
+    corresponding Pydantic model.
+    """
+
+    def __init__(self) -> None:
+        self.properties_cache: dict[str, type[BaseModel]] = {}
+
+    def create_model_from_json_schema(
+        self,
+        schema: dict[str, Any],
+        model_name: str = "DynamicModel",
+    ) -> type[BaseModel]:
+        """
+        Create a Pydantic model from a JSON Schema.
+
+        Args:
+            schema: A JSON Schema dictionary containing properties and required fields.
+            model_name: The name of the model.
+
+        Returns:
+            A Pydantic model class.
+
+        """
+        defs = schema.get("$defs", {})
+
+        for cls_name, cls_schema in defs.items():
+            self.properties_cache[cls_name] = self._create_model(
+                cls_schema,
+                cls_name,
+                defs,
+            )
+
+        return self._create_model(schema, model_name)
+
+    def _create_model(
+        self,
+        schema: dict,
+        model_name: str,
+        defs: dict = {},
+    ) -> type[BaseModel]:
+        """Create a Pydantic model from a schema."""
+        if model_name in self.properties_cache:
+            return self.properties_cache[model_name]
+
+        fields = self._extract_fields(schema, defs)
+        model = create_model(model_name, **fields)
+        self.properties_cache[model_name] = model
+        return model
+
+    def remove_model_fields(
+        self,
+        model: type[BaseModel],
+        fields_to_remove: Set[str],
+        model_name: str,
+    ) -> type[BaseModel]:
+        """Remove specified fields from a Pydantic model, returning a new model."""
+        fields = {
+            name: (
+                field.annotation,
+                field.default if field.is_required() else field.default,
+            )
+            for name, field in model.model_fields.items()
+            if name not in fields_to_remove
+        }
+        return create_model(model_name, **fields)
+
+
+class McpToolSpec(BaseToolSpec):
     """
     MCPToolSpec will get the tools from MCP Client (only need to implement ClientSession) and convert them to LlamaIndex's FunctionTool objects.
 
@@ -48,7 +121,12 @@ class McpToolSpec(
         self.global_partial_params = global_partial_params
         self.partial_params_by_tool = partial_params_by_tool
         self.include_resources = include_resources
-        self.properties_cache = {}
+        self._converter = JsonSchemaToPydantic()
+
+    @property
+    def properties_cache(self) -> dict[str, type[BaseModel]]:
+        """Backward-compatible access to the converter's properties cache."""
+        return self._converter.properties_cache
 
     async def fetch_tools(self) -> List[Any]:
         """
@@ -62,7 +140,6 @@ class McpToolSpec(
         tools = response.tools if hasattr(response, "tools") else []
 
         if self.allowed_tools is None:
-            # get all tools by default
             return tools
 
         if any(self.allowed_tools):
@@ -135,24 +212,18 @@ class McpToolSpec(
         function_tool_list: List[FunctionTool] = []
         for tool in tools_list:
             fn = self._create_tool_fn(tool.name)
-            # Create a Pydantic model based on the tool inputSchema
             model_schema = self.create_model_from_json_schema(
                 tool.inputSchema, model_name=f"{tool.name}_Schema"
             )
-            # Set up global partial params as default
             tool_partial_params = dict(self.global_partial_params or {})
-            # Override with tool-specific partial params
             if self.partial_params_by_tool and tool.name in self.partial_params_by_tool:
                 tool_overrides = self.partial_params_by_tool[tool.name]
                 for key, value in tool_overrides.items():
                     if value is None:
-                        # Remove the param if set to None
                         tool_partial_params.pop(key, None)
                     else:
-                        # Override or add the param
                         tool_partial_params[key] = value
 
-            # Remove fields that are set as partial params
             if tool_partial_params:
                 model_schema = self.remove_model_fields(
                     model_schema,
@@ -204,43 +275,8 @@ class McpToolSpec(
         schema: dict[str, Any],
         model_name: str = "DynamicModel",
     ) -> type[BaseModel]:
-        """
-        To create a Pydantic model from the JSON Schema of MCP tools.
-
-        Args:
-            schema: A JSON Schema dictionary containing properties and required fields.
-            model_name: The name of the model.
-
-        Returns:
-            A Pydantic model class.
-
-        """
-        defs = schema.get("$defs", {})
-
-        # Process all type definitions
-        for cls_name, cls_schema in defs.items():
-            self.properties_cache[cls_name] = self._create_model(
-                cls_schema,
-                cls_name,
-                defs,
-            )
-
-        return self._create_model(schema, model_name)
-
-    def _create_model(
-        self,
-        schema: dict,
-        model_name: str,
-        defs: dict = {},
-    ) -> type[BaseModel]:
-        """Create a Pydantic model from a schema."""
-        if model_name in self.properties_cache:
-            return self.properties_cache[model_name]
-
-        fields = self._extract_fields(schema, defs)
-        model = create_model(model_name, **fields)
-        self.properties_cache[model_name] = model
-        return model
+        """Convert a JSON Schema to a Pydantic model. Delegates to the internal converter."""
+        return self._converter.create_model_from_json_schema(schema, model_name)
 
     def remove_model_fields(
         self,
@@ -248,15 +284,8 @@ class McpToolSpec(
         fields_to_remove: Set[str],
         model_name: str,
     ) -> type[BaseModel]:
-        fields = {
-            name: (
-                field.annotation,
-                field.default if field.is_required() else field.default,
-            )
-            for name, field in model.model_fields.items()
-            if name not in fields_to_remove
-        }
-        return create_model(model_name, **fields)
+        """Remove fields from a Pydantic model. Delegates to the internal converter."""
+        return self._converter.remove_model_fields(model, fields_to_remove, model_name)
 
 
 def patch_sync(func_async: Callable) -> Callable:
@@ -265,7 +294,6 @@ def patch_sync(func_async: Callable) -> Callable:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = None
-        # If the current environment is asynchronous, raise an exception to prompt the use of the asynchronous interface
         if loop and loop.is_running():
             raise RuntimeError(
                 "In an asynchronous environment, synchronous calls are not supported. Please use the asynchronous interface (e.g., to_tool_list_async) instead."

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/tool_spec_mixins.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Union, Literal, Type, TYPE_CHECKING
 from pydantic import Field
 
 if TYPE_CHECKING:
-    from llama_index.tools.mcp.base import McpToolSpec
+    from llama_index.tools.mcp.base import JsonSchemaToPydantic
 
 # Map JSON Schema types to Python types
 json_type_mapping: Dict[str, Type] = {
@@ -17,7 +17,7 @@ json_type_mapping: Dict[str, Type] = {
 
 class TypeResolutionMixin:
     def _resolve_field_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         field_schema: dict,
         defs: dict,
     ) -> Any:
@@ -31,7 +31,7 @@ class TypeResolutionMixin:
         return self._resolve_basic_type(field_schema, defs)
 
     def _resolve_reference(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         field_schema: dict,
         defs: dict,
     ) -> Any:
@@ -56,7 +56,7 @@ class TypeResolutionMixin:
         )
 
     def _resolve_union_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         schema: dict,
         defs: dict,
     ) -> Any:
@@ -67,7 +67,7 @@ class TypeResolutionMixin:
         return Union[tuple(union_types)] if len(union_types) > 1 else union_types[0]
 
     def _resolve_union_option(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         option: dict,
         defs: dict,
     ) -> Any:
@@ -81,7 +81,7 @@ class TypeResolutionMixin:
         return self._resolve_basic_type(option, defs)
 
     def _resolve_basic_type(
-        self: "McpToolSpec",
+        self: "JsonSchemaToPydantic",
         schema: dict,
         defs: dict,
     ) -> Any:
@@ -97,12 +97,16 @@ class TypeResolutionMixin:
 
 
 class TypeCreationMixin:
-    def _create_list_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+    def _create_list_type(
+        self: "JsonSchemaToPydantic", schema: dict, defs: dict
+    ) -> type:
         """Create a List type from schema."""
         item_type = self._resolve_field_type(schema["items"], defs)
         return List[item_type]
 
-    def _create_dict_type(self: "McpToolSpec", schema: dict, defs: dict) -> type:
+    def _create_dict_type(
+        self: "JsonSchemaToPydantic", schema: dict, defs: dict
+    ) -> type:
         """Create a Dict type from schema."""
         additional_props = schema.get("additionalProperties")
 
@@ -115,11 +119,11 @@ class TypeCreationMixin:
 
         return Dict[str, Any]
 
-    def _is_simple_array(self: "McpToolSpec", schema: dict) -> bool:
+    def _is_simple_array(self: "JsonSchemaToPydantic", schema: dict) -> bool:
         """Check if schema is a simple array type."""
         return schema.get("type") == "array" and "items" in schema
 
-    def _is_simple_object(self: "McpToolSpec", schema: dict) -> bool:
+    def _is_simple_object(self: "JsonSchemaToPydantic", schema: dict) -> bool:
         """Check if schema is a simple object type."""
         additional_props = schema.get("additionalProperties")
         return (
@@ -129,13 +133,13 @@ class TypeCreationMixin:
             and isinstance(additional_props, dict)
         )
 
-    def _extract_ref_name(self: "McpToolSpec", ref_path: str) -> str:
+    def _extract_ref_name(self: "JsonSchemaToPydantic", ref_path: str) -> str:
         """Extract reference name from $ref path."""
         return ref_path.split("#/$defs/")[-1]
 
 
 class FieldExtractionMixin:
-    def _extract_fields(self: "McpToolSpec", schema: dict, defs: dict) -> dict:
+    def _extract_fields(self: "JsonSchemaToPydantic", schema: dict, defs: dict) -> dict:
         """Extract Pydantic fields from schema."""
         properties = self._get_properties(schema)
         required_fields = set(schema.get("required", []))
@@ -161,7 +165,7 @@ class FieldExtractionMixin:
 
         return fields
 
-    def _get_properties(self: "McpToolSpec", schema: dict) -> dict:
+    def _get_properties(self: "JsonSchemaToPydantic", schema: dict) -> dict:
         """Get properties from schema, handling enum types."""
         if "enum" in schema:
             # For enum types, create a property with the schema name as the key

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.5.0"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/conftest.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+from llama_index.tools.mcp import BasicMCPClient
+
+SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "server.py")
+
+
+@pytest.fixture(scope="session")
+def client() -> BasicMCPClient:
+    """Create a basic MCP client connected to the test server."""
+    return BasicMCPClient("python", args=[SERVER_SCRIPT], timeout=5)

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_schema_converter.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_schema_converter.py
@@ -1,0 +1,200 @@
+from typing import Dict, List, Literal, get_args
+
+from llama_index.tools.mcp import JsonSchemaToPydantic
+
+
+def test_basic_object_schema():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "A name"},
+            "age": {"type": "integer"},
+        },
+        "required": ["name"],
+    }
+    model = converter.create_model_from_json_schema(schema, "Person")
+
+    assert model.__name__ == "Person"
+    fields = model.model_fields
+    assert "name" in fields
+    assert "age" in fields
+    assert fields["name"].is_required()
+    assert not fields["age"].is_required()
+
+    instance = model(name="Alice")
+    assert instance.name == "Alice"
+    assert instance.age is None
+
+
+def test_ref_and_nested_models():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "address": {"$ref": "#/$defs/Address"},
+        },
+        "required": ["address"],
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "properties": {
+                    "street": {"type": "string"},
+                    "city": {"type": "string"},
+                },
+                "required": ["street", "city"],
+            },
+        },
+    }
+    model = converter.create_model_from_json_schema(schema, "Person")
+
+    assert "Address" in converter.properties_cache
+    address_model = converter.properties_cache["Address"]
+    assert "street" in address_model.model_fields
+    assert "city" in address_model.model_fields
+
+    json_schema = model.model_json_schema()
+    assert json_schema["properties"]["address"]["$ref"] == "#/$defs/Address"
+    assert "Address" in json_schema["$defs"]
+
+
+def test_anyof_union():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+            },
+        },
+        "required": ["value"],
+    }
+    model = converter.create_model_from_json_schema(schema, "UnionModel")
+
+    value_field = model.model_fields["value"]
+    args = get_args(value_field.annotation)
+    assert str in args
+    assert int in args
+
+
+def test_enum_to_literal():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "color": {"enum": ["red", "green", "blue"]},
+        },
+        "required": ["color"],
+    }
+    model = converter.create_model_from_json_schema(schema, "ColorModel")
+
+    color_field = model.model_fields["color"]
+    assert color_field.annotation == Literal["red", "green", "blue"]
+
+
+def test_array_of_items():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "numbers": {
+                "type": "array",
+                "items": {"type": "integer"},
+            },
+        },
+        "required": ["numbers"],
+    }
+    model = converter.create_model_from_json_schema(schema, "ArrayModel")
+
+    numbers_field = model.model_fields["numbers"]
+    assert numbers_field.annotation == List[int]
+
+
+def test_remove_model_fields():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "string"},
+            "b": {"type": "integer"},
+            "c": {"type": "boolean"},
+        },
+        "required": ["a", "b", "c"],
+    }
+    model = converter.create_model_from_json_schema(schema, "Original")
+    reduced = converter.remove_model_fields(model, {"b"}, "Reduced")
+
+    assert "a" in reduced.model_fields
+    assert "b" not in reduced.model_fields
+    assert "c" in reduced.model_fields
+    assert reduced.__name__ == "Reduced"
+
+
+def test_optional_field_with_default():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "count": {"type": "integer", "default": 42},
+        },
+        "required": ["name"],
+    }
+    model = converter.create_model_from_json_schema(schema, "Defaults")
+
+    assert model.model_fields["name"].is_required()
+    assert not model.model_fields["count"].is_required()
+    assert model.model_fields["count"].default == 42
+
+    instance = model(name="test")
+    assert instance.count == 42
+
+
+def test_additional_properties_dict():
+    converter = JsonSchemaToPydantic()
+    schema = {
+        "type": "object",
+        "properties": {
+            "metadata": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+        },
+        "required": ["metadata"],
+    }
+    model = converter.create_model_from_json_schema(schema, "DictModel")
+
+    metadata_field = model.model_fields["metadata"]
+    assert metadata_field.annotation == Dict[str, str]
+
+
+def test_matches_mcp_tool_spec_output(client):
+    """Verify that standalone converter produces the same schema as McpToolSpec."""
+    from llama_index.tools.mcp import McpToolSpec
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"$ref": "#/$defs/Name"},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["name", "tags"],
+        "$defs": {
+            "Name": {
+                "type": "object",
+                "properties": {"first": {"type": "string"}, "last": {"type": "string"}},
+                "required": ["first", "last"],
+            },
+        },
+    }
+
+    converter = JsonSchemaToPydantic()
+    standalone_model = converter.create_model_from_json_schema(schema, "TestSchema")
+
+    tool_spec = McpToolSpec(client)
+    spec_model = tool_spec.create_model_from_json_schema(schema, "TestSchema")
+
+    assert standalone_model.model_json_schema() == spec_model.model_json_schema()

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -1,4 +1,3 @@
-import os
 from typing import Literal, get_args
 
 import pytest
@@ -6,19 +5,11 @@ import pytest
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.tools.mcp import (
     BasicMCPClient,
+    JsonSchemaToPydantic,
     McpToolSpec,
     get_tools_from_mcp_url,
     aget_tools_from_mcp_url,
 )
-
-# Path to the test server script - adjust as needed
-SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "server.py")
-
-
-@pytest.fixture(scope="session")
-def client() -> BasicMCPClient:
-    """Create a basic MCP client connected to the test server."""
-    return BasicMCPClient("python", args=[SERVER_SCRIPT], timeout=5)
 
 
 def test_class():
@@ -143,9 +134,9 @@ def test_resolve_union_option_with_enum(client: BasicMCPClient):
     _resolve_union_option should handle enum entries in anyOf schemas,
     resolving them to Literal types instead of falling through to str.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
-    result = tool_spec._resolve_union_option({"enum": ["red", "green", "blue"]}, {})
+    result = converter._resolve_union_option({"enum": ["red", "green", "blue"]}, {})
     assert result == Literal["red", "green", "blue"]
 
 
@@ -153,7 +144,7 @@ def test_resolve_union_type_multiple_enums(client: BasicMCPClient):
     """
     Test that anyOf with multiple enum entries resolves to a Union of Literals.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -161,7 +152,7 @@ def test_resolve_union_type_multiple_enums(client: BasicMCPClient):
             {"enum": ["cyan", "magenta", "yellow"]},
         ]
     }
-    resolved = tool_spec._resolve_union_type(schema, {})
+    resolved = converter._resolve_union_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert Literal["red", "green", "blue"] in args
@@ -172,7 +163,7 @@ def test_resolve_optional_literal(client: BasicMCPClient):
     """
     Test that anyOf with enum + null resolves to Optional[Literal[...]].
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -180,7 +171,7 @@ def test_resolve_optional_literal(client: BasicMCPClient):
             {"type": "null"},
         ]
     }
-    resolved = tool_spec._resolve_union_type(schema, {})
+    resolved = converter._resolve_union_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert type(None) in args
@@ -191,7 +182,7 @@ def test_resolve_field_type_delegates_anyof_enums(client: BasicMCPClient):
     """
     Test that _resolve_field_type correctly delegates anyOf with enum entries.
     """
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     schema = {
         "anyOf": [
@@ -199,7 +190,7 @@ def test_resolve_field_type_delegates_anyof_enums(client: BasicMCPClient):
             {"enum": ["z"]},
         ]
     }
-    resolved = tool_spec._resolve_field_type(schema, {})
+    resolved = converter._resolve_field_type(schema, {})
     args = get_args(resolved)
     assert len(args) == 2
     assert Literal["x", "y"] in args
@@ -210,23 +201,23 @@ def test_additional_properties_false_parsing(client: BasicMCPClient):
     """Test that schemas with additionalProperties: false are parsed correctly."""
     from typing import Dict, Any
 
-    tool_spec = McpToolSpec(client)
+    converter = JsonSchemaToPydantic()
 
     # Test case 1: additionalProperties is False
     schema_false = {"type": "object", "additionalProperties": False}
-    assert not tool_spec._is_simple_object(schema_false)
-    result_type = tool_spec._create_dict_type(schema_false, {})
+    assert not converter._is_simple_object(schema_false)
+    result_type = converter._create_dict_type(schema_false, {})
     assert result_type == Dict[str, Any]
 
     # Test case 2: additionalProperties is None
     schema_none = {"type": "object", "additionalProperties": None}
-    result_type = tool_spec._create_dict_type(schema_none, {})
+    result_type = converter._create_dict_type(schema_none, {})
     assert result_type == Dict[str, Any]
 
     # Test case 3: additionalProperties is a dict (should be treated as simple object)
     schema_dict = {"type": "object", "additionalProperties": {"type": "string"}}
-    assert tool_spec._is_simple_object(schema_dict)
-    result_type = tool_spec._create_dict_type(schema_dict, {})
+    assert converter._is_simple_object(schema_dict)
+    result_type = converter._create_dict_type(schema_dict, {})
     assert result_type == Dict[str, str]
 
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/uv.lock
@@ -1856,7 +1856,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
Closes #22510

I ran into this while working with raw `mcp.types.Tool` definitions — I already had the tool schemas in hand and just needed to convert them to Pydantic models, but the only way to reach `create_model_from_json_schema` was to construct an `McpToolSpec`, which demands a `ClientSession` I didn't need and wasn't going to use.

The conversion logic itself never touches `self.client`. It only reads `self.properties_cache`. So the coupling is accidental, not intentional.

This PR extracts the conversion into a standalone `JsonSchemaToPydantic` class:

```python
from llama_index.tools.mcp import JsonSchemaToPydantic

converter = JsonSchemaToPydantic()
fn_schema = converter.create_model_from_json_schema(
    tool.inputSchema, model_name=f"{tool.name}_Schema"
)
```

`McpToolSpec` now holds a `JsonSchemaToPydantic` instance internally and delegates `create_model_from_json_schema` / `remove_model_fields` to it. `properties_cache` is exposed as a `@property` so existing code that reads it still works. The three mixins (`TypeResolutionMixin`, `TypeCreationMixin`, `FieldExtractionMixin`) are now base classes of `JsonSchemaToPydantic` instead of `McpToolSpec`.

No existing public API changed. `to_tool_list_async` produces identical output — the delegation is transparent.

**Tests:**
- Added `tests/test_schema_converter.py` with 10 client-free tests covering ``/nested models, `anyOf`, enum → Literal, arrays, `remove_model_fields`, optional fields with defaults, `additionalProperties` dicts, and a parity check that standalone converter output matches `McpToolSpec` output for the same schema.
- Repointed 5 existing internal-helper tests (`_resolve_*`, `_is_simple_object`, `_create_dict_type`) to instantiate `JsonSchemaToPydantic` directly.
- Extracted the shared `client` fixture into `conftest.py` so both test files can use it.
- Full suite: 60 passed. `ruff check` and `ruff format --check` clean.

Version bumped to 0.5.0 (new public API = minor bump per semver). CHANGELOG updated.