### PR TITLE
fix(core): pass docstring param descriptions into the tool schema (#22413)

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -244,11 +244,11 @@ class FunctionTool(AsyncBaseTool):
                     fn_to_parse,
                     additional_fields=None,
                     ignore_fields=ignore_fields,
+                    param_descriptions={
+                        param_name: doc.strip()
+                        for param_name, doc in param_docs.items()
+                    },
                 )
-                if fn_schema is not None and param_docs:
-                    for param_name, field in fn_schema.model_fields.items():
-                        if not field.description and param_name in param_docs:
-                            field.description = param_docs[param_name].strip()
 
             tool_metadata = ToolMetadata(
                 name=name,

--- a/llama-index-core/llama_index/core/tools/utils.py
+++ b/llama-index-core/llama_index/core/tools/utils.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -25,6 +26,7 @@ def create_schema_from_function(
         List[Union[Tuple[str, Type, Any], Tuple[str, Type]]]
     ] = None,
     ignore_fields: Optional[List[str]] = None,
+    param_descriptions: Optional[Dict[str, str]] = None,
 ) -> Type[BaseModel]:
     """
     Create schema from function.
@@ -32,9 +34,15 @@ def create_schema_from_function(
         - datetime.date -> format: "date"
         - datetime.datetime -> format: "date-time"
         - datetime.time -> format: "time"
+    - `param_descriptions` supplies fallback descriptions (e.g. parsed from the
+      function's docstring) for parameters that don't carry one of their own.
+      These must be passed in here rather than assigned to `model_fields` after
+      the fact: `model_json_schema()` is derived from the core schema frozen at
+      `create_model()` time, so a later mutation never reaches the schema.
     """
     fields = {}
     ignore_fields = ignore_fields or []
+    param_descriptions = param_descriptions or {}
     params = signature(func).parameters
 
     for param_name in params:
@@ -65,6 +73,9 @@ def create_schema_from_function(
                 ):
                     json_schema_extra.update(args[1].json_schema_extra)
 
+        if description is None:
+            description = param_descriptions.get(param_name)
+
         # Add format based on param_type
         if param_type == datetime.date:
             json_schema_extra.setdefault("format", "date")
@@ -84,6 +95,14 @@ def create_schema_from_function(
             )
         elif isinstance(param_default, FieldInfo):
             # Field with pydantic.Field as default value
+            if param_default.description is None and description is not None:
+                # Merge rather than assign: pydantic builds the field from the
+                # attributes the FieldInfo records as explicitly set, so a plain
+                # `param_default.description = ...` would never reach the schema
+                # (and would edit the caller's instance).
+                param_default = FieldInfo.merge_field_infos(
+                    param_default, description=description
+                )
             fields[param_name] = (param_type, param_default)
         else:
             fields[param_name] = (

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -353,6 +353,71 @@ def test_fn_schema_docstring_descriptions():
     assert fields["b"].description == "an optional string"
 
 
+def test_fn_schema_docstring_descriptions_reach_the_json_schema():
+    """
+    Docstring param descriptions must survive into the schema sent to the LLM.
+
+    Regression test: they used to be assigned to `model_fields` after
+    `create_model()` had already frozen the core schema, so `model_json_schema()`
+    -- and therefore `to_openai_tool()` -- never saw them.
+    """
+
+    def search(query: str, top_k: int = 5) -> str:
+        """
+        Search the web.
+
+        Args:
+            query (str): The search query string.
+            top_k (int): Number of results to return.
+
+        """
+        return "ok"
+
+    tool = FunctionTool.from_defaults(fn=search)
+
+    properties = tool.metadata.to_openai_tool()["function"]["parameters"]["properties"]
+    assert properties["query"]["description"] == "The search query string."
+    assert properties["top_k"]["description"] == "Number of results to return."
+
+
+def test_explicit_field_description_wins_over_docstring():
+    """A description on the parameter itself takes precedence over the docstring."""
+
+    def search(query: str = Field(default="", description="explicit")) -> str:
+        """
+        Search the web.
+
+        Args:
+            query (str): from the docstring
+
+        """
+        return "ok"
+
+    tool = FunctionTool.from_defaults(fn=search)
+
+    properties = tool.metadata.to_openai_tool()["function"]["parameters"]["properties"]
+    assert properties["query"]["description"] == "explicit"
+
+
+def test_docstring_fills_a_field_default_without_a_description():
+    """A bare `Field` default still picks the description up from the docstring."""
+
+    def search(query: str = Field(default="")) -> str:
+        """
+        Search the web.
+
+        Args:
+            query (str): The search query string.
+
+        """
+        return "ok"
+
+    tool = FunctionTool.from_defaults(fn=search)
+
+    properties = tool.metadata.to_openai_tool()["function"]["parameters"]["properties"]
+    assert properties["query"]["description"] == "The search query string."
+
+
 def test_docstring_param_extraction_javadoc_style():
     def tool_fn(foo: int, bar: str) -> str:
         """

--- a/llama-index-core/tests/tools/test_utils.py
+++ b/llama-index-core/tests/tools/test_utils.py
@@ -148,3 +148,57 @@ def test_create_schema_with_date_and_metadata():
 
     assert properties["timestamp"]["format"] == "date-time"
     assert properties["timestamp"]["example"] == "2023-05-12T08:00:00"
+
+
+def test_create_schema_from_function_with_param_descriptions() -> None:
+    """Test that param_descriptions land in the generated JSON schema."""
+
+    def tmp_function(x: int, y: str = "a") -> str:
+        return str(x)
+
+    schema = create_schema_from_function(
+        "TestSchema",
+        tmp_function,
+        param_descriptions={"x": "An integer", "y": "A string"},
+    )
+    actual_schema = schema.model_json_schema()
+
+    assert actual_schema["properties"]["x"]["description"] == "An integer"
+    assert actual_schema["properties"]["y"]["description"] == "A string"
+    assert actual_schema["properties"]["y"]["default"] == "a"
+    assert actual_schema["required"] == ["x"]
+
+
+def test_param_descriptions_do_not_override_an_explicit_description() -> None:
+    """A description on the parameter itself wins over the fallback."""
+
+    def tmp_function(
+        x: Annotated[int, "From the annotation"],
+        y: str = Field("a", description="From the field"),
+    ) -> str:
+        return str(x)
+
+    schema = create_schema_from_function(
+        "TestSchema",
+        tmp_function,
+        param_descriptions={"x": "Fallback", "y": "Fallback"},
+    )
+    actual_schema = schema.model_json_schema()
+
+    assert actual_schema["properties"]["x"]["description"] == "From the annotation"
+    assert actual_schema["properties"]["y"]["description"] == "From the field"
+
+
+def test_param_descriptions_do_not_mutate_the_callers_field() -> None:
+    """Filling in a description must not write back to the shared FieldInfo."""
+    shared_field = Field("a")
+
+    def tmp_function(x: str = shared_field) -> str:
+        return x
+
+    schema = create_schema_from_function(
+        "TestSchema", tmp_function, param_descriptions={"x": "A string"}
+    )
+
+    assert schema.model_json_schema()["properties"]["x"]["description"] == "A string"
+    assert shared_field.description is None


### PR DESCRIPTION
Fixes #22413.

### Problem

`FunctionTool.from_defaults` parses per-parameter descriptions out of the docstring, then applies them like this:

```python
for param_name, field in fn_schema.model_fields.items():
    if not field.description and param_name in param_docs:
        field.description = param_docs[param_name].strip()
```

That runs *after* `create_schema_from_function` has already called `create_model()`. Pydantic v2 derives `model_json_schema()` from the core schema frozen at that point, so the mutation is only ever visible through `model_fields` — the schema actually sent to the LLM (`to_openai_tool()`, `get_parameters_dict()`) emits `description: null` for every parameter.

```console
parsed : {'query': 'The search query string.', 'top_k': 'Number of results to return.'}
emitted: {'query': None, 'top_k': None}
```

### Fix

Add an optional `param_descriptions` mapping to `create_schema_from_function`, applied while the fields are being built, and have `from_defaults` pass `param_docs` through it instead of mutating afterwards. Precedence is unchanged: a description the parameter carries itself (`Annotated[int, "..."]`, or a `Field(description=...)` default) still wins over the docstring.

The `Field`-default branch uses `FieldInfo.merge_field_infos` rather than assigning `.description`, for the same reason as the original bug — pydantic builds the field from the attributes a `FieldInfo` records as explicitly set, so a plain attribute assignment would not reach the schema (and would edit the caller's `FieldInfo` instance). Verified on both pydantic `2.8.0` (the floor in `llama-index-core/pyproject.toml`) and `2.13.4`.

`create_schema_from_function`'s other callers (`ondemand_loader_tool.py`, `tool_spec/load_and_search/base.py`) are unaffected — the new argument is optional.

### Tests

Added to the existing files, next to the tests that already cover this area:

`tests/tools/test_base.py`
- `test_fn_schema_docstring_descriptions_reach_the_json_schema` — the issue's repro, asserted against `to_openai_tool()`
- `test_explicit_field_description_wins_over_docstring`
- `test_docstring_fills_a_field_default_without_a_description`

`tests/tools/test_utils.py`
- `test_create_schema_from_function_with_param_descriptions`
- `test_param_descriptions_do_not_override_an_explicit_description`
- `test_param_descriptions_do_not_mutate_the_callers_field`

Verified against `llama-index-core==0.14.23` with `tools/utils.py` and `tools/function_tool.py` replaced by `main@c864fcf` (blob SHAs confirmed identical), running `tests/tools/`:

| | before | after |
|---|---|---|
| 6 new tests | 5 failed, 1 passed | 6 passed |
| pre-existing `tests/tools/` | 36 passed | 36 passed |

`test_retreiver_tool` and `test_ondemand_loader_tool` fail identically before and after — they need live OpenAI embeddings, which my environment has no key for.

`ruff check` / `ruff format --check` clean at the pinned `v0.11.8` with the repo's root config; `mypy` clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
