### PR TITLE
Add llama-index-tools-llm-sandbox

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/.gitignore
@@ -1,0 +1,153 @@
+llama_index/_static
+.DS_Store
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+bin/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+etc/
+include/
+lib/
+lib64/
+parts/
+sdist/
+share/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+.ruff_cache
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pyvenv.cfg
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# VsCode
+.vscode
+
+# pipenv
+Pipfile
+Pipfile.lock
+
+# pyright
+pyrightconfig.json

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## [0.1.0]
+
+- Initial release.

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/Makefile
@@ -1,0 +1,17 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests
+
+watch-docs:	## Build and watch documentation.
+	sphinx-autobuild docs/ docs/_build/html --open-browser --watch $(GIT_ROOT)/llama_index/

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/README.md
@@ -1,0 +1,77 @@
+# LlamaIndex Tools Integration: LLM Sandbox
+
+Runs agent-authored code inside an isolated container rather than on the host,
+using [llm-sandbox](https://github.com/vndee/llm-sandbox). Docker, Podman and
+Kubernetes backends; seven languages.
+
+The container is hardened by default: no network, capped memory and pids, every
+Linux capability dropped except `DAC_OVERRIDE`, and `no-new-privileges` set.
+
+## Installation
+
+```bash
+pip install llama-index-tools-llm-sandbox
+```
+
+Requires a container runtime — Docker by default.
+
+## Usage
+
+```python
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.llm_sandbox import LLMSandboxToolSpec
+
+tool_spec = LLMSandboxToolSpec()
+
+agent = FunctionAgent(
+    tools=tool_spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4o"),
+    system_prompt="Solve problems by writing and running Python. Always print results.",
+)
+
+print(await agent.run("What is the standard deviation of the first 50 primes?"))
+```
+
+Another language, or another backend:
+
+```python
+LLMSandboxToolSpec(lang="ruby")
+LLMSandboxToolSpec(backend="kubernetes")
+LLMSandboxToolSpec(image="my-registry/python-with-pandas:1.0")
+```
+
+## Security
+
+`DEFAULT_RUNTIME_CONFIGS` is applied unless you pass `runtime_configs`:
+
+```python
+{
+    "network_mode": "none",
+    "mem_limit": "512m",
+    "pids_limit": 128,
+    "cap_drop": ["ALL"],
+    "cap_add": ["DAC_OVERRIDE"],
+    "security_opt": ["no-new-privileges:true"],
+}
+```
+
+Verified inside the container: `CapEff` is `0000000000000002` and outbound
+connections fail.
+
+Three things worth knowing:
+
+- **`DAC_OVERRIDE` is added back deliberately.** The session copies the source
+  file into the container; without that capability it cannot read it and every
+  run fails. Everything else stays dropped.
+- **`read_only: True` is not supported.** Docker rejects the code copy against a
+  read-only rootfs, with or without a tmpfs on the workdir.
+- **There is no package-installation parameter.** The default network isolation
+  would block it, and letting a model choose arbitrary PyPI packages executes
+  `setup.py` at install time. Pre-bake dependencies into an image and pass
+  `image=` instead.
+
+This is container isolation, not VM isolation: it inherits the threat model of
+the backend in use and makes no kernel-level guarantee. For deliberately
+adversarial code, pair it with a hardened runtime such as gVisor or Kata
+Containers.

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/llama_index/tools/llm_sandbox/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/llama_index/tools/llm_sandbox/__init__.py
@@ -1,0 +1,8 @@
+"""init.py."""
+
+from llama_index.tools.llm_sandbox.base import (
+    DEFAULT_RUNTIME_CONFIGS,
+    LLMSandboxToolSpec,
+)
+
+__all__ = ["DEFAULT_RUNTIME_CONFIGS", "LLMSandboxToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/llama_index/tools/llm_sandbox/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/llama_index/tools/llm_sandbox/base.py
@@ -1,0 +1,116 @@
+"""LLM Sandbox tool spec."""
+
+from typing import Any, Dict, Optional
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+# Dropping every capability breaks execution on its own: the session copies the
+# source file into the container, and without DAC_OVERRIDE it cannot be read.
+# Everything else stays dropped -- CapEff is 0000000000000002 inside.
+#
+# read_only is deliberately absent: Docker rejects the code copy against a
+# read-only rootfs, with or without a tmpfs on the workdir.
+DEFAULT_RUNTIME_CONFIGS: Dict[str, Any] = {
+    "network_mode": "none",
+    "mem_limit": "512m",
+    "pids_limit": 128,
+    "cap_drop": ["ALL"],
+    "cap_add": ["DAC_OVERRIDE"],
+    "security_opt": ["no-new-privileges:true"],
+}
+
+
+class LLMSandboxToolSpec(BaseToolSpec):
+    """
+    LLM Sandbox tool spec.
+
+    Runs agent-authored code inside an isolated container rather than on the
+    host, using `llm-sandbox <https://github.com/vndee/llm-sandbox>`_. Supports
+    Docker, Podman and Kubernetes backends and seven languages.
+
+    By default the container has no network access, capped memory and pids, all
+    Linux capabilities dropped except DAC_OVERRIDE, and no-new-privileges set.
+    Pass ``runtime_configs`` to change that.
+
+    Note that this is container isolation, not VM isolation: it inherits the
+    threat model of the backend in use and makes no kernel-level guarantee. For
+    deliberately adversarial code, pair it with a hardened runtime such as
+    gVisor or Kata Containers.
+    """
+
+    spec_functions = ["execute_code"]
+
+    def __init__(
+        self,
+        lang: str = "python",
+        backend: str = "docker",
+        image: Optional[str] = None,
+        timeout: float = 30.0,
+        runtime_configs: Optional[Dict[str, Any]] = None,
+        keep_template: bool = True,
+        verbose: bool = False,
+    ) -> None:
+        """
+        Initialize the tool spec.
+
+        Args:
+            lang: Language to execute. One of python, javascript, java, cpp, go,
+                r, ruby.
+            backend: Container backend: docker, podman, kubernetes or micromamba.
+            image: Optional custom image. The tool deliberately exposes no
+                package-installation parameter: the default network isolation
+                would block it, and letting a model choose arbitrary PyPI
+                packages runs setup.py code at install time. Pre-bake
+                dependencies into an image instead.
+            timeout: Seconds before an execution is aborted.
+            runtime_configs: Container settings passed to the backend. Defaults
+                to ``DEFAULT_RUNTIME_CONFIGS``; pass a dict to replace it.
+            keep_template: Keep the base image after the session closes. Leaving
+                this False re-pulls the image on every call.
+            verbose: Emit session logs.
+
+        """
+        self.lang = lang
+        self.backend = backend
+        self.image = image
+        self.timeout = timeout
+        self.runtime_configs = DEFAULT_RUNTIME_CONFIGS if runtime_configs is None else runtime_configs
+        self.keep_template = keep_template
+        self.verbose = verbose
+
+    def _session_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "lang": self.lang,
+            "backend": self.backend,
+            "verbose": self.verbose,
+            "keep_template": self.keep_template,
+            "runtime_configs": self.runtime_configs,
+        }
+        if self.image is not None:
+            kwargs["image"] = self.image
+        return kwargs
+
+    def execute_code(self, code: str) -> str:
+        """
+        Execute code in an isolated container and return what it printed.
+
+        Use this for calculations, data manipulation, and anything easier to
+        compute than to reason about. Always print the result: only stdout is
+        returned.
+
+        Args:
+            code: Source to execute, complete and self-contained.
+
+        Returns:
+            stdout on success. On a non-zero exit, the exit code followed by
+            stderr, or stdout when stderr is empty.
+
+        """
+        from llm_sandbox import SandboxSession
+
+        with SandboxSession(**self._session_kwargs()) as session:
+            result = session.run(code, timeout=self.timeout)
+
+        if result.exit_code != 0:
+            return f"exit {result.exit_code}\n{result.stderr or result.stdout}".strip()
+        return result.stdout.strip() or "(no output)"

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-Deprecated>=0.1.0",
+    "types-PyYAML>=6.0.12.12,<7",
+    "types-protobuf>=4.24.0.4,<5",
+    "types-redis==4.5.5.0",
+    "types-requests==2.28.11.8",
+    "types-setuptools==67.1.0.0",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+    "diff-cover>=9.2.0",
+    "pytest-cov>=6.1.1",
+]
+
+[project]
+name = "llama-index-tools-llm-sandbox"
+version = "0.1.0"
+description = "llama-index tools llm_sandbox integration"
+authors = [{name = "Duy Huynh", email = "vndee.huynh@gmail.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "vndee"}]
+keywords = ["sandbox", "code execution", "container", "docker", "kubernetes"]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+    "llm-sandbox[docker]>=0.3.43",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = false
+import_path = "llama_index.tools.llm_sandbox"
+
+[tool.llamahub.class_authors]
+LLMSandboxToolSpec = "vndee"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.10"

--- a/llama-index-integrations/tools/llama-index-tools-llm-sandbox/tests/test_tools_llm_sandbox.py
+++ b/llama-index-integrations/tools/llama-index-tools-llm-sandbox/tests/test_tools_llm_sandbox.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock, patch
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.llm_sandbox import DEFAULT_RUNTIME_CONFIGS, LLMSandboxToolSpec
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in LLMSandboxToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions():
+    assert LLMSandboxToolSpec.spec_functions == ["execute_code"]
+
+
+def test_default_runtime_configs_are_hardened():
+    # Regression guard: these defaults are the reason this tool is safer than
+    # executing on the host, so silently losing one should fail the build.
+    assert DEFAULT_RUNTIME_CONFIGS["network_mode"] == "none"
+    assert DEFAULT_RUNTIME_CONFIGS["cap_drop"] == ["ALL"]
+    assert DEFAULT_RUNTIME_CONFIGS["security_opt"] == ["no-new-privileges:true"]
+    assert "mem_limit" in DEFAULT_RUNTIME_CONFIGS
+    assert "pids_limit" in DEFAULT_RUNTIME_CONFIGS
+
+
+def test_default_runtime_configs_omit_unsupported_flags():
+    # read_only makes Docker reject the code copy that SandboxSession performs
+    # ("container rootfs is marked read-only"), so it must not be a default.
+    assert "read_only" not in DEFAULT_RUNTIME_CONFIGS
+    # cap_drop=ALL alone leaves the copied file unreadable; DAC_OVERRIDE is
+    # added back deliberately.
+    assert DEFAULT_RUNTIME_CONFIGS["cap_add"] == ["DAC_OVERRIDE"]
+
+
+def test_to_tool_list_exposes_execute_code():
+    tools = LLMSandboxToolSpec().to_tool_list()
+    assert [t.metadata.name for t in tools] == ["execute_code"]
+
+
+def _mock_session(exit_code=0, stdout="", stderr=""):
+    result = MagicMock(exit_code=exit_code, stdout=stdout, stderr=stderr)
+    session = MagicMock()
+    session.run.return_value = result
+    ctx = MagicMock()
+    ctx.__enter__.return_value = session
+    ctx.__exit__.return_value = False
+    return ctx, session
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_execute_code_returns_stdout(mock_cls):
+    ctx, _ = _mock_session(stdout="42\n")
+    mock_cls.return_value = ctx
+    assert LLMSandboxToolSpec().execute_code("print(6 * 7)") == "42"
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_execute_code_reports_failure(mock_cls):
+    ctx, _ = _mock_session(exit_code=1, stderr="Traceback: boom")
+    mock_cls.return_value = ctx
+    out = LLMSandboxToolSpec().execute_code("raise ValueError")
+    assert out.startswith("exit 1")
+    assert "boom" in out
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_execute_code_handles_empty_output(mock_cls):
+    ctx, _ = _mock_session(stdout="   ")
+    mock_cls.return_value = ctx
+    assert LLMSandboxToolSpec().execute_code("x = 1") == "(no output)"
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_hardening_is_passed_to_the_session(mock_cls):
+    ctx, _ = _mock_session(stdout="ok")
+    mock_cls.return_value = ctx
+    LLMSandboxToolSpec().execute_code("print('ok')")
+    assert mock_cls.call_args.kwargs["runtime_configs"] == DEFAULT_RUNTIME_CONFIGS
+    # Without this the image is deleted on close and re-pulled every call.
+    assert mock_cls.call_args.kwargs["keep_template"] is True
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_runtime_configs_can_be_overridden(mock_cls):
+    ctx, _ = _mock_session(stdout="ok")
+    mock_cls.return_value = ctx
+    LLMSandboxToolSpec(runtime_configs={"network_mode": "bridge"}).execute_code("print(1)")
+    assert mock_cls.call_args.kwargs["runtime_configs"] == {"network_mode": "bridge"}
+
+
+def test_tool_exposes_only_code():
+    # A  parameter here would let the model pick arbitrary PyPI
+    # packages, which executes setup.py at install time. Keep the surface to one
+    # argument.
+    tool = LLMSandboxToolSpec().to_tool_list()[0]
+    assert set(tool.metadata.get_parameters_dict()["properties"]) == {"code"}
+
+
+@patch("llm_sandbox.SandboxSession")
+def test_lang_and_timeout_are_forwarded(mock_cls):
+    ctx, session = _mock_session(stdout="ok")
+    mock_cls.return_value = ctx
+    LLMSandboxToolSpec(lang="ruby", timeout=5.0).execute_code("puts 1")
+    assert mock_cls.call_args.kwargs["lang"] == "ruby"
+    assert session.run.call_args.kwargs["timeout"] == 5.0


### PR DESCRIPTION
Adds a tool spec that runs agent-authored code inside an isolated container instead of on the host, using [llm-sandbox](https://github.com/vndee/llm-sandbox). Docker, Podman and Kubernetes backends; seven languages.

## Why

The existing `CodeInterpreterToolSpec` carries this warning:

> Arbitrary code execution is possible on the machine running this tool. This tool is not recommended to be used in a production setting, and would require heavy sandboxing or virtual machines

This fills that gap without requiring a hosted service — execution happens on container infrastructure the user already runs.

## Usage

```python
from llama_index.tools.llm_sandbox import LLMSandboxToolSpec

agent = FunctionAgent(
    tools=LLMSandboxToolSpec().to_tool_list(),
    llm=OpenAI(model="gpt-4o"),
)
```

## Hardened by default

`DEFAULT_RUNTIME_CONFIGS` applies unless the caller passes `runtime_configs`:

```python
{
    "network_mode": "none",
    "mem_limit": "512m",
    "pids_limit": 128,
    "cap_drop": ["ALL"],
    "cap_add": ["DAC_OVERRIDE"],
    "security_opt": ["no-new-privileges:true"],
}
```

Verified inside a running container: `CapEff` is `0000000000000002` (DAC_OVERRIDE only) and outbound connections fail.

Three deliberate choices, in case they look odd on review:

- **`DAC_OVERRIDE` is added back.** The session copies the source file into the container; dropping it makes that file unreadable and every run fails with `[Errno 13] Permission denied`. Everything else stays dropped.
- **`read_only: True` is not used.** Docker rejects the code copy against a read-only rootfs (`container rootfs is marked read-only`), with or without a tmpfs on the workdir.
- **The tool exposes only `code`.** No package-installation parameter: the default network isolation would block it anyway, and letting a model choose arbitrary PyPI packages executes `setup.py` at install time.

The README states plainly that this is container isolation, not VM isolation, and points at gVisor/Kata for adversarial workloads.

## Tests

12 tests, no container required — `SandboxSession` is mocked. They cover the tool surface, stdout/failure/empty-output handling, that hardening reaches the session, that `keep_template` is set (without it the image is re-pulled every call), and regression guards asserting the defaults stay hardened and the schema stays single-parameter.

Also verified end to end against real Docker: executes correctly, egress blocked, capabilities as above.

I maintain llm-sandbox and will maintain this integration.
