### PR TITLE
fix: GoogleDriveReader returns None instead of a list when an error is swallowed

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/llama_index/readers/google/drive/base.py
@@ -437,14 +437,15 @@ class GoogleDriveReader(
                 )
             return fileids_meta
 
-    def _download_file(self, fileid: str, filename: str) -> str:
+    def _download_file(self, fileid: str, filename: str) -> Optional[str]:
         """
         Download the file with fileid and filename
         Args:
             fileid: file id of the file in google drive
             filename: filename with which it will be downloaded
         Returns:
-            The downloaded filename, which may have a new extension.
+            The downloaded filename, which may have a new extension, or None
+            if the download failed and raise_errors is False.
         """
         from io import BytesIO
 
@@ -493,6 +494,7 @@ class GoogleDriveReader(
                 logger.error(
                     f"An error occurred while downloading file: {e}", exc_info=True
                 )
+            return None
 
     def _load_data_fileids_meta(self, fileids_meta: List[List[str]]) -> List[Document]:
         """
@@ -518,6 +520,10 @@ class GoogleDriveReader(
                     fileid = fileid_meta[0]
                     filepath = os.path.join(temp_dir, fileid)
                     final_filepath = self._download_file(fileid, filepath)
+                    if final_filepath is None:
+                        # The download failed and was swallowed; nothing was
+                        # written to temp_dir, so there is no file to describe.
+                        continue
 
                     # Add metadata of the file to metadata dictionary
                     metadata[final_filepath] = {
@@ -546,6 +552,7 @@ class GoogleDriveReader(
                     f"An error occurred while loading data from fileids meta: {e}",
                     exc_info=True,
                 )
+            return []
 
     def _load_from_file_ids(
         self,
@@ -584,6 +591,7 @@ class GoogleDriveReader(
                 logger.error(
                     f"An error occurred while loading with fileid: {e}", exc_info=True
                 )
+            return []
 
     def _load_from_folder(
         self,
@@ -620,6 +628,7 @@ class GoogleDriveReader(
                 logger.error(
                     f"An error occurred while loading from folder: {e}", exc_info=True
                 )
+            return []
 
     def load_data(
         self,

--- a/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-google/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-google"
-version = "0.7.2"
+version = "0.7.3"
 description = "llama-index readers google integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-google/tests/test_readers_google_drive.py
+++ b/llama-index-integrations/readers/llama-index-readers-google/tests/test_readers_google_drive.py
@@ -197,3 +197,105 @@ class TestGoogleDriveReader(unittest.TestCase):
             assert filename == google_drive_id + ".pdf"
             # also should have tried to write the file
             mock_file().write.assert_called_once()
+
+    def _reader(self):
+        return GoogleDriveReader(
+            client_config={
+                "client_id": "example_client_id",
+                "client_secret": "example_client_secret",
+            },
+        )
+
+    def test_load_data_returns_a_list_when_a_folder_load_fails(self):
+        """
+        A swallowed error must still produce a list, not None.
+
+        load_data is annotated and documented as returning List[Document], and
+        its own "neither folder_id nor file_ids" branch returns []. When
+        raise_errors is False (the default) an error used to fall off the end
+        of _load_from_folder, so callers doing `for doc in reader.load_data()`
+        got a TypeError far away from the failure that was actually logged.
+        """
+        reader = self._reader()
+        reader._creds = MagicMock()
+
+        with (
+            patch.object(reader, "_get_credentials", return_value=MagicMock()),
+            patch.object(
+                reader, "_get_fileids_meta", side_effect=RuntimeError("drive is down")
+            ),
+        ):
+            documents = reader.load_data(folder_id="some_folder")
+
+        assert documents == []
+
+    def test_load_data_returns_a_list_when_a_file_id_load_fails(self):
+        reader = self._reader()
+        reader._creds = MagicMock()
+
+        with (
+            patch.object(reader, "_get_credentials", return_value=MagicMock()),
+            patch.object(
+                reader, "_get_fileids_meta", side_effect=RuntimeError("drive is down")
+            ),
+        ):
+            documents = reader.load_data(file_ids=["some_file"])
+
+        assert documents == []
+
+    def test_load_data_still_raises_when_raise_errors_is_set(self):
+        """Opting in to raise_errors must keep propagating."""
+        reader = GoogleDriveReader(
+            client_config={
+                "client_id": "example_client_id",
+                "client_secret": "example_client_secret",
+            },
+            raise_errors=True,
+        )
+        reader._creds = MagicMock()
+
+        with (
+            patch.object(reader, "_get_credentials", return_value=MagicMock()),
+            patch.object(
+                reader, "_get_fileids_meta", side_effect=RuntimeError("drive is down")
+            ),
+            pytest.raises(RuntimeError, match="drive is down"),
+        ):
+            reader.load_data(folder_id="some_folder")
+
+    def test_download_file_returns_none_when_the_error_is_swallowed(self):
+        reader = self._reader()
+        reader._creds = MagicMock()
+
+        with patch("googleapiclient.discovery.build", side_effect=RuntimeError("boom")):
+            assert reader._download_file("fileid", "filename") is None
+
+    def test_a_failed_download_does_not_poison_the_metadata_map(self):
+        """A file that failed to download is skipped rather than keyed by None."""
+        reader = self._reader()
+        reader._creds = MagicMock()
+
+        captured = {}
+
+        def fake_reader(temp_dir, file_extractor=None, file_metadata=None):
+            loader = MagicMock()
+            loader.load_data.return_value = []
+            captured["file_metadata"] = file_metadata
+            return loader
+
+        fileids_meta = [["id1", "author", "path", "mime", "created", "modified"]]
+
+        with (
+            patch.object(reader, "_download_file", return_value=None),
+            patch(
+                "llama_index.readers.google.drive.base.SimpleDirectoryReader",
+                side_effect=fake_reader,
+            ),
+        ):
+            documents = reader._load_data_fileids_meta(fileids_meta)
+
+        assert documents == []
+        with pytest.raises(KeyError):
+            # nothing was recorded for the failed file, and in particular
+            # nothing was recorded under the key None
+            captured["file_metadata"](None)


### PR DESCRIPTION
## Description

`GoogleDriveReader.load_data` is annotated and documented as returning `List[Document]`, and its own "neither `folder_id` nor `file_ids`" branch returns `[]`:

```python
if folder_id:
    return self._load_from_folder(drive_id, folder_id, mime_types, query_string)
elif file_ids:
    return self._load_from_file_ids(drive_id, file_ids, mime_types, query_string)
else:
    logger.warning("Either 'folder_id' or 'file_ids' must be provided.")
    return []
```

But with `raise_errors=False`, which is the default (`raise_errors: bool = Field(default=False)`), an error fell off the end of `_load_from_folder`, `_load_from_file_ids` and `_load_data_fileids_meta`. Their handlers log and then simply end:

```python
except Exception as e:
    if self.raise_errors:
        raise
    else:
        logger.error(f"An error occurred while loading from folder: {e}", exc_info=True)
    # <- falls through, returns None
```

So `load_data()` returned `None`, and a caller doing the obvious thing got a `TypeError` pointing far away from the failure that was actually logged:

```python
for doc in reader.load_data(folder_id=...):   # TypeError: 'NoneType' object is not iterable
```

The convention for this is already in the same file. `_get_fileids_meta`'s handler ends with `return fileids_meta` rather than falling through. The other three now do the same and return `[]`.

`_download_file` had the same shape but is annotated `-> str`. It is now `Optional[str]` with an explicit `return None`, its docstring says so, and `_load_data_fileids_meta` skips a file whose download failed instead of adding an entry keyed by `None` to the metadata map.

Nothing changes when `raise_errors=True`: errors still propagate exactly as before, and there is a test for that.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added new unit tests to cover the change

Five tests added to `tests/test_readers_google_drive.py`. **Three of them fail against the current code and pass with this change**:

- `test_load_data_returns_a_list_when_a_folder_load_fails`
- `test_load_data_returns_a_list_when_a_file_id_load_fails`
- `test_a_failed_download_does_not_poison_the_metadata_map`

The other two pass either way and are there to pin the contract rather than to catch this bug, which I would rather state plainly than imply five regression tests:

- `test_load_data_still_raises_when_raise_errors_is_set` — guards that opting in to `raise_errors` keeps propagating
- `test_download_file_returns_none_when_the_error_is_swallowed` — pins the newly documented `Optional[str]` return

Full file is `13 passed` (8 existing plus these 5). `ruff check` and `ruff format --check` are clean at the `v0.11.8` pinned in `.pre-commit-config.yaml`.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added Google Colab support for the newly added notebooks — n/a, no notebooks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
- [x] Bumped the package patch version, `0.7.2` to `0.7.3`, per the convention in recent merged PRs touching integration packages
