### PR TITLE
feat: migrate llama-index-tools-mcp to mcp 2.x

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/examples/mcp_server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/examples/mcp_server.py
@@ -1,5 +1,5 @@
 import argparse
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from pydantic import BaseModel, IPvAnyAddress
 import ipinfo
 import os
@@ -8,7 +8,7 @@ import dotenv
 dotenv.load_dotenv()
 
 # Create MCP server
-mcp = FastMCP("BasicServer")
+mcp = MCPServer("BasicServer")
 
 
 class IPDetails(BaseModel):

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -55,7 +55,7 @@ class McpToolSpec(
         An asynchronous method to get the tools list from MCP Client. If allowed_tools is set, it will filter the tools.
 
         Returns:
-            A list of tools, each tool object needs to contain name, description, inputSchema properties.
+            A list of tools, each tool object needs to contain name, description, input_schema properties.
 
         """
         response = await self.client.list_tools()
@@ -83,8 +83,8 @@ class McpToolSpec(
             static_response.resources if hasattr(static_response, "resources") else []
         )
         dynamic_resources = (
-            dynamic_response.resourceTemplates
-            if hasattr(dynamic_response, "resourceTemplates")
+            dynamic_response.resource_templates
+            if hasattr(dynamic_response, "resource_templates")
             else []
         )
         resources = static_resources + dynamic_resources
@@ -135,9 +135,9 @@ class McpToolSpec(
         function_tool_list: List[FunctionTool] = []
         for tool in tools_list:
             fn = self._create_tool_fn(tool.name)
-            # Create a Pydantic model based on the tool inputSchema
+            # Create a Pydantic model based on the tool input_schema
             model_schema = self.create_model_from_json_schema(
-                tool.inputSchema, model_name=f"{tool.name}_Schema"
+                tool.input_schema, model_name=f"{tool.name}_Schema"
             )
             # Set up global partial params as default
             tool_partial_params = dict(self.global_partial_params or {})

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -3,7 +3,6 @@ import logging
 import io
 
 from contextlib import asynccontextmanager
-from datetime import timedelta
 from typing import (
     Optional,
     List,
@@ -15,10 +14,10 @@ from typing import (
     Any,
 )
 from urllib.parse import urlparse, parse_qs
-from httpx import AsyncClient, Timeout
+from httpx2 import AsyncClient, Timeout
 from mcp.client.session import ClientSession
 from mcp.shared._httpx_utils import create_mcp_http_client
-from mcp.shared.session import ProgressFnT
+from mcp.shared.dispatcher import ProgressFnT
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client, StdioServerParameters
 from mcp.client.streamable_http import streamable_http_client
@@ -112,7 +111,7 @@ class BasicMCPClient(ClientSession):
         sampling_callback: Optional callback for handling sampling messages.
         headers: Optional headers to pass by sse client or streamable http client
         tool_call_logs_callback: Async function to store the logs deriving from an MCP tool call: logs are provided as a list of strings, representing log messages. Defaults to None.
-        http_client: Optional httpx AsyncClient to use for Streamable transport. Will ignore timeout and headers parameters if provided.
+        http_client: Optional httpx2 AsyncClient to use for Streamable transport. Will ignore timeout and headers parameters if provided.
 
     """
 
@@ -185,7 +184,7 @@ class BasicMCPClient(ClientSession):
             timeout: The timeout for HTTP operations in seconds. Default is 30.
             sse_read_timeout: The timeout for SSE read operations in seconds. Default is 300.
             tool_call_logs_callback: Async function to store the logs deriving from an MCP tool call: logs are provided as a list of strings, representing log messages. Defaults to None.
-            http_client: Optional httpx AsyncClient to use for Streamable transport. Will ignore timeout and headers parameters if provided.
+            http_client: Optional httpx2 AsyncClient to use for Streamable transport. Will ignore timeout and headers parameters if provided.
 
         Returns:
             An authenticated MCP client
@@ -242,7 +241,7 @@ class BasicMCPClient(ClientSession):
                 ) as streams:
                     async with ClientSession(
                         *streams,
-                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        read_timeout_seconds=float(self.timeout),
                         sampling_callback=self.sampling_callback,
                     ) as session:
                         await session.initialize()
@@ -256,7 +255,7 @@ class BasicMCPClient(ClientSession):
                     async with ClientSession(
                         read,
                         write,
-                        read_timeout_seconds=timedelta(seconds=self.timeout),
+                        read_timeout_seconds=float(self.timeout),
                         sampling_callback=self.sampling_callback,
                     ) as session:
                         await session.initialize()
@@ -269,7 +268,7 @@ class BasicMCPClient(ClientSession):
             async with stdio_client(server_parameters) as streams:
                 async with ClientSession(
                     *streams,
-                    read_timeout_seconds=timedelta(seconds=self.timeout),
+                    read_timeout_seconds=float(self.timeout),
                     sampling_callback=self.sampling_callback,
                 ) as session:
                     await session.initialize()
@@ -287,9 +286,9 @@ class BasicMCPClient(ClientSession):
                 stream_handler,
             ],
         )
-        # Also enable logging for specific FastMCP components
-        fastmcp_logger = logging.getLogger("fastmcp")
-        fastmcp_logger.setLevel(logging.DEBUG)
+        # Also enable logging for specific MCP components
+        mcp_logger = logging.getLogger("mcp")
+        mcp_logger.setLevel(logging.DEBUG)
 
         # Enable HTTP transport logging to see network details
         http_logger = logging.getLogger("httpx")
@@ -393,7 +392,7 @@ class BasicMCPClient(ClientSession):
                             blocks=[
                                 ImageBlock(
                                     image=message.content.data,
-                                    image_mimetype=message.content.mimeType,
+                                    image_mimetype=message.content.mime_type,
                                 )
                             ],
                         )

--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/utils.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from mcp.client.session import ClientSession
-from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.mcpserver import MCPServer, Context
 from pydantic import BaseModel
 
 from llama_index.core.tools import FunctionTool
@@ -79,8 +79,8 @@ def workflow_as_mcp(
     workflow_name: Optional[str] = None,
     workflow_description: Optional[str] = None,
     start_event_model: Optional[BaseModel] = None,
-    **fastmcp_init_kwargs: Any,
-) -> FastMCP:
+    **mcp_server_init_kwargs: Any,
+) -> MCPServer:
     """
     Convert a workflow to an MCP app.
 
@@ -97,14 +97,14 @@ def workflow_as_mcp(
         start_event_model (optional):
             The start event model of the workflow. Can be a `BaseModel` or a `StartEvent` class.
             Defaults to the workflow's custom `StartEvent` class.
-        **fastmcp_init_kwargs:
-            Additional keyword arguments to pass to the FastMCP constructor.
+        **mcp_server_init_kwargs:
+            Additional keyword arguments to pass to the MCPServer constructor.
 
     Returns:
         The MCP app object.
 
     """
-    app = FastMCP(**fastmcp_init_kwargs)
+    app = MCPServer(**mcp_server_init_kwargs)
 
     # Dynamically get the start event class -- this is a bit of a hack
     StartEventCLS = start_event_model or workflow._start_event_class
@@ -134,7 +134,7 @@ def workflow_as_mcp(
 
         async for event in handler.stream_events():
             if not isinstance(event, StopEvent):
-                await context.log("info", message=event.model_dump_json())
+                await context.log("info", data=event.model_dump_json())
 
         return await handler
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
     "tools",
 ]
 dependencies = [
-    "mcp>=1.24.0,<2",
+    "mcp>=2.0.0,<3",
     "llama-index-core>=0.13.0,<0.15",
     "pydantic>=2.0.0,<3",
 ]

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.4.8"
+version = "0.5.0"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
@@ -6,8 +6,8 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Dict, Optional
 
-from mcp.server.fastmcp import FastMCP, Context, Image
-from mcp.server.fastmcp.prompts import base
+from mcp.server.mcpserver import MCPServer, Context, Image
+from mcp.server.mcpserver.prompts import base
 from PIL import Image as PILImage
 import numpy as np
 import io
@@ -16,7 +16,7 @@ from tests.schemas import TestName, TestMethod, TestList
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
+async def app_lifespan(server: MCPServer) -> AsyncIterator[None]:
     """
     Context manager for the MCP server lifetime.
     """
@@ -32,7 +32,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[None]:
 
 
 # Create the MCP server
-mcp = FastMCP(
+mcp = MCPServer(
     "TestAllFeatures",
     instructions="A test server that demonstrates all MCP features",
     dependencies=["pillow", "numpy"],

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,5 +1,5 @@
 import os
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 import pytest
 
 from llama_index.tools.mcp import BasicMCPClient
@@ -73,7 +73,7 @@ async def test_read_resources(client: BasicMCPClient):
     # Test static resource
     resource = await client.read_resource("config://app")
     assert isinstance(resource, types.ReadResourceResult)
-    assert resource.contents[0].mimeType == "text/plain"
+    assert resource.contents[0].mime_type == "text/plain"
     config_text = resource.contents[0].text
     assert "app_name" in config_text
     assert "MCP Test Server" in config_text


### PR DESCRIPTION
# Description

Migrates the `llama-index-tools-mcp` integration to the MCP Python SDK 2.x line. The previous pin (`mcp>=1.24.0,<2`) blocks `mcp` 2.0.0, which removed the server-side `FastMCP` module, changed several model fields from camelCase to snake_case, moved a couple of public symbols, and switched the HTTP/SSE client layer to `httpx2`. This updates the integration, its test server, and the example to the 2.0 API and loosens the pin to `mcp>=2.0.0,<3`.

This takes the "upgrade to 2.x" approach (require the 2.x SDK) rather than supporting both 1.x and 2.x side by side.

Fixes #22515

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes (0.4.8 → 0.5.0)
- [ ] No

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(Breaking only in that it now requires `mcp` 2.x; the public llama-index API is unchanged.)

## What changed

- **Dependency**: `mcp>=1.24.0,<2` → `mcp>=2.0.0,<3`.
- **`client.py`**
  - `ProgressFnT` moved from the removed `mcp.shared.session` to `mcp.shared.dispatcher`.
  - `ClientSession(read_timeout_seconds=...)` now takes float seconds instead of a `timedelta`.
  - `http_client` typing switched from `httpx` to `httpx2` (2.0 builds its HTTP/SSE clients and OAuth provider on `httpx2`); docstrings updated.
  - `message.content.mimeType` → `mime_type`.
- **`base.py`**
  - `ListResourceTemplatesResult.resourceTemplates` → `resource_templates` (this was a silent failure before — the `hasattr` guard always fell through to `[]`).
  - `tool.inputSchema` → `tool.input_schema`.
- **`utils.py`**
  - `mcp.server.fastmcp.FastMCP` was removed in 2.0 → `mcp.server.mcpserver.MCPServer`.
  - `Context.log(..., message=...)` → `data=...` (the 2.0 signature).
- **`tests/server.py`, `examples/mcp_server.py`**: `FastMCP` → `MCPServer`, prompts `base` import moved to `mcp.server.mcpserver.prompts`.
- **`tests/test_client.py`**: `mimeType` → `mime_type`; provided HTTP client uses `httpx2.AsyncClient`.

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Ran the package test suites against `mcp` 2.0.0:

- `llama-index-tools-mcp` tests: **51 passed** (spins up the in-repo MCP stdio server).
- `llama-index-tools-mcp-discovery` tests: **3 passed**.
- `ruff check` clean on the integration and tests (the example file has pre-existing docstring-style warnings unrelated to this change).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
