### PR TITLE
fix(core): store VectorMemory sub_dicts as JSON so flat-metadata vector stores work

### DIFF
--- a/llama-index-core/llama_index/core/memory/vector_memory.py
+++ b/llama-index-core/llama_index/core/memory/vector_memory.py
@@ -5,6 +5,7 @@ Memory backed by a vector database.
 
 """
 
+import json
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
@@ -39,10 +40,26 @@ def _get_starter_node_for_new_batch() -> TextNode:
     return TextNode(
         id_=str(uuid.uuid4()),
         text="",
-        metadata={"sub_dicts": []},
+        # `sub_dicts` is stored as a JSON string (rather than a raw list of
+        # dicts) so that the metadata value stays a flat scalar. Some vector
+        # stores (e.g. Chroma) reject non-scalar metadata values.
+        metadata={"sub_dicts": json.dumps([])},
         excluded_embed_metadata_keys=["sub_dicts"],
         excluded_llm_metadata_keys=["sub_dicts"],
     )
+
+
+def _get_sub_dicts(node_metadata: Dict[str, Any]) -> List[Dict]:
+    """
+    Read the `sub_dicts` list back out of node metadata.
+
+    Handles both the current JSON-string encoding and the raw list encoding
+    used before this was fixed, so previously-persisted stores keep working.
+    """
+    sub_dicts = node_metadata.get("sub_dicts", [])
+    if isinstance(sub_dicts, str):
+        return json.loads(sub_dicts)
+    return sub_dicts
 
 
 class VectorMemory(BaseMemory):
@@ -147,7 +164,7 @@ class VectorMemory(BaseMemory):
         return [
             ChatMessage.model_validate(sub_dict)
             for node in nodes
-            for sub_dict in node.metadata["sub_dicts"]
+            for sub_dict in _get_sub_dicts(node.metadata)
         ]
 
     def get_all(self) -> List[ChatMessage]:
@@ -189,7 +206,9 @@ class VectorMemory(BaseMemory):
             self.cur_batch_textnode.text += sub_dict["content"] or ""
         else:
             self.cur_batch_textnode.text += " " + (sub_dict["content"] or "")
-        self.cur_batch_textnode.metadata["sub_dicts"].append(sub_dict)
+        sub_dicts = _get_sub_dicts(self.cur_batch_textnode.metadata)
+        sub_dicts.append(sub_dict)
+        self.cur_batch_textnode.metadata["sub_dicts"] = json.dumps(sub_dicts)
         self._commit_node(override_last=True)
 
     def set(self, messages: List[ChatMessage]) -> None:

--- a/llama-index-core/tests/agent/memory/test_vector_memory.py
+++ b/llama-index-core/tests/agent/memory/test_vector_memory.py
@@ -1,10 +1,15 @@
 """Test vector memory."""
 
+import json
 from typing import Any, List
 from llama_index.core.memory import VectorMemory
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from unittest.mock import patch
 from llama_index.core.llms import ChatMessage
+from llama_index.core.vector_stores.utils import (
+    _validate_is_flat_dict,
+    node_to_metadata_dict,
+)
 
 
 def mock_get_text_embedding(text: str) -> List[float]:
@@ -59,6 +64,67 @@ def test_vector_memory(
     msgs = vector_memory.get("What does Jerry like?")
 
     # assert
+    assert len(msgs) == 2
+    assert msgs[0].content == "Jerry likes juice."
+    assert msgs[1].content == "That's nice."
+
+
+def test_vector_memory_metadata_is_flat() -> None:
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/15681.
+
+    `sub_dicts` used to be stored as a raw list of dicts in node metadata,
+    which vector stores that require flat scalar metadata (e.g. Chroma, via
+    `flat_metadata=True`) reject with a `ValueError`. It must now be a
+    JSON-encoded string.
+    """
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None, embed_model=MockEmbedding(embed_dim=5)
+    )
+    vector_memory.put(ChatMessage.from_str("Jerry likes juice.", "user"))
+    vector_memory.put(ChatMessage.from_str("That's nice.", "assistant"))
+
+    metadata = node_to_metadata_dict(
+        vector_memory.cur_batch_textnode, remove_text=True, flat_metadata=True
+    )
+    # should not raise, unlike before the fix
+    _validate_is_flat_dict(metadata)
+
+    sub_dicts = json.loads(metadata["sub_dicts"])
+    assert len(sub_dicts) == 2
+    assert sub_dicts[0]["content"] == "Jerry likes juice."
+    assert sub_dicts[1]["content"] == "That's nice."
+
+
+@patch.object(MockEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding)
+@patch.object(
+    MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+def test_vector_memory_get_with_legacy_list_sub_dicts(
+    _mock_get_text_embeddings: Any, _mock_get_text_embedding: Any
+) -> None:
+    """
+    `get()` must still work against nodes persisted before the fix, where
+    `sub_dicts` metadata was a raw list of dicts rather than a JSON string.
+    """
+    embed_model = MockEmbedding(embed_dim=5)
+    vector_memory = VectorMemory.from_defaults(
+        vector_store=None,
+        embed_model=embed_model,
+        retriever_kwargs={"similarity_top_k": 1},
+    )
+    vector_memory.put(ChatMessage.from_str("Jerry likes juice.", "user"))
+    vector_memory.put(ChatMessage.from_str("That's nice.", "assistant"))
+
+    # simulate a node persisted by a pre-fix version of VectorMemory
+    legacy_sub_dicts = json.loads(
+        vector_memory.cur_batch_textnode.metadata["sub_dicts"]
+    )
+    vector_memory.cur_batch_textnode.metadata["sub_dicts"] = legacy_sub_dicts
+    vector_memory._commit_node(override_last=True)
+
+    msgs = vector_memory.get("What does Jerry like?")
+
     assert len(msgs) == 2
     assert msgs[0].content == "Jerry likes juice."
     assert msgs[1].content == "That's nice."


### PR DESCRIPTION
Fixes #15681

## Problem

`VectorMemory.put()` batches chat messages into a single `TextNode` and stores them as a raw `list[dict]` under `node.metadata["sub_dicts"]`. Vector stores that enforce flat scalar metadata (`str`/`int`/`float`/`None`) — Chroma does this via `flat_metadata=True` — reject that list value at insert time with:

```
ValueError: Value for metadata sub_dicts must be one of (str, int, float, None)
```

On older `chromadb` versions this failed silently on write instead, which then surfaced later as a confusing `KeyError: 'sub_dicts'` in `get()`. `SimpleVectorStore` (the default, in-memory backend) never validates flat metadata, so this only shows up with backends like Chroma — see the investigation from @shivamlalakiya on the issue.

The same underlying mismatch was already worked around by hand in the Redis vector store integration, which manually pops `sub_dicts` before writing rather than fixing it at the source.

## Fix

`VectorMemory` now JSON-encodes the `sub_dicts` list before storing it in metadata, and decodes it back out in `get()`. This keeps the metadata value a flat string, so any vector store that enforces flat metadata works without special-casing. `get()` also transparently handles nodes written by older versions of `VectorMemory` (where `sub_dicts` was still a raw list), so already-persisted stores keep working after upgrading.

Added two regression tests in `test_vector_memory.py`:
- `test_vector_memory_metadata_is_flat` reproduces the Chroma-style rejection directly via `node_to_metadata_dict(..., flat_metadata=True)` + `_validate_is_flat_dict`, without needing a live Chroma instance.
- `test_vector_memory_get_with_legacy_list_sub_dicts` verifies `get()` still works against metadata persisted by a pre-fix version of `VectorMemory`.

Note `VectorMemory` is deprecated in favor of `Memory` + `VectorMemoryBlock`, which already works correctly with Chroma. This fix is scoped to keep the still-shipped `VectorMemory` from breaking (and failing confusingly) for existing users, not to encourage new usage of it.

## Release note

Fixed a bug where `VectorMemory` raised `ValueError`/`KeyError` when used with vector stores that require flat metadata (e.g. `ChromaVectorStore`).

---

_Disclaimer: this change was drafted with the assistance of an AI coding agent (Claude), reviewed and verified by me before submission._
