### PR TITLE
Add FunASR endpoint audio reader

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-file/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-file/README.md
@@ -1,6 +1,6 @@
 # LlamaIndex Readers Integration: File
 
-```bash
+```sh
 pip install llama-index-readers-file
 ```
 
@@ -23,6 +23,7 @@ Provides support for the following loaders:
 - PptxReader
 - PandasCSVReader
 - VideoAudioReader
+- FunASRAudioReader
 - UnstructuredReader
 - PyMuPDFReader
 - ImageTabularChartReader
@@ -33,7 +34,7 @@ Provides support for the following loaders:
 
 ## Installation
 
-```bash
+```sh
 pip install llama-index-readers-file
 ```
 
@@ -59,6 +60,7 @@ from llama_index.readers.file import (
     PptxReader,
     PandasCSVReader,
     VideoAudioReader,
+    FunASRAudioReader,
     UnstructuredReader,
     PyMuPDFReader,
     ImageTabularChartReader,
@@ -195,6 +197,21 @@ file_extractor = {".csv": parser}  # Add other CSV formats as needed
 documents = SimpleDirectoryReader(
     "./data", file_extractor=file_extractor
 ).load_data()
+
+# FunASR Audio Reader example
+# Requires a running FunASR OpenAI-compatible server:
+# funasr-server --device cpu --model sensevoice --port 8000
+parser = FunASRAudioReader(
+    endpoint_url="http://localhost:8000",
+    model="sensevoice",)
+file_extractor = {
+    ".mp3": parser,
+    ".wav": parser,}
+documents = SimpleDirectoryReader(
+    "./data", file_extractor=file_extractor
+).load_data()
+
+
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/).

--- a/llama-index-integrations/readers/llama-index-readers-file/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-file/README.md
@@ -203,15 +203,15 @@ documents = SimpleDirectoryReader(
 # funasr-server --device cpu --model sensevoice --port 8000
 parser = FunASRAudioReader(
     endpoint_url="http://localhost:8000",
-    model="sensevoice",)
+    model="sensevoice",
+)
 file_extractor = {
     ".mp3": parser,
-    ".wav": parser,}
+    ".wav": parser,
+}
 documents = SimpleDirectoryReader(
     "./data", file_extractor=file_extractor
 ).load_data()
-
-
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/run-llama/llama_index/).

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/__init__.py
@@ -20,6 +20,7 @@ from llama_index.readers.file.tabular import (
 )
 from llama_index.readers.file.unstructured import UnstructuredReader
 from llama_index.readers.file.video_audio import VideoAudioReader
+from llama_index.readers.file.funasr_audio import FunASRAudioReader
 from llama_index.readers.file.xml import XMLReader
 
 __all__ = [
@@ -39,6 +40,7 @@ __all__ = [
     "PandasCSVReader",
     "PandasExcelReader",
     "VideoAudioReader",
+    "FunASRAudioReader",
     "UnstructuredReader",
     "PyMuPDFReader",
     "ImageTabularChartReader",

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/__init__.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.readers.file.funasr_audio.base import FunASRAudioReader
+
+__all__ = ["FunASRAudioReader"]

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
@@ -15,6 +15,7 @@ class FunASRAudioReader(BaseReader):
         self,
         endpoint_url: str = "http://localhost:8000",
         model: str = "sensevoice",
+        language: Optional[str] = None,
         response_format: str = "json",
         timeout: int = 120,
         **kwargs: Any,
@@ -22,8 +23,42 @@ class FunASRAudioReader(BaseReader):
         super().__init__(**kwargs)
         self.endpoint_url = endpoint_url.rstrip("/")
         self.model = model
+        self.language = language
         self.response_format = response_format
         self.timeout = timeout
+
+    def _extract_transcript(self, result: Dict[str, Any]) -> str:
+        """Extract transcript text from common FunASR-compatible responses."""
+        if result.get("text"):
+            return result["text"]
+
+        if result.get("transcript"):
+            return result["transcript"]
+
+        if result.get("transcription"):
+            return result["transcription"]
+
+        segments = result.get("segments")
+        if isinstance(segments, list):
+            return " ".join(
+                segment.get("text", "")
+                for segment in segments
+                if isinstance(segment, dict)
+            ).strip()
+
+        return ""
+
+    def _build_request_data(self) -> Dict[str, str]:
+        """Build request payload for the transcription endpoint."""
+        data = {
+            "model": self.model,
+            "response_format": self.response_format,
+        }
+
+        if self.language:
+            data["language"] = self.language
+
+        return data
 
     def load_data(
         self,
@@ -32,27 +67,25 @@ class FunASRAudioReader(BaseReader):
         fs: Optional[AbstractFileSystem] = None,
     ) -> List[Document]:
         """Transcribe an audio file using FunASR endpoint."""
-
         url = f"{self.endpoint_url}/v1/audio/transcriptions"
 
         metadata = extra_info.copy() if extra_info else {}
         metadata.update(
             {
-                "source": str(file),
+                "source_path": str(file),
                 "model": self.model,
-                "endpoint_url": self.endpoint_url,
+                "endpoint": url,
             }
         )
+
+        data = self._build_request_data()
 
         if fs:
             with fs.open(file, "rb") as f:
                 response = requests.post(
                     url,
                     files={"file": (Path(file).name, f)},
-                    data={
-                        "model": self.model,
-                        "response_format": self.response_format,
-                    },
+                    data=data,
                     timeout=self.timeout,
                 )
         else:
@@ -60,17 +93,18 @@ class FunASRAudioReader(BaseReader):
                 response = requests.post(
                     url,
                     files={"file": (Path(file).name, f)},
-                    data={
-                        "model": self.model,
-                        "response_format": self.response_format,
-                    },
+                    data=data,
                     timeout=self.timeout,
                 )
 
         response.raise_for_status()
         result = response.json()
 
-        transcript = result.get("text", "")
+        transcript = self._extract_transcript(result)
+
+        if "segments" in result:
+            metadata["segments"] = result["segments"]
+
         metadata["raw_response"] = result
 
         return [Document(text=transcript, metadata=metadata)]

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+from fsspec import AbstractFileSystem
+
+from llama_index.core.readers.base import BaseReader
+from llama_index.core.schema import Document
+
+
+class FunASRAudioReader(BaseReader):
+    """Audio reader using a FunASR OpenAI-compatible transcription endpoint."""
+
+    def __init__(
+        self,
+        endpoint_url: str = "http://localhost:8000",
+        model: str = "sensevoice",
+        response_format: str = "json",
+        timeout: int = 120,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.endpoint_url = endpoint_url.rstrip("/")
+        self.model = model
+        self.response_format = response_format
+        self.timeout = timeout
+
+    def load_data(
+        self,
+        file: Path,
+        extra_info: Optional[Dict] = None,
+        fs: Optional[AbstractFileSystem] = None,
+    ) -> List[Document]:
+        """Transcribe an audio file using FunASR endpoint."""
+
+        url = f"{self.endpoint_url}/v1/audio/transcriptions"
+
+        metadata = extra_info.copy() if extra_info else {}
+        metadata.update(
+            {
+                "source": str(file),
+                "model": self.model,
+                "endpoint_url": self.endpoint_url,
+            }
+        )
+
+        if fs:
+            with fs.open(file, "rb") as f:
+                response = requests.post(
+                    url,
+                    files={"file": (Path(file).name, f)},
+                    data={
+                        "model": self.model,
+                        "response_format": self.response_format,
+                    },
+                    timeout=self.timeout,
+                )
+        else:
+            with open(file, "rb") as f:
+                response = requests.post(
+                    url,
+                    files={"file": (Path(file).name, f)},
+                    data={
+                        "model": self.model,
+                        "response_format": self.response_format,
+                    },
+                    timeout=self.timeout,
+                )
+
+        response.raise_for_status()
+        result = response.json()
+
+        transcript = result.get("text", "")
+        metadata["raw_response"] = result
+
+        return [Document(text=transcript, metadata=metadata)]

--- a/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/llama_index/readers/file/funasr_audio/base.py
@@ -98,11 +98,15 @@ class FunASRAudioReader(BaseReader):
                 )
 
         response.raise_for_status()
-        result = response.json()
 
-        transcript = self._extract_transcript(result)
+        if self.response_format in {"json", "verbose_json"}:
+            result: Any = response.json()
+            transcript = self._extract_transcript(result)
+        else:
+            result = response.text
+            transcript = result.strip()
 
-        if "segments" in result:
+        if isinstance(result, dict) and "segments" in result:
             metadata["segments"] = result["segments"]
 
         metadata["raw_response"] = result

--- a/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-file/pyproject.toml
@@ -76,6 +76,7 @@ dependencies = [
     "pandas>=2.0.0,<3",
     "llama-index-core>=0.13.0,<0.15",
     "defusedxml>=0.7.1",
+    "requests>=2.31.0,<3",
 ]
 
 [project.optional-dependencies]
@@ -121,6 +122,7 @@ PyMuPDFReader = "iamarunbrahma"
 RTFReader = "FunkyOz"
 UnstructuredReader = "thejessezhang"
 VideoAudioReader = "llama-index"
+FunASRAudioReader = "sriharan0804"
 XMLReader = "mmaatouk"
 
 [tool.mypy]

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from llama_index.readers.file import FunASRAudioReader
+
+
+def test_funasr_audio_reader(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "text": "Hello from FunASR",
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        reader = FunASRAudioReader(
+            endpoint_url="http://localhost:8000",
+            model="sensevoice",
+        )
+        docs = reader.load_data(audio_file)
+
+    assert len(docs) == 1
+    assert docs[0].text == "Hello from FunASR"
+    assert docs[0].metadata["source"] == str(audio_file)
+    assert docs[0].metadata["model"] == "sensevoice"
+    assert docs[0].metadata["endpoint_url"] == "http://localhost:8000"
+    assert docs[0].metadata["raw_response"] == {"text": "Hello from FunASR"}
+
+    mock_post.assert_called_once()

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
@@ -4,28 +4,83 @@ from unittest.mock import Mock, patch
 from llama_index.readers.file import FunASRAudioReader
 
 
-def test_funasr_audio_reader(tmp_path: Path) -> None:
+def test_funasr_audio_reader_text_response(tmp_path: Path) -> None:
     audio_file = tmp_path / "test.wav"
     audio_file.write_bytes(b"fake audio")
 
     mock_response = Mock()
     mock_response.raise_for_status.return_value = None
-    mock_response.json.return_value = {
-        "text": "Hello from FunASR",
-    }
+    mock_response.json.return_value = {"text": "Hello from FunASR"}
 
     with patch("requests.post", return_value=mock_response) as mock_post:
         reader = FunASRAudioReader(
             endpoint_url="http://localhost:8000",
             model="sensevoice",
+            language="en",
         )
         docs = reader.load_data(audio_file)
 
     assert len(docs) == 1
     assert docs[0].text == "Hello from FunASR"
-    assert docs[0].metadata["source"] == str(audio_file)
+    assert docs[0].metadata["source_path"] == str(audio_file)
     assert docs[0].metadata["model"] == "sensevoice"
-    assert docs[0].metadata["endpoint_url"] == "http://localhost:8000"
-    assert docs[0].metadata["raw_response"] == {"text": "Hello from FunASR"}
+    assert docs[0].metadata["endpoint"] == (
+        "http://localhost:8000/v1/audio/transcriptions"
+    )
 
     mock_post.assert_called_once()
+    _, kwargs = mock_post.call_args
+    assert kwargs["data"]["model"] == "sensevoice"
+    assert kwargs["data"]["language"] == "en"
+
+
+def test_funasr_audio_reader_transcript_response(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"transcript": "Hello transcript"}
+
+    with patch("requests.post", return_value=mock_response):
+        reader = FunASRAudioReader()
+        docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "Hello transcript"
+
+
+def test_funasr_audio_reader_transcription_response(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"transcription": "Hello transcription"}
+
+    with patch("requests.post", return_value=mock_response):
+        reader = FunASRAudioReader()
+        docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "Hello transcription"
+
+
+def test_funasr_audio_reader_segments_response(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    segments = [
+        {"text": "Hello"},
+        {"text": "from"},
+        {"text": "segments"},
+    ]
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"segments": segments}
+
+    with patch("requests.post", return_value=mock_response):
+        reader = FunASRAudioReader()
+        docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "Hello from segments"
+    assert docs[0].metadata["segments"] == segments

--- a/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
+++ b/llama-index-integrations/readers/llama-index-readers-file/tests/test_funasr_audio.py
@@ -84,3 +84,22 @@ def test_funasr_audio_reader_segments_response(tmp_path: Path) -> None:
 
     assert docs[0].text == "Hello from segments"
     assert docs[0].metadata["segments"] == segments
+
+
+def test_funasr_audio_reader_plain_text_response(tmp_path: Path) -> None:
+    audio_file = tmp_path / "test.wav"
+    audio_file.write_bytes(b"fake audio")
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.text = "Hello from plain text"
+    mock_response.json.side_effect = AssertionError("JSON parser should not be called")
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        reader = FunASRAudioReader(response_format="text")
+        docs = reader.load_data(audio_file)
+
+    assert docs[0].text == "Hello from plain text"
+    assert docs[0].metadata["raw_response"] == "Hello from plain text"
+    assert mock_post.call_args.kwargs["data"]["response_format"] == "text"
+    mock_response.json.assert_not_called()

--- a/llama-index-integrations/readers/llama-index-readers-file/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-file/uv.lock
@@ -1904,6 +1904,7 @@ dependencies = [
     { name = "llama-index-core" },
     { name = "pandas" },
     { name = "pypdf" },
+    { name = "requests" },
     { name = "striprtf" },
 ]
 
@@ -1944,13 +1945,14 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0.0,<3" },
     { name = "pymupdf", marker = "extra == 'pymupdf'", specifier = ">=1.23.21,<2" },
     { name = "pypdf", specifier = ">=6.1.3,<7" },
+    { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "striprtf", specifier = ">=0.0.26,<0.0.27" },
 ]
 provides-extras = ["pymupdf"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "fpdf2", specifier = "==2.7.8" },

--- a/llama-index-integrations/readers/llama-index-readers-file/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-file/uv.lock
@@ -1952,7 +1952,7 @@ provides-extras = ["pymupdf"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=26.5.1" },
+    { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<=23.9.1" },
     { name = "codespell", extras = ["toml"], specifier = ">=2.2.6" },
     { name = "diff-cover", specifier = ">=9.2.0" },
     { name = "fpdf2", specifier = "==2.7.8" },


### PR DESCRIPTION
## Summary

- add FunASRAudioReader for OpenAI-compatible FunASR transcription endpoints
- support JSON/verbose JSON responses and plain-text response formats
- expose the reader from llama_index.readers.file
- document endpoint usage and add focused request/response tests

This is a current-main rescue of #21958. It preserves the two original commits authored by @sriharan0804 and includes the plain-text response fix developed in sriharan0804/llama_index#2.

This PR is intentionally endpoint-only. The separate in-process/local reader proposed in #21996 remains independent.

## Validation

- focused reader tests: 5 passed
- full llama-index-readers-file suite: 66 passed, 4 skipped, 1 xpassed
- pre-commit over all 7 changed files: all applicable hooks passed
- Python bytecode compilation over the reader and tests: passed
- uv build: source distribution and wheel built successfully
- git diff check against upstream main: clean

## AI assistance

AI assistance was used to prepare this rescue branch. The final diff, preserved authorship, tests, formatting/type checks, package build, and upstream-main scope were manually reviewed and verified.
