### PR TITLE
fix: preserve parallel tool results before return direct

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -152,6 +152,7 @@ class FunctionAgent(BaseWorkflowAgent):
         scratchpad: List[ChatMessage] = await ctx.store.get(
             self.scratchpad_key, default=[]
         )
+        return_direct_result: Optional[ToolCallResult] = None
 
         for tool_call_result in results:
             scratchpad.append(
@@ -165,15 +166,18 @@ class FunctionAgent(BaseWorkflowAgent):
             if (
                 tool_call_result.return_direct
                 and tool_call_result.tool_name != "handoff"
+                and return_direct_result is None
             ):
-                scratchpad.append(
-                    ChatMessage(
-                        role="assistant",
-                        content=str(tool_call_result.tool_output.content),
-                        additional_kwargs={"tool_call_id": tool_call_result.tool_id},
-                    )
+                return_direct_result = tool_call_result
+
+        if return_direct_result is not None:
+            scratchpad.append(
+                ChatMessage(
+                    role="assistant",
+                    content=str(return_direct_result.tool_output.content),
+                    additional_kwargs={"tool_call_id": return_direct_result.tool_id},
                 )
-                break
+            )
 
         await ctx.store.set(self.scratchpad_key, scratchpad)
 

--- a/llama-index-core/tests/agent/workflow/test_function_call.py
+++ b/llama-index-core/tests/agent/workflow/test_function_call.py
@@ -1,13 +1,14 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from llama_index.core.agent.workflow import BaseWorkflowAgent
+from llama_index.core.agent.workflow import BaseWorkflowAgent, FunctionAgent
 from llama_index.core.agent.workflow.workflow_events import (
     AgentInput,
     AgentOutput,
     ToolCallResult,
 )
 from llama_index.core.llms import ChatMessage
+from llama_index.core.llms.mock import MockFunctionCallingLLM
 from llama_index.core.memory import BaseMemory
 from llama_index.core.tools import FunctionTool, ToolOutput
 from llama_index.core.workflow.context import Context
@@ -62,6 +63,55 @@ def test_agent():
         tools=[],
         llm=None,  # Will use default
     )
+
+
+@pytest.mark.asyncio
+async def test_function_agent_records_all_parallel_results_before_return_direct(
+    mock_context, mock_memory
+):
+    """All parallel tool responses must be recorded before returning directly."""
+    agent = FunctionAgent(llm=MockFunctionCallingLLM())
+    mock_context.store.get.return_value = []
+
+    direct_result = ToolCallResult(
+        tool_name="direct_tool",
+        tool_kwargs={},
+        tool_id="direct-id",
+        tool_output=ToolOutput(
+            content="direct result",
+            tool_name="direct_tool",
+            raw_input={},
+            raw_output="direct result",
+            is_error=False,
+        ),
+        return_direct=True,
+    )
+    ordinary_result = ToolCallResult(
+        tool_name="ordinary_tool",
+        tool_kwargs={},
+        tool_id="ordinary-id",
+        tool_output=ToolOutput(
+            content="ordinary result",
+            tool_name="ordinary_tool",
+            raw_input={},
+            raw_output="ordinary result",
+            is_error=False,
+        ),
+        return_direct=False,
+    )
+
+    await agent.handle_tool_call_results(
+        mock_context, [direct_result, ordinary_result], mock_memory
+    )
+
+    scratchpad = mock_context.store.set.await_args.args[1]
+    recorded_tool_ids = [
+        message.additional_kwargs["tool_call_id"]
+        for message in scratchpad
+        if message.role == "tool"
+    ]
+    assert recorded_tool_ids == ["direct-id", "ordinary-id"]
+    assert [message.role for message in scratchpad] == ["tool", "tool", "assistant"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

## Summary

- Record every completed parallel tool result before finalizing a `return_direct` response.
- Match aggregation by selecting the first successful direct result, then suppressing an assistant answer if that selected result is handoff.
- Keep tool-response ordering protocol-complete in the agent scratchpad and memory.

## Problem

`FunctionAgent.handle_tool_call_results()` stopped iterating after the first `return_direct=True` result. With parallel tool calls enabled, any later completed tool result was omitted from the scratchpad. The next LLM turn could therefore see an assistant tool call without the matching `tool_call_id` response.

## Fix

The handler now appends every tool response first, remembers the first eligible direct result, and appends the direct assistant message only after all tool responses have been recorded. Selection now matches the aggregator: skip error outputs, select the first successful direct result, and only then exclude handoff from assistant rendering.

No external dependencies are added.

## New Package?

- [x] No

## Version Bump?

- [x] No — this changes `llama-index-core`, which the template exempts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

RED before the production change:

- The regression expected `["direct-id", "ordinary-id"]`.
- Existing behavior recorded only `["direct-id"]`.

GREEN after the change:

- Focused regression: passed
- `tests/agent/workflow/test_function_call.py`: `9 passed`
- Focused plus adjacent workflow tests: `21 passed`
- Full `llama-index-core/tests/agent/workflow`: `65 passed, 3 skipped`
- Changed-file pre-commit hooks: Ruff lint/format, mypy, Prettier, codespell, whitespace/conflict checks all passed
- `git diff --check`: passed

## Suggested Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint`

## AI Assistance

This patch was prepared with Codex under the contributor's direction. Codex performed the no-race triage, RED/GREEN implementation, and repository checks documented above. This draft intentionally does not claim an independent manual self-review or rerun by the contributor.

No competing open issue or pull request covering this root cause was found immediately before publication.

## Follow-up verification (2026-09-21)

Community review identified error/handoff selection cases. Commit eab11fac6 adds five parameterized handler regressions: failed direct + ordinary, failed direct + successful direct, successful handoff + direct, failed handoff + direct, and two successful direct results. Every case asserts retention of both tool-call IDs and the selected assistant content where applicable.

Before this follow-up: 3 failed / 2 passed. After: full agent/workflow directory 70 passed / 3 skipped. All configured changed-file pre-commit hooks and git diff --check pass. The configured mypy hook is a shell environment-setting entry, so its pass is not independent type-check evidence. Tests use mocks, no model API. Current-main f475afd8a's unmodified handler was also tested in the PR test environment: 4 failed / 1 passed; this is handler-level baseline evidence, not a full current-main suite run. Draft and human self-review status are unchanged.
