### PR TITLE
fix(core): accept a ReAct final answer without a "Thought:" prefix

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -33,16 +33,28 @@ def action_input_parser(json_str: str) -> dict:
 
 
 def extract_final_response(input_text: str) -> Tuple[str, str]:
-    pattern = r"\s*Thought:(.*?)Answer:(.*?)(?:$)"
-
-    match = re.search(pattern, input_text, re.DOTALL)
-    if not match:
+    # Split on the first "Answer:" rather than matching thought and answer in one
+    # pattern. Mirrors `extract_tool_use`: the prompt asks the model to always
+    # start with "Thought:", but models drop it, so whatever precedes "Answer:"
+    # is taken as the thought instead of failing the parse.
+    #
+    # Deliberately not a single regex with a lazy prefix: `.*?Answer:(.*?)$`
+    # under DOTALL backtracks quadratically when "Answer:" is absent, which is
+    # the failure mode fixed in #22334 for the sibling tool-use pattern.
+    answer_match = re.search(r"Answer:", input_text)
+    if not answer_match:
         raise ValueError(
             f"Could not extract final answer from input text: {input_text}"
         )
 
-    thought = match.group(1).strip()
-    answer = match.group(2).strip()
+    before_answer = input_text[: answer_match.start()]
+    answer = input_text[answer_match.end() :].strip()
+
+    thought_match = re.search(r"Thought:", before_answer)
+    thought = (
+        before_answer[thought_match.end() :] if thought_match else before_answer
+    ).strip()
+
     return thought, answer
 
 

--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -33,14 +33,7 @@ def action_input_parser(json_str: str) -> dict:
 
 
 def extract_final_response(input_text: str) -> Tuple[str, str]:
-    # Split on the first "Answer:" rather than matching thought and answer in one
-    # pattern. Mirrors `extract_tool_use`: the prompt asks the model to always
-    # start with "Thought:", but models drop it, so whatever precedes "Answer:"
-    # is taken as the thought instead of failing the parse.
-    #
-    # Deliberately not a single regex with a lazy prefix: `.*?Answer:(.*?)$`
-    # under DOTALL backtracks quadratically when "Answer:" is absent, which is
-    # the failure mode fixed in #22334 for the sibling tool-use pattern.
+    # Models drop the "Thought:" prefix, so take whatever precedes "Answer:" as the thought.
     answer_match = re.search(r"Answer:", input_text)
     if not answer_match:
         raise ValueError(

--- a/llama-index-core/tests/agent/react/test_react_output_parser.py
+++ b/llama-index-core/tests/agent/react/test_react_output_parser.py
@@ -213,12 +213,6 @@ Answer: Answer contains Legislative Action: here is the legislative action conte
 
 
 def test_extract_final_response_no_thought() -> None:
-    """
-    A preamble without the "Thought:" prefix is taken as the thought.
-
-    `extract_tool_use` already accepts this shape (see
-    `test_extract_tool_use_no_thought`); the answer path should match it.
-    """
     mock_input_text = """\
 I have enough information to answer the question without using any more tools.
 Answer: 2
@@ -232,7 +226,6 @@ Answer: 2
 
 
 def test_extract_final_response_answer_only() -> None:
-    """An answer with no preceding thought at all still parses."""
     mock_input_text = "Answer: 2\n"
 
     thought, answer = extract_final_response(mock_input_text)
@@ -241,18 +234,12 @@ def test_extract_final_response_answer_only() -> None:
 
 
 def test_extract_final_response_no_answer_raises() -> None:
-    """Text without an "Answer:" is still a parse failure."""
     with pytest.raises(ValueError, match="Could not extract final answer"):
         extract_final_response("Thought: I am still thinking about it.\n")
 
 
 def test_extract_final_response_is_linear_without_answer() -> None:
-    """
-    Guard against the backtracking class fixed in #22334.
-
-    Matching the thought and the answer in one lazy DOTALL pattern is quadratic
-    when "Answer:" never appears: the same 80 KB input took ~42 s that way.
-    """
+    # Same backtracking class as #22334: a lazy DOTALL pattern needs minutes here.
     mock_input_text = "Thought: " + ("x" * 200_000)
 
     start = time.perf_counter()
@@ -260,6 +247,4 @@ def test_extract_final_response_is_linear_without_answer() -> None:
         extract_final_response(mock_input_text)
     elapsed = time.perf_counter() - start
 
-    # Measured at well under 1 ms; a quadratic pattern needs minutes at this
-    # size, so the bound is loose enough not to flake on a loaded runner.
     assert elapsed < 1.0

--- a/llama-index-core/tests/agent/react/test_react_output_parser.py
+++ b/llama-index-core/tests/agent/react/test_react_output_parser.py
@@ -1,3 +1,7 @@
+import time
+
+import pytest
+
 from llama_index.core.agent.react.output_parser import (
     extract_final_response,
     extract_tool_use,
@@ -206,3 +210,56 @@ Answer: Answer contains Legislative Action: here is the legislative action conte
         answer
         == "Answer contains Legislative Action: here is the legislative action content."
     )
+
+
+def test_extract_final_response_no_thought() -> None:
+    """
+    A preamble without the "Thought:" prefix is taken as the thought.
+
+    `extract_tool_use` already accepts this shape (see
+    `test_extract_tool_use_no_thought`); the answer path should match it.
+    """
+    mock_input_text = """\
+I have enough information to answer the question without using any more tools.
+Answer: 2
+"""
+    thought, answer = extract_final_response(mock_input_text)
+    assert (
+        thought
+        == "I have enough information to answer the question without using any more tools."
+    )
+    assert answer == "2"
+
+
+def test_extract_final_response_answer_only() -> None:
+    """An answer with no preceding thought at all still parses."""
+    mock_input_text = "Answer: 2\n"
+
+    thought, answer = extract_final_response(mock_input_text)
+    assert thought == ""
+    assert answer == "2"
+
+
+def test_extract_final_response_no_answer_raises() -> None:
+    """Text without an "Answer:" is still a parse failure."""
+    with pytest.raises(ValueError, match="Could not extract final answer"):
+        extract_final_response("Thought: I am still thinking about it.\n")
+
+
+def test_extract_final_response_is_linear_without_answer() -> None:
+    """
+    Guard against the backtracking class fixed in #22334.
+
+    Matching the thought and the answer in one lazy DOTALL pattern is quadratic
+    when "Answer:" never appears: the same 80 KB input took ~42 s that way.
+    """
+    mock_input_text = "Thought: " + ("x" * 200_000)
+
+    start = time.perf_counter()
+    with pytest.raises(ValueError, match="Could not extract final answer"):
+        extract_final_response(mock_input_text)
+    elapsed = time.perf_counter() - start
+
+    # Measured at well under 1 ms; a quadratic pattern needs minutes at this
+    # size, so the bound is loose enough not to flake on a loaded runner.
+    assert elapsed < 1.0

--- a/llama-index-core/tests/agent/workflow/test_react_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_react_agent.py
@@ -1,5 +1,9 @@
+import pytest
+
 from llama_index.core.agent.workflow import ReActAgent
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.llms import MockLLM
+from llama_index.core.llms.mock import MockFunctionCallingLLM
 from llama_index.core.prompts import PromptTemplate
 
 
@@ -25,3 +29,40 @@ def test_react_agent_prompts():
     prompts = agent.get_prompts()
     assert len(prompts) == 1
     assert new_prompt == prompts["react_header"]
+
+
+def _no_thought_agent(content: str) -> ReActAgent:
+    """A ReActAgent whose LLM never emits the "Thought:" prefix."""
+    return ReActAgent(
+        name="calculator",
+        description="Answers questions",
+        tools=[],
+        llm=MockFunctionCallingLLM(
+            response_generator=lambda messages, **kwargs: ChatMessage(
+                role=MessageRole.ASSISTANT, content=content
+            )
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    [
+        "I worked it out.\nAnswer: The sum is 8",
+        "Answer: The sum is 8",
+    ],
+    ids=["preamble_instead_of_thought", "answer_only"],
+)
+async def test_react_agent_answer_without_thought(content: str) -> None:
+    """
+    An answer without "Thought:" ends the run instead of looping to max iterations.
+
+    The LLM here always replies in the same shape, so if the answer does not
+    parse the agent retries until it hits the iteration ceiling.
+    """
+    agent = _no_thought_agent(content)
+
+    response = await agent.run(user_msg="Can you add 5 and 3?")
+
+    assert "The sum is 8" in str(response.response)

--- a/llama-index-core/tests/agent/workflow/test_react_agent.py
+++ b/llama-index-core/tests/agent/workflow/test_react_agent.py
@@ -32,7 +32,6 @@ def test_react_agent_prompts():
 
 
 def _no_thought_agent(content: str) -> ReActAgent:
-    """A ReActAgent whose LLM never emits the "Thought:" prefix."""
     return ReActAgent(
         name="calculator",
         description="Answers questions",
@@ -55,12 +54,7 @@ def _no_thought_agent(content: str) -> ReActAgent:
     ids=["preamble_instead_of_thought", "answer_only"],
 )
 async def test_react_agent_answer_without_thought(content: str) -> None:
-    """
-    An answer without "Thought:" ends the run instead of looping to max iterations.
-
-    The LLM here always replies in the same shape, so if the answer does not
-    parse the agent retries until it hits the iteration ceiling.
-    """
+    # The LLM always replies in the same shape, so a failed parse loops to max iterations.
     agent = _no_thought_agent(content)
 
     response = await agent.run(user_msg="Can you add 5 and 3?")


### PR DESCRIPTION
# Description

`ReActOutputParser` accepts an **Action** step whose `Thought:` prefix is missing, but rejects an **Answer** step in the same shape. `extract_tool_use` was made tolerant in #19190 (fixing #19187, which also added `test_extract_tool_use_no_thought`); `extract_final_response` was not updated to match and still requires `Thought:`.

The halves of the parser therefore disagree, and the consequence is not cosmetic. `ReActOutputParser.parse` dispatches to `extract_final_response` whenever `Answer:` appears, and `ReActAgent.take_step` converts the resulting `ValueError` into a retry. If the model's style is *persistent* -- an unprompted or small/quantised model -- the retry never converges, so the agent can call tools but can never finish.

Measured on released 0.14.23 with a mock LLM that always replies `Answer: The sum is 8`:

| output shape | before | after |
| --- | --- | --- |
| `Thought: ...\nAnswer: ...` | 1 LLM call | 1 LLM call |
| `I worked it out.\nAnswer: ...` | **`WorkflowRuntimeError: Max iterations of 20 reached!`** after 20 calls | 1 LLM call |
| `Answer: ...` | **`WorkflowRuntimeError: Max iterations of 20 reached!`** after 20 calls | 1 LLM call |

The fix splits on the first `Answer:` and treats whatever precedes it as the thought, stripping a leading `Thought:` when present -- the same tolerance `extract_tool_use` already has.

### Why not a single regex

The natural-looking one-liner, `(?:\s*Thought:(.*?)|(.*?))Answer:(.*?)$` under `DOTALL`, reintroduces the quadratic backtracking that #22334 fixed for the sibling tool-use pattern. I wrote it first, then measured it with no `Answer:` present:

| input size | one-regex alternative | this PR |
| --- | --- | --- |
| 1 KB | 6.9 ms | <0.1 ms |
| 20 KB | 2 595 ms | <0.1 ms |
| 80 KB | **42 780 ms** | 0.1 ms |
| 2 MB | (not attempted) | 1.2 ms |

So I discarded it for the linear split, and `test_extract_final_response_is_linear_without_answer` pins that property so the next person is not tempted back into it.

Behaviour is otherwise unchanged: all four pre-existing `extract_final_response` tests still pass untouched, including the multiline-answer and the `Answer: ... Legislative Action: ...` cases, and text with no `Answer:` at all still raises `ValueError`.

Fixes #22563

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No -- this change is in `llama-index-core`, which the template excludes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four parser-level cases in `tests/agent/react/test_react_output_parser.py`:

- `test_extract_final_response_no_thought` -- a preamble in place of `Thought:`
- `test_extract_final_response_answer_only` -- a bare `Answer: 2`
- `test_extract_final_response_no_answer_raises` -- missing `Answer:` is still a `ValueError`
- `test_extract_final_response_is_linear_without_answer` -- the backtracking guard above

Plus a parametrized agent-level case in `tests/agent/workflow/test_react_agent.py`, `test_react_agent_answer_without_thought`, which drives a real `ReActAgent` end to end.

Both were confirmed red on an unmodified tree before being kept:

```
# parser tests, fix reverted
2 failed, 16 passed
  test_extract_final_response_no_thought   -> ValueError: Could not extract final answer from input text: Answer: 2
  test_extract_final_response_answer_only  -> ValueError: Could not extract final answer from input text: Answer: 2

# agent test, fix reverted
2 failed, 1 passed
  test_react_agent_answer_without_thought[preamble_instead_of_thought] -> WorkflowRuntimeError: Max iterations of 20 reached!
  test_react_agent_answer_without_thought[answer_only]                 -> WorkflowRuntimeError: Max iterations of 20 reached!
```

With the fix, the whole `llama-index-core` agent suite is green:

```
uv run -- pytest tests/agent/ -q
95 passed, 3 skipped
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

On the last point, `make` is unavailable in my environment, so I ran the underlying hooks directly on the three changed files -- `ruff check` (clean), `ruff format --check` (clean), and `mypy` with the flags from `.pre-commit-config.yaml` (`Success: no issues found`). `ruff check` did flag `D213` on my new docstrings, and those fixes are included.
