### PR TITLE
fix(node_parser): respect include_metadata in SentenceWindowNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/sentence_window.py
+++ b/llama-index-core/llama_index/core/node_parser/text/sentence_window.py
@@ -115,25 +115,26 @@ class SentenceWindowNodeParser(NodeParser):
             )
 
             # add window to each node
-            for i, node in enumerate(nodes):
-                window_nodes = nodes[
-                    max(0, i - self.window_size) : min(
-                        i + self.window_size + 1, len(nodes)
+            if self.include_metadata:
+                for i, node in enumerate(nodes):
+                    window_nodes = nodes[
+                        max(0, i - self.window_size) : min(
+                            i + self.window_size + 1, len(nodes)
+                        )
+                    ]
+
+                    node.metadata[self.window_metadata_key] = " ".join(
+                        [n.text for n in window_nodes]
                     )
-                ]
+                    node.metadata[self.original_text_metadata_key] = node.text
 
-                node.metadata[self.window_metadata_key] = " ".join(
-                    [n.text for n in window_nodes]
-                )
-                node.metadata[self.original_text_metadata_key] = node.text
-
-                # exclude window metadata from embed and llm
-                node.excluded_embed_metadata_keys.extend(
-                    [self.window_metadata_key, self.original_text_metadata_key]
-                )
-                node.excluded_llm_metadata_keys.extend(
-                    [self.window_metadata_key, self.original_text_metadata_key]
-                )
+                    # exclude window metadata from embed and llm
+                    node.excluded_embed_metadata_keys.extend(
+                        [self.window_metadata_key, self.original_text_metadata_key]
+                    )
+                    node.excluded_llm_metadata_keys.extend(
+                        [self.window_metadata_key, self.original_text_metadata_key]
+                    )
 
             all_nodes.extend(nodes)
 

--- a/llama-index-core/tests/node_parser/test_node_parser.py
+++ b/llama-index-core/tests/node_parser/test_node_parser.py
@@ -1,5 +1,6 @@
 from typing import Any, List, Sequence
 from llama_index.core.node_parser import NodeParser
+from llama_index.core.node_parser.text.sentence_window import SentenceWindowNodeParser
 from llama_index.core.schema import BaseNode, TextNode, Document, NodeRelationship
 
 
@@ -39,3 +40,18 @@ def test__postprocess_parsed_nodes_include_metadata_parent_doc():
     ret = np._postprocess_parsed_nodes(nodes, {})
     for i, node in enumerate(ret):
         assert node.metadata == {"node_number": i, "document_type": "root"}
+
+
+def test_sentence_window_include_metadata_false() -> None:
+    document = Document(
+        text="This is a test 1. This is a test 2. This is a test 3.",
+        metadata={"author": "Test Author"},
+    )
+
+    node_parser = SentenceWindowNodeParser.from_defaults(include_metadata=False)
+
+    nodes = node_parser.get_nodes_from_documents([document])
+
+    assert len(nodes) == 3
+    assert "window" not in nodes[0].metadata
+    assert "original_text" not in nodes[0].metadata


### PR DESCRIPTION
# Description

Guards window metadata population in `SentenceWindowNodeParser` with `if self.include_metadata:` so that instantiating the parser with `include_metadata=False` prevents `window` and `original_text` metadata keys from being attached to output nodes.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_sentence_window_include_metadata_false` in `tests/node_parser/test_node_parser.py`. Ran `pytest tests/node_parser/test_node_parser.py` (3 passed).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes