### PR TITLE
fix(agent): make extract_final_response accept missing Thought: prefix

### DIFF
--- a/llama-index-core/llama_index/core/agent/react/output_parser.py
+++ b/llama-index-core/llama_index/core/agent/react/output_parser.py
@@ -33,17 +33,25 @@ def action_input_parser(json_str: str) -> dict:
 
 
 def extract_final_response(input_text: str) -> Tuple[str, str]:
-    pattern = r"\s*Thought:(.*?)Answer:(.*?)(?:$)"
+    # Try with "Thought:" prefix first (existing behavior)
+    pattern_thought = r"\s*Thought:(.*?)Answer:(.*?)(?:$)"
+    match = re.search(pattern_thought, input_text, re.DOTALL)
+    if match:
+        thought = match.group(1).strip()
+        answer = match.group(2).strip()
+        return thought, answer
 
-    match = re.search(pattern, input_text, re.DOTALL)
-    if not match:
-        raise ValueError(
-            f"Could not extract final answer from input text: {input_text}"
-        )
+    # Fallback: no "Thought:" prefix (matching extract_tool_use behavior)
+    pattern_no_thought = r"\s*(.*?)Answer:(.*?)(?:$)"
+    match = re.search(pattern_no_thought, input_text, re.DOTALL)
+    if match:
+        thought = match.group(1).strip()
+        answer = match.group(2).strip()
+        return thought, answer
 
-    thought = match.group(1).strip()
-    answer = match.group(2).strip()
-    return thought, answer
+    raise ValueError(
+        f"Could not extract final answer from input text: {input_text}"
+    )
 
 
 def parse_action_reasoning_step(output: str) -> ActionReasoningStep:

--- a/llama-index-core/tests/agent/react/test_react_output_parser.py
+++ b/llama-index-core/tests/agent/react/test_react_output_parser.py
@@ -191,6 +191,16 @@ This is the second line."""
     )
 
 
+def test_extract_final_response_no_thought() -> None:
+    mock_input_text = """\
+I have enough information to answer the question without using any more tools.
+Answer: 2
+"""
+    thought, answer = extract_final_response(mock_input_text)
+    assert thought == "I have enough information to answer the question without using any more tools."
+    assert answer == "2"
+
+
 def test_react_output_parser_handles_action_in_answer() -> None:
     mock_input_text = """\
 Thought: I have enough information to answer the question without using any more tools.


### PR DESCRIPTION
Fixes #22563

extract_tool_use was made Thought-optional in PR #19190, but extract_final_response still requires Thought:. This causes agents to loop to max_iterations when the model omits Thought:.

Fix: try two patterns in extract_final_response:
1. With Thought: (existing behavior)
2. Without Thought: (new, matching extract_tool_use behavior)

Two separate regex patterns avoid catastrophic backtracking.

All 15 existing tests pass + 1 new test added.