### PR TITLE
fix(missing_documentation): Def `asyncio_module` in llama-index-core/llama_index/core/as

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -23,6 +23,32 @@ def get_asyncio_module(show_progress: bool = False) -> Any:
 
 
 def asyncio_module(show_progress: bool = False) -> Any:
+    """Return the asyncio module, optionally substituted with tqdm_asyncio for progress display.
+
+    .. deprecated::
+        Use :func:`get_asyncio_module` instead.  This function is a thin
+        compatibility shim and will be removed in a future release.
+
+    Args:
+        show_progress (bool): When *True*, returns ``tqdm.asyncio.tqdm_asyncio`` so
+            that coroutine gathering calls automatically render a progress bar.
+            When *False* (default), returns the standard :mod:`asyncio` module.
+
+    Returns:
+        Any: Either the built-in :mod:`asyncio` module or
+        ``tqdm.asyncio.tqdm_asyncio``, depending on *show_progress*.
+
+    Example:
+        >>> import asyncio
+        >>> from llama_index.core.async_utils import asyncio_module
+        >>> import warnings
+        >>> with warnings.catch_warnings():
+        ...     warnings.simplefilter("ignore", DeprecationWarning)
+        ...     mod = asyncio_module(show_progress=False)
+        >>> mod is asyncio
+        True
+
+    """
     import warnings
 
     warnings.warn(
@@ -173,3 +199,5 @@ async def run_jobs(
         results = await asyncio.gather(*pool_jobs)
 
     return results
+
+# Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -37,3 +37,31 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+# Tests for the deprecated asyncio_module() shim
+# Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
+
+import asyncio as _asyncio
+import warnings as _warnings
+
+from llama_index.core.async_utils import asyncio_module
+
+
+def test_asyncio_module_returns_asyncio_when_no_progress() -> None:
+    """asyncio_module(show_progress=False) should return the standard asyncio module."""
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", DeprecationWarning)
+        mod = asyncio_module(show_progress=False)
+    assert mod is _asyncio
+
+
+def test_asyncio_module_emits_deprecation_warning() -> None:
+    """asyncio_module() must emit a DeprecationWarning pointing to get_asyncio_module."""
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        asyncio_module()
+    assert len(caught) == 1
+    w = caught[0]
+    assert issubclass(w.category, DeprecationWarning)
+    assert "get_asyncio_module" in str(w.message)


### PR DESCRIPTION
## TLDR

        **Gap:** Def `asyncio_module` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example

        **Wedge type:** `missing_documentation`

        **Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L25

        ## Changes

        - `llama-index-core/llama_index/core/async_utils.py`
- `llama-index-core/tests/test_async_utils.py`

        **Diff size:** 56 lines across 2 file(s)

        ## Pre-submission checklist

        - [x] Minimal change — touches at most 3 files
        - [x] Tests updated (if test suite present)
        - [x] No CI/CD, Dockerfile, or lock file modifications
        - [x] Diff reviewed for secrets

        ## AI Assistance Disclosure

        This contribution was AI-assisted using Hermes Agent (Nous Research).

        Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>