### PR TITLE
feat(core): add JsonSchemaToPydantic — JSON Schema → Pydantic model converter

### DIFF
--- a/llama-index-core/llama_index/core/tools/__init__.py
+++ b/llama-index-core/llama_index/core/tools/__init__.py
@@ -1,6 +1,7 @@
 """Tools."""
 
 from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.json_schema import JsonSchemaToPydantic
 from llama_index.core.tools.query_engine import QueryEngineTool
 from llama_index.core.tools.query_plan import QueryPlanTool
 from llama_index.core.tools.retriever_tool import RetrieverTool
@@ -26,6 +27,7 @@ __all__ = [
     "ToolMetadata",
     "ToolOutput",
     "FunctionTool",
+    "JsonSchemaToPydantic",
     "QueryPlanTool",
     "ToolSelection",
     "call_tool_with_selection",

--- a/llama-index-core/llama_index/core/tools/json_schema.py
+++ b/llama-index-core/llama_index/core/tools/json_schema.py
@@ -64,6 +64,9 @@ class JsonSchemaToPydantic:
             A Pydantic model class.
 
         """
+        # Each call converts a self-contained schema; start from an empty cache so
+        # a $defs type from one schema cannot leak into a later one of the same name.
+        self.properties_cache = {}
         defs = schema.get("$defs", {})
 
         # Process all type definitions

--- a/llama-index-core/llama_index/core/tools/json_schema.py
+++ b/llama-index-core/llama_index/core/tools/json_schema.py
@@ -1,0 +1,258 @@
+"""
+Convert a JSON Schema (e.g. a tool's input schema) into a Pydantic model.
+
+The inverse-input twin of ``create_schema_from_function``: that utility builds a
+model from a Python function signature, this one builds a model from a JSON
+Schema dictionary — such as the ``inputSchema`` of an MCP tool definition or any
+other tool-calling schema obtained without a Python callable.
+"""
+
+from typing import Any, Dict, List, Literal, Set, Type, Union
+
+from llama_index.core.bridge.pydantic import BaseModel, Field, create_model
+
+# Map JSON Schema types to Python types
+json_type_mapping: Dict[str, Type] = {
+    "string": str,
+    "number": float,
+    "integer": int,
+    "boolean": bool,
+    "object": Dict,
+    "array": List,
+}
+
+
+class JsonSchemaToPydantic:
+    """
+    Convert JSON Schemas into Pydantic models.
+
+    Handles ``$defs``/``$ref`` references (cached per instance in
+    ``properties_cache``), ``anyOf`` unions, ``enum`` -> ``Literal``,
+    typed arrays and dict-like objects, and required/optional fields
+    with defaults::
+
+        from llama_index.core.tools import JsonSchemaToPydantic
+
+        converter = JsonSchemaToPydantic()
+        model = converter.create_model_from_json_schema(
+            tool.inputSchema, model_name=f"{tool.name}_Schema"
+        )
+
+    Instances cache the models they build by name, so schemas sharing
+    ``$defs`` resolve to the same nested model classes. Use one instance
+    per family of related schemas (e.g. per tool spec).
+    """
+
+    def __init__(self) -> None:
+        self.properties_cache: Dict[str, Type[BaseModel]] = {}
+
+    # ---- public API ----
+
+    def create_model_from_json_schema(
+        self,
+        schema: dict[str, Any],
+        model_name: str = "DynamicModel",
+    ) -> type[BaseModel]:
+        """
+        Create a Pydantic model from a JSON Schema dictionary.
+
+        Args:
+            schema: A JSON Schema dictionary containing properties and required fields.
+            model_name: The name of the model.
+
+        Returns:
+            A Pydantic model class.
+
+        """
+        defs = schema.get("$defs", {})
+
+        # Process all type definitions
+        for cls_name, cls_schema in defs.items():
+            self.properties_cache[cls_name] = self._create_model(
+                cls_schema,
+                cls_name,
+                defs,
+            )
+
+        return self._create_model(schema, model_name)
+
+    def remove_model_fields(
+        self,
+        model: type[BaseModel],
+        fields_to_remove: Set[str],
+        model_name: str,
+    ) -> type[BaseModel]:
+        """Return a copy of ``model`` with ``fields_to_remove`` dropped."""
+        fields = {
+            name: (
+                field.annotation,
+                field.default if field.is_required() else field.default,
+            )
+            for name, field in model.model_fields.items()
+            if name not in fields_to_remove
+        }
+        return create_model(model_name, **fields)
+
+    # ---- model construction ----
+
+    def _create_model(
+        self,
+        schema: dict,
+        model_name: str,
+        defs: dict = {},
+    ) -> type[BaseModel]:
+        """Create a Pydantic model from a schema."""
+        if model_name in self.properties_cache:
+            return self.properties_cache[model_name]
+
+        fields = self._extract_fields(schema, defs)
+        model = create_model(model_name, **fields)
+        self.properties_cache[model_name] = model
+        return model
+
+    def _extract_fields(self, schema: dict, defs: dict) -> dict:
+        """Extract Pydantic fields from schema."""
+        properties = self._get_properties(schema)
+        required_fields = set(schema.get("required", []))
+
+        # For enum schemas, treat them as required by default
+        if "enum" in schema:
+            required_fields = {schema.get("title", "enum_field")}
+
+        fields = {}
+        for field_name, field_schema in properties.items():
+            field_type = self._resolve_field_type(field_schema, defs)
+            default_value, final_type = self._set_field_default(
+                field_name,
+                required_fields,
+                field_type,
+                field_schema,
+            )
+
+            fields[field_name] = (
+                final_type,
+                Field(default_value, description=field_schema.get("description", "")),
+            )
+
+        return fields
+
+    def _get_properties(self, schema: dict) -> dict:
+        """Get properties from schema, handling enum types."""
+        if "enum" in schema:
+            # For enum types, create a property with the schema name as the key
+            # This ensures the enum is treated as a required field
+            return {schema.get("title", "enum_field"): schema}
+        return schema.get("properties", {})
+
+    @staticmethod
+    def _set_field_default(
+        field: str,
+        required_fields: set[str],
+        ftype: Any,
+        field_schema: dict,
+    ) -> tuple[type(Ellipsis) | None, Any]:
+        """Set default value and make type optional if needed."""
+        if field in required_fields:
+            return ..., ftype
+        default_value = field_schema.get("default")
+        if default_value is None:
+            ftype = ftype | type(None)
+        return default_value, ftype
+
+    # ---- type resolution ----
+
+    def _resolve_field_type(self, field_schema: dict, defs: dict) -> Any:
+        """Resolve the Python type from a field schema."""
+        if "$ref" in field_schema:
+            return self._resolve_reference(field_schema, defs)
+        if "enum" in field_schema:
+            return Literal[tuple(field_schema["enum"])]
+        if "anyOf" in field_schema:
+            return self._resolve_union_type(field_schema, defs)
+        return self._resolve_basic_type(field_schema, defs)
+
+    def _resolve_reference(self, field_schema: dict, defs: dict) -> Any:
+        """Resolve a $ref reference."""
+        ref_name = self._extract_ref_name(field_schema["$ref"])
+
+        if ref_name not in defs:
+            return self.properties_cache.get(ref_name)
+
+        ref_schema = defs[ref_name]
+
+        if "anyOf" in ref_schema:
+            return self._resolve_union_type(ref_schema, defs)
+        if self._is_simple_array(ref_schema):
+            return self._create_list_type(ref_schema, defs)
+        if self._is_simple_object(ref_schema):
+            return self._create_dict_type(ref_schema, defs)
+        return self.properties_cache.get(ref_name) or self._create_model(
+            ref_schema,
+            ref_name,
+            defs,
+        )
+
+    def _resolve_union_type(self, schema: dict, defs: dict) -> Any:
+        """Resolve a Union type (anyOf)."""
+        union_types = [
+            self._resolve_union_option(option, defs) for option in schema["anyOf"]
+        ]
+        return Union[tuple(union_types)] if len(union_types) > 1 else union_types[0]
+
+    def _resolve_union_option(self, option: dict, defs: dict) -> Any:
+        """Resolve a single option in a union type."""
+        if "$ref" in option:
+            return self._resolve_reference(option, defs)
+        if "enum" in option:
+            return Literal[tuple(option["enum"])]
+        if option.get("type") == "null":
+            return type(None)
+        return self._resolve_basic_type(option, defs)
+
+    def _resolve_basic_type(self, schema: dict, defs: dict) -> Any:
+        """Resolve a basic JSON Schema type."""
+        json_type = schema.get("type", "string")
+        json_type = json_type[0] if isinstance(json_type, list) else json_type
+
+        if self._is_simple_array(schema):
+            return self._create_list_type(schema, defs)
+        if self._is_simple_object(schema):
+            return self._create_dict_type(schema, defs)
+        return json_type_mapping.get(json_type, str)
+
+    def _create_list_type(self, schema: dict, defs: dict) -> type:
+        """Create a List type from schema."""
+        item_type = self._resolve_field_type(schema["items"], defs)
+        return List[item_type]
+
+    def _create_dict_type(self, schema: dict, defs: dict) -> type:
+        """Create a Dict type from schema."""
+        additional_props = schema.get("additionalProperties")
+
+        if additional_props is False or additional_props is None:
+            return Dict[str, Any]
+
+        if isinstance(additional_props, dict):
+            value_type = self._resolve_field_type(additional_props, defs)
+            return Dict[str, value_type]
+
+        return Dict[str, Any]
+
+    def _is_simple_array(self, schema: dict) -> bool:
+        """Check if schema is a simple array type."""
+        return schema.get("type") == "array" and "items" in schema
+
+    def _is_simple_object(self, schema: dict) -> bool:
+        """Check if schema is a simple object type."""
+        additional_props = schema.get("additionalProperties")
+        return (
+            schema.get("type") == "object"
+            and "additionalProperties" in schema
+            and additional_props is not False
+            and isinstance(additional_props, dict)
+        )
+
+    @staticmethod
+    def _extract_ref_name(ref_path: str) -> str:
+        """Extract reference name from $ref path."""
+        return ref_path.split("#/$defs/")[-1]

--- a/llama-index-core/llama_index/core/tools/json_schema.py
+++ b/llama-index-core/llama_index/core/tools/json_schema.py
@@ -82,12 +82,13 @@ class JsonSchemaToPydantic:
         fields_to_remove: Set[str],
         model_name: str,
     ) -> type[BaseModel]:
-        """Return a copy of ``model`` with ``fields_to_remove`` dropped."""
+        """Return a copy of ``model`` with ``fields_to_remove`` dropped.
+
+        Surviving fields keep their full ``FieldInfo`` — rebuilding from only
+        (annotation, default) would erase descriptions and other metadata.
+        """
         fields = {
-            name: (
-                field.annotation,
-                field.default if field.is_required() else field.default,
-            )
+            name: (field.annotation, field)
             for name, field in model.model_fields.items()
             if name not in fields_to_remove
         }

--- a/llama-index-core/tests/tools/test_json_schema.py
+++ b/llama-index-core/tests/tools/test_json_schema.py
@@ -133,3 +133,16 @@ def test_remove_model_fields_preserves_descriptions() -> None:
     assert props["mode"]["description"] == "Rounding mode"
     assert props["mode"]["default"] == "fast"
     assert trimmed.model_json_schema()["required"] == ["b"]
+
+
+def test_defs_name_collision_across_calls() -> None:
+    """Two schemas that reuse a $defs name with different shapes must not collide."""
+    conv = JsonSchemaToPydantic()
+    a = {"type": "object", "properties": {"item": {"$ref": "#/$defs/Item"}}, "required": ["item"],
+         "$defs": {"Item": {"type": "object", "properties": {"weight_kg": {"type": "number"}}, "required": ["weight_kg"]}}}
+    b = {"type": "object", "properties": {"item": {"$ref": "#/$defs/Item"}}, "required": ["item"],
+         "$defs": {"Item": {"type": "object", "properties": {"color": {"type": "string"}}, "required": ["color"]}}}
+    ma = conv.create_model_from_json_schema(a, "toolA_Schema")
+    mb = conv.create_model_from_json_schema(b, "toolB_Schema")
+    assert set(ma.model_fields["item"].annotation.model_fields) == {"weight_kg"}
+    assert set(mb.model_fields["item"].annotation.model_fields) == {"color"}

--- a/llama-index-core/tests/tools/test_json_schema.py
+++ b/llama-index-core/tests/tools/test_json_schema.py
@@ -1,0 +1,115 @@
+"""Tests for JsonSchemaToPydantic — JSON Schema -> Pydantic model conversion."""
+
+from typing import Dict, Any, Literal, get_args
+
+from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.tools import JsonSchemaToPydantic
+
+# Shaped like a real tool inputSchema: a $ref to a nested model, an array,
+# an enum, and an optional (anyOf + null) field.
+TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"$ref": "#/$defs/PersonName"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "color": {"enum": ["red", "green", "blue"]},
+        "note": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+    },
+    "required": ["name", "color"],
+    "$defs": {
+        "PersonName": {
+            "type": "object",
+            "properties": {
+                "first": {"type": "string"},
+                "last": {"type": "string"},
+            },
+            "required": ["first"],
+        }
+    },
+}
+
+
+def test_basic_model_construction() -> None:
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+
+    assert issubclass(model, BaseModel)
+    assert set(model.model_fields) == {"name", "tags", "color", "note"}
+
+    # required vs optional
+    assert model.model_fields["name"].is_required()
+    assert model.model_fields["color"].is_required()
+    assert not model.model_fields["note"].is_required()
+
+
+def test_nested_ref_resolves_to_a_submodel() -> None:
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+
+    name_type = model.model_fields["name"].annotation
+    assert isinstance(name_type, type) and issubclass(name_type, BaseModel)
+    assert set(name_type.model_fields) == {"first", "last"}
+    # The submodel is also cached under its $defs name.
+    assert "PersonName" in converter.properties_cache
+
+
+def test_array_items_are_typed() -> None:
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+    # tags isn't required, so its annotation is Optional[List[str]]; unwrap
+    # the Optional and check the list item type.
+    tags_type = model.model_fields["tags"].annotation
+    list_type = next(a for a in get_args(tags_type) if a is not type(None))
+    assert get_args(list_type) == (str,)
+
+
+def test_remove_model_fields() -> None:
+    converter = JsonSchemaToPydantic()
+    model = converter.create_model_from_json_schema(TOOL_SCHEMA, "Tool_Schema")
+    trimmed = converter.remove_model_fields(model, {"note", "tags"}, "Tool_Schema")
+    assert set(trimmed.model_fields) == {"name", "color"}
+
+
+def test_enum_resolves_to_literal() -> None:
+    """
+    Regression coverage carried over from
+    https://github.com/run-llama/llama_index/issues/20109 — enum entries in
+    anyOf schemas must resolve to Literal types, not fall through to str.
+    """
+    converter = JsonSchemaToPydantic()
+
+    assert (
+        converter._resolve_union_option({"enum": ["red", "green", "blue"]}, {})
+        == Literal["red", "green", "blue"]
+    )
+
+    resolved = converter._resolve_union_type(
+        {"anyOf": [{"enum": ["a", "b"]}, {"type": "null"}]}, {}
+    )
+    args = get_args(resolved)
+    assert type(None) in args
+    assert Literal["a", "b"] in args
+
+
+def test_additional_properties_variants() -> None:
+    converter = JsonSchemaToPydantic()
+
+    schema_false = {"type": "object", "additionalProperties": False}
+    assert not converter._is_simple_object(schema_false)
+    assert converter._create_dict_type(schema_false, {}) == Dict[str, Any]
+
+    schema_typed = {"type": "object", "additionalProperties": {"type": "string"}}
+    assert converter._is_simple_object(schema_typed)
+    assert converter._create_dict_type(schema_typed, {}) == Dict[str, str]
+
+
+def test_json_schema_round_trip_defaults() -> None:
+    """Optional field with a default keeps the default."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "default": 10},
+        },
+    }
+    model = JsonSchemaToPydantic().create_model_from_json_schema(schema, "M")
+    assert model().limit == 10

--- a/llama-index-core/tests/tools/test_json_schema.py
+++ b/llama-index-core/tests/tools/test_json_schema.py
@@ -113,3 +113,23 @@ def test_json_schema_round_trip_defaults() -> None:
     }
     model = JsonSchemaToPydantic().create_model_from_json_schema(schema, "M")
     assert model().limit == 10
+
+
+def test_remove_model_fields_preserves_descriptions() -> None:
+    """Surviving fields keep description, default, and requiredness."""
+    from llama_index.core.bridge.pydantic import Field, create_model
+
+    converter = JsonSchemaToPydantic()
+    model = create_model(
+        "Tool_Schema",
+        a=(float, Field(..., description="First addend")),
+        b=(float, Field(..., description="Second addend")),
+        mode=(str, Field("fast", description="Rounding mode")),
+    )
+    trimmed = converter.remove_model_fields(model, {"a"}, "Tool_Schema")
+    props = trimmed.model_json_schema()["properties"]
+
+    assert props["b"]["description"] == "Second addend"
+    assert props["mode"]["description"] == "Rounding mode"
+    assert props["mode"]["default"] == "fast"
+    assert trimmed.model_json_schema()["required"] == ["b"]


### PR DESCRIPTION
## Description

Follow-up to the discussion on #22536, where @logan-markewich pointed out the JSON-Schema→Pydantic conversion is "more of a llama-index-core type of feature". This PR adds it to core as `JsonSchemaToPydantic`, a sibling of `create_schema_from_function` in `llama_index/core/tools/` — the two are inverse-input twins (function signature → model vs JSON Schema → model).

```python
from llama_index.core.tools import JsonSchemaToPydantic

converter = JsonSchemaToPydantic()
model = converter.create_model_from_json_schema(
    tool.inputSchema, model_name=f"{tool.name}_Schema"
)
```

Covers `$defs`/`$ref` (cached per instance), `anyOf` unions, `enum` → `Literal`, typed arrays and dict-like objects, required/optional fields with defaults, plus `remove_model_fields` for partial-param trimming. Implemented as one cohesive class in a new `tools/json_schema.py` module (rather than appending ~250 lines to `utils.py`), using `bridge.pydantic` imports per core convention.

The logic is a consolidation of the converter that lives in `llama-index-tools-mcp` today (including the #20109 enum-in-anyOf regression behavior, which has a carried-over test). Once this lands, the MCP integration can delegate to it in a small follow-up, and #22536 can be closed or reduced accordingly.

## How Has This Been Tested?

- New `tests/tools/test_json_schema.py`: nested `$ref` submodels, typed arrays, enum→Literal (incl. the #20109 regression), `additionalProperties` variants, defaults round-trip, `remove_model_fields`.
- Full `tests/tools/` suite: **70 passed, 4 skipped** — no regressions from the export addition.
- `ruff check` / `ruff format` clean.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)