### PR TITLE
fix(lancedb): escape IDs in vector-store delete filters

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/llama_index/vector_stores/lancedb/base.py
@@ -44,6 +44,11 @@ class TableNotFoundError(Exception):
     """Raised when the specified table does not exist."""
 
 
+def _quote_lance_string(value: str) -> str:
+    """Return a safely quoted Lance SQL string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
 def _to_lance_filter(
     standard_filters: MetadataFilters,
     metadata_keys: Optional[list],
@@ -419,7 +424,7 @@ class LanceDBVectorStore(BasePydanticVectorStore):
             ref_doc_id (str): The doc_id of the document to delete.
 
         """
-        self.table.delete(f'{self.doc_id_key} = "' + ref_doc_id + '"')
+        self.table.delete(f"{self.doc_id_key} = {_quote_lance_string(ref_doc_id)}")
 
     def delete_nodes(self, node_ids: List[str], **delete_kwargs: Any) -> None:
         """
@@ -429,7 +434,12 @@ class LanceDBVectorStore(BasePydanticVectorStore):
             node_ids (List[str]): The list of node_ids to delete.
 
         """
-        self.table.delete('id in ("' + '","'.join(node_ids) + '")')
+        table = self.table
+        if not node_ids:
+            return
+
+        ids = ",".join(_quote_lance_string(node_id) for node_id in node_ids)
+        table.delete(f"id in ({ids})")
 
     def get_nodes(
         self,

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-lancedb"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index vector_stores lancedb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/tests/test_vector_stores_lancedb.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/tests/test_vector_stores_lancedb.py
@@ -278,6 +278,32 @@ def test_delete(tmp_path: Path, text_node_list: list[TextNode]) -> None:
     deps is None,
     reason="Need to install lancedb locally to run this test.",
 )
+def test_delete_escapes_ref_doc_id(
+    tmp_path: Path, text_node_list: list[TextNode]
+) -> None:
+    vector_store = LanceDBVectorStore(
+        uri=str(tmp_path / "test_lancedb"), mode="overwrite"
+    )
+    quoted_ref_doc_id = 'customer\'s "draft"'
+    quoted_node = TextNode(
+        text="quoted document",
+        id_="quoted-ref-doc-node",
+        embedding=[0.1, 0.2, 0.3],
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id=quoted_ref_doc_id)
+        },
+    )
+    vector_store.add([*text_node_list, quoted_node])
+
+    vector_store.delete(ref_doc_id=quoted_ref_doc_id)
+
+    assert vector_store._table.count_rows() == len(text_node_list)
+
+
+@pytest.mark.skipif(
+    deps is None,
+    reason="Need to install lancedb locally to run this test.",
+)
 def test_delete_nodes(tmp_path: Path, text_node_list: list[TextNode]) -> None:
     # given
     vector_store = LanceDBVectorStore(
@@ -290,6 +316,29 @@ def test_delete_nodes(tmp_path: Path, text_node_list: list[TextNode]) -> None:
 
     # then
     assert vector_store._table.count_rows() == len(text_node_list) - 2
+
+
+@pytest.mark.skipif(
+    deps is None,
+    reason="Need to install lancedb locally to run this test.",
+)
+def test_delete_nodes_escapes_node_ids(
+    tmp_path: Path, text_node_list: list[TextNode]
+) -> None:
+    vector_store = LanceDBVectorStore(
+        uri=str(tmp_path / "test_lancedb"), mode="overwrite"
+    )
+    quoted_node_id = 'node\'s "draft"'
+    quoted_node = TextNode(
+        text="quoted node",
+        id_=quoted_node_id,
+        embedding=[0.1, 0.2, 0.3],
+    )
+    vector_store.add([*text_node_list, quoted_node])
+
+    vector_store.delete_nodes(node_ids=[quoted_node_id])
+
+    assert vector_store._table.count_rows() == len(text_node_list)
 
 
 @pytest.mark.skipif(

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/uv.lock
@@ -1891,7 +1891,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-vector-stores-lancedb"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "lancedb" },


### PR DESCRIPTION
# Description

Escapes document and node IDs before interpolating them into LanceDB delete predicates in the vector-store integration. Values are now single-quoted with embedded apostrophes doubled, so IDs containing quotes cannot break or widen the predicate. Empty node ID lists remain a no-op after table validation.

This covers the vector-store sibling path identified in #22543 but not changed by #22576, which only adds managed-index tests.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

Bumps `llama-index-vector-stores-lancedb` from 0.5.0 to 0.5.1.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Regression tests create and delete real LanceDB rows whose document and node IDs contain both apostrophes and double quotes.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the package formatter and linter

## Verification

- `python -m pytest tests/test_vector_stores_lancedb.py -q` (28 passed)
- `ruff format --check llama_index/vector_stores/lancedb/base.py tests/test_vector_stores_lancedb.py`
- `ruff check llama_index/vector_stores/lancedb/base.py tests/test_vector_stores_lancedb.py`
- `uv lock --check`

## AI Assistance

I used AI assistance to inspect the affected query construction, implement the focused fix, and draft regression tests. I reviewed the final diff, verified the predicates against real local LanceDB tables, and ran the checks listed above.