### PR TITLE
fix(core): keep incomplete string values in parse_partial_json

### DIFF
--- a/llama-index-core/llama_index/core/llms/utils.py
+++ b/llama-index-core/llama_index/core/llms/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union, Dict
+from typing import TYPE_CHECKING, List, Optional, Union, Dict
 import json
 
 if TYPE_CHECKING:
@@ -124,6 +124,25 @@ def resolve_llm(
     return llm
 
 
+def _terminate_partial_string(s: str, string_start: int) -> str:
+    r"""
+    Close the unterminated string token that starts at ``string_start``.
+
+    The tail of the token may be a truncated escape sequence (a lone ``\`` or a
+    cut ``\uXXXX``), which cannot be closed as-is. Trim from the end until the
+    token parses, which is at most a handful of characters.
+    """
+    token = s[string_start:]
+    while not token.endswith('"'):
+        try:
+            json.loads(token + '"')
+            break
+        except json.JSONDecodeError:
+            token = token[:-1]
+
+    return s[:string_start] + token + '"'
+
+
 def parse_partial_json(s: str) -> Dict:
     """
     Parse an incomplete JSON string into a valid python dictionary.
@@ -139,15 +158,26 @@ def parse_partial_json(s: str) -> Dict:
 
     # Initialize variables.
     new_s = ""
-    stack = []
+    stack: List[str] = []
     is_inside_string = False
     escaped = False
+    # Where the string token being scanned starts, and whether it is an object key.
+    string_start = -1
+    string_is_key = False
+    # Start of an object key that has no ":" after it yet.
+    dangling_key_start = -1
+    # Start of a bare literal (number/true/false/null) that may be cut mid-token.
+    literal_start = -1
+    # Last structural character seen outside a string, used to tell a key from a value.
+    last_structural = ""
 
     # Process each character in the string one at a time.
     for char in s:
         if is_inside_string:
             if char == '"' and not escaped:
                 is_inside_string = False
+                if string_is_key:
+                    dangling_key_start = string_start
             elif char == "\n" and not escaped:
                 char = "\\n"  # Replace the newline character with the escape sequence.
             elif char == "\\":
@@ -158,41 +188,77 @@ def parse_partial_json(s: str) -> Dict:
             if char == '"':
                 is_inside_string = True
                 escaped = False
+                string_start = len(new_s)
+                # Only a string sitting in an object right after "{" or "," is a key.
+                string_is_key = (
+                    bool(stack) and stack[-1] == "}" and last_structural in ("{", ",")
+                )
+                literal_start = -1
             elif char == "{":
                 stack.append("}")
+                last_structural = char
+                literal_start = -1
             elif char == "[":
                 stack.append("]")
+                last_structural = char
+                literal_start = -1
             elif char == "}" or char == "]":
                 if stack and stack[-1] == char:
                     stack.pop()
                 else:
                     # Mismatched closing character; the input is malformed.
                     raise ValueError("Malformed partial JSON encountered.")
+                last_structural = ""
+                literal_start = -1
+            elif char == ":":
+                last_structural = char
+                dangling_key_start = -1
+                literal_start = -1
+            elif char == ",":
+                last_structural = char
+                literal_start = -1
+            elif not char.isspace() and literal_start == -1:
+                literal_start = len(new_s)
 
         # Append the processed character to the new string.
         new_s += char
 
-    # If we're still inside a string at the end of processing and no colon was found after the opening quote,
-    # this is an incomplete key - remove it
-    if is_inside_string and '"' in new_s and ":" not in new_s[new_s.rindex('"') :]:
-        new_s = new_s[: new_s.rindex('"')]
-    elif is_inside_string:
-        new_s += '"'
+    if is_inside_string:
+        if string_is_key:
+            # An incomplete key carries no information at all -- drop it.
+            dangling_key_start = string_start
+        else:
+            # An incomplete value does, so keep what has arrived so far.
+            new_s = _terminate_partial_string(new_s, string_start)
 
-    # Check if we have an incomplete key-value pair
-    new_s = new_s.rstrip()
-    if new_s.endswith(":"):
-        new_s += " null"  # Add a default value for incomplete value
-    elif new_s.endswith(","):
-        new_s = new_s[:-1]  # Remove the trailing comma
+    if dangling_key_start != -1:
+        # A key with no value yet; drop it along with the comma introducing it.
+        new_s = new_s[:dangling_key_start]
+        literal_start = -1
 
-    # Close any remaining open structures in the reverse order that they were opened.
-    for closing_char in reversed(stack):
-        new_s += closing_char
+    def close(text: str) -> str:
+        # Check if we have an incomplete key-value pair
+        text = text.rstrip()
+        if text.endswith(":"):
+            text += " null"  # Add a default value for incomplete value
+        elif text.endswith(","):
+            text = text[:-1]  # Remove the trailing comma
 
-    # Attempt to parse the modified string as JSON.
-    try:
-        return json.loads(new_s)
-    except json.JSONDecodeError:
-        # If we still can't parse the string as JSON, raise error to indicate failure.
-        raise ValueError("Malformed partial JSON encountered.")
+        # Close any remaining open structures in the reverse order they were opened.
+        return text + "".join(reversed(stack))
+
+    attempts = [new_s]
+    if literal_start != -1:
+        # A trailing literal may be a value cut mid-token ("1.", "tru", "-"),
+        # which is only detectable by failing to parse it.
+        attempts.append(new_s[:literal_start])
+
+    for attempt in attempts:
+        # Attempt to parse the modified string as JSON.
+        try:
+            return json.loads(close(attempt))
+        except json.JSONDecodeError:
+            continue
+
+    # If we still can't parse the string as JSON, raise error to indicate failure.
+    raise ValueError("Malformed partial JSON encountered.")

--- a/llama-index-core/tests/llms/test_utils.py
+++ b/llama-index-core/tests/llms/test_utils.py
@@ -1,0 +1,104 @@
+import json
+
+import pytest
+from llama_index.core.llms.utils import parse_partial_json
+
+
+@pytest.mark.parametrize(
+    ("partial", "expected"),
+    [
+        # already-valid JSON is returned untouched
+        ("{}", {}),
+        ('{"a": 1}', {"a": 1}),
+        ('{"a": [1, 2]}', {"a": [1, 2]}),
+        # an unterminated string value keeps the characters received so far
+        ('{"a": "abc', {"a": "abc"}),
+        ('{"a": "', {"a": ""}),
+        ('{"a": ""', {"a": ""}),
+        ('{"outer": {"inner": "wor', {"outer": {"inner": "wor"}}),
+        ('{"a": {"b": [{"c": "de', {"a": {"b": [{"c": "de"}]}}),
+        # ... including the last element of an array
+        ('{"items": ["alpha", "bet', {"items": ["alpha", "bet"]}),
+        ('["par', ["par"]),
+        # ... and strings whose content looks structural
+        ('{"a": "has: colon', {"a": "has: colon"}),
+        ('{"a": "has {brace', {"a": "has {brace"}),
+        ('{"a": "has \\"quote', {"a": 'has "quote'}),
+        ('{"a": "back\\\\', {"a": "back\\"}),
+        ('{"a": "line1\nline2', {"a": "line1\nline2"}),
+        # an escape sequence cut mid-way is dropped, the rest is kept
+        ('{"a": "back\\', {"a": "back"}),
+        ('{"a": "uni \\u12', {"a": "uni "}),
+        # a key with no value yet carries no information, so it is dropped
+        ('{"a": 1, "b', {"a": 1}),
+        ('{"a": 1, "b"', {"a": 1}),
+        ('{"ke', {}),
+        ('{"a"', {}),
+        ("{", {}),
+        ("[", []),
+        # a value that has not started yet is null
+        ('{"a":', {"a": None}),
+        # ... as is a literal cut mid-token, which cannot be guessed
+        ('{"a": 1.', {"a": None}),
+        ('{"a": -', {"a": None}),
+        ('{"a": 1e', {"a": None}),
+        ('{"a": tru', {"a": None}),
+        # a trailing comma is dropped
+        ('{"a": 1,', {"a": 1}),
+        ("[1,", [1]),
+        # a complete literal is kept
+        ('{"a": 12', {"a": 12}),
+        ('{"a": [[1, 2], [3', {"a": [[1, 2], [3]]}),
+    ],
+)
+def test_parse_partial_json(partial: str, expected: object) -> None:
+    assert parse_partial_json(partial) == expected
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    ["", "   ", "}", "]", "{]", '{"a": 1}}', "[1, 2]]", '{"a" "b"}', "gibberish"],
+)
+def test_parse_partial_json_raises_on_malformed(malformed: str) -> None:
+    with pytest.raises(ValueError):
+        parse_partial_json(malformed)
+
+
+STREAMED_TOOL_ARGS = [
+    '{"query": "who won the 2026 world cup?", "top_k": 5, "rerank": true}',
+    '{"path": "C:\\\\Users\\\\me\\\\notes.txt", "mode": "r"}',
+    '{"messages": [{"role": "user", "content": "hi \\"there\\""}], "stream": false}',
+    '{"filters": {"and": [{"key": "year", "op": ">=", "value": 2024}]}, "limit": null}',
+    '{"text": "line one\\nline two", "emoji": "\\u2764\\ufe0f done"}',
+    '[{"a": 1}, {"b": [true, false, null]}]',
+]
+
+
+def _assert_consistent_with(partial: object, final: object) -> None:
+    """Every value in a partial parse must be a prefix of the final value."""
+    if partial is None:
+        # a value that has not started streaming yet
+        return
+    if isinstance(final, dict):
+        assert isinstance(partial, dict)
+        for key, value in partial.items():
+            assert key in final, f"invented key {key!r}"
+            _assert_consistent_with(value, final[key])
+    elif isinstance(final, list):
+        assert isinstance(partial, list)
+        assert len(partial) <= len(final), "invented list element"
+        for got, want in zip(partial, final):
+            _assert_consistent_with(got, want)
+    elif isinstance(final, str):
+        assert isinstance(partial, str) and final.startswith(partial), (
+            f"{partial!r} is not a prefix of {final!r}"
+        )
+
+
+@pytest.mark.parametrize("doc", STREAMED_TOOL_ARGS)
+def test_parse_partial_json_over_every_prefix(doc: str) -> None:
+    """Simulate a tool call streamed one character at a time."""
+    final = json.loads(doc)
+    for end in range(1, len(doc) + 1):
+        _assert_consistent_with(parse_partial_json(doc[:end]), final)
+    assert parse_partial_json(doc) == final


### PR DESCRIPTION
# Description

`parse_partial_json` is the repair function every LLM integration uses to render a tool call while its arguments are still streaming (`llama-index-llms-openai` — both `base.py` and `responses.py` — plus `anthropic`, `bedrock-converse`, `ai21`, `ibm`, `oci-data-science`, and core's `MockLLM`). On `main` it destroys exactly the data it is supposed to preserve.

The repair step ran after the scan and had to guess, from the output string alone, whether the still-open string was a key or a value:

```python
if is_inside_string and '"' in new_s and ":" not in new_s[new_s.rindex('"'):]:
    new_s = new_s[: new_s.rindex('"')]
```

For a value, `rindex('"')` finds that value's *opening* quote, so the text truncates back to it, falls into the `endswith(":")` branch below, and gets ` null` appended. On `main`:

```python
parse_partial_json('{"a": "hel')              # -> {'a': None}          expected {'a': 'hel'}
parse_partial_json('{"outer": {"inner": "wor')# -> {'outer': {'inner': None}}
parse_partial_json('{"items": ["alpha", "bet')# -> {'items': ['alpha']}  element dropped entirely
parse_partial_json('["par')                   # -> []
parse_partial_json('{"a": "has \\"quote')     # -> ValueError
parse_partial_json('{"a": "uni \\u12')        # -> {'a': None}
parse_partial_json('{"a": 1, "b"')            # -> ValueError
parse_partial_json('{"a": tru')               # -> ValueError
```

So a partially-streamed string argument reaches the UI (and any `on_tool_call` style consumer) as `null`, and a partial last array element vanishes. The `ValueError` cases are less harmful — every caller catches it and falls back to `{}` or skips the update — but they mean no incremental arguments render at all for that chunk.

## The fix

Stop guessing after the fact and carry the small amount of state the scanner already almost has:

- when a string opens, record where it starts and whether it is an **object key** (a string in an object right after `{` or `,`) or a **value**;
- an incomplete **value** is closed, keeping the characters received so far. If its tail is a truncated escape (a lone `\` or a cut `\uXXXX`) the tail is trimmed until the token parses;
- an incomplete **key**, or a complete key with no `:` yet, is dropped along with the comma that introduced it — it carries no information;
- a trailing bare literal is only discarded if it does not parse, so `{"a": 12` still yields `12` while `{"a": 1.` / `tru` / `-` / `1e` yield `null`, matching the existing convention that a value which has not arrived is `null`.

Behaviour is a strict widening: **every input that parsed before parses to the same value**, including `{"a": "has: colon` (which worked only by accident of the `":" not in ...` heuristic), `{"a":` → `{'a': None}`, trailing-comma trimming, and the newline escaping. Malformed input (`{]`, `}`, `[1, 2]]`, `''`) still raises `ValueError`.

Fixes #20881

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — `llama-index-core` is exempt

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

New `llama-index-core/tests/llms/test_utils.py` (the module had no test file):

1. A 31-case table pinning both the fixed cases and every previously-working case, so a future refactor cannot silently regress them.
2. `test_parse_partial_json_raises_on_malformed` — malformed input still raises.
3. `test_parse_partial_json_over_every_prefix` — the real invariant. For six realistic tool-call payloads (Windows paths, escaped quotes, `\n`, `\uXXXX`, nested objects/arrays, `true`/`false`/`null`) it feeds **every prefix**, character by character, and asserts no prefix raises, no key or array element is invented, every partial string is a genuine prefix of the final string, and the full document parses exactly. That last test fails 57 times on `main` and passes here.

```
$ pytest tests/llms/ -q
85 passed

$ pytest tests/llms/ tests/response_synthesizers/ tests/agent/ -q
298 passed, 3 skipped

$ mypy llama_index
Success: no issues found in 479 source files
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
