### PR TITLE
fix(core): always declare "required" in a tool's parameter schema

### DIFF
--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -43,6 +43,11 @@ class ToolMetadata:
                 for k, v in parameters.items()
                 if k in ["type", "properties", "required", "definitions", "$defs"]
             }
+            # pydantic leaves "required" out when nothing is required, but the
+            # OpenAI function-calling spec expects the key to be there -- some
+            # servers (vLLM) reject a tool that omits it -- so spell out the
+            # empty case
+            parameters.setdefault("required", [])
         return parameters
 
     @property

--- a/llama-index-core/tests/tools/test_types.py
+++ b/llama-index-core/tests/tools/test_types.py
@@ -2,6 +2,7 @@ import pytest
 
 from llama_index.core.bridge.pydantic import BaseModel
 from llama_index.core.program.function_program import get_function_tool
+from llama_index.core.tools import FunctionTool
 from llama_index.core.tools.types import ToolMetadata
 
 
@@ -38,3 +39,31 @@ def test_nested_tool_schema() -> None:
 
     assert schema["required"][0] == "inner"
     assert schema["properties"] == {"inner": {"$ref": "#/$defs/Inner"}}
+
+
+def test_zero_parameter_tool_schema_declares_required() -> None:
+    def ping() -> str:
+        """Ping the service."""
+        return "pong"
+
+    tool = FunctionTool.from_defaults(fn=ping)
+
+    assert tool.metadata.get_parameters_dict() == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+    parameters = tool.metadata.to_openai_tool()["function"]["parameters"]
+    assert parameters["required"] == []
+
+
+def test_all_optional_parameters_tool_schema_declares_required() -> None:
+    def greet(name: str = "world") -> str:
+        """Greet someone."""
+        return f"hello {name}"
+
+    tool = FunctionTool.from_defaults(fn=greet)
+
+    schema = tool.metadata.get_parameters_dict()
+    assert schema["required"] == []
+    assert set(schema["properties"]) == {"name"}


### PR DESCRIPTION
# Description

A `FunctionTool` whose function takes no arguments emits a parameter schema with no `"required"` key:

```python
def ping() -> str:
    """Ping the service."""
    return "pong"

FunctionTool.from_defaults(fn=ping).metadata.to_openai_tool()
# {'type': 'function', 'function': {'name': 'ping', 'description': '...',
#   'parameters': {'properties': {}, 'type': 'object'}}}
#                                  ^ no "required"
```

`model_json_schema()` omits `required` when nothing is required, and the key filter in `get_parameters_dict` (`if k in ["type", "properties", "required", ...]`) can only pass through keys that are already there. vLLM enforces the key, so **any** zero-argument tool breaks `FunctionAgent` / `AgentWorkflow` against a vLLM-served model — and zero-argument tools (`get_current_time`, `list_sessions`, `ping`, …) are very common.

The same gap hits a tool whose arguments are all defaulted:

```python
def greet(name: str = "world") -> str: ...
# {'properties': {'name': {...}}, 'type': 'object'}   <- also no "required"
```

Fix: `parameters.setdefault("required", [])`. The `fn_schema is None` branch above already declares `required` explicitly, so this just makes the two branches consistent. Tools that do have required arguments are untouched — pydantic already emits the key for them.

Fixes #18928

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — `llama-index-core` is exempt

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Two tests in `llama-index-core/tests/tools/test_types.py`, one for the zero-argument case (asserting the full dict, and that it survives into `to_openai_tool()`) and one for the all-defaulted case. Both fail on `main`.

```
$ pytest tests/tools/ tests/program/ tests/agent/ -q
194 passed, 7 skipped

$ pytest tests -q          # whole llama-index-core suite
1463 passed, 39 skipped, 6 xfailed

$ mypy llama_index
Success: no issues found in 479 source files
```

The existing `test_openai_tool_schema`-style assertions that pin `set(parameter_dict.keys()) == {"type", "properties", "required"}` use schemas that already have required fields, so they are unaffected.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
