### PR TITLE
feat(core): add opt-in fallback_to_llm for empty retrieval (#20894)

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -102,6 +102,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
+        fallback_to_llm: bool = False,
     ):
         self._retriever = retriever
         self._llm = llm
@@ -133,6 +134,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         self._token_counter = TokenCounter()
         self._verbose = verbose
+        self._fallback_to_llm = fallback_to_llm
 
     @classmethod
     def from_defaults(
@@ -148,6 +150,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         skip_condense: bool = False,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         verbose: bool = False,
+        fallback_to_llm: bool = False,
         **kwargs: Any,
     ) -> "CondensePlusContextChatEngine":
         """Initialize a CondensePlusContextChatEngine from default parameters."""
@@ -170,6 +173,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             node_postprocessors=node_postprocessors,
             system_prompt=system_prompt,
             verbose=verbose,
+            fallback_to_llm=fallback_to_llm,
         )
 
     def _condense_question(
@@ -251,6 +255,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             streaming,
             qa_function_mappings=self._context_prompt_template.function_mappings,
             refine_function_mappings=self._context_refine_prompt_template.function_mappings,
+            fallback_to_llm=self._fallback_to_llm,
         )
 
     def _run_c3(

--- a/llama-index-core/llama_index/core/chat_engine/context.py
+++ b/llama-index-core/llama_index/core/chat_engine/context.py
@@ -71,6 +71,7 @@ class ContextChatEngine(BaseChatEngine):
         context_template: Optional[Union[str, PromptTemplate]] = None,
         context_refine_template: Optional[Union[str, PromptTemplate]] = None,
         callback_manager: Optional[CallbackManager] = None,
+        fallback_to_llm: bool = False,
     ) -> None:
         self._retriever = retriever
         self._llm = llm
@@ -87,6 +88,7 @@ class ContextChatEngine(BaseChatEngine):
         if isinstance(context_refine_template, str):
             context_refine_template = PromptTemplate(context_refine_template)
         self._context_refine_template = context_refine_template
+        self._fallback_to_llm = fallback_to_llm
 
         self.callback_manager = callback_manager or CallbackManager([])
         for node_postprocessor in self._node_postprocessors:
@@ -104,6 +106,7 @@ class ContextChatEngine(BaseChatEngine):
         context_template: Optional[Union[str, PromptTemplate]] = None,
         context_refine_template: Optional[Union[str, PromptTemplate]] = None,
         llm: Optional[LLM] = None,
+        fallback_to_llm: bool = False,
         **kwargs: Any,
     ) -> "ContextChatEngine":
         """Initialize a ContextChatEngine from default parameters."""
@@ -135,6 +138,7 @@ class ContextChatEngine(BaseChatEngine):
             callback_manager=Settings.callback_manager,
             context_template=context_template,
             context_refine_template=context_refine_template,
+            fallback_to_llm=fallback_to_llm,
         )
 
     def _get_nodes(self, message: str) -> List[NodeWithScore]:
@@ -195,6 +199,7 @@ class ContextChatEngine(BaseChatEngine):
             streaming,
             qa_function_mappings=self._context_template.function_mappings,
             refine_function_mappings=self._context_refine_template.function_mappings,
+            fallback_to_llm=self._fallback_to_llm,
         )
 
     @trace_method("chat")

--- a/llama-index-core/llama_index/core/chat_engine/utils.py
+++ b/llama-index-core/llama_index/core/chat_engine/utils.py
@@ -37,6 +37,7 @@ def get_response_synthesizer(
     streaming: bool = False,
     qa_function_mappings: Optional[Dict[str, Callable]] = None,
     refine_function_mappings: Optional[Dict[str, Callable]] = None,
+    fallback_to_llm: bool = False,
 ) -> CompactAndRefine:
     return CompactAndRefine(
         llm=llm,
@@ -50,6 +51,7 @@ def get_response_synthesizer(
             function_mappings=refine_function_mappings,
         ),
         streaming=streaming,
+        fallback_to_llm=fallback_to_llm,
     )
 
 

--- a/llama-index-core/llama_index/core/response_synthesizers/base.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/base.py
@@ -74,6 +74,7 @@ class BaseSynthesizer(PromptMixin, DispatcherSpanMixin):
         output_cls: Optional[Type[BaseModel]] = None,
         empty_response: Optional[str] = None,
         multimodal: bool = False,
+        fallback_to_llm: bool = False,
     ) -> None:
         """Init params."""
         self._llm = llm or Settings.llm
@@ -86,6 +87,7 @@ class BaseSynthesizer(PromptMixin, DispatcherSpanMixin):
         self._output_cls = output_cls
         self._empty_response = empty_response or "Empty Response"
         self._multimodal = multimodal
+        self._fallback_to_llm = fallback_to_llm
         self._prompt_helper: PromptHelper
         if multimodal:
             if not is_chat_model(self._llm):
@@ -242,7 +244,7 @@ class BaseSynthesizer(PromptMixin, DispatcherSpanMixin):
             )
         )
 
-        if len(nodes) == 0:
+        if len(nodes) == 0 and not self._fallback_to_llm:
             if self._streaming:
                 empty_response_stream = StreamingResponse(
                     response_gen=self._empty_response_generator()
@@ -322,7 +324,7 @@ class BaseSynthesizer(PromptMixin, DispatcherSpanMixin):
                 query=query,
             )
         )
-        if len(nodes) == 0:
+        if len(nodes) == 0 and not self._fallback_to_llm:
             if self._streaming:
                 empty_response_stream = AsyncStreamingResponse(
                     response_gen=self._empty_response_agenerator()

--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -222,6 +222,7 @@ class Refine(BaseSynthesizer):
             Callable[[BasePromptTemplate], BasePydanticProgram]
         ] = None,
         multimodal: bool = False,
+        fallback_to_llm: bool = False,
     ) -> None:
         super().__init__(
             llm=llm,
@@ -230,6 +231,7 @@ class Refine(BaseSynthesizer):
             chat_prompt_helper=chat_prompt_helper,
             streaming=streaming,
             multimodal=multimodal,
+            fallback_to_llm=fallback_to_llm,
         )
         self._text_qa_template = text_qa_template or DEFAULT_TEXT_QA_PROMPT_SEL
         self._refine_template = refine_template or DEFAULT_REFINE_PROMPT_SEL

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -1,8 +1,10 @@
 import time
+from typing import List
 
 import pytest
 
 from llama_index.core import MockEmbedding
+from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.base.llms.types import MessageRole
 from llama_index.core.chat_engine.condense_plus_context import (
     CondensePlusContextChatEngine,
@@ -10,7 +12,7 @@ from llama_index.core.chat_engine.condense_plus_context import (
 from llama_index.core.indices import VectorStoreIndex
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.memory import ChatMemoryBuffer
-from llama_index.core.schema import Document
+from llama_index.core.schema import Document, NodeWithScore, QueryBundle
 
 SYSTEM_PROMPT = "Talk like a pirate."
 
@@ -138,3 +140,58 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+class _EmptyRetriever(BaseRetriever):
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return []
+
+    async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return []
+
+
+def _empty_context_engine(fallback_to_llm: bool) -> CondensePlusContextChatEngine:
+    return CondensePlusContextChatEngine.from_defaults(
+        _EmptyRetriever(),
+        llm=MockLLM(),
+        system_prompt=SYSTEM_PROMPT,
+        fallback_to_llm=fallback_to_llm,
+    )
+
+
+def test_empty_retrieval_returns_empty_response_by_default():
+    chat_engine = _empty_context_engine(fallback_to_llm=False)
+
+    assert str(chat_engine.chat("Hello World!")) == "Empty Response"
+    assert (
+        "".join(_empty_context_engine(False).stream_chat("Hello World!").response_gen)
+        == "Empty Response"
+    )
+
+
+def test_empty_retrieval_calls_llm_when_fallback_enabled():
+    chat_engine = _empty_context_engine(fallback_to_llm=True)
+    response = chat_engine.chat("Hello World!")
+
+    # MockLLM echoes the prompt, so this only passes if the LLM was really called
+    assert "Empty Response" not in str(response)
+    assert SYSTEM_PROMPT in str(response)
+    assert "Hello World!" in str(response)
+    assert len(chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_retrieval_astream_chat_with_fallback():
+    chat_engine = _empty_context_engine(fallback_to_llm=True)
+    stream = await chat_engine.astream_chat("Hello World!")
+    response = "".join([token async for token in stream.async_response_gen()])
+
+    assert "Empty Response" not in response
+    assert SYSTEM_PROMPT in response
+
+    default_engine = _empty_context_engine(fallback_to_llm=False)
+    default_stream = await default_engine.astream_chat("Hello World!")
+    assert (
+        "".join([token async for token in default_stream.async_response_gen()])
+        == "Empty Response"
+    )

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -252,3 +252,34 @@ async def test_aget_nodes_calls_async_postprocessor() -> None:
 
     assert postprocessor.called_async is True
     assert postprocessor.called_sync is False
+
+
+class _EmptyRetriever(BaseRetriever):
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return []
+
+    async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return []
+
+
+def _empty_context_engine(fallback_to_llm: bool) -> ContextChatEngine:
+    return ContextChatEngine.from_defaults(
+        _EmptyRetriever(),
+        llm=MockLLM(),
+        system_prompt=SYSTEM_PROMPT,
+        fallback_to_llm=fallback_to_llm,
+    )
+
+
+def test_empty_retrieval_returns_empty_response_by_default():
+    assert str(_empty_context_engine(False).chat("Hello World!")) == "Empty Response"
+
+
+def test_empty_retrieval_calls_llm_when_fallback_enabled():
+    chat_engine = _empty_context_engine(True)
+    response = chat_engine.chat("Hello World!")
+
+    # MockLLM echoes the prompt, so this only passes if the LLM was really called
+    assert "Empty Response" not in str(response)
+    assert SYSTEM_PROMPT in str(response)
+    assert len(chat_engine.chat_history) == 2


### PR DESCRIPTION
# Description

When a retriever returns zero nodes, `BaseSynthesizer.synthesize` / `asynthesize` short-circuit to the hardcoded `"Empty Response"` and never call the LLM:

https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/response_synthesizers/base.py#L245
https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/response_synthesizers/base.py#L325

That is a good default — a query engine should not answer from outside its knowledge base — but multi-tenant RAG with metadata filters legitimately retrieves 0 nodes, and there is currently no way to opt out. The system prompt and the chat history are both ignored, in under a second, with no exception raised.

This is not limited to `astream_chat` as the issue title suggests. All four methods of both `CondensePlusContextChatEngine` and `ContextChatEngine` are affected (`ContextChatEngine` shares `chat_engine/utils.py::get_response_synthesizer`), as verified below.

## The change

`fallback_to_llm: bool = False` on `BaseSynthesizer.__init__`, threaded through `Refine` (and so `CompactAndRefine`), `chat_engine/utils.py::get_response_synthesizer`, and the two context chat engines' `__init__` / `from_defaults`. The zero-node guard becomes `if len(nodes) == 0 and not self._fallback_to_llm:`.

Nothing else was needed: `CompactAndRefine._make_compact_text_chunks(query, [])` already returns `[""]`, so once the guard is bypassed the normal synthesis path handles the empty case in sync, async and streaming form.

Following @logan-markewich's direction on the issue — *"If someone wants to actually fix this, this needs to be an option on the chat engine, not a default behaviour"* — and @AstraBert's review notes on the earlier attempts: the default is `False`, and the parameter is named `fallback_to_llm` exactly as suggested in the review of #21040. One name is used at every level so there is nothing to bikeshed.

**Deliberately out of scope:** `response_synthesizers/factory.py::get_response_synthesizer`. Threading the flag there means one parameter plus seven constructor branches, and it would expose the flag on `TreeSummarize` / `SimpleSummarize` / `Accumulate`, whose zero-chunk behaviour I have not verified. Query engines are therefore unchanged and keep today's behaviour exactly. Happy to extend if a maintainer prefers that.

**Also worth noting:** `#20942` was closed as "already fixed by #20897", but #20897 fixes #20895 (chat history lost when a stream is not fully consumed) and does not touch the empty-node path. #20894 is still unfixed on `main`.

Fixes #20894

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — `llama-index-core` is exempt

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Three tests in `tests/chat_engine/test_condense_plus_context.py` and two in `tests/chat_engine/test_context.py`. Each pins **both** sides of the contract: the default still returns `"Empty Response"` (so no existing behaviour moves), and with `fallback_to_llm=True` the response contains the system prompt — `MockLLM` echoes its prompt, so that assertion can only pass if the LLM was genuinely called.

Verified behaviour, an empty retriever on both engines, all four methods:

```
CondensePlusContextChatEngine fallback_to_llm=False     ContextChatEngine fallback_to_llm=False
   chat          'Empty Response'                          chat          'Empty Response'
   achat         'Empty Response'                          achat         'Empty Response'
   stream_chat   'Empty Response'                          stream_chat   'Empty Response'
   astream_chat  'Empty Response'                          astream_chat  'Empty Response'

CondensePlusContextChatEngine fallback_to_llm=True      ContextChatEngine fallback_to_llm=True
   chat          'text text text text'                     chat          'text text text text'
   achat         'text text text text'                     achat         'text text text text'
   stream_chat   'text text text text'                     stream_chat   'text text text text'
   astream_chat  'text text text text'                     astream_chat  'text text text text'
```

```
$ pytest tests/chat_engine/ -q
42 passed

$ pytest tests -q          # whole llama-index-core suite
1466 passed, 39 skipped, 6 xfailed

$ mypy llama_index
Success: no issues found in 479 source files
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
