### PR TITLE
feat(core): give ChatMessage an id_ (#14881)

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import uuid
 from abc import ABC
 
 from enum import Enum
@@ -1162,6 +1163,32 @@ class ChatMessage(BaseRecursiveContentBlock):
     role: MessageRole = MessageRole.USER
     additional_kwargs: dict[str, Any] = Field(default_factory=dict)
     blocks: list[ContentBlock] = Field(default_factory=list)
+    id_: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description=(
+            "Unique ID of the message. Generated on creation, so a message read "
+            "back from a store persisted before this field existed gets a new one."
+        ),
+    )
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Compare messages by content.
+
+        The per-message ``id_`` is deliberately excluded, so two messages carrying
+        the same thing stay equal the way they were before ``id_`` existed.
+        """
+        if not isinstance(other, ChatMessage) or type(self) is not type(other):
+            return NotImplemented
+        return (self.role, self.additional_kwargs, self.blocks) == (
+            other.role,
+            other.additional_kwargs,
+            other.blocks,
+        )
+
+    def can_merge(self, other: Self) -> bool:
+        """Two mergeable messages differ in ``id_``, which must not block the merge."""
+        return super().can_merge(other.model_copy(update={"id_": self.id_}))
 
     def __init__(self, /, content: Any | None = None, **data: Any) -> None:
         """

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -175,6 +175,7 @@ def test_chat_message_serializer():
             "some_object": {"some_field": ""},
         },
         "blocks": [{"block_type": "text", "text": "test content"}],
+        "id_": m.id_,
     }
 
 
@@ -189,6 +190,7 @@ def test_chat_message_legacy_roundtrip():
         "additional_kwargs": {},
         "blocks": [{"block_type": "text", "text": "foo"}],
         "role": MessageRole.USER,
+        "id_": m.id_,
     }
 
 
@@ -1956,3 +1958,48 @@ def test_tool_call_block_format():
     # Currently, ToolCallBlock does not support template vars
     assert formatted_block.tool_name == "{tool_name}"
     assert formatted_block.tool_kwargs == {"param": "{param_value}"}
+
+
+def test_chat_message_gets_a_unique_id():
+    m1 = ChatMessage(content="same text")
+    m2 = ChatMessage(content="same text")
+
+    assert m1.id_ and m2.id_
+    assert m1.id_ != m2.id_
+    assert ChatMessage(content="x", id_="fixed").id_ == "fixed"
+
+
+def test_chat_message_equality_ignores_id():
+    m1 = ChatMessage(content="same text")
+    m2 = ChatMessage(content="same text")
+
+    assert m1.id_ != m2.id_
+    assert m1 == m2
+    assert m1 != ChatMessage(content="other text")
+    assert m1 != ChatMessage(content="same text", role=MessageRole.ASSISTANT)
+    assert m1 != ChatMessage(content="same text", additional_kwargs={"a": 1})
+    assert m1 != "same text"
+
+
+def test_chat_message_id_survives_a_roundtrip():
+    m = ChatMessage(content="persisted")
+
+    assert ChatMessage.model_validate(m.model_dump()).id_ == m.id_
+
+    # data persisted before id_ existed still loads, and gets an id_ of its own
+    legacy = ChatMessage.model_validate(
+        {"role": MessageRole.USER, "blocks": [{"block_type": "text", "text": "old"}]}
+    )
+    assert legacy.id_
+
+
+@pytest.mark.asyncio
+async def test_chat_message_amerge_ignores_differing_ids():
+    m1 = ChatMessage(content="Hello")
+    m2 = ChatMessage(content="world!")
+    assert m1.id_ != m2.id_
+
+    merged = await ChatMessage.amerge([m1, m2], chunk_size=10000)
+
+    assert len(merged) == 1
+    assert merged[0].content == "Hello world!"


### PR DESCRIPTION
# Description

`ChatMessage` has no id, so every chat store, memory implementation and observability integration invents its own correlation key. This has been P1 and open since 2024-07.

Adds `id_: str`, a `uuid4` by default, mirroring the `BaseNode.id_` precedent in `schema.py`.

Two extra pieces are what make it a non-event for existing code, and neither is optional:

**1. `__eq__` ignores `id_`.** Without it, `ChatMessage(content="x") != ChatMessage(content="x")`, which breaks 30+ existing assertions and, more importantly, is a silent behaviour change for any user comparing messages.

**2. `can_merge` ignores `id_`.** This is the non-obvious one. `BaseRecursiveContentBlock.can_merge` (`types.py:822`) compares the *entire* `model_dump()` minus the nested-blocks field:

```python
atts = {k: v for k, v in self.model_dump().items() if k != self.nested_blocks_field_name()}
```

A per-message uuid lands in that dict, so **no two messages would ever be mergeable**. Measured on the core suite: the field alone gives 54 failures (up from a 12-failure baseline of unrelated `pandas` import errors), including `RecursionError` in `tree_summarize`, `ValueError` from `PromptHelper.repack`, and dropped image blocks in `simple_summarize`. It is a functional regression, not test churn. The override brings that to the 2 serializer assertions below.

```python
def can_merge(self, other: Self) -> bool:
    return super().can_merge(other.model_copy(update={"id_": self.id_}))
```

Both are scoped to `ChatMessage` — no generic exclude-list on the base class for one field at one call site, and not `Field(exclude=True)`, which would drop `id_` from `model_dump()` and defeat persistence.

## Notes for the reviewer

- **Pre-existing persisted data**: rows written before this change have no `id_`, so each read mints a fresh one. Ids are stable only from the first write after upgrading. The field description says so. `Optional[str] = None` would avoid it but gives up auto-generation, which is the point of the issue.
- **`amerge`** gives the merged message `cur_blocks[0].id_` (it builds from `cur_blocks[0].model_dump()`). Inheriting the first message's id seemed more useful than minting a new one; happy to change.
- **`asplit`** makes every split share the parent's `id_`. Splits are ephemeral prompt-construction artifacts that get merged back and are never persisted, so I left it alone rather than adding code. One-line fix (`attributes.pop("id_", None)`) if you would rather they were distinct.
- **No leak to providers**: integrations convert via explicit `to_*_message_dict` functions, not `model_dump()` (`grep -rn "model_dump(" llama-index-integrations/llms` finds no message dumps). The only core `model_dump()` consumers are `storage/chat_store/sql.py` (intended) and `memory/vector_memory.py`, where `id_` lands in node metadata harmlessly.

Fixes #14881

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — `llama-index-core` is exempt

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four tests in `tests/base/llms/test_types.py`: ids are unique and explicitly settable; equality ignores `id_` while still discriminating on role / blocks / `additional_kwargs` / non-`ChatMessage`; `id_` survives a `model_dump` → `model_validate` round trip and legacy data without the key still loads; and `amerge` of two messages with different ids still returns one message — the guard for piece 2 above.

Two existing tests were updated: `test_chat_message_serializer` and `test_chat_message_legacy_roundtrip` both assert the full `model_dump()` dict, so `"id_": m.id_` was added. Those are the only two assertions in the suite that needed touching.

```
$ pytest tests -q          # whole llama-index-core suite
1465 passed, 39 skipped, 6 xfailed

$ mypy llama_index
Success: no issues found in 479 source files
```

`ChatMessage.__hash__` was already `None` before this change (pydantic does that for any non-frozen model), so defining `__eq__` costs no hashability.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
