### PR TITLE
fix(missing_documentation): Def `asyncio_module` in llama-index-core/llama_index/core/as

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -23,6 +23,31 @@ def get_asyncio_module(show_progress: bool = False) -> Any:
 
 
 def asyncio_module(show_progress: bool = False) -> Any:
+    """Return the asyncio module or a tqdm-wrapped equivalent (deprecated).
+
+    .. deprecated::
+        Use :func:`get_asyncio_module` instead.  This function will be removed
+        in a future release.
+
+    Args:
+        show_progress (bool): If ``True``, returns ``tqdm.asyncio.tqdm_asyncio``
+            so that async gather calls display a progress bar.  If ``False``
+            (the default), returns the standard :mod:`asyncio` module.
+
+    Returns:
+        Any: Either the built-in :mod:`asyncio` module or
+        ``tqdm.asyncio.tqdm_asyncio``, depending on *show_progress*.
+
+    Example:
+        >>> import warnings
+        >>> from llama_index.core.async_utils import asyncio_module
+        >>> with warnings.catch_warnings():
+        ...     warnings.simplefilter("ignore", DeprecationWarning)
+        ...     mod = asyncio_module(show_progress=False)
+        >>> import asyncio
+        >>> mod is asyncio
+        True
+    """
     import warnings
 
     warnings.warn(

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -37,3 +37,29 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_asyncio_module_deprecation_warning() -> None:
+    """asyncio_module() should emit a DeprecationWarning."""
+    import warnings
+    from llama_index.core.async_utils import asyncio_module
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        asyncio_module()
+
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+        "Expected a DeprecationWarning from asyncio_module()"
+    )
+
+
+def test_asyncio_module_returns_asyncio_by_default() -> None:
+    """asyncio_module(show_progress=False) should return the asyncio module."""
+    import warnings
+    from llama_index.core.async_utils import asyncio_module
+
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        mod = asyncio_module(show_progress=False)
+
+    assert mod is asyncio


### PR DESCRIPTION
## TLDR

        **Gap:** Def `asyncio_module` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example

        **Wedge type:** `missing_documentation`

        **Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L25

        ## Changes

        - `llama-index-core/llama_index/core/async_utils.py`
- `llama-index-core/tests/test_async_utils.py`

        **Diff size:** 51 lines across 2 file(s)

        ## Pre-submission checklist

        - [x] Minimal change — touches at most 3 files
        - [x] Tests updated (if test suite present)
        - [x] No CI/CD, Dockerfile, or lock file modifications
        - [x] Diff reviewed for secrets

        ## AI Assistance Disclosure

        This contribution was AI-assisted using Hermes Agent (Nous Research).

        Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>