### PR TITLE
fix(missing_documentation): Def `get_asyncio_module` in llama-index-core/llama_index/cor

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -12,6 +12,37 @@ dispatcher = instrument.get_dispatcher(__name__)
 
 
 def get_asyncio_module(show_progress: bool = False) -> Any:
+    """Return the asyncio module to use, optionally with progress-bar support.
+
+    When *show_progress* is ``True`` the function returns
+    :class:`tqdm.asyncio.tqdm_asyncio`, which wraps standard asyncio
+    gather/wait calls with a ``tqdm`` progress bar.  Otherwise the
+    built-in :mod:`asyncio` module is returned unchanged.
+
+    Args:
+        show_progress (bool): If ``True``, return ``tqdm.asyncio.tqdm_asyncio``
+            so that async gathering operations display a progress bar.
+            Defaults to ``False``.
+
+    Returns:
+        Any: Either :mod:`asyncio` or :class:`tqdm.asyncio.tqdm_asyncio`,
+        both of which expose a compatible ``gather`` / ``as_completed``
+        interface.
+
+    Example:
+        .. code-block:: python
+
+            from llama_index.core.async_utils import get_asyncio_module
+
+            # Plain asyncio (no progress bar)
+            module = get_asyncio_module(show_progress=False)
+            results = module.run(some_coroutine())
+
+            # With tqdm progress bar
+            module = get_asyncio_module(show_progress=True)
+            results = module.gather(*coroutines)
+
+    """
     if show_progress:
         from tqdm.asyncio import tqdm_asyncio
 

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -37,3 +37,40 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_asyncio_module
+# ---------------------------------------------------------------------------
+
+def test_get_asyncio_module_default_returns_asyncio() -> None:
+    """get_asyncio_module() with no arguments should return the asyncio module."""
+    from llama_index.core.async_utils import get_asyncio_module
+
+    module = get_asyncio_module()
+    assert module is asyncio
+
+
+def test_get_asyncio_module_show_progress_false_returns_asyncio() -> None:
+    """get_asyncio_module(show_progress=False) should return the asyncio module."""
+    from llama_index.core.async_utils import get_asyncio_module
+
+    module = get_asyncio_module(show_progress=False)
+    assert module is asyncio
+
+
+def test_get_asyncio_module_show_progress_true_returns_tqdm() -> None:
+    """get_asyncio_module(show_progress=True) should return tqdm_asyncio."""
+    pytest.importorskip("tqdm")
+    from tqdm.asyncio import tqdm_asyncio
+    from llama_index.core.async_utils import get_asyncio_module
+
+    module = get_asyncio_module(show_progress=True)
+    assert module is tqdm_asyncio
+
+
+def test_get_asyncio_module_has_gather() -> None:
+    """The returned module must expose a 'gather' attribute in both modes."""
+    from llama_index.core.async_utils import get_asyncio_module
+
+    assert hasattr(get_asyncio_module(show_progress=False), "gather")


### PR DESCRIPTION
## TLDR

        **Gap:** Def `get_asyncio_module` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example [BLOCKED:Tests failed after retry: pants --level=error --no-local-cache --changed-since=origin/main --changed-dependents=transitive --no-test-use-coverage test

        **Wedge type:** `missing_documentation`

        **Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L14

        ## Changes

        - `llama-index-core/llama_index/core/async_utils.py`
- `llama-index-core/tests/test_async_utils.py`

        **Diff size:** 68 lines across 2 file(s)

        ## Pre-submission checklist

        - [x] Minimal change — touches at most 3 files
        - [x] Tests updated (if test suite present)
        - [x] No CI/CD, Dockerfile, or lock file modifications
        - [x] Diff reviewed for secrets

        ## AI Assistance Disclosure

        This contribution was AI-assisted using Hermes Agent (Nous Research).

        Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>