### PR TITLE
fix(core): respect zero voice export limits

### DIFF
--- a/llama-index-core/llama_index/core/voice_agents/base.py
+++ b/llama-index-core/llama_index/core/voice_agents/base.py
@@ -128,7 +128,7 @@ class BaseVoiceAgent(ABC):
 
         """
         messages = self._messages
-        if limit:
+        if limit is not None:
             if limit <= len(messages):
                 messages = messages[:limit]
         if filter:
@@ -154,7 +154,7 @@ class BaseVoiceAgent(ABC):
 
         """
         events = self._events
-        if limit:
+        if limit is not None:
             if limit <= len(events):
                 events = events[:limit]
         if filter:

--- a/llama-index-core/tests/voice_agents/test_subclasses.py
+++ b/llama-index-core/tests/voice_agents/test_subclasses.py
@@ -184,6 +184,20 @@ async def test_websocket_subclassing(mock_websocket: MockVoiceAgentWebsocket):
     assert mock_websocket.ws._is_closed
 
 
+def test_agent_export_zero_limit(mock_agent: MockVoiceAgent):
+    mock_agent._events = [
+        BaseVoiceAgentEvent(type_t="send"),
+        BaseVoiceAgentEvent(type_t="text"),
+    ]
+    mock_agent._messages = [
+        ChatMessage(role="user", content="Hello world"),
+        ChatMessage(role="assistant", content="content"),
+    ]
+
+    assert mock_agent.export_events(limit=0) == []
+    assert mock_agent.export_messages(limit=0) == []
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(not websockets_available, reason="websockets library not installed")
 async def test_agent_subclassing(mock_agent: MockVoiceAgent):


### PR DESCRIPTION
# Description

`BaseVoiceAgent.export_messages()` and `export_events()` document `limit` as the maximum number of records to return, but both used a truthiness check. As a result, an explicit `limit=0` was treated like `None` and returned every recorded message or event.

This changes the guard to distinguish `None` from zero. Existing behavior for positive limits, limits larger than the collection, filters, and omitted limits is unchanged.

Fixes # (N/A; regression found on the current default branch)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — `llama-index-core` is exempt

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

### Verification

- Before the fix: `pytest tests/voice_agents/test_subclasses.py -q -k export_zero_limit` failed because `limit=0` returned two events.
- After the fix: `pytest tests/voice_agents -q` -> `2 passed, 3 skipped` (the skipped tests require the optional `websockets` dependency).
- `ruff check llama_index/core/voice_agents/base.py tests/voice_agents/test_subclasses.py`
- `ruff format --check llama_index/core/voice_agents/base.py tests/voice_agents/test_subclasses.py`
- `mypy llama_index/core/voice_agents/base.py`

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for newly added notebooks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally
- [x] I ran the package lint and format checks on the changed files

## AI Assistance

I used AI assistance to inspect the export-limit behavior, search for duplicate issues and pull requests, and draft the focused regression test. I reviewed the final two-line implementation, verified the test fails before and passes after the change, and ran the checks listed above.