### PR TITLE
fix(oci-data-science): honor per-call strict false

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/llama_index/llms/oci_data_science/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/llama_index/llms/oci_data_science/base.py
@@ -856,7 +856,7 @@ class OCIDataScience(FunctionCallingLLM):
         )
 
         # Determine strict mode
-        strict = strict or self.strict
+        strict = self.strict if strict is None else strict
 
         if self.metadata.is_function_calling_model:
             for tool_spec in tool_specs:

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-oci-data-science"
-version = "1.1.0"
+version = "1.1.1"
 description = "llama-index llms OCI Data Science integration"
 authors = [{name = "Dmitrii Cherkasov", email = "dmitrii.cherkasov@oracle.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_llms_oci_data_science.py
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/tests/test_llms_oci_data_science.py
@@ -298,6 +298,18 @@ def test_prepare_chat_with_tools_tool_not_required(llm):
     assert result["tools"][0]["function"]["name"] == "search_tool"
 
 
+def test_prepare_chat_with_tools_allows_disabling_strict_per_call(llm):
+    llm.strict = True
+
+    result = llm._prepare_chat_with_tools(
+        tools=[search_tool],
+        user_msg="Search for information about Python",
+        strict=False,
+    )
+
+    assert "strict" not in result["tools"][0]["function"]
+
+
 def test_prepare_chat_with_tools_explicit_tool_choice_overrides_tool_required(llm):
     """Test that explicit tool_choice parameter overrides tool_required."""
     user_msg = "Search for information about Python"

--- a/llama-index-integrations/llms/llama-index-llms-oci-data-science/uv.lock
+++ b/llama-index-integrations/llms/llama-index-llms-oci-data-science/uv.lock
@@ -1833,7 +1833,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-llms-oci-data-science"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`OCIDataScience._prepare_chat_with_tools()` currently resolves strict mode with
`strict or self.strict`. As a result, a caller cannot disable strict mode for one
request when the LLM instance was configured with `strict=True`.

This change distinguishes an omitted value (`None`) from an explicit `False`, so
per-call configuration overrides the instance default as documented. It also adds
a regression test and bumps the integration package version to `1.1.1`.

No additional dependencies are required.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Verification:

- `pytest tests/test_llms_oci_data_science.py -q` (`17 passed`)
- `ruff check llama_index/llms/oci_data_science/base.py tests/test_llms_oci_data_science.py`
- `ruff format --check llama_index/llms/oci_data_science/base.py tests/test_llms_oci_data_science.py`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI Assistance

AI-assisted code search was used to identify the candidate and help draft the
test and description. I reviewed every changed line, reproduced the failure
before the fix, and ran the verification commands above after the fix.
