### PR TITLE
fix(core): respect empty condense chat history

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -174,7 +174,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     def chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
-        chat_history = chat_history or self._memory.get(input=message)
+        if chat_history is None:
+            chat_history = self._memory.get(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
@@ -219,7 +220,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     def stream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
-        chat_history = chat_history or self._memory.get(input=message)
+        if chat_history is None:
+            chat_history = self._memory.get(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
@@ -277,7 +279,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     async def achat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
-        chat_history = chat_history or await self._memory.aget(input=message)
+        if chat_history is None:
+            chat_history = await self._memory.aget(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)
@@ -322,7 +325,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     async def astream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
-        chat_history = chat_history or await self._memory.aget(input=message)
+        if chat_history is None:
+            chat_history = await self._memory.aget(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)

--- a/llama-index-core/tests/chat_engine/test_condense_question.py
+++ b/llama-index-core/tests/chat_engine/test_condense_question.py
@@ -50,6 +50,19 @@ def test_condense_question_chat_engine_with_init_history(patch_llm_predictor) ->
     )
 
 
+def test_condense_question_chat_engine_respects_empty_history(
+    patch_llm_predictor,
+) -> None:
+    query_engine = Mock(spec=BaseQueryEngine)
+    query_engine.query.side_effect = lambda x: Response(response=x)
+    engine = CondenseQuestionChatEngine.from_defaults(query_engine=query_engine)
+
+    engine.chat("previous message")
+    response = engine.chat("standalone message", chat_history=[])
+
+    assert str(response) == "standalone message"
+
+
 def test_stream_chat_history_write_completes_on_early_exit() -> None:
     def token_gen():
         for token in ["Hello", " ", "World", "!"]:


### PR DESCRIPTION
# Description

`CondenseQuestionChatEngine` currently resolves a per-call chat history with
`chat_history or self._memory.get(...)`. This treats an explicitly empty list as
if no override was provided, so a caller cannot request a standalone turn after
the engine has accumulated history.

This change only falls back to memory when `chat_history is None`, consistently
across the synchronous, streaming, asynchronous, and asynchronous streaming
entry points. A regression test proves that `chat_history=[]` leaves the new
message uncondensed.

No additional dependencies are required.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (llama-index-core)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Verification:

- `pytest tests/chat_engine/test_condense_question.py -q` (`4 passed`)
- `ruff check llama_index/core/chat_engine/condense_question.py tests/chat_engine/test_condense_question.py`
- `ruff format --check llama_index/core/chat_engine/condense_question.py tests/chat_engine/test_condense_question.py`
- `mypy llama_index/core/chat_engine/condense_question.py`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI Assistance

AI-assisted code search was used to identify the candidate and help draft the
test and description. I reviewed every changed line, reproduced the failure
before the fix, and ran the verification commands above after the fix.
