### PR TITLE
fix(core): await pydantic multi selector program

### DIFF
--- a/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
@@ -155,4 +155,17 @@ class PydanticMultiSelector(BaseSelector):
     async def _aselect(
         self, choices: Sequence[ToolMetadata], query: QueryBundle
     ) -> SelectorResult:
-        return self._select(choices, query)
+        # prepare input
+        context_list = _build_choices_text(choices)
+        max_outputs = self._max_outputs or len(choices)
+
+        # predict
+        prediction = await self._selector_program.acall(
+            num_choices=len(choices),
+            max_outputs=max_outputs,
+            context_list=context_list,
+            query_str=query.query_str,
+        )
+
+        # parse output
+        return _pydantic_output_to_selector_result(prediction)

--- a/llama-index-core/tests/selectors/test_pydantic_selectors.py
+++ b/llama-index-core/tests/selectors/test_pydantic_selectors.py
@@ -1,0 +1,36 @@
+from typing import Any, Type
+
+import pytest
+
+from llama_index.core.base.base_selector import MultiSelection, SingleSelection
+from llama_index.core.selectors.pydantic_selectors import PydanticMultiSelector
+from llama_index.core.types import BasePydanticProgram
+
+
+class AsyncOnlyMultiSelectionProgram(BasePydanticProgram[MultiSelection]):
+    @property
+    def output_cls(self) -> Type[MultiSelection]:
+        return MultiSelection
+
+    def __call__(self, *args: Any, **kwargs: Any) -> MultiSelection:
+        raise AssertionError("The synchronous program should not be called")
+
+    async def acall(self, *args: Any, **kwargs: Any) -> MultiSelection:
+        return MultiSelection(
+            selections=[SingleSelection(index=1, reason="most relevant")]
+        )
+
+
+@pytest.mark.asyncio
+async def test_pydantic_multi_selector_uses_async_program() -> None:
+    selector = PydanticMultiSelector(
+        selector_program=AsyncOnlyMultiSelectionProgram(),
+        max_outputs=1,
+    )
+
+    result = await selector.aselect(
+        choices=["apple", "pear"],
+        query="Which fruit is most relevant?",
+    )
+
+    assert result.inds == [0]


### PR DESCRIPTION
# Description

`PydanticMultiSelector._aselect()` currently delegates to the synchronous
`_select()` implementation. As a result, `aselect()` invokes the program's
blocking `__call__` method inside the event loop instead of awaiting `acall()`.

This change implements the asynchronous path consistently with
`PydanticSingleSelector`: it builds the same selection context, awaits the
program's `acall()`, and converts the returned Pydantic selection normally.

The regression test uses an async-only program whose synchronous call raises,
proving that `aselect()` no longer enters the synchronous path.

No additional dependencies are required.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (llama-index-core)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Verification:

- `pytest tests/selectors/test_pydantic_selectors.py tests/selectors/test_llm_selectors.py -q` (`4 passed`)
- `ruff check llama_index/core/selectors/pydantic_selectors.py tests/selectors/test_pydantic_selectors.py`
- `ruff format --check llama_index/core/selectors/pydantic_selectors.py tests/selectors/test_pydantic_selectors.py`
- `mypy llama_index/core/selectors/pydantic_selectors.py tests/selectors/test_pydantic_selectors.py`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI Assistance

AI-assisted code search was used to identify the candidate and help draft the
test and description. I reviewed every changed line, reproduced the failure
before the fix, and ran the verification commands above after the fix.
