### PR TITLE
fix(missing_documentation): Def `chunks` in llama-index-core/llama_index/core/async_util

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -113,6 +113,29 @@ def run_async_tasks(
 
 
 def chunks(iterable: Iterable, size: int) -> Iterable:
+    """Split an iterable into fixed-size chunks, padding the last chunk with ``None``.
+
+    Uses :func:`itertools.zip_longest` under the hood so that every chunk
+    yielded is exactly ``size`` elements long.  If the iterable length is not
+    evenly divisible by ``size`` the final chunk is padded with ``None``
+    values.
+
+    Args:
+        iterable (Iterable): The input iterable to split into chunks.
+        size (int): The maximum number of elements per chunk.  Must be a
+            positive integer.
+
+    Returns:
+        Iterable: An iterable of tuples, each of length ``size``.  The last
+        tuple may contain ``None`` fill values if ``len(iterable)`` is not a
+        multiple of ``size``.
+
+    Example:
+        >>> list(chunks([1, 2, 3, 4, 5], 2))
+        [(1, 2), (3, 4), (5, None)]
+        >>> list(chunks(range(6), 3))
+        [(0, 1, 2), (3, 4, 5)]
+    """
     args = [iter(iterable)] * size
     return zip_longest(*args, fillvalue=None)
 

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -37,3 +37,31 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+from llama_index.core.async_utils import chunks
+
+
+def test_chunks_even_split() -> None:
+    """chunks() splits an evenly-divisible iterable into equal-size tuples."""
+    result = list(chunks([1, 2, 3, 4], 2))
+    assert result == [(1, 2), (3, 4)]
+
+
+def test_chunks_with_padding() -> None:
+    """chunks() pads the last tuple with None when the iterable length is not
+    a multiple of the chunk size."""
+    result = list(chunks([1, 2, 3, 4, 5], 2))
+    assert result == [(1, 2), (3, 4), (5, None)]
+
+
+def test_chunks_size_larger_than_iterable() -> None:
+    """chunks() returns a single padded tuple when size > len(iterable)."""
+    result = list(chunks([1, 2], 5))
+    assert result == [(1, 2, None, None, None)]
+
+
+def test_chunks_empty_iterable() -> None:
+    """chunks() yields nothing for an empty iterable."""
+    result = list(chunks([], 3))
+    assert result == []


### PR DESCRIPTION
## TLDR

        **Gap:** Def `chunks` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example

        **Wedge type:** `missing_documentation`

        **Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L115

        ## Changes

        - `llama-index-core/llama_index/core/async_utils.py`
- `llama-index-core/tests/test_async_utils.py`

        **Diff size:** 51 lines across 2 file(s)

        ## Pre-submission checklist

        - [x] Minimal change — touches at most 3 files
        - [x] Tests updated (if test suite present)
        - [x] No CI/CD, Dockerfile, or lock file modifications
        - [x] Diff reviewed for secrets

        ## AI Assistance Disclosure

        This contribution was AI-assisted using Hermes Agent (Nous Research).

        Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>