### PR TITLE
fix: stop __getstate__ deleting attributes from the object being pickled

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -124,6 +124,15 @@ class BaseComponent(BaseModel):
     def __getstate__(self) -> Dict[str, Any]:
         state = super().__getstate__()
 
+        # `BaseModel.__getstate__` hands back the live `__dict__` and
+        # `__pydantic_private__` mappings, so they are shallow-copied before
+        # anything is dropped from them. Without the copies, dropping an
+        # unpickleable attribute here would also delete it from the object
+        # being pickled, leaving the original broken after serialization.
+        state["__dict__"] = dict(state["__dict__"])
+        if state.get("__pydantic_private__") is not None:
+            state["__pydantic_private__"] = dict(state["__pydantic_private__"])
+
         # remove attributes that are not pickleable -- kind of dangerous
         keys_to_remove = []
         for key, val in state["__dict__"].items():

--- a/llama-index-core/tests/schema/test_base_component.py
+++ b/llama-index-core/tests/schema/test_base_component.py
@@ -1,8 +1,15 @@
-from typing import Callable
+import pickle
+from typing import Any, Callable
 
 import pytest
 from llama_index.core.schema import BaseComponent
 from pydantic.fields import PrivateAttr
+
+
+class PickleableComponent(BaseComponent):
+    """Defined at module level so that instances can actually be pickled."""
+
+    fn: Any = None
 
 
 @pytest.fixture()
@@ -50,6 +57,40 @@ def test__getstate__():
         "__pydantic_fields_set__": set(),
         "__pydantic_private__": {"_text": "test private attr"},
     }
+
+
+def test__getstate__does_not_mutate_the_original():
+    """Pickling must not strip unpickleable attributes off the live object."""
+
+    class MyComponent(BaseComponent):
+        fn: Any = None
+        _private_fn: Any = PrivateAttr(default=None)
+
+    mc = MyComponent(fn=lambda x: x)
+    mc._private_fn = lambda x: x
+
+    state = mc.__getstate__()
+
+    # the emitted state still drops what cannot be pickled ...
+    assert "fn" not in state["__dict__"]
+    assert "_private_fn" not in state["__pydantic_private__"]
+
+    # ... but the object that was pickled is left intact
+    assert mc.fn is not None
+    assert mc._private_fn is not None
+
+
+def test_pickle_round_trip_leaves_original_usable():
+    """A real `pickle.dumps` must not break the object it serialized."""
+    component = PickleableComponent(fn=lambda x: x)
+
+    restored = pickle.loads(pickle.dumps(component))
+
+    # the unpickleable attribute is absent from the copy ...
+    assert restored.fn is None
+    # ... and still present on the original
+    assert component.fn is not None
+    assert component.fn(1) == 1
 
 
 def test__setstate__():


### PR DESCRIPTION
Fixes #22578.

BaseComponent.__getstate__ mutates the object it is asked to pickle.
pydantic's BaseModel.__getstate__ hands back the live self.__dict__ (and
__pydantic_private__), not copies, so the `del state["__dict__"][key]` loop
deletes unpickleable attributes off the instance itself. Under pydantic v2
field access reads straight from __dict__ with no fallback to the default, so
the attribute is gone for good.

The emitted pickle is fine; the source object is what breaks. That makes it
awkward to trace, because the AttributeError shows up later somewhere else —
typically in a caching, copy.deepcopy, multiprocessing or Ray/Celery path
where the same object is reused after being serialized.

Reproduced on main:

    mc = MyComponent(fn=lambda x: x)
    pickle.dumps(mc)
    mc.fn   # AttributeError: 'MyComponent' object has no attribute 'fn'

Fix is to shallow-copy both mappings before pruning them. The pruning logic
and the emitted state are unchanged.

Added two tests — one on __getstate__ directly, one on a real pickle
round-trip. Both fail on main and pass with the change.
