### PR TITLE
fix(vllm): filter unsupported SamplingParams kwargs (best_of)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/llama_index/llms/vllm/base.py
@@ -1,5 +1,7 @@
+import inspect
 import json
-from typing import Any, Callable, Dict, List, Optional, Sequence
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -91,7 +93,11 @@ class Vllm(LLM):
 
     best_of: Optional[int] = Field(
         default=None,
-        description="Number of output sequences that are generated from the prompt.",
+        description=(
+            "Number of output sequences that are generated from the prompt. "
+            "Only passed through when set and when supported by the installed "
+            "vLLM version (removed from SamplingParams in vLLM >= 0.19.0)."
+        ),
     )
 
     presence_penalty: float = Field(
@@ -254,7 +260,9 @@ class Vllm(LLM):
             "top_k": self.top_k,
             "top_p": self.top_p,
         }
-        return {**base_kwargs}
+        # Drop unset optionals (e.g. best_of=None) so SamplingParams is not
+        # handed kwargs it no longer accepts (#21371, vLLM >= 0.19.0).
+        return {k: v for k, v in base_kwargs.items() if v is not None}
 
     @atexit.register
     def close():
@@ -272,6 +280,37 @@ class Vllm(LLM):
             **kwargs,
         }
 
+    def _filter_sampling_params(
+        self,
+        params: Dict[str, Any],
+        *,
+        valid_keys: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
+        """Keep only kwargs accepted by the installed vLLM SamplingParams.
+
+        vLLM periodically renames or removes sampling fields. ``best_of`` was
+        removed in vLLM >= 0.19.0; passing it raises TypeError and breaks every
+        ``.complete()`` call (#21371). When *valid_keys* is omitted, the keys
+        are resolved from ``vllm.SamplingParams.__init__``.
+        """
+        if valid_keys is None:
+            from vllm import SamplingParams
+
+            valid_keys = (
+                set(inspect.signature(SamplingParams.__init__).parameters) - {"self"}
+            )
+        unsupported = set(params) - valid_keys
+        if unsupported:
+            warnings.warn(
+                "The following sampling kwargs are not supported by the "
+                "installed vLLM version and will be ignored: "
+                f"{sorted(unsupported)}",
+                UserWarning,
+                stacklevel=3,
+            )
+            return {k: v for k, v in params.items() if k in valid_keys}
+        return params
+
     @llm_chat_callback()
     def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
         kwargs = kwargs if kwargs else {}
@@ -288,7 +327,7 @@ class Vllm(LLM):
 
         from vllm import SamplingParams
 
-        # build sampling parameters
+        params = self._filter_sampling_params(params)
         sampling_params = SamplingParams(**params)
         outputs = self._client.generate([prompt], sampling_params)
         return CompletionResponse(text=outputs[0].outputs[0].text)

--- a/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-vllm"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index llms vllm integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
+++ b/llama-index-integrations/llms/llama-index-llms-vllm/tests/test_llms_vllm.py
@@ -1,4 +1,12 @@
+import sys
+import types
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.base.llms.types import CompletionResponse
 from llama_index.core.callbacks import CallbackManager
 
 
@@ -28,3 +36,165 @@ def test_server_callback() -> None:
     )
     assert remote.callback_manager == callback_manager
     del remote
+
+
+# ---------------------------------------------------------------------------
+# vLLM SamplingParams compatibility (#21371)
+# ---------------------------------------------------------------------------
+
+
+def _make_vllm_stub(*, accept_best_of: bool) -> types.ModuleType:
+    """Minimal ``vllm`` module stub.
+
+    When *accept_best_of* is False the SamplingParams signature omits
+    ``best_of``, matching vLLM >= 0.19.0.
+    """
+    vllm_mod = types.ModuleType("vllm")
+
+    if accept_best_of:
+
+        class FakeSamplingParams:
+            def __init__(
+                self,
+                temperature: float = 1.0,
+                max_tokens: int = 512,
+                n: int = 1,
+                top_p: float = 1.0,
+                top_k: int = -1,
+                frequency_penalty: float = 0.0,
+                presence_penalty: float = 0.0,
+                ignore_eos: bool = False,
+                stop=None,
+                logprobs=None,
+                best_of=None,
+            ) -> None:
+                self.kwargs = {k: v for k, v in locals().items() if k != "self"}
+
+    else:
+
+        class FakeSamplingParams:  # type: ignore[no-redef]
+            def __init__(
+                self,
+                temperature: float = 1.0,
+                max_tokens: int = 512,
+                n: int = 1,
+                top_p: float = 1.0,
+                top_k: int = -1,
+                frequency_penalty: float = 0.0,
+                presence_penalty: float = 0.0,
+                ignore_eos: bool = False,
+                stop=None,
+                logprobs=None,
+            ) -> None:
+                # Mirror real Python: unexpected kwargs raise TypeError.
+                # (This __init__ has no **kwargs, so Python enforces it.)
+                self.kwargs = {k: v for k, v in locals().items() if k != "self"}
+
+    class FakeLLM:
+        def __init__(
+            self,
+            model=None,
+            tensor_parallel_size=1,
+            trust_remote_code=False,
+            dtype="auto",
+            download_dir=None,
+            **kw,
+        ) -> None:
+            pass
+
+        def generate(self, prompts, sampling_params):
+            out = MagicMock()
+            out.outputs = [MagicMock(text="ok")]
+            return [out]
+
+    vllm_mod.SamplingParams = FakeSamplingParams
+    vllm_mod.LLM = FakeLLM
+    return vllm_mod
+
+
+def _vllm_construct(**overrides):
+    """Pydantic construct without loading a real vLLM model."""
+    from llama_index.llms.vllm import Vllm
+
+    fields = dict(
+        model="stub-model",
+        temperature=0.0,
+        max_new_tokens=16,
+        n=1,
+        best_of=None,
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+        top_p=1.0,
+        top_k=-1,
+        stop=None,
+        ignore_eos=False,
+        logprobs=None,
+        is_chat_model=False,
+    )
+    fields.update(overrides)
+    return Vllm.model_construct(**fields)
+
+
+def _make_vllm_instance(monkeypatch, *, accept_best_of: bool, **field_overrides):
+    """Build a Vllm instance without loading a real model."""
+    stub = _make_vllm_stub(accept_best_of=accept_best_of)
+    monkeypatch.setitem(sys.modules, "vllm", stub)
+
+    llm = _vllm_construct(**field_overrides)
+    llm._client = stub.LLM()
+    return llm, stub
+
+
+def test_model_kwargs_omits_unset_best_of():
+    """Default best_of=None must not appear in kwargs passed to SamplingParams."""
+    llm = _vllm_construct(temperature=0.1, max_new_tokens=32)
+
+    assert "best_of" not in llm._model_kwargs
+    assert llm._model_kwargs["temperature"] == 0.1
+
+
+def test_model_kwargs_includes_set_best_of():
+    llm = _vllm_construct(temperature=0.1, max_new_tokens=32, best_of=2)
+
+    assert llm._model_kwargs["best_of"] == 2
+
+
+def test_complete_works_when_vllm_removed_best_of(monkeypatch):
+    """#21371: vLLM >= 0.19 SamplingParams has no best_of — complete() must work."""
+    llm, stub = _make_vllm_instance(monkeypatch, accept_best_of=False)
+    # Even if a caller still sets best_of on the wrapper, filter it out.
+    llm.best_of = 2
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = llm.complete("hello")
+
+    assert isinstance(result, CompletionResponse)
+    assert result.text == "ok"
+    assert any("best_of" in str(w.message) for w in caught)
+
+
+def test_complete_passes_best_of_when_supported(monkeypatch):
+    llm, stub = _make_vllm_instance(monkeypatch, accept_best_of=True, best_of=3)
+
+    captured = {}
+
+    def capture_generate(prompts, sampling_params):
+        captured["params"] = sampling_params
+        out = MagicMock()
+        out.outputs = [MagicMock(text="ok")]
+        return [out]
+
+    llm._client.generate = capture_generate
+    result = llm.complete("hello")
+    assert result.text == "ok"
+    assert captured["params"].kwargs.get("best_of") == 3
+
+
+def test_filter_sampling_params_drops_unknown_keys(monkeypatch):
+    llm, _stub = _make_vllm_instance(monkeypatch, accept_best_of=False)
+    filtered = llm._filter_sampling_params(
+        {"temperature": 0.2, "best_of": 2, "not_a_param": 1},
+        valid_keys={"temperature", "max_tokens"},
+    )
+    assert filtered == {"temperature": 0.2}


### PR DESCRIPTION
## Summary

Fixes #21371: `llama-index-llms-vllm` hardcodes `best_of` into `_model_kwargs`. vLLM **≥ 0.19.0** removed `best_of` from `SamplingParams`, so every `.complete()` raises:

```text
TypeError: SamplingParams.__init__() got an unexpected keyword argument 'best_of'
```

### Fix

1. **`_model_kwargs`** — drop `None` optionals (so default `best_of=None` is not passed).
2. **`_filter_sampling_params`** — keep only kwargs accepted by the installed `SamplingParams.__init__` signature; warn on dropped keys.
3. **`complete()`** — filter before constructing `SamplingParams`.

This is a fresh PR for the same root cause as #21372 (3 approvals, closed by stale bot), #21537, and #21906 (closed as duplicates of #21372). The bug is still present on `main`.

Package version: `0.7.0` → `0.7.1`.

## Test plan

- [x] `uv run -- pytest tests/test_llms_vllm.py` in `llama-index-llms-vllm` (8 passed)
  - omits unset `best_of`
  - keeps set `best_of` when supported
  - completes without error when stub omits `best_of`
  - filters arbitrary unknown kwargs
- [ ] CI green on this PR