### PR TITLE
fix(eval): use last-match for verdict extraction in pairwise comparison and JSON parsing

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/pairwise.py
+++ b/llama-index-core/llama_index/core/evaluation/pairwise.py
@@ -1,6 +1,7 @@
 """Pairwise evaluation."""
 
 import asyncio
+import re
 from enum import Enum
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
@@ -63,17 +64,21 @@ DEFAULT_EVAL_TEMPLATE = ChatPromptTemplate(
 def _default_parser_function(
     eval_response: str,
 ) -> Tuple[Optional[bool], Optional[float], Optional[str]]:
-    # Extract from response
+    # Extract from response using last-match so that a verdict token echoed
+    # in reasoning does not override the judge's final verdict.
     feedback: Optional[str] = ""
-    if "[[A]]" in eval_response:
-        passing: Optional[bool] = True
-        score = 1.0
-    elif "[[B]]" in eval_response:
-        passing = False
-        score = 0.0
-    elif "[[C]]" in eval_response:
-        passing = None
-        score = 0.5
+    pairwise_matches = re.findall(r"\[\[([ABC])\]\]", eval_response)
+    if pairwise_matches:
+        verdict = pairwise_matches[-1]
+        if verdict == "A":
+            passing: Optional[bool] = True
+            score = 1.0
+        elif verdict == "B":
+            passing = False
+            score = 0.0
+        else:
+            passing = None
+            score = 0.5
     else:
         passing = None
         score = None

--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -112,9 +112,4 @@ def parse_code_markdown(text: str, only_last: bool) -> List[str]:
 
 def extract_json_str(text: str) -> str:
     """Extract JSON string from text."""
-    # NOTE: this regex parsing is taken from langchain.output_parsers.pydantic
-    match = re.search(r"\{.*\}", text.strip(), re.MULTILINE | re.IGNORECASE | re.DOTALL)
-    if not match:
-        raise ValueError(f"Could not extract json string from output: {text}")
-
-    return match.group()
+    return _marshal_llm_to_json(text)


### PR DESCRIPTION
## Summary

Two LLM-as-judge evaluators in llama_index extract verdicts using first-match parsing:

1. **`PairwiseComparisonEvaluator`** (`evaluation/pairwise.py:68`): Uses `if "[[A]]" in eval_response` substring checks in A-before-B-before-C order. A judge response containing `[[A]]` in reasoning and `[[B]]` as the verdict selects A.

2. **`extract_json_str`** (`output_parsers/utils.py:113`): Uses `re.search(r"\{.*\}")` (first-match regex). The sibling function `_marshal_llm_to_json` in the **same file** (line 12) already does first-brace-to-last-brace spanning and documents the verdict-injection risk. This fix simply routes `extract_json_str` through `_marshal_llm_to_json` instead of duplicating the logic with a weaker regex.

## Fix

- **Pairwise**: Replace `in` substring chain with `re.findall(r"\[\[([ABC])\]\]", eval_response)[-1]` (last match).
- **JSON**: Replace the regex with a call to `_marshal_llm_to_json`.

## Verification

- `ruff check`: all checks passed
- 2 files changed, 16 insertions, 16 deletions
- `_marshal_llm_to_json` confirmed present in the same module (line 12)