### PR TITLE
fix(core): preserve zero recursive retrieval scores

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -124,7 +124,7 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
         retrieved_nodes: List[NodeWithScore] = []
         for n in nodes:
             node = n.node
-            score = n.score or 1.0
+            score = n.score if n.score is not None else 1.0
             if isinstance(node, IndexNode):
                 obj = node.obj or self.object_map.get(node.index_id, None)
                 if obj is not None:
@@ -158,7 +158,7 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
         retrieved_nodes: List[NodeWithScore] = []
         for n in nodes:
             node = n.node
-            score = n.score or 1.0
+            score = n.score if n.score is not None else 1.0
             if isinstance(node, IndexNode):
                 obj = node.obj or self.object_map.get(node.index_id, None)
                 if obj is not None:

--- a/llama-index-core/tests/base/test_base_retriever.py
+++ b/llama-index-core/tests/base/test_base_retriever.py
@@ -1,0 +1,36 @@
+from typing import List
+
+import pytest
+
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.schema import IndexNode, NodeWithScore, QueryBundle, TextNode
+
+
+class ZeroScoreRecursiveRetriever(BaseRetriever):
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return [
+            NodeWithScore(
+                node=IndexNode(
+                    index_id="child",
+                    text="index",
+                    obj=TextNode(text="child"),
+                ),
+                score=0.0,
+            )
+        ]
+
+    async def _aretrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return self._retrieve(query_bundle)
+
+
+def test_recursive_retrieval_preserves_zero_score() -> None:
+    nodes = ZeroScoreRecursiveRetriever().retrieve("query")
+
+    assert nodes[0].score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_recursive_retrieval_preserves_zero_score() -> None:
+    nodes = await ZeroScoreRecursiveRetriever().aretrieve("query")
+
+    assert nodes[0].score == 0.0


### PR DESCRIPTION
# Description

Recursive retrieval currently uses `score or 1.0` when forwarding the score
from an `IndexNode` to its resolved child. As a result, a valid score of `0.0`
is changed to `1.0`, turning the lowest relevance into the highest relevance.

This change only falls back to `1.0` when the score is `None`, preserving
explicit zero scores in both synchronous and asynchronous recursive retrieval.

AI assistance was used to audit candidate code paths and draft the regression
tests. I reproduced the bug on `main`, reviewed every changed line, and
validated the behavior with the commands below.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (core package)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Commands:

```text
pytest tests/retrievers tests/base/test_base_retriever.py -q
# 7 passed

ruff check llama_index/core/base/base_retriever.py tests/base/test_base_retriever.py
ruff format --check llama_index/core/base/base_retriever.py tests/base/test_base_retriever.py
mypy llama_index/core/base/base_retriever.py tests/base/test_base_retriever.py
```

The focused reproduction returned `1.0` for both sync and async paths before
the change. The new tests assert that both paths return `0.0`.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally with my changes
