### PR TITLE
fix(core): narrow broad except in run_async_tasks so task exceptions are not swallowed

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -88,7 +88,10 @@ def run_async_tasks(
         try:
             import nest_asyncio
             from tqdm.asyncio import tqdm
-
+        except ImportError:
+            # tqdm.asyncio not available; fall through to plain asyncio.gather
+            pass
+        else:
             # jupyter notebooks already have an event loop running
             # we need to reuse it instead of creating a new one
             nest_asyncio.apply()
@@ -97,13 +100,7 @@ def run_async_tasks(
             async def _tqdm_gather() -> List[Any]:
                 return await tqdm.gather(*tasks_to_execute, desc=progress_bar_desc)
 
-            tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
-            return tqdm_outputs
-        # run the operation w/o tqdm on hitting a fatal
-        # may occur in some environments where tqdm.asyncio
-        # is not supported
-        except Exception:
-            pass
+            return loop.run_until_complete(_tqdm_gather())
 
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+from llama_index.core.async_utils import batch_gather, asyncio_run, run_async_tasks
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +37,34 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_run_async_tasks_propagates_exception_without_progress() -> None:
+    """Task exceptions must propagate when show_progress=False."""
+
+    async def ok() -> int:
+        return 1
+
+    async def fail() -> int:
+        raise ValueError("task failure")
+
+    with pytest.raises(ValueError, match="task failure"):
+        run_async_tasks([ok(), fail()], show_progress=False)
+
+
+def test_run_async_tasks_propagates_exception_with_progress() -> None:
+    """Task exceptions must propagate even when show_progress=True.
+
+    Regression for the bug where the broad `except Exception: pass` in the
+    tqdm path swallowed task failures, then re-awaiting consumed coroutines
+    raised an unrelated RuntimeError instead of the original ValueError.
+    """
+
+    async def ok() -> int:
+        return 1
+
+    async def fail() -> int:
+        raise ValueError("task failure")
+
+    with pytest.raises(ValueError, match="task failure"):
+        run_async_tasks([ok(), fail()], show_progress=True)


### PR DESCRIPTION
Fixes #22493

## Root cause

`run_async_tasks` wraps both the tqdm imports **and** task execution in a single `except Exception: pass`. The intent was to fall back gracefully when `tqdm.asyncio` is unavailable (import error). But the broad catch also covers `loop.run_until_complete(_tqdm_gather())`, so exceptions raised by the tasks are swallowed. The coroutines are consumed at that point, so the fallback re-awaits them and the real error is replaced by an unrelated `RuntimeError("cannot reuse already awaited coroutine")`.

## What changed

Split the try/except so only the two import lines are guarded:

```python
# before
try:
    import nest_asyncio
    from tqdm.asyncio import tqdm
    ...
    loop.run_until_complete(_tqdm_gather())   # task exceptions swallowed here
    return tqdm_outputs
except Exception:
    pass

# after
try:
    import nest_asyncio
    from tqdm.asyncio import tqdm
except ImportError:
    pass   # only import failures fall through
else:
    ...
    return loop.run_until_complete(_tqdm_gather())   # propagates normally
```

## Test evidence

Verified the behaviour difference with a self-contained repro:

```
=== BUGGY ===  show_progress=True → RuntimeError("cannot reuse already awaited coroutine")
=== FIXED ===  show_progress=True → ValueError("task failure")  ✓
```

Regression tests added in `llama-index-core/tests/test_async_utils.py` (two new cases: with and without `show_progress`).

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.