### PR TITLE
docs: fix Azure Cosmos DB for NoSQL API reference

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/llama_index/vector_stores/azurecosmosnosql/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/llama_index/vector_stores/azurecosmosnosql/base.py
@@ -28,11 +28,11 @@ USER_AGENT = ("LlamaIndex-CDBNoSql-VectorStore-Python",)
 
 class AzureCosmosDBNoSqlVectorSearch(BasePydanticVectorStore):
     """
-    Azure CosmosDB NoSQL vCore Vector Store.
+    Azure Cosmos DB for NoSQL vector store.
 
-    To use, you should have both:
-    -the ``azure-cosmos`` python package installed
-    -from llama_index.vector_stores.azurecosmosnosql import AzureCosmosDBNoSqlVectorSearch
+    Install the ``azure-cosmos`` package and import
+    ``AzureCosmosDBNoSqlVectorSearch`` from
+    ``llama_index.vector_stores.azurecosmosnosql``.
     """
 
     stores_text: bool = True
@@ -72,14 +72,42 @@ class AzureCosmosDBNoSqlVectorSearch(BasePydanticVectorStore):
         Initialize the vector store.
 
         Args:
-            cosmos_client: Client used to connect to azure cosmosdb no sql account.
-            database_name: Name of the database to be created.
-            container_name: Name of the container to be created.
-            embedding: Text embedding model to use.
-            vector_embedding_policy: Vector Embedding Policy for the container.
-            indexing_policy: Indexing Policy for the container.
-            cosmos_container_properties: Container Properties for the container.
-            cosmos_database_properties: Database Properties for the container.
+            cosmos_client: Initialized Azure Cosmos DB client.
+            vector_embedding_policy: Container vector embedding policy. It must
+                contain a non-empty ``vectorEmbeddings`` list. The first entry's
+                ``path`` identifies the embedding field stored with each node.
+            indexing_policy: Container indexing policy. When ``create_container``
+                is true, it must contain a non-empty ``vectorIndexes`` list. The
+                embedding path should also be excluded from regular indexing.
+            cosmos_container_properties: Container creation options. The
+                ``partition_key`` entry is required when ``create_container`` is
+                true. Supported entries include ``default_ttl``,
+                ``offer_throughput``, ``unique_key_policy``,
+                ``conflict_resolution_policy``, ``analytical_storage_ttl``,
+                ``computed_properties``, ``etag``, ``match_condition``,
+                ``session_token``, and ``initial_headers``.
+            cosmos_database_properties: Optional database creation options,
+                including ``offer_throughput``, ``session_token``,
+                ``initial_headers``, ``etag``, and ``match_condition``. Defaults
+                to ``None``; pass an empty mapping when no options are needed.
+            database_name: Database to retrieve or create. Defaults to
+                ``"vectorSearchDB"``.
+            container_name: Container to retrieve or create. Defaults to
+                ``"vectorSearchContainer"``.
+            create_container: Whether to validate the required vector and
+                container policies before initializing resources. Defaults to
+                true. The database and container are always retrieved or created
+                with the SDK's ``create_*_if_not_exists`` methods.
+            id_key: Document field used for node IDs. Defaults to ``"id"``.
+            text_key: Document field used for node text. Defaults to ``"text"``.
+            metadata_key: Document field used for node metadata. Defaults to
+                ``"metadata"``.
+            **kwargs: Additional keyword arguments accepted for compatibility.
+                They are not currently used.
+
+        Raises:
+            ValueError: If ``create_container`` is true and the vector index,
+                vector embedding, or partition key configuration is empty.
 
         """
         super().__init__()

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-azurecosmosnosql/pyproject.toml
@@ -56,7 +56,7 @@ contains_example = false
 import_path = "llama_index.vector_stores.azurecosmosnosql"
 
 [tool.llamahub.class_authors]
-AzureCosmosDBMongoDBVectorSearch = "llama-index"
+AzureCosmosDBNoSqlVectorSearch = "llama-index"
 
 [tool.mypy]
 disallow_untyped_defs = true


### PR DESCRIPTION
## Description

The Azure Cosmos DB for NoSQL API reference is generated from integration metadata, but this package's `class_authors` table names the MongoDB vector-store class. Its source docstring also describes NoSQL as vCore, lists a removed `embedding` argument, and omits current constructor options and defaults.

This change:
- registers `AzureCosmosDBNoSqlVectorSearch` as the API-reference member;
- corrects the class description and import guidance;
- documents the current constructor arguments, defaults, configuration requirements, and validation errors.

There are no runtime behavior or dependency changes. The generated API page is intentionally excluded because `docs/scripts/prepare_for_build.py` regenerates API-reference files during the release workflow.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No - this changes source documentation and docs-generator metadata only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

Validation performed:
- `ruff check` and `ruff format --check` on the changed Python source
- `codespell` on both changed files
- installed-package import of `AzureCosmosDBNoSqlVectorSearch`
- `pytest -q tests/test_vector_stores_azurecosmosnosql.py` (`1 passed`)
- focused TOML/source assertions and `git diff --check`
- official `docs/scripts/prepare_for_build.py` run completed successfully and generated the corrected NoSQL member before generated outputs were restored

The docs generator currently needs a temporary TOML 1.0 parser compatibility shim because an unrelated upstream integration manifest cannot be parsed by pinned `toml` 0.10.2. Package mypy is also not clean on the current dependency set: pinned mypy 0.991 cannot parse current NumPy stubs under the package's Python 3.8 target, and skipping third-party imports exposes five pre-existing `Optional` dereferences in untouched constructor code.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing focused unit tests pass locally with my changes