### PR TITLE
fix: raise ValueError for empty Cohere texts list in BedrockEmbedding

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -521,6 +521,10 @@ class BedrockEmbedding(BaseEmbedding):
                 "query": "search_query",
             }
             payload = [payload] if isinstance(payload, str) else payload
+            if not payload:
+                raise ValueError(
+                    "Cohere embedding payload must contain at least one text."
+                )
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
             request_body = json.dumps(
                 {

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -521,9 +521,9 @@ class BedrockEmbedding(BaseEmbedding):
                 "query": "search_query",
             }
             payload = [payload] if isinstance(payload, str) else payload
-            if not payload:
+            if not payload or all(not p.strip() for p in payload):
                 raise ValueError(
-                    "Cohere embedding payload must contain at least one text."
+                    "Cohere embedding payload must contain at least one non-empty text."
                 )
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
             request_body = json.dumps(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -323,9 +323,24 @@ class TestBedrockEmbedding(TestCase):
         )
 
         with pytest.raises(
-            ValueError, match="Cohere embedding payload must contain at least one text"
+            ValueError,
+            match="Cohere embedding payload must contain at least one non-empty text",
         ):
             bedrock_embedding._get_request_body("cohere", [], "text")
+
+    def test_get_request_body_cohere_blank_only_list_raises(self) -> None:
+        bedrock_embedding = BedrockEmbedding(
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
+            client=self.bedrock_client,
+        )
+
+        # A non-empty list whose entries are all empty/whitespace-only is
+        # equally un-embeddable and must raise the same as an empty list.
+        with pytest.raises(
+            ValueError,
+            match="Cohere embedding payload must contain at least one non-empty text",
+        ):
+            bedrock_embedding._get_request_body("cohere", ["", "   ", "\n"], "text")
 
     def test_get_text_embedding_cohere_empty_list_raises(self) -> None:
         bedrock_embedding = BedrockEmbedding(
@@ -337,7 +352,8 @@ class TestBedrockEmbedding(TestCase):
         # directly) must raise locally instead of sending an invalid request
         # to AWS Bedrock.
         with pytest.raises(
-            ValueError, match="Cohere embedding payload must contain at least one text"
+            ValueError,
+            match="Cohere embedding payload must contain at least one non-empty text",
         ):
             bedrock_embedding._get_embedding([], "text")
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -8,6 +8,7 @@ from botocore.response import StreamingBody
 from botocore.stub import ANY as BOTOCORE_ANY
 from botocore.stub import Stubber
 from llama_index.embeddings.bedrock import BedrockEmbedding, Models
+from llama_index.embeddings.bedrock.base import PROVIDERS
 
 exp_embed = [
     0.017410278,
@@ -315,6 +316,31 @@ class TestBedrockEmbedding(TestCase):
         bedrock_stubber.deactivate()
 
         bedrock_stubber.assert_no_pending_responses()
+
+    def test_get_request_body_cohere_empty_list_raises(self) -> None:
+        bedrock_embedding = BedrockEmbedding(
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
+            client=self.bedrock_client,
+        )
+
+        with pytest.raises(
+            ValueError, match="Cohere embedding payload must contain at least one text"
+        ):
+            bedrock_embedding._get_request_body(PROVIDERS.COHERE.value, [], "text")
+
+    def test_get_text_embedding_cohere_empty_list_raises(self) -> None:
+        bedrock_embedding = BedrockEmbedding(
+            model_name=Models.COHERE_EMBED_ENGLISH_V3,
+            client=self.bedrock_client,
+        )
+
+        # A non-empty batch that resolves to an empty list of texts to embed
+        # (e.g. via `_get_embedding` called directly) must raise locally
+        # instead of sending an invalid request to AWS Bedrock.
+        with pytest.raises(
+            ValueError, match="Cohere embedding payload must contain at least one text"
+        ):
+            bedrock_embedding._get_embedding([], "text")
 
     def test_application_inference_profile_in_invoke_model_request(self) -> None:
         bedrock_stubber = Stubber(self.bedrock_client)

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -8,7 +8,6 @@ from botocore.response import StreamingBody
 from botocore.stub import ANY as BOTOCORE_ANY
 from botocore.stub import Stubber
 from llama_index.embeddings.bedrock import BedrockEmbedding, Models
-from llama_index.embeddings.bedrock.base import PROVIDERS
 
 exp_embed = [
     0.017410278,
@@ -326,7 +325,7 @@ class TestBedrockEmbedding(TestCase):
         with pytest.raises(
             ValueError, match="Cohere embedding payload must contain at least one text"
         ):
-            bedrock_embedding._get_request_body(PROVIDERS.COHERE.value, [], "text")
+            bedrock_embedding._get_request_body("cohere", [], "text")
 
     def test_get_text_embedding_cohere_empty_list_raises(self) -> None:
         bedrock_embedding = BedrockEmbedding(
@@ -334,9 +333,9 @@ class TestBedrockEmbedding(TestCase):
             client=self.bedrock_client,
         )
 
-        # A non-empty batch that resolves to an empty list of texts to embed
-        # (e.g. via `_get_embedding` called directly) must raise locally
-        # instead of sending an invalid request to AWS Bedrock.
+        # An empty list of texts to embed (e.g. via `_get_embedding` called
+        # directly) must raise locally instead of sending an invalid request
+        # to AWS Bedrock.
         with pytest.raises(
             ValueError, match="Cohere embedding payload must contain at least one text"
         ):


### PR DESCRIPTION
Fixes #22382

## Root cause
In `BedrockEmbedding._get_request_body()` (Cohere branch), the payload was never checked for emptiness before being serialized and sent to AWS Bedrock's `invoke_model`. An empty texts list produces an invalid request that AWS rejects with an opaque `ValidationException` instead of failing fast locally.

## Fix
Raise `ValueError("Cohere embedding payload must contain at least one text.")` before building the request body when the texts list is empty.

## Verification
Added two regression tests (direct `_get_request_body` call and `_get_embedding([], "text")`), both asserting the `ValueError`. Full bedrock test suite: 26 passed, 3 skipped (pre-existing skips due to `aioboto3` not being installed, unrelated to this change).