### PR TITLE
fix(sharepoint): forward recursive=False flag through list_resources and _list_drive_contents

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -389,6 +389,7 @@ class SharePointReader(
             sharepoint_site_name=self.sharepoint_site_name,
             sharepoint_site_id=self.sharepoint_site_id,
             sharepoint_folder_id=folder_id,
+            recursive=include_subfolders,
         )
 
         metadata = {}
@@ -748,9 +749,12 @@ class SharePointReader(
 
         return file_paths
 
-    def _list_drive_contents(self) -> List[Path]:
+    def _list_drive_contents(self, recursive: bool = True) -> List[Path]:
         """
         Helper method to fetch the contents of the drive.
+
+        Args:
+            recursive (bool): If True, files from all subfolders are listed.
 
         Returns:
             List[Path]: List of file paths.
@@ -766,9 +770,11 @@ class SharePointReader(
 
         for item in items:
             if "folder" in item:
+                if not recursive:
+                    continue
                 # Append folder path
                 folder_paths = self._list_folder_contents(
-                    item["id"], recursive=True, current_path=item["name"]
+                    item["id"], recursive=recursive, current_path=item["name"]
                 )
                 file_paths.extend(folder_paths)
             elif "file" in item:
@@ -839,7 +845,7 @@ class SharePointReader(
                 file_paths.extend(folder_contents)
             else:
                 # Fetch drive contents
-                drive_contents = self._list_drive_contents()
+                drive_contents = self._list_drive_contents(recursive=recursive)
                 file_paths.extend(drive_contents)
         except Exception as exp:
             logger.error("An error occurred while listing files in SharePoint: %s", exp)

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -579,6 +579,67 @@ def test_get_all_items_with_pagination_empty_result():
     assert len(items) == 0
 
 
+def test_list_drive_contents_non_recursive_skips_folders():
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22320.
+
+    When recursive=False, _list_drive_contents must not descend into subfolders.
+    """
+    reader = SharePointReader(
+        client_id="dummy_client_id",
+        client_secret="dummy_client_secret",
+        tenant_id="dummy_tenant_id",
+    )
+    reader._drive_id_endpoint = "https://graph.microsoft.com/v1.0/sites/s/drives"
+    reader._drive_id = "d1"
+
+    items = [
+        {"id": "folder1_id", "name": "Subfolder", "folder": {"childCount": 2}},
+        {"id": "file1_id", "name": "root_file.txt", "file": {}},
+    ]
+
+    with (
+        patch.object(
+            SharePointReader,
+            "_get_all_items_with_pagination",
+            return_value=items,
+        ),
+        patch.object(
+            SharePointReader, "_list_folder_contents"
+        ) as mock_list_folder,
+    ):
+        paths = reader._list_drive_contents(recursive=False)
+
+    mock_list_folder.assert_not_called()
+    assert paths == [Path("root_file.txt")]
+
+
+def test_download_files_passes_recursive_false_to_list_resources(sharepoint_reader):
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22320.
+
+    _download_files_and_extract_metadata must forward include_subfolders=False
+    to list_resources as recursive=False.
+    """
+    import tempfile
+
+    with (
+        patch.object(
+            SharePointReader, "list_resources", return_value=[]
+        ) as mock_list,
+        tempfile.TemporaryDirectory() as tmpdir,
+    ):
+        sharepoint_reader._download_files_and_extract_metadata(
+            folder_id="dummy_folder_id",
+            download_dir=tmpdir,
+            include_subfolders=False,
+        )
+
+    mock_list.assert_called_once()
+    _, kwargs = mock_list.call_args
+    assert kwargs.get("recursive") is False
+
+
 def test_drive_id_endpoint_set_when_drive_id_provided():
     """
     Test that _drive_id_endpoint is set even when drive_id is provided directly.

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -614,6 +614,48 @@ def test_list_drive_contents_non_recursive_skips_folders():
     assert paths == [Path("root_file.txt")]
 
 
+def test_list_drive_contents_recursive_includes_subfolder_files():
+    """
+    Complement to test_list_drive_contents_non_recursive_skips_folders.
+
+    When recursive=True, _list_drive_contents must descend into subfolders and
+    return both the root-level file and the file inside the subfolder.  Root files
+    are returned as plain paths (no container prefix); subfolder files are returned
+    under the subfolder name — neither is silently omitted.
+    """
+    reader = SharePointReader(
+        client_id="dummy_client_id",
+        client_secret="dummy_client_secret",
+        tenant_id="dummy_tenant_id",
+    )
+    reader._drive_id_endpoint = "https://graph.microsoft.com/v1.0/sites/s/drives"
+    reader._drive_id = "d1"
+
+    root_items = [
+        {"id": "folder1_id", "name": "Subfolder", "folder": {"childCount": 1}},
+        {"id": "file1_id", "name": "root_file.txt", "file": {}},
+    ]
+
+    def mock_pagination(url):
+        return root_items
+
+    with patch.object(
+        SharePointReader,
+        "_get_all_items_with_pagination",
+        side_effect=mock_pagination,
+    ), patch.object(
+        SharePointReader,
+        "_list_folder_contents",
+        return_value=[Path("Subfolder/nested_file.txt")],
+    ) as mock_list_folder:
+        paths = reader._list_drive_contents(recursive=True)
+
+    mock_list_folder.assert_called_once_with("folder1_id", recursive=True, current_path="Subfolder")
+    assert Path("root_file.txt") in paths
+    assert Path("Subfolder/nested_file.txt") in paths
+    assert len(paths) == 2
+
+
 def test_download_files_passes_recursive_false_to_list_resources(sharepoint_reader):
     """
     Regression test for https://github.com/run-llama/llama_index/issues/22320.


### PR DESCRIPTION
## Summary

Fixes #22320 — `SharePointReader` was silently ignoring `recursive=False` during remote file discovery.

### Root cause

`list_resources` accepted a `recursive` parameter but **never forwarded it** to `_list_drive_contents`, so the drive root path always traversed all subfolders regardless of the caller's intent.  Similarly, `_download_files_and_extract_metadata` did not pass `include_subfolders` through to `list_resources`.

### Changes

| File | What changed |
|---|---|
| `base.py` | `_list_drive_contents` now accepts `recursive: bool = True`; when `False`, folder items are skipped instead of being recursed |
| `base.py` | `list_resources` passes `recursive` to `_list_drive_contents` (was hardcoded to default `True`) |
| `base.py` | `_download_files_and_extract_metadata` forwards `include_subfolders` to `list_resources` as `recursive=include_subfolders` |
| `tests/test_readers_microsoft_sharepoint.py` | Two regression tests: one verifying `_list_drive_contents(recursive=False)` skips subfolders; one verifying `_download_files_and_extract_metadata` propagates the flag |

### Test evidence

```
tests/test_readers_microsoft_sharepoint.py::test_list_drive_contents_non_recursive_skips_folders PASSED
tests/test_readers_microsoft_sharepoint.py::test_download_files_passes_recursive_false_to_list_resources PASSED
20 passed in 1.05s
```

> ⚠️ This PR was developed with the assistance of an AI coding assistant (Claude). All changes have been reviewed and tested by the submitter.