### PR TITLE
Add native async support to LLMRerank

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
@@ -119,7 +119,7 @@ class LLMRerank(BaseNodePostprocessor):
         return sorted(initial_results, key=lambda x: x.score or 0.0, reverse=True)[
             : self.top_n
         ]
-    
+
     async def _apostprocess_nodes(
         self,
         nodes: List[NodeWithScore],

--- a/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
@@ -119,3 +119,47 @@ class LLMRerank(BaseNodePostprocessor):
         return sorted(initial_results, key=lambda x: x.score or 0.0, reverse=True)[
             : self.top_n
         ]
+    
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        if query_bundle is None:
+            raise ValueError("Query bundle must be provided.")
+        if len(nodes) == 0:
+            return []
+
+        initial_results: List[NodeWithScore] = []
+        for idx in range(0, len(nodes), self.choice_batch_size):
+            nodes_batch = [
+                node.node for node in nodes[idx : idx + self.choice_batch_size]
+            ]
+
+            query_str = query_bundle.query_str
+            # Don't include non text types for non-chat models
+            fmt_batch = self._format_node_batch_fn(nodes_batch)
+            # call each batch independently
+            kwargs = {"query_str": query_str}
+            if is_chat_model(self.llm):
+                kwargs["context_messages"] = fmt_batch
+            else:
+                kwargs["context_str"] = fmt_batch
+            raw_response = await self.llm.apredict(self.choice_select_prompt, **kwargs)
+
+            raw_choices, relevances = self._parse_choice_select_answer_fn(
+                raw_response, len(nodes_batch)
+            )
+            choice_idxs = [int(choice) - 1 for choice in raw_choices]
+            choice_nodes = [nodes_batch[idx] for idx in choice_idxs]
+            relevances = relevances or [1.0 for _ in choice_nodes]
+            initial_results.extend(
+                [
+                    NodeWithScore(node=node, score=relevance)
+                    for node, relevance in zip(choice_nodes, relevances)
+                ]
+            )
+
+        return sorted(initial_results, key=lambda x: x.score or 0.0, reverse=True)[
+            : self.top_n
+        ]

--- a/llama-index-core/tests/postprocessor/test_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_llm_rerank.py
@@ -95,6 +95,12 @@ def mock_llm_chat_or_complete(
         else CompletionResponse(text="\n".join(result_strs))
     )
 
+async def mock_llm_achat_or_acomplete(
+    self: Any, messages_or_formatted_prompt, **kwargs
+) -> ChatResponse:
+    """Async patch for llm predictor predict."""
+    return mock_llm_chat_or_complete(self, messages_or_formatted_prompt, **kwargs)
+
 
 def mock_format_node_batch_fn(nodes: List[BaseNode]) -> str:
     """Mock format node batch fn."""
@@ -169,3 +175,35 @@ def test_llm_rerank_multimodal(png_1px_b64, mp3_bytes, mp4_bytes) -> None:
     assert result_nodes[1].node.get_content_blocks() == [ImageBlock(image=png_1px_b64)]
     assert result_nodes[2].node.get_content_blocks() == [ImageBlock(image=png_1px_b64)]
     assert result_nodes[3].node.get_content_blocks() == [TextBlock(text="Test3")]
+
+@pytest.mark.asyncio
+@patch.object(
+    MockLLM,
+    "acomplete",
+    mock_llm_achat_or_acomplete,
+)
+async def test_llm_rerank_async() -> None:
+    """Test LLM rerank (async)."""
+    nodes = [
+        TextNode(text="Test"),
+        TextNode(text="Test2"),
+        TextNode(text="Test3"),
+        TextNode(text="Test4"),
+        TextNode(text="Test5"),
+        TextNode(text="Test6"),
+        TextNode(text="Test7"),
+        TextNode(text="Test8"),
+    ]
+    nodes_with_score = [NodeWithScore(node=n) for n in nodes]
+
+    # choice batch size 4 (so two batches)
+    # take top-3 across all data
+    llm_rerank = LLMRerank(choice_batch_size=4, top_n=3)
+    query_str = "What is?"
+    result_nodes = await llm_rerank.apostprocess_nodes(
+        nodes_with_score, QueryBundle(query_str)
+    )
+    assert len(result_nodes) == 3
+    assert result_nodes[0].node.get_content() == "Test7"
+    assert result_nodes[1].node.get_content() == "Test5"
+    assert result_nodes[2].node.get_content() == "Test3"

--- a/llama-index-core/tests/postprocessor/test_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_llm_rerank.py
@@ -95,6 +95,7 @@ def mock_llm_chat_or_complete(
         else CompletionResponse(text="\n".join(result_strs))
     )
 
+
 async def mock_llm_achat_or_acomplete(
     self: Any, messages_or_formatted_prompt, **kwargs
 ) -> ChatResponse:
@@ -175,6 +176,7 @@ def test_llm_rerank_multimodal(png_1px_b64, mp3_bytes, mp4_bytes) -> None:
     assert result_nodes[1].node.get_content_blocks() == [ImageBlock(image=png_1px_b64)]
     assert result_nodes[2].node.get_content_blocks() == [ImageBlock(image=png_1px_b64)]
     assert result_nodes[3].node.get_content_blocks() == [TextBlock(text="Test3")]
+
 
 @pytest.mark.asyncio
 @patch.object(


### PR DESCRIPTION
# Description
LLMRerank previously had no real async implementation. It relied on the default `_apostprocess_nodes` from `BaseNodePostprocessor`, which just ran the sync `_postprocess_nodes` method in a background thread via `asyncio.to_thread`. This PR adds a native async override in `LLMRerank` using `await self.llm.apredict(...)`, so async callers get genuine async 
behavior instead of a thread-wrapped sync call.

Fixes #22596

## New Package?
- [x] No

## Version Bump?
- [x] No

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

Added `test_llm_rerank_async`, mirroring the existing sync test but calling `apostprocess_nodes` instead. Patched `MockLLM.acomplete` with an async wrapper to simulate a real async LLM call. Ran `uv run ruff format` and `uv run ruff check` on both changed files - all checks pass. Ran the 
full test file locally - all 3 tests pass:
llama-index-core\tests\postprocessor\test_llm_rerank.py::test_llm_rerank PASSED
llama-index-core\tests\postprocessor\test_llm_rerank.py::test_llm_rerank_multimodal PASSED
llama-index-core\tests\postprocessor\test_llm_rerank.py::test_llm_rerank_async PASSED
3 passed in 0.11s
<img width="1202" height="376" alt="Fix_22596" src="https://github.com/user-attachments/assets/33933362-a8a7-41d9-8f97-93f535964445" />

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes