### PR TITLE
fix(retrievers-bm25): allow PyStemmer 3.x for Python 3.14 wheels

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-retrievers-bm25"
-version = "0.8.0"
+version = "0.8.1"
 description = "llama-index retrievers bm25 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
@@ -34,7 +34,9 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "bm25s>=0.2.7.post1",
-    "pystemmer>=2.2.0.1,<3",
+    # Allow PyStemmer 3.x (cp314 wheels; 2.x has no 3.14 wheels and source
+    # builds fetch snowballstem.org, which fails in air-gapped environments).
+    "pystemmer>=2.2.0.1,<4",
     "llama-index-core>=0.13.1,<0.15",
 ]
 

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/uv.lock
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/uv.lock
@@ -2064,7 +2064,7 @@ dev = [
 requires-dist = [
     { name = "bm25s", specifier = ">=0.2.7.post1" },
     { name = "llama-index-core", specifier = ">=0.13.1,<0.15" },
-    { name = "pystemmer", specifier = ">=2.2.0.1,<3" },
+    { name = "pystemmer", specifier = ">=2.2.0.1,<4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description

Fixes #22601

`llama-index-retrievers-bm25` pinned `pystemmer>=2.2.0.1,<3`. PyStemmer 2.x has no cp314 wheels (and never will — upstream moved to 3.x), so Python 3.14 installs fall back to a source build that downloads `libstemmer_c` from `snowballstem.org`. That fails in air-gapped environments, even though the package advertises `requires-python = ">=3.10,<4.0"`.

`bm25s` itself does not upper-bound PyStemmer. This package only uses:

```python
import Stemmer
Stemmer.Stemmer("english")
# + stemWords(...)
```

Those APIs are unchanged in PyStemmer 3.1.0 (verified on this branch).

### Change

```diff
-pystemmer = ">=2.2.0.1,<3"
+pystemmer = ">=2.2.0.1,<4"
```

- Bump package version `0.8.0` → `0.8.1` (rebased; upstream had already shipped `0.8.0`)
- Matching one-line `uv.lock` specifier update (no full lock regenerate; the lock still resolves 2.2.0.3 for current default Python — installs from `pyproject.toml` can pick 3.x)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] N/A (existing integration)

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I ran `make test` (or package tests) and verified no regressions

Details:

```bash
cd llama-index-integrations/retrievers/llama-index-retrievers-bm25
uv run --with 'pystemmer==3.1.0' -- pytest tests/ -q
# 5 passed
```

Also confirmed `Stemmer.Stemmer("english").stemWords(["running", "queries"])` → `['run', 'queri']` under PyStemmer 3.1.0.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to ensure my code passes the formatting and lint checks