### PR TITLE
fix(sharepoint): prevent same-named file overwrite across folders

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.9.2] - 2026-08-08
+
+### Fixed
+
+- Prevent silent overwrite of same-named files from different SharePoint folders by staging downloads with a Graph item-id key while preserving the original filename in metadata (#22318)
+
 ## [0.8.0] - 2026-02-15
 
 ### Added

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -1,5 +1,6 @@
 """SharePoint files reader."""
 
+import hashlib
 import html
 import logging
 import os
@@ -435,8 +436,13 @@ class SharePointReader(
             str: The path of the downloaded file in the temporary directory.
 
         """
-        # Get the download URL for the file.
-        file_name = item["name"]
+        # Stage by Graph driveItem id so same-named files in different folders
+        # do not overwrite each other. Original filename is kept in metadata
+        # via _extract_metadata_for_file (file_name). Preserve the extension so
+        # SimpleDirectoryReader can select the correct file parser.
+        file_suffix = Path(item["name"]).suffix
+        item_digest = hashlib.sha256(item["id"].encode("utf-8")).hexdigest()
+        file_name = f"{item_digest}{file_suffix}"
 
         content = self._get_file_content_by_url(item)
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 description = "llama-index readers microsoft_sharepoint integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -172,6 +172,66 @@ def test_list_resources(sharepoint_reader):
     assert file_paths[1] == Path("dummy_site_name/dummy_folder_path/file2.txt")
 
 
+def test_download_same_named_files_from_different_folders(sharepoint_reader):
+    """Same basename in different folders must not overwrite each other."""
+    sharepoint_reader.attach_permission_metadata = False
+    remote_paths = [
+        Path("dummy_site_name/Contracts/2025/report.txt"),
+        Path("dummy_site_name/Contracts/2026/report.txt"),
+    ]
+    items = {
+        remote_paths[0]: {
+            "id": "item-2025",
+            "name": "report.txt",
+            "parentReference": {"path": "/drive/root:/Contracts/2025"},
+        },
+        remote_paths[1]: {
+            "id": "item-2026",
+            "name": "report.txt",
+            "parentReference": {"path": "/drive/root:/Contracts/2026"},
+        },
+    }
+
+    with (
+        patch.object(SharePointReader, "list_resources", return_value=remote_paths),
+        patch.object(
+            SharePointReader,
+            "_get_item_from_path",
+            side_effect=lambda path: items[path],
+        ),
+        patch.object(
+            SharePointReader,
+            "_get_file_content_by_url",
+            side_effect=lambda item: f"content:{item['id']}".encode(),
+        ),
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        metadata = sharepoint_reader._download_files_and_extract_metadata(
+            "dummy_folder_id", temp_dir
+        )
+        documents = sharepoint_reader._load_documents_with_metadata(
+            metadata, temp_dir, recursive=False
+        )
+
+        local_names = {Path(file_path).name for file_path in metadata}
+        assert len(metadata) == 2
+        assert len(local_names) == 2
+        assert all(Path(file_path).suffix == ".txt" for file_path in metadata)
+        # Staging path is keyed by item id, not the original basename.
+        assert "report.txt" not in local_names
+        assert {meta["file_name"] for meta in metadata.values()} == {"report.txt"}
+        assert {meta["file_id"] for meta in metadata.values()} == {
+            "item-2025",
+            "item-2026",
+        }
+
+        assert {doc.metadata["file_id"]: doc.text for doc in documents} == {
+            "item-2025": "content:item-2025",
+            "item-2026": "content:item-2026",
+        }
+        assert all(doc.metadata["file_name"] == "report.txt" for doc in documents)
+
+
 def test_load_documents_with_metadata(sharepoint_reader):
     # Setting the _drive_id_endpoint manually to avoid the AttributeError
     sharepoint_reader._drive_id_endpoint = (

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/uv.lock
@@ -1949,7 +1949,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-microsoft-sharepoint"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`SharePointReader` staged downloads with only `item["name"]` under a flat temp directory. Distinct SharePoint items in different folders that share a basename (e.g. `Contracts/2025/report.txt` and `Contracts/2026/report.txt`) therefore wrote to the same local path; the later download overwrote the earlier file and its metadata entry, so ingestion silently dropped documents.

This change keys the temporary staging filename by a SHA-256 digest of the Graph `driveItem.id`, preserves the original extension for file-parser selection, and keeps the original `file_name` / `file_id` in document metadata (unchanged extraction path). Downloads remain in a flat temp directory.

Scope is limited to the `llama-index-readers-microsoft-sharepoint` package. Orthogonal open SharePoint work (path traversal, recursive flag, logging) is intentionally not mixed in.

Fixes #22318

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Added `test_download_same_named_files_from_different_folders` covering two Graph items with different IDs/parents, same basename, distinct contents, and preserved metadata. Full package suite: **19 passed**.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Note: prior attempt #22323 was closed by the author after no maintainer response; this reopens the same bug with a focused regression test.