### PR TITLE
Fix Qdrant IDF model import compatibility

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -6,7 +6,8 @@ An index that is built on top of an existing Qdrant collection.
 """
 
 import logging
-from typing import Any, Callable, List, Optional, Tuple, Union, cast
+from importlib import import_module
+from typing import Any, Callable, List, Optional, Set, Tuple, Union, cast
 
 import qdrant_client
 from qdrant_client import QdrantClient, AsyncQdrantClient
@@ -51,7 +52,6 @@ from qdrant_client.http.models import (
     HasIdCondition,
     IsEmptyCondition,
 )
-from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
 from qdrant_client.http.exceptions import UnexpectedResponse
 
 logger = logging.getLogger(__name__)
@@ -67,6 +67,27 @@ LEGACY_UNNAMED_VECTOR = (
     ""  # The empty string used for unnamed vectors in older collections
 )
 DOCUMENT_ID_KEY = "doc_id"
+
+
+def _load_idf_embedding_models() -> Set[str]:
+    """Load Qdrant FastEmbed sparse models that need IDF modifiers."""
+    for module_name in (
+        "qdrant_client.fastembed_common",
+        "qdrant_client.qdrant_fastembed",
+    ):
+        try:
+            module = import_module(module_name)
+        except ImportError:
+            continue
+
+        idf_embedding_models = getattr(module, "IDF_EMBEDDING_MODELS", None)
+        if idf_embedding_models is not None:
+            return cast(Set[str], idf_embedding_models)
+
+    return set()
+
+
+IDF_EMBEDDING_MODELS = _load_idf_embedding_models()
 
 
 class QdrantVectorStore(BasePydanticVectorStore):

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import requests
 import httpx
+from types import SimpleNamespace
 
 from qdrant_client import QdrantClient
 from qdrant_client.http.models import (
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.qdrant import QdrantVectorStore
+from llama_index.vector_stores.qdrant.base import _load_idf_embedding_models
 from llama_index.core.schema import TextNode
 from llama_index.core.vector_stores.types import (
     VectorStoreQuery,
@@ -38,6 +40,40 @@ requires_qdrant_server = pytest.mark.skipif(
 def test_class():
     names_of_base_classes = [b.__name__ for b in QdrantVectorStore.__mro__]
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
+
+
+def test_load_idf_embedding_models_prefers_fastembed_common(monkeypatch) -> None:
+    def import_module_mock(module_name: str) -> SimpleNamespace:
+        if module_name == "qdrant_client.fastembed_common":
+            return SimpleNamespace(IDF_EMBEDDING_MODELS={"new"})
+        if module_name == "qdrant_client.qdrant_fastembed":
+            return SimpleNamespace(IDF_EMBEDDING_MODELS={"old"})
+        raise ImportError
+
+    monkeypatch.setattr(
+        "llama_index.vector_stores.qdrant.base.import_module",
+        import_module_mock,
+    )
+
+    assert _load_idf_embedding_models() == {"new"}
+
+
+def test_load_idf_embedding_models_falls_back_to_qdrant_fastembed(
+    monkeypatch,
+) -> None:
+    def import_module_mock(module_name: str) -> SimpleNamespace:
+        if module_name == "qdrant_client.fastembed_common":
+            return SimpleNamespace()
+        if module_name == "qdrant_client.qdrant_fastembed":
+            return SimpleNamespace(IDF_EMBEDDING_MODELS={"old"})
+        raise ImportError
+
+    monkeypatch.setattr(
+        "llama_index.vector_stores.qdrant.base.import_module",
+        import_module_mock,
+    )
+
+    assert _load_idf_embedding_models() == {"old"}
 
 
 def test_delete__and_get_nodes(vector_store: QdrantVectorStore) -> None:


### PR DESCRIPTION
## Summary

- load `IDF_EMBEDDING_MODELS` from `qdrant_client.fastembed_common` first, which is where newer `qdrant-client` releases expose it
- fall back to the older `qdrant_client.qdrant_fastembed` location for older supported versions
- avoid a top-level import crash when the old module no longer exports the constant
- add regression tests for the new-location and old-location loader behavior

Fixes #22612.

## Testing

- `UV_CACHE_DIR=/private/tmp/llamaindex-qdrant-uv-cache .venv/bin/uv run --group dev pytest tests/test_vector_stores_qdrant.py -k load_idf_embedding_models`
- `UV_CACHE_DIR=/private/tmp/llamaindex-qdrant-uv-cache .venv/bin/uv run python - <<'PY' ... PY` smoke import with resolved `qdrant-client==1.18.0`
- `UV_CACHE_DIR=/private/tmp/llamaindex-qdrant-uv-cache .venv/bin/uv run --with qdrant-client==1.19.0 python - <<'PY' ... PY` smoke import with forced `qdrant-client==1.19.0`
- `UV_CACHE_DIR=/private/tmp/llamaindex-qdrant-uv-cache .venv/bin/uv run ruff check llama_index/vector_stores/qdrant/base.py tests/test_vector_stores_qdrant.py`
- `UV_CACHE_DIR=/private/tmp/llamaindex-qdrant-uv-cache .venv/bin/uv run ruff format llama_index/vector_stores/qdrant/base.py tests/test_vector_stores_qdrant.py --diff`
- `git diff --check`

I also tried running the full `tests/test_vector_stores_qdrant.py` file locally. The import/unit portions ran, but the full file could not complete in this environment because several hybrid FastEmbed tests attempted to download BM25 model metadata from Hugging Face and failed DNS resolution.
