### PR TITLE
fix(qdrant): import IDF_EMBEDDING_MODELS from its canonical location (qdrant-client 1.19.0 compat)

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -51,7 +51,14 @@ from qdrant_client.http.models import (
     HasIdCondition,
     IsEmptyCondition,
 )
-from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
+
+try:
+    # canonical location since qdrant-client 1.14.1; the re-export from
+    # qdrant_client.qdrant_fastembed was removed in qdrant-client 1.19.0
+    from qdrant_client.fastembed_common import IDF_EMBEDDING_MODELS
+except ImportError:
+    # fallback for qdrant-client < 1.14.1
+    from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
 from qdrant_client.http.exceptions import UnexpectedResponse
 
 logger = logging.getLogger(__name__)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-qdrant"
-version = "0.10.2"
+version = "0.10.3"
 description = "llama-index vector_stores qdrant integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<3.14"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -40,6 +40,27 @@ def test_class():
     assert BasePydanticVectorStore.__name__ in names_of_base_classes
 
 
+def test_import_without_qdrant_fastembed_reexport(monkeypatch) -> None:
+    """
+    Regression test for https://github.com/run-llama/llama_index/issues/22612.
+
+    qdrant-client 1.19.0 removed the ``IDF_EMBEDDING_MODELS`` re-export from
+    ``qdrant_client.qdrant_fastembed``; its canonical location is
+    ``qdrant_client.fastembed_common``. Simulate the 1.19.0 module layout and
+    make sure the integration can still be imported.
+    """
+    import importlib
+
+    import qdrant_client.qdrant_fastembed
+    import llama_index.vector_stores.qdrant.base as qdrant_base
+
+    monkeypatch.delattr(
+        qdrant_client.qdrant_fastembed, "IDF_EMBEDDING_MODELS", raising=False
+    )
+    reloaded = importlib.reload(qdrant_base)
+    assert isinstance(reloaded.IDF_EMBEDDING_MODELS, set)
+
+
 def test_delete__and_get_nodes(vector_store: QdrantVectorStore) -> None:
     vector_store.delete_nodes(node_ids=["11111111-1111-1111-1111-111111111111"])
 


### PR DESCRIPTION
# Description

`llama-index-vector-stores-qdrant` cannot be imported at all when `qdrant-client>=1.19.0` is installed:

```
ImportError: cannot import name 'IDF_EMBEDDING_MODELS' from 'qdrant_client.qdrant_fastembed'
```

**Root cause:** qdrant-client v1.19.0 (released 2026-08-04) removed the deprecated `add`/`query` methods in [qdrant/qdrant-client#1210](https://github.com/qdrant/qdrant-client/pull/1210), and with them the `# region imports used in deprecated methods` block in `qdrant_client/qdrant_fastembed.py` that re-exported `IDF_EMBEDDING_MODELS`. The constant's canonical location has been `qdrant_client.fastembed_common` since qdrant-client 1.14.1 (before that, from 1.11.0 to 1.13.x, it was defined directly in `qdrant_client.qdrant_fastembed`; it does not exist at all before 1.11.0). `base.py` imported it from the old re-export location at module import time, so the whole integration broke on import — even for users not using hybrid/sparse search.

CI did not catch this because the package's `uv.lock` pins qdrant-client 1.18.0 (which still has the re-export), while fresh user installs resolve 1.19.0 (`pyproject.toml` has `qdrant-client>=1.16.0` with no upper bound).

**Fix:** import `IDF_EMBEDDING_MODELS` from `qdrant_client.fastembed_common` (works on every qdrant-client version this package supports, `>=1.16.0`, including 1.19.0+), with a guarded fallback to the old `qdrant_client.qdrant_fastembed` location for anyone running an older client (1.11.0–1.14.0):

```python
try:
    # canonical location since qdrant-client 1.14.1; the re-export from
    # qdrant_client.qdrant_fastembed was removed in qdrant-client 1.19.0
    from qdrant_client.fastembed_common import IDF_EMBEDDING_MODELS
except ImportError:
    # fallback for qdrant-client < 1.14.1
    from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
```

**Version-compat matrix for `IDF_EMBEDDING_MODELS`:**

| qdrant-client | `qdrant_fastembed` (old import) | `fastembed_common` (new import) |
|---|---|---|
| < 1.11.0 | absent | absent |
| 1.11.0 – 1.13.x | defined here | absent (module may not exist) |
| 1.14.1 – 1.18.x | re-export only | defined here |
| >= 1.19.0 | **removed** (qdrant/qdrant-client#1210) | defined here |

Note for reviewers/issue readers: the issue body pins `qdrant-client==1.17.0`, but the import works fine on 1.17.0 (verified locally — the re-export still exists there). The reporter's environment must have actually resolved qdrant-client 1.19.0; the correct workaround pin is `qdrant-client<1.19.0`, and this PR removes the need for any pin.

Fixes #22612

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.10.2 -> 0.10.3)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_import_without_qdrant_fastembed_reexport`, which simulates the qdrant-client 1.19.0 module layout (deletes the `IDF_EMBEDDING_MODELS` attribute from `qdrant_client.qdrant_fastembed` via `monkeypatch`, then reloads the integration's `base` module), so the regression is guarded even while CI's lockfile is on qdrant-client 1.18.0. It fails deterministically before the fix on every client version and needs no live Qdrant server.

**Before the fix**, with qdrant-client 1.19.0 the suite cannot even collect:

```
ImportError while loading conftest '...\tests\conftest.py'.
tests\conftest.py:5: in <module>
    from llama_index.vector_stores.qdrant import QdrantVectorStore
llama_index\vector_stores\qdrant\__init__.py:1: in <module>
    from llama_index.vector_stores.qdrant.base import QdrantVectorStore
llama_index\vector_stores\qdrant\base.py:54: in <module>
    from qdrant_client.qdrant_fastembed import IDF_EMBEDDING_MODELS
E   ImportError: cannot import name 'IDF_EMBEDDING_MODELS' from 'qdrant_client.qdrant_fastembed'
```

and with qdrant-client 1.17.0 the new test fails:

```
llama_index\vector_stores\qdrant\base.py:54: ImportError
=========================== short test summary info ===========================
FAILED tests/test_vector_stores_qdrant.py::test_import_without_qdrant_fastembed_reexport
1 failed in 0.32s
```

**After the fix** (full suite, Windows 11, Python 3.13.9, fastembed 0.8.0):

- qdrant-client 1.17.0:

```
30 passed, 16 skipped, 2 warnings in 3.44s
```

- qdrant-client 1.19.0:

```
30 passed, 16 skipped, 1 warning in 2.74s
```

The 16 skipped tests are the pre-existing server-gated tests (`QDRANT_URL` / `QDRANT_CLUSTER_URL` not set); no live-server test was run. No pre-existing failures were observed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` / `ruff format` (pinned 0.11.11) on the changed files
