### PR TITLE
fix(core): raise clear ValueError for malformed LLM output in PIINodePostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/pii.py
+++ b/llama-index-core/llama_index/core/postprocessor/pii.py
@@ -67,9 +67,22 @@ class PIINodePostprocessor(BaseNodePostprocessor):
 
         response = self.llm.predict(pii_prompt, context_str=text, query_str=task_str)
         splits = response.split("Output Mapping:")
+        if len(splits) < 2:
+            raise ValueError(
+                "Could not parse the LLM's response: expected the response to "
+                "contain an 'Output Mapping:' section, but it did not. "
+                f"Raw response: {response!r}"
+            )
         text_output = splits[0].strip()
         json_str_output = splits[1].strip()
-        json_dict = json.loads(json_str_output)
+        try:
+            json_dict = json.loads(json_str_output)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                "Could not parse the LLM's response: the 'Output Mapping:' "
+                f"section was not valid JSON ({e}). "
+                f"Raw response: {response!r}"
+            ) from e
         return text_output, json_dict
 
     def _postprocess_nodes(

--- a/llama-index-core/tests/postprocessor/test_pii.py
+++ b/llama-index-core/tests/postprocessor/test_pii.py
@@ -1,0 +1,53 @@
+"""PII postprocessor tests."""
+
+import pytest
+from llama_index.core.base.llms.types import CompletionResponse
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.postprocessor.pii import PIINodePostprocessor
+
+
+class NoMarkerMockLLM(MockLLM):
+    """Mock LLM that returns a response with no 'Output Mapping:' marker."""
+
+    def complete(self, prompt, formatted: bool = False, **kwargs) -> CompletionResponse:
+        return CompletionResponse(text="I cannot process this request.")
+
+
+class InvalidJsonMockLLM(MockLLM):
+    """Mock LLM that returns a marker followed by invalid JSON."""
+
+    def complete(self, prompt, formatted: bool = False, **kwargs) -> CompletionResponse:
+        return CompletionResponse(
+            text="Hello [NAME1].\nOutput Mapping:\nnot valid json at all"
+        )
+
+
+class ValidMockLLM(MockLLM):
+    """Mock LLM that returns a well-formed response."""
+
+    def complete(self, prompt, formatted: bool = False, **kwargs) -> CompletionResponse:
+        return CompletionResponse(
+            text='Hello [NAME1].\nOutput Mapping:\n{"NAME1": "Zhang Wei"}'
+        )
+
+
+def test_mask_pii_missing_marker_raises_value_error() -> None:
+    """Response without an 'Output Mapping:' marker should raise a clear ValueError."""
+    postprocessor = PIINodePostprocessor(llm=NoMarkerMockLLM())
+    with pytest.raises(ValueError, match="Output Mapping"):
+        postprocessor.mask_pii("Some context with PII")
+
+
+def test_mask_pii_invalid_json_raises_value_error() -> None:
+    """Response with malformed JSON after the marker should raise a clear ValueError."""
+    postprocessor = PIINodePostprocessor(llm=InvalidJsonMockLLM())
+    with pytest.raises(ValueError, match="not valid JSON"):
+        postprocessor.mask_pii("Some context with PII")
+
+
+def test_mask_pii_valid_response() -> None:
+    """A well-formed response should still parse correctly."""
+    postprocessor = PIINodePostprocessor(llm=ValidMockLLM())
+    text_output, json_dict = postprocessor.mask_pii("Some context with PII")
+    assert text_output == "Hello [NAME1]."
+    assert json_dict == {"NAME1": "Zhang Wei"}


### PR DESCRIPTION
## Summary

Fixes #22431.

`PIINodePostprocessor.mask_pii()` assumed the LLM's response always contains an `"Output Mapping:"` marker followed by valid JSON:

```python
splits = response.split("Output Mapping:")
text_output = splits[0].strip()
json_str_output = splits[1].strip()   # IndexError if the marker is missing
json_dict = json.loads(json_str_output)  # JSONDecodeError if not valid JSON
```

LLM output is inherently unreliable (refusals, formatting drift, models that ignore instructions, extra trailing text, etc.), so neither assumption holds in practice. When they fail, callers got a raw `IndexError: list index out of range` or `json.decoder.JSONDecodeError` instead of a clear, actionable error pointing at the actual problem (as also noted in the older, never-fixed #9314).

## Changes

- Guard the `"Output Mapping:"` marker lookup and raise a `ValueError` (including the raw LLM response) when it's missing.
- Wrap the `json.loads` call and raise a `ValueError` (including the raw response and the underlying `JSONDecodeError`) when the mapping section isn't valid JSON.

## Test plan

- Added `llama-index-core/tests/postprocessor/test_pii.py` with regression tests using a `MockLLM` subclass that returns malformed output for both failure modes, plus a happy-path test.
- Verified the new tests fail on `main` (raw `IndexError`/`JSONDecodeError`, no message match) and pass with this fix.
- `uv run -- pytest tests/postprocessor/` -> 16 passed, 2 skipped (unrelated, require `spacy`).
- `uv run ruff check` / `uv run ruff format --check` on changed files -> clean.