### PR TITLE
fix(core): preserve asyncio_run runtime errors

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -44,37 +44,30 @@ def asyncio_run(coro: Coroutine) -> Any:
     try:
         # Check if there's an existing event loop
         loop = asyncio.get_event_loop()
-
-        # Check if the loop is already running
-        if loop.is_running():
-            # If loop is already running, run in a separate thread
-            # Snapshot the current context so we can propagate contextvars
-            ctx = contextvars.copy_context()
-
-            def run_coro_in_thread() -> Any:
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                try:
-                    return ctx.run(new_loop.run_until_complete, coro)
-                finally:
-                    new_loop.close()
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(run_coro_in_thread)
-                return future.result()
-        else:
-            # If we're here, there's an existing loop but it's not running
-            return loop.run_until_complete(coro)
-
-    except RuntimeError as e:
+    except RuntimeError:
         # If we can't get the event loop, we're likely in a different thread
-        try:
-            return asyncio.run(coro)
-        except RuntimeError as e:
-            raise RuntimeError(
-                "Detected nested async. Please use nest_asyncio.apply() to allow nested event loops."
-                "Or, use async entry methods like `aquery()`, `aretriever`, `achat`, etc."
-            )
+        return asyncio.run(coro)
+
+    # Check if the loop is already running
+    if loop.is_running():
+        # If loop is already running, run in a separate thread
+        # Snapshot the current context so we can propagate contextvars
+        ctx = contextvars.copy_context()
+
+        def run_coro_in_thread() -> Any:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                return ctx.run(new_loop.run_until_complete, coro)
+            finally:
+                new_loop.close()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(run_coro_in_thread)
+            return future.result()
+
+    # If we're here, there's an existing loop but it's not running
+    return loop.run_until_complete(coro)
 
 
 def run_async_tasks(

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -18,6 +18,29 @@ def test_batch_gather_indivisible_task_list() -> None:
     assert results == list(range(len(coroutines)))
 
 
+def test_asyncio_run_preserves_runtime_error_from_coroutine() -> None:
+    async def fail() -> None:
+        raise RuntimeError("original failure")
+
+    with pytest.raises(RuntimeError, match="original failure"):
+        asyncio_run(fail())
+
+
+def test_asyncio_run_preserves_runtime_error_in_no_loop_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail() -> None:
+        raise RuntimeError("fallback failure")
+
+    def raise_no_loop() -> None:
+        raise RuntimeError("no current event loop")
+
+    monkeypatch.setattr(asyncio, "get_event_loop", raise_no_loop)
+
+    with pytest.raises(RuntimeError, match="fallback failure"):
+        asyncio_run(fail())
+
+
 @pytest.mark.asyncio
 async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
     """
@@ -37,3 +60,12 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_run_preserves_runtime_error_when_loop_running() -> None:
+    async def fail() -> None:
+        raise RuntimeError("threaded failure")
+
+    with pytest.raises(RuntimeError, match="threaded failure"):
+        asyncio_run(fail())


### PR DESCRIPTION
## Description

`asyncio_run()` wrapped event-loop discovery and coroutine execution in the same `try` block. That meant a `RuntimeError` raised by the coroutine itself could be caught as if event-loop lookup failed, replacing the original application/provider error with the generic nested-async message.

This narrows the fallback to `asyncio.get_event_loop()` only, so coroutine `RuntimeError`s propagate unchanged. The existing running-loop path still runs the coroutine in a separate thread and still propagates its exception through `future.result()`.

Fixes #22401

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added regression tests covering the normal loop path, no-loop fallback path, and already-running-loop/thread path.
- [x] `ruff check llama_index/core/async_utils.py tests/test_async_utils.py`
- [x] `ruff format --check llama_index/core/async_utils.py tests/test_async_utils.py`
- [x] Direct smoke checks against the edited `asyncio_run()` implementation for all three exception paths.

I could not run the full focused pytest file in this sandbox: `uv` panicked before running tests, and the fallback global pytest environment was missing `pytest_asyncio`.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
