### PR TITLE
Fix similarity_top_k=0 returning all results

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -31,7 +31,7 @@ def get_top_k_embeddings(
         similarity = similarity_fn(query_embedding_np, emb)  # type: ignore[arg-type]
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
-            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+            if similarity_top_k is not None and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
     result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
 
@@ -136,7 +136,9 @@ def get_top_k_mmr_embeddings(
     results: List[Tuple[Any, Any]] = []
 
     embedding_length = len(embeddings or [])
-    similarity_top_k_count = similarity_top_k or embedding_length
+    similarity_top_k_count = (
+        similarity_top_k if similarity_top_k is not None else embedding_length
+    )
     while len(results) < min(similarity_top_k_count, embedding_length):
         # Calculate the similarity score the for the leading one.
         results.append((score, high_score_id))

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -108,3 +108,49 @@ def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
         query_embedding, embeddings, similarity_top_k=2
     )
     assert unset_ids == [0, 1]
+
+
+def test_get_top_k_embeddings_top_k_zero() -> None:
+    """
+    An explicit similarity_top_k of 0 must return zero results.
+
+    Because 0 is falsy, ``if similarity_top_k:`` skipped the heap-trimming
+    logic entirely, causing every embedding to be returned instead of none.
+    """
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [0.7, 0.7], [0.5, 0.5]]
+
+    result_sims, result_ids = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_sims == []
+    assert result_ids == []
+
+    # similarity_top_k=None should still return all embeddings (no limit).
+    result_sims_none, result_ids_none = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=None
+    )
+    assert len(result_ids_none) == 4
+
+
+def test_get_top_k_mmr_embeddings_top_k_zero() -> None:
+    """
+    An explicit similarity_top_k of 0 must return zero results from MMR.
+
+    Because 0 is falsy, ``similarity_top_k or embedding_length`` silently
+    replaced 0 with the full embedding count, returning all embeddings.
+    """
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0], [0.7, 0.7], [0.5, 0.5]]
+
+    result_sims, result_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_sims == []
+    assert result_ids == []
+
+    # similarity_top_k=None should still return all embeddings (no limit).
+    result_sims_none, result_ids_none = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=None
+    )
+    assert len(result_ids_none) == 4


### PR DESCRIPTION
## Summary

Fixes #22508

Classic Python falsy-zero bug: two functions in `embedding_utils.py` used truthy checks on `similarity_top_k`, making an explicit `0` indistinguishable from `None`. Since `None` means "no limit", asking for zero results returned **all** embeddings instead of none.

## Changes

### `llama-index-core/llama_index/core/indices/query/embedding_utils.py`

1. **`get_top_k_embeddings`** (line 34): Changed `if similarity_top_k and ...` to `if similarity_top_k is not None and ...` so the heap-trimming logic runs when `similarity_top_k=0`, correctly producing an empty result.

2. **`get_top_k_mmr_embeddings`** (line 139): Changed `similarity_top_k or embedding_length` to `similarity_top_k if similarity_top_k is not None else embedding_length` so `similarity_top_k=0` yields zero iterations instead of iterating over all embeddings.

### `llama-index-core/tests/indices/query/test_embedding_utils.py`

Added two regression tests:
- `test_get_top_k_embeddings_top_k_zero` - verifies empty results for `similarity_top_k=0` and full results for `similarity_top_k=None`
- `test_get_top_k_mmr_embeddings_top_k_zero` - same verification for the MMR variant

Note: `get_top_k_embeddings_learner` already handles 0 correctly via `sorted_ix[:similarity_top_k]`, so no change needed there.
