### PR TITLE
fix: serialize provider objects in chat messages

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -47,6 +47,8 @@ from llama_index.core.constants import DEFAULT_CONTEXT_WINDOW, DEFAULT_NUM_OUTPU
 from llama_index.core.schema import ImageDocument
 from llama_index.core.utils import get_tokenizer, resolve_binary
 
+_TO_DICT_METHOD = "to_dict"
+
 _logger = logging.getLogger(__name__)
 
 
@@ -1252,6 +1254,9 @@ class ChatMessage(BaseRecursiveContentBlock):
         if isinstance(value, BaseModel):
             value.model_rebuild()  # ensures all fields are initialized and serializable
             return value.model_dump()  # type: ignore
+        to_dict = getattr(type(value), _TO_DICT_METHOD, None)
+        if callable(to_dict):
+            return self._recursive_serialization(to_dict(value))
         if isinstance(value, dict):
             return {
                 key: self._recursive_serialization(value)

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from io import BytesIO
 from pathlib import Path
 from unittest import mock
@@ -31,6 +32,10 @@ from llama_index.core.bridge.pydantic import ValidationError
 from llama_index.core.node_parser import TokenTextSplitter
 from llama_index.core.schema import ImageDocument
 from pydantic import AnyUrl
+
+TOOL_CALLS_KEY = "tool_calls"
+TOOL_NAME_KEY = "name"
+TOOL_NAME = "lookup"
 
 
 @pytest.fixture()
@@ -175,6 +180,22 @@ def test_chat_message_serializer():
             "some_object": {"some_field": ""},
         },
         "blocks": [{"block_type": "text", "text": "test content"}],
+    }
+
+
+def test_chat_message_serializer_with_class_level_to_dict():
+    class ProtoMessage:
+        @classmethod
+        def to_dict(cls, value):
+            return {TOOL_NAME_KEY: value.name}
+
+        def __init__(self, name: str):
+            self.name = name
+
+    message = ChatMessage(additional_kwargs={TOOL_CALLS_KEY: [ProtoMessage(TOOL_NAME)]})
+
+    assert json.loads(message.model_dump_json())["additional_kwargs"] == {
+        TOOL_CALLS_KEY: [{TOOL_NAME_KEY: TOOL_NAME}]
     }
 
 

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-postgres/tests/test_chat_store_postgres_chat_store.py
@@ -12,6 +12,21 @@ from llama_index.core.storage.chat_store.base import BaseChatStore
 from llama_index.storage.chat_store.postgres import PostgresChatStore
 from llama_index.storage.chat_store.postgres.base import get_data_model
 
+TOOL_CALLS_KEY = "tool_calls"
+TOOL_NAME_KEY = "name"
+TOOL_NAME = "lookup"
+SERIALIZATION_TEST_KEY = "provider_tool_call"
+
+
+class ProtoMessage:
+    @classmethod
+    def to_dict(cls, value):
+        return {TOOL_NAME_KEY: value.name}
+
+    def __init__(self, name: str):
+        self.name = name
+
+
 try:
     import asyncpg  # noqa
     import psycopg  # noqa
@@ -99,6 +114,19 @@ def test_postgres_add_message(postgres_chat_store: PostgresChatStore):
     result = postgres_chat_store.get_messages(key)
 
     assert result[0].content == "add_message_test" and result[0].role == "user"
+
+
+@pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")
+def test_postgres_add_message_with_class_level_to_dict(
+    postgres_chat_store: PostgresChatStore,
+):
+    message = ChatMessage(additional_kwargs={TOOL_CALLS_KEY: [ProtoMessage(TOOL_NAME)]})
+
+    postgres_chat_store.add_message(SERIALIZATION_TEST_KEY, message=message)
+
+    assert postgres_chat_store.get_messages(SERIALIZATION_TEST_KEY)[
+        0
+    ].additional_kwargs == {TOOL_CALLS_KEY: [{TOOL_NAME_KEY: TOOL_NAME}]}
 
 
 @pytest.mark.skipif(no_packages, reason="asyncpg, psycopg and sqlalchemy not installed")


### PR DESCRIPTION
# Description

Fixes #19992

`ChatMessage` now recursively converts provider objects that expose a class-level `to_dict` method before Pydantic serializes `additional_kwargs`. This supports Gemini proto-plus `FunctionCall` values at the shared serialization boundary used by Postgres and other chat stores.

The change includes a focused serializer unit test and a live Postgres add/read round-trip regression test. No runtime dependency was added.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — production change is in `llama-index-core`, which is exempt; the Postgres integration change is test-only.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

## Test verification (RED → GREEN)

Unmodified `main`, exact Gemini object:

```text
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'google.ai.generativelanguage_v1beta.types.content.FunctionCall'>
```

Unmodified `main`, live `PostgresChatStore.add_message` regression test:

```text
FAILED tests/test_chat_store_postgres_chat_store.py::test_postgres_add_message_with_class_level_to_dict
1 failed in 28.76s
```

Patched branch:

```text
Gemini FunctionCall serialized successfully
1 passed in 13.56s
```

## Full local suite

- Command: `./run-ci.sh`
- Result: same-or-better than baseline; no new failures, skips, ignores, or errors
- Core module: `110 passed`
- Postgres integration module: `18 passed`
- Full core baseline: `1466 passed, 14 failed`; patched: `1467 passed, 13 failed` (same 13 pre-existing reader failures)
- Changed production lines: `100%` coverage (`4/4`)
- `uv run --frozen make format`
- `uv run --frozen make lint`

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] Documentation changes are not required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass or match the documented upstream baseline
- [x] I ran the repository format and lint commands

AI assistance was used to investigate the shared serialization path and draft the tests. The exact Gemini failure, live Postgres path, full affected suites, lint, format, and changed-line coverage were verified locally.
