### PR TITLE
fix(sharepoint): avoid overwriting same-named files

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/llama_index/readers/microsoft_sharepoint/base.py
@@ -435,8 +435,9 @@ class SharePointReader(
             str: The path of the downloaded file in the temporary directory.
 
         """
-        # Get the download URL for the file.
-        file_name = item["name"]
+        # Use the item ID for the temporary path so same-named files do not overwrite
+        # each other. Keep the original name in the extracted metadata below.
+        file_name = f"{item['id']}{Path(item['name']).suffix}"
 
         content = self._get_file_content_by_url(item)
 

--- a/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
+++ b/llama-index-integrations/readers/llama-index-readers-microsoft-sharepoint/tests/test_readers_microsoft_sharepoint.py
@@ -215,6 +215,41 @@ def test_load_documents_with_metadata(sharepoint_reader):
         assert documents[1].text == "File 2 content"
 
 
+def test_download_files_with_same_name_use_unique_paths(sharepoint_reader):
+    sharepoint_reader.attach_permission_metadata = False
+
+    items = [
+        {
+            "id": "file1_id",
+            "name": "report.txt",
+            "content": b"File 1 content",
+        },
+        {
+            "id": "file2_id",
+            "name": "report.txt",
+            "content": b"File 2 content",
+        },
+    ]
+
+    def get_file_content(item):
+        return item["content"]
+
+    with patch.object(
+        SharePointReader,
+        "_get_file_content_by_url",
+        side_effect=get_file_content,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            first_path = sharepoint_reader._download_file_by_url(items[0], tmpdirname)
+            second_path = sharepoint_reader._download_file_by_url(items[1], tmpdirname)
+
+            assert first_path != second_path
+            assert Path(first_path).suffix == ".txt"
+            assert Path(second_path).suffix == ".txt"
+            assert Path(first_path).read_bytes() == b"File 1 content"
+            assert Path(second_path).read_bytes() == b"File 2 content"
+
+
 def test_required_exts():
     sharepoint_reader = SharePointReader(
         client_id="dummy_client_id",


### PR DESCRIPTION
## Summary

- avoid overwriting files when SharePoint contains the same filename in different folders
- use the Microsoft Graph item ID for temporary download paths while preserving the original filename in metadata

Closes #22318

## Test plan

- `uv run --no-cache --no-project --with pytest --with requests --with 'llama-index-core>=0.14.23,<0.15.0' pytest -q -p no:cacheprovider tests/test_readers_microsoft_sharepoint.py` (19 passed)
- `uv run --no-cache --no-project --with ruff ruff check llama_index/readers/microsoft_sharepoint/base.py tests/test_readers_microsoft_sharepoint.py`
- `uv run --no-cache --no-project --with ruff ruff format --check llama_index/readers/microsoft_sharepoint/base.py tests/test_readers_microsoft_sharepoint.py`

## AI assistance

I used AI assistance to inspect the issue, draft the focused patch and regression test, and run the checks listed above. I reviewed the final diff and understand the behavior change.
