### PR TITLE
fix(core): preserve RuntimeError raised by coroutine in asyncio_run

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -42,39 +42,39 @@ def asyncio_run(coro: Coroutine) -> Any:
     If an event loop is already running, uses threading to run in a separate thread.
     """
     try:
-        # Check if there's an existing event loop
+        # Check if there's an existing event loop. A RuntimeError here means
+        # there is no current event loop in this thread, so fall back to
+        # asyncio.run(). Only loop discovery belongs in this try block: running
+        # the coroutine inside it would swallow RuntimeErrors raised by the
+        # coroutine itself and misreport them as nested-async failures.
         loop = asyncio.get_event_loop()
+    except RuntimeError:
+        # No current event loop in this thread; create one via asyncio.run().
+        # Any RuntimeError raised by asyncio.run() here originates from the
+        # coroutine itself (not nested-async, because get_event_loop() above
+        # would have succeeded if a loop were running). Let it propagate.
+        return asyncio.run(coro)
 
-        # Check if the loop is already running
-        if loop.is_running():
-            # If loop is already running, run in a separate thread
-            # Snapshot the current context so we can propagate contextvars
-            ctx = contextvars.copy_context()
+    # Check if the loop is already running
+    if loop.is_running():
+        # If loop is already running, run in a separate thread
+        # Snapshot the current context so we can propagate contextvars
+        ctx = contextvars.copy_context()
 
-            def run_coro_in_thread() -> Any:
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                try:
-                    return ctx.run(new_loop.run_until_complete, coro)
-                finally:
-                    new_loop.close()
+        def run_coro_in_thread() -> Any:
+            new_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(new_loop)
+            try:
+                return ctx.run(new_loop.run_until_complete, coro)
+            finally:
+                new_loop.close()
 
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(run_coro_in_thread)
-                return future.result()
-        else:
-            # If we're here, there's an existing loop but it's not running
-            return loop.run_until_complete(coro)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(run_coro_in_thread)
+            return future.result()
 
-    except RuntimeError as e:
-        # If we can't get the event loop, we're likely in a different thread
-        try:
-            return asyncio.run(coro)
-        except RuntimeError as e:
-            raise RuntimeError(
-                "Detected nested async. Please use nest_asyncio.apply() to allow nested event loops."
-                "Or, use async entry methods like `aquery()`, `aretriever`, `achat`, etc."
-            )
+    # If we're here, there's an existing loop but it's not running
+    return loop.run_until_complete(coro)
 
 
 def run_async_tasks(

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+
 import pytest
 from llama_index.core.async_utils import batch_gather, asyncio_run
 
@@ -37,3 +38,44 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+def test_asyncio_run_propagates_coroutine_runtime_error() -> None:
+    """A RuntimeError raised by the coroutine itself must propagate unchanged."""
+
+    async def fail() -> None:
+        raise RuntimeError("original failure")
+
+    with pytest.raises(RuntimeError, match="original failure"):
+        asyncio_run(fail())
+
+
+def test_asyncio_run_propagates_runtime_error_in_no_loop_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-event-loop fallback must not mask the coroutine's RuntimeError."""
+
+    async def fail() -> None:
+        raise RuntimeError("fallback failure")
+
+    def raise_no_loop() -> None:
+        raise RuntimeError("no current event loop in thread")
+
+    monkeypatch.setattr(asyncio, "get_event_loop", raise_no_loop)
+    with pytest.raises(RuntimeError, match="fallback failure"):
+        asyncio_run(fail())
+
+
+def test_asyncio_run_no_loop_fallback_runs_coroutine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no current event loop, the coroutine still runs via asyncio.run()."""
+
+    async def answer() -> int:
+        return 42
+
+    def raise_no_loop() -> None:
+        raise RuntimeError("no current event loop in thread")
+
+    monkeypatch.setattr(asyncio, "get_event_loop", raise_no_loop)
+    assert asyncio_run(answer()) == 42


### PR DESCRIPTION
Closes #22401

## Problem

`asyncio_run()` wrapped both event-loop discovery *and* coroutine execution in a single `try` with a broad `except RuntimeError`. A `RuntimeError` raised by the coroutine itself was therefore caught, the already-awaited coroutine was re-run via `asyncio.run()`, and the original failure was replaced with the generic (and misleading) "Detected nested async" error — hiding real application/provider errors that callers need to diagnose.

## Fix

Narrow the `try` block to only cover loop discovery (`asyncio.get_event_loop()`), which is the only call whose `RuntimeError` legitimately means "no current loop, fall back to `asyncio.run()`". Coroutine execution now happens outside the `try`, so its `RuntimeError`s propagate unchanged.

In the no-loop fallback, any `RuntimeError` from `asyncio.run()` is now allowed to propagate directly. Since `get_event_loop()` only raises when no loop exists in this thread, `asyncio.run()` will never hit the nested-async case in this path — the nested-async scenario is already handled by the `loop.is_running()` branch at the top, which runs the coroutine in a separate thread.

## Tests

Added regression tests covering:
- coroutine `RuntimeError` propagates unchanged (the reported bug)
- no-loop fallback does not mask the coroutine's `RuntimeError`
- no-loop fallback still runs the coroutine via `asyncio.run()`

Full `llama-index-core` suite: 1455 passed, 0 failed. `make lint` clean.

---

*This PR was developed with AI assistance (GitHub Copilot); the fix and tests were reviewed and verified locally by a human.*