### PR TITLE
fix(core): skip empty/whitespace-only text in SemanticDoubleMergingSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_double_merging_splitter.py
@@ -230,7 +230,10 @@ class SemanticDoubleMergingSplitterNodeParser(NodeParser):
         for node in nodes:
             text = node.get_content()
             sentences = self.sentence_splitter(text)
-            sentences = [s.strip() for s in sentences]
+            sentences = [s.strip() for s in sentences if s.strip()]
+            if not sentences:
+                # Nothing to split (e.g. empty or whitespace-only text).
+                continue
             initial_chunks = self._create_initial_chunks(sentences)
             chunks = self._merge_initial_chunks(initial_chunks)
 

--- a/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_double_merging_splitter.py
@@ -146,6 +146,40 @@ def test_embed_model_single_sentence_document() -> None:
     assert nodes[0].get_content() == "Only one sentence here."
 
 
+def test_empty_document_does_not_raise() -> None:
+    """An empty document must not crash with IndexError (see #17032)."""
+    empty_doc = Document(text="")
+    embed = MockEmbedding(embed_dim=4)
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(
+        embed_model=embed,
+    )
+    nodes = splitter.get_nodes_from_documents([empty_doc])
+    assert nodes == []
+
+
+def test_whitespace_only_document_does_not_raise() -> None:
+    """A whitespace/newline-only document must not crash with IndexError (see #17032)."""
+    whitespace_doc = Document(text="   \n\n  \t  ")
+    embed = MockEmbedding(embed_dim=4)
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(
+        embed_model=embed,
+    )
+    nodes = splitter.get_nodes_from_documents([whitespace_doc])
+    assert nodes == []
+
+
+def test_mixed_empty_and_nonempty_documents() -> None:
+    """An empty document mixed with real documents should be skipped, not crash the batch."""
+    embed = MockEmbedding(embed_dim=4)
+    splitter = SemanticDoubleMergingSplitterNodeParser.from_defaults(
+        embed_model=embed,
+    )
+    real_doc = Document(text="Only one sentence here.")
+    nodes = splitter.get_nodes_from_documents([Document(text=""), real_doc])
+    assert len(nodes) == 1
+    assert nodes[0].get_content() == "Only one sentence here."
+
+
 def test_clean_text_advanced() -> None:
     """Test that _clean_text_advanced properly filters out stopwords from a string."""
     from llama_index.core.utils import globals_helper


### PR DESCRIPTION
Fixes #17032

## Problem
`SemanticDoubleMergingSplitterNodeParser` raises `IndexError: list index
out of range` when given an empty or whitespace-only `Document`. This
issue was reported and diagnosed with the exact fix by a maintainer
(@logan-markewich), but was auto-closed by the stale bot after 7 days
without a PR ever landing. The bug is still present on `main`.

Root cause: `build_semantic_nodes_from_nodes` strips each sentence but
never filters out sentences that become empty, so `_create_initial_chunks`
indexes into a possibly-empty list at `sentences[0]`.

## Fix
Filter out blank sentences after stripping, and skip a document
entirely if no sentences remain — the same pattern already used for
empty sections in `HTMLNodeParser` (#22125).

## Testing
- Added 3 regression tests: empty document, whitespace/newline-only
  document, and a batch mixing an empty document with a real one.
- `uv run -- pytest tests/node_parser/test_semantic_double_merging_splitter.py -q`
  → 7 passed, 6 skipped (pre-existing, gated on local spacy model)
- Full `llama-index-core` suite: 1482 passed, 22 skipped, 6 xfailed, 0
  failed (baseline was 1479/22/6/0 — delta is exactly the 3 new tests)
- `ruff check` / `ruff format --check` clean on both changed files