### PR TITLE
fix: treat similarity_top_k=0 as zero results, not unlimited

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -31,7 +31,7 @@ def get_top_k_embeddings(
         similarity = similarity_fn(query_embedding_np, emb)  # type: ignore[arg-type]
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
-            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+            if similarity_top_k is not None and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
     result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
 
@@ -136,7 +136,7 @@ def get_top_k_mmr_embeddings(
     results: List[Tuple[Any, Any]] = []
 
     embedding_length = len(embeddings or [])
-    similarity_top_k_count = similarity_top_k or embedding_length
+    similarity_top_k_count = similarity_top_k if similarity_top_k is not None else embedding_length
     while len(results) < min(similarity_top_k_count, embedding_length):
         # Calculate the similarity score the for the leading one.
         results.append((score, high_score_id))

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -108,3 +108,47 @@ def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
         query_embedding, embeddings, similarity_top_k=2
     )
     assert unset_ids == [0, 1]
+
+
+def test_get_top_k_embeddings_top_k_zero() -> None:
+    """
+    An explicit ``similarity_top_k=0`` must return no results.
+
+    ``similarity_top_k=None`` means "no limit", but because 0 is falsy the
+    guard ``if similarity_top_k and ...`` treated an explicit 0 the same as
+    None, so asking for zero results returned *every* embedding.
+    """
+    query_embedding = [1.0, 0.0, 0.0]
+    embeddings = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    result_similarities, result_ids = get_top_k_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_similarities == []
+    assert result_ids == []
+
+    # None still means "no limit" and returns everything.
+    _, all_ids = get_top_k_embeddings(query_embedding, embeddings, similarity_top_k=None)
+    assert len(all_ids) == 3
+
+
+def test_get_top_k_mmr_embeddings_top_k_zero() -> None:
+    """
+    An explicit ``similarity_top_k=0`` must return no results for the MMR path
+    too. ``similarity_top_k or embedding_length`` previously discarded the
+    explicit 0 and fell back to returning every embedding.
+    """
+    query_embedding = [1.0, 0.0, 0.0]
+    embeddings = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    result_similarities, result_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert result_similarities == []
+    assert result_ids == []
+
+    # None still means "no limit" and returns everything.
+    _, all_ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=None
+    )
+    assert len(all_ids) == 3


### PR DESCRIPTION
## Fixes #22508

### Bug

`get_top_k_embeddings` and `get_top_k_mmr_embeddings` test `similarity_top_k` truthily, so an explicit `0` is indistinguishable from `None`. Since `None` means *no limit*, asking for zero results returns **every** embedding.

```python
# embedding_utils.py
if similarity_top_k and len(similarity_heap) > similarity_top_k:   # 0 is falsy -> never pops
similarity_top_k_count = similarity_top_k or embedding_length      # 0 -> embedding_length
```

The sibling `get_top_k_embeddings_learner` uses `sorted_ix[:similarity_top_k]` and handles `0` correctly, so the three functions disagreed on the same contract.

### Fix

- `get_top_k_embeddings`: `if similarity_top_k is not None and ...`
- `get_top_k_mmr_embeddings`: `similarity_top_k if similarity_top_k is not None else embedding_length`

This is the same falsy-zero class already fixed in this file for `mmr_threshold` (`mmr_threshold if mmr_threshold is not None else 0.5`, see `test_get_top_k_mmr_embeddings_threshold_zero`).

### Tests

Added `test_get_top_k_embeddings_top_k_zero` and `test_get_top_k_mmr_embeddings_top_k_zero` asserting `top_k=0` -> empty and `top_k=None` -> all. Full `test_embedding_utils.py`: **4 passed**.