### PR TITLE
fix: do not swallow task exceptions in run_async_tasks

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -89,6 +89,13 @@ def run_async_tasks(
             import nest_asyncio
             from tqdm.asyncio import tqdm
 
+            tqdm_available = True
+        # fall back to the plain path on hitting a fatal, which may occur in
+        # some environments where tqdm.asyncio is not supported
+        except Exception:
+            tqdm_available = False
+
+        if tqdm_available:
             # jupyter notebooks already have an event loop running
             # we need to reuse it instead of creating a new one
             nest_asyncio.apply()
@@ -99,11 +106,6 @@ def run_async_tasks(
 
             tqdm_outputs: List[Any] = loop.run_until_complete(_tqdm_gather())
             return tqdm_outputs
-        # run the operation w/o tqdm on hitting a fatal
-        # may occur in some environments where tqdm.asyncio
-        # is not supported
-        except Exception:
-            pass
 
     async def _gather() -> List[Any]:
         return await asyncio.gather(*tasks_to_execute)

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 import pytest
-from llama_index.core.async_utils import batch_gather, asyncio_run
+from llama_index.core.async_utils import batch_gather, asyncio_run, run_async_tasks
 
 
 def test_batch_gather_indivisible_task_list() -> None:
@@ -37,3 +37,25 @@ async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
         assert result == "sentinel_value"
     finally:
         test_var.reset(token)
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_run_async_tasks_propagates_task_exception(show_progress: bool) -> None:
+    """
+    A task exception must surface unchanged regardless of ``show_progress``.
+
+    The ``show_progress=True`` path wrapped task execution in
+    ``except Exception: pass``, so a task error was swallowed and the fallback
+    re-awaited the already-consumed coroutines, replacing the real error with
+    an unrelated ``RuntimeError``. ``show_progress`` is cosmetic and must not
+    change error semantics.
+    """
+
+    async def ok() -> int:
+        return 1
+
+    async def fail() -> int:
+        raise ValueError("ORIGINAL task failure")
+
+    with pytest.raises(ValueError, match="ORIGINAL task failure"):
+        run_async_tasks([ok(), fail()], show_progress=show_progress)


### PR DESCRIPTION
## Fixes #22493

### Bug

When `show_progress=True`, `run_async_tasks` wraps both the tqdm import **and** task execution in `except Exception: pass`:

```python
try:
    import nest_asyncio
    from tqdm.asyncio import tqdm
    ...
    tqdm_outputs = loop.run_until_complete(_tqdm_gather())  # task execution also inside try
    return tqdm_outputs
except Exception:
    pass   # swallows task errors, then falls through
```

The comment shows the intent is to fall back only when `tqdm.asyncio` is unsupported, but a task exception is also swallowed. The coroutines are already consumed, so the fallback `_gather()` re-awaits them and the real error is replaced by a misleading `RuntimeError: Detected nested async...` (which advises `nest_asyncio.apply()` — already called just above).

`show_progress` is cosmetic and should not change error semantics.

### Fix

Guard only the tqdm **import** in the try/except; run the tasks outside it so task exceptions propagate unchanged. The tqdm-unsupported fallback to the plain path is preserved.

### Tests

Added a parametrized regression test (`show_progress` False/True) asserting the original `ValueError` surfaces in both cases. `test_async_utils.py`: **4 passed**.