### PR TITLE
fix(core): make MultiStepQueryEngine.aquery() actually async

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/multistep_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/multistep_query_engine.py
@@ -100,7 +100,7 @@ class MultiStepQueryEngine(BaseQueryEngine):
         with self.callback_manager.event(
             CBEventType.QUERY, payload={EventPayload.QUERY_STR: query_bundle.query_str}
         ) as query_event:
-            nodes, source_nodes, metadata = self._query_multistep(query_bundle)
+            nodes, source_nodes, metadata = await self._aquery_multistep(query_bundle)
 
             final_response = await self._response_synthesizer.asynthesize(
                 query=query_bundle,
@@ -153,6 +153,60 @@ class MultiStepQueryEngine(BaseQueryEngine):
                 break
 
             cur_response = self._query_engine.query(updated_query_bundle)
+
+            # append to response builder
+            cur_qa_text = (
+                f"\nQuestion: {updated_query_bundle.query_str}\n"
+                f"Answer: {cur_response!s}"
+            )
+            text_chunks.append(cur_qa_text)
+            for source_node in cur_response.source_nodes:
+                source_nodes.append(source_node)
+            # update metadata
+            final_response_metadata["sub_qa"].append(
+                (updated_query_bundle.query_str, cur_response)
+            )
+
+            prev_reasoning += (
+                f"- {updated_query_bundle.query_str}\n- {cur_response!s}\n"
+            )
+            cur_steps += 1
+
+        nodes = [
+            NodeWithScore(node=TextNode(text=text_chunk)) for text_chunk in text_chunks
+        ]
+        return nodes, source_nodes, final_response_metadata
+
+    async def _aquery_multistep(
+        self, query_bundle: QueryBundle
+    ) -> Tuple[List[NodeWithScore], List[NodeWithScore], Dict[str, Any]]:
+        """Run query combiner (async)."""
+        prev_reasoning = ""
+        cur_response = None
+        should_stop = False
+        cur_steps = 0
+
+        # use response
+        final_response_metadata: Dict[str, Any] = {"sub_qa": []}
+
+        text_chunks = []
+        source_nodes = []
+        while not should_stop:
+            if self._num_steps is not None and cur_steps >= self._num_steps:
+                should_stop = True
+                break
+            elif should_stop:
+                break
+
+            updated_query_bundle = self._combine_queries(query_bundle, prev_reasoning)
+
+            # TODO: make stop logic better
+            stop_dict = {"query_bundle": updated_query_bundle}
+            if self._stop_fn(stop_dict):
+                should_stop = True
+                break
+
+            cur_response = await self._query_engine.aquery(updated_query_bundle)
 
             # append to response builder
             cur_qa_text = (

--- a/llama-index-core/tests/query_engine/test_multistep_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_multistep_query_engine.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llama_index.core.base.response.schema import Response
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.query_engine.multistep_query_engine import MultiStepQueryEngine
+from llama_index.core.schema import QueryBundle
+
+
+def _make_query_engine():
+    engine = MagicMock()
+    engine.callback_manager = CallbackManager([])
+    resp = Response(response="answer", source_nodes=[])
+    engine.query.return_value = resp
+    engine.aquery = AsyncMock(return_value=resp)
+    return engine
+
+
+def _make_query_transform():
+    transform = MagicMock()
+    transform.side_effect = lambda query_bundle, metadata=None: QueryBundle(
+        query_str="step query"
+    )
+    return transform
+
+
+def test_query_calls_sync_query_engine():
+    engine = _make_query_engine()
+    mse = MultiStepQueryEngine(
+        query_engine=engine,
+        query_transform=_make_query_transform(),
+        num_steps=1,
+    )
+
+    mse.query("hello")
+
+    engine.query.assert_called_once()
+    engine.aquery.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aquery_calls_async_query_engine():
+    """
+    Regression test: aquery() must await the wrapped engine's aquery(),
+    not silently fall back to its synchronous query().
+    """
+    engine = _make_query_engine()
+    mse = MultiStepQueryEngine(
+        query_engine=engine,
+        query_transform=_make_query_transform(),
+        num_steps=1,
+    )
+
+    await mse.aquery("hello")
+
+    engine.aquery.assert_awaited_once()
+    engine.query.assert_not_called()


### PR DESCRIPTION
Fixes #22635

## Problem
`MultiStepQueryEngine._aquery()` delegated all step iteration to the
shared `_query_multistep()` helper, which unconditionally called the
wrapped query engine's **synchronous** `.query()` — never `.aquery()`.
So `aquery()` on this class did real async work only for the final
response-synthesis call; every retrieval/LLM step of the multi-step
loop ran synchronously and blocked the event loop.

## Fix
Added `_aquery_multistep()`, an async twin of `_query_multistep()` that
awaits `self._query_engine.aquery(...)`, and pointed `_aquery()` at it.
This mirrors the existing sync/async split already used by
`SubQuestionQueryEngine` (`_query_subq` / `_aquery_subq`), so the fix
matches an established pattern in this package rather than introducing
a new one.

## Testing
- Added `tests/query_engine/test_multistep_query_engine.py` with two
  tests: `.query()` calls the sync engine method, `.aquery()` awaits
  the async engine method. Verified the async test fails on unfixed
  code (`AssertionError: Expected aquery to have been awaited once.
  Awaited 0 times.`) and passes after the fix.
- Full `llama-index-core` suite: 1481 passed, 22 skipped, 6 xfailed, 0
  failed (baseline 1479/22/6/0 — delta is exactly the 2 new tests).
- `ruff check` / `ruff format --check` clean on both changed files.
