### PR TITLE
fix(core): docstore ingestion hash poison & eager deletes on failed run

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -5,6 +5,7 @@ import os
 import re
 import warnings
 from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial
 from hashlib import sha256
@@ -259,6 +260,23 @@ class DocstoreStrategy(str, Enum):
     UPSERTS_AND_DELETE = "upserts_and_delete"
 
 
+@dataclass
+class _PlannedRun:
+    """
+    Decisions for one run, computed read-only and applied only after
+    transformations succeed.
+    """
+
+    nodes_to_run: List[BaseNode] = field(default_factory=list)
+    # changed documents: old docstore entry and old vectors removed before the
+    # new chunks are added (the new chunks carry the same ref_doc_id). A set:
+    # multiple input nodes sharing a ref_doc_id must schedule ONE delete —
+    # vector_store.delete has no idempotency guarantee across backends.
+    ref_docs_to_delete: set[str] = field(default_factory=set)
+    # documents missing from the input under UPSERTS_AND_DELETE
+    docs_to_purge: List[str] = field(default_factory=list)
+
+
 class IngestionPipeline(BaseModel):
     """
     An ingestion pipeline that can be applied to data.
@@ -448,63 +466,75 @@ class IngestionPipeline(BaseModel):
 
         return input_nodes
 
-    def _handle_duplicates(
+    def _plan_duplicates(
         self,
         nodes: Sequence[BaseNode],
-    ) -> Sequence[BaseNode]:
-        """Handle docstore duplicates by checking all hashes."""
+    ) -> _PlannedRun:
+        """Plan docstore de-duplication by checking all hashes. Read-only."""
         assert self.docstore is not None
 
         existing_hashes = self.docstore.get_all_document_hashes()
         current_hashes: set[str] = set()
-        nodes_to_run = []
+        planned = _PlannedRun()
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
-                nodes_to_run.append(node)
+                planned.nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
-        return nodes_to_run
+        return planned
 
-    def _handle_upserts(
+    def _plan_upserts(
         self,
         nodes: Sequence[BaseNode],
-    ) -> Sequence[BaseNode]:
-        """Handle docstore upserts by checking hashes and ids."""
+        effective_strategy: DocstoreStrategy,
+    ) -> _PlannedRun:
+        """Plan docstore upserts by checking hashes and ids. Read-only."""
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
-        deduped_nodes_to_run = []
+        planned = _PlannedRun()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
             existing_hash = self.docstore.get_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
-                deduped_nodes_to_run.append(node)
+                planned.nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
-                deduped_nodes_to_run.append(node)
+                planned.ref_docs_to_delete.add(ref_doc_id)
+                planned.nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
-        if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
-            # Identify missing docs and delete them from docstore and vector store
+        if effective_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
+            # Identify docs missing from the input; deletion is deferred until
+            # the run is known to have succeeded
             existing_doc_ids_before = set(
                 self.docstore.get_all_document_hashes().values()
             )
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                self.docstore.delete_document(ref_doc_id)
+            planned.docs_to_purge.extend(sorted(doc_ids_to_delete))
 
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
+        return planned
 
-        return deduped_nodes_to_run
+    def _apply_planned_deletes(self, planned: _PlannedRun) -> None:
+        """
+        Apply the deletions decided at planning time. Runs only after
+        transformations have succeeded, and before the new chunks are added to
+        the vector store: the new chunks carry the same ref_doc_id as the old
+        ones, so deleting later would drop them too.
+        """
+        assert self.docstore is not None
+
+        for ref_doc_id in sorted(planned.ref_docs_to_delete):
+            self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
+
+        for ref_doc_id in planned.docs_to_purge:
+            self.docstore.delete_document(ref_doc_id)
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
 
     @staticmethod
     def _node_batcher(
@@ -527,10 +557,11 @@ class IngestionPipeline(BaseModel):
         if effective_strategy in (
             DocstoreStrategy.UPSERTS,
             DocstoreStrategy.UPSERTS_AND_DELETE,
+            DocstoreStrategy.DUPLICATES_ONLY,
         ):
+            # hashes are recorded here, not at planning time, so a failed run
+            # never marks a document as ingested
             self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
-            self.docstore.add_documents(nodes, store_text=store_doc_text)
-        elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
             self.docstore.add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
@@ -571,37 +602,27 @@ class IngestionPipeline(BaseModel):
         """
         input_nodes = self._prepare_inputs(documents, nodes)
 
-        effective_strategy = self.docstore_strategy
-        if (
-            self.docstore is not None
-            and self.vector_store is None
-            and self.docstore_strategy
-            in (DocstoreStrategy.UPSERTS, DocstoreStrategy.UPSERTS_AND_DELETE)
-        ):
-            warnings.warn(
-                f"docstore_strategy='{self.docstore_strategy.value}' requires a vector store "
-                "to apply upsert/delete semantics; falling back to 'duplicates_only' for this run. "
-                "pipeline.docstore_strategy is unchanged.",
-                UserWarning,
-                stacklevel=3,
-            )
-            effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
+        effective_strategy = self._resolve_effective_strategy()
 
-        # check if we need to dedup
+        # decide what to run (read-only); store mutations are deferred until
+        # the transformations have succeeded
+        planned: Optional[_PlannedRun] = None
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = self._handle_upserts(input_nodes)
+                planned = self._plan_upserts(input_nodes, effective_strategy)
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
-                nodes_to_run = self._handle_duplicates(input_nodes)
+                planned = self._plan_duplicates(input_nodes)
             else:
                 raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
         elif self.docstore is not None and self.vector_store is None:
-            nodes_to_run = self._handle_duplicates(input_nodes)
-        else:
-            nodes_to_run = input_nodes
+            planned = self._plan_duplicates(input_nodes)
+
+        nodes_to_run = (
+            planned.nodes_to_run if planned is not None else list(input_nodes)
+        )
 
         if num_workers and num_workers > 1:
             num_cpus = multiprocessing.cpu_count()
@@ -647,6 +668,11 @@ class IngestionPipeline(BaseModel):
 
         nodes = nodes or []
 
+        # transformations succeeded: apply the deferred deletions first (the
+        # new chunks share ref_doc_id with the old ones), then the writes
+        if planned is not None:
+            self._apply_planned_deletes(planned)
+
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]
             if nodes_with_embeddings:
@@ -661,6 +687,24 @@ class IngestionPipeline(BaseModel):
 
         return nodes
 
+    def _resolve_effective_strategy(self) -> DocstoreStrategy:
+        """Strategy actually applied by a run with the current stores."""
+        if (
+            self.docstore is not None
+            and self.vector_store is None
+            and self.docstore_strategy
+            in (DocstoreStrategy.UPSERTS, DocstoreStrategy.UPSERTS_AND_DELETE)
+        ):
+            warnings.warn(
+                f"docstore_strategy='{self.docstore_strategy.value}' requires a vector store "
+                "to apply upsert/delete semantics; falling back to 'duplicates_only' for this run. "
+                "pipeline.docstore_strategy is unchanged.",
+                UserWarning,
+                stacklevel=4,
+            )
+            return DocstoreStrategy.DUPLICATES_ONLY
+        return self.docstore_strategy
+
     # ------ async methods ------
     async def _aupdate_docstore(
         self,
@@ -674,73 +718,84 @@ class IngestionPipeline(BaseModel):
         if effective_strategy in (
             DocstoreStrategy.UPSERTS,
             DocstoreStrategy.UPSERTS_AND_DELETE,
+            DocstoreStrategy.DUPLICATES_ONLY,
         ):
+            # hashes are recorded here, not at planning time, so a failed run
+            # never marks a document as ingested
             await self.docstore.aset_document_hashes({n.id_: n.hash for n in nodes})
-            await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
-        elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
             await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
 
-    async def _ahandle_duplicates(
+    async def _aplan_duplicates(
         self,
         nodes: Sequence[BaseNode],
-        store_doc_text: bool = True,
-    ) -> Sequence[BaseNode]:
-        """Handle docstore duplicates by checking all hashes."""
+    ) -> _PlannedRun:
+        """Plan docstore de-duplication by checking all hashes. Read-only."""
         assert self.docstore is not None
 
         existing_hashes = await self.docstore.aget_all_document_hashes()
         current_hashes: set[str] = set()
-        nodes_to_run = []
+        planned = _PlannedRun()
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
-                nodes_to_run.append(node)
+                planned.nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
-        return nodes_to_run
+        return planned
 
-    async def _ahandle_upserts(
+    async def _aplan_upserts(
         self,
         nodes: Sequence[BaseNode],
-        store_doc_text: bool = True,
-    ) -> Sequence[BaseNode]:
-        """Handle docstore upserts by checking hashes and ids."""
+        effective_strategy: DocstoreStrategy,
+    ) -> _PlannedRun:
+        """Plan docstore upserts by checking hashes and ids. Read-only."""
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
-        deduped_nodes_to_run = []
+        planned = _PlannedRun()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
             existing_hash = await self.docstore.aget_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
-                deduped_nodes_to_run.append(node)
+                planned.nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
-                deduped_nodes_to_run.append(node)
+                planned.ref_docs_to_delete.add(ref_doc_id)
+                planned.nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
-        if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
-            # Identify missing docs and delete them from docstore and vector store
+        if effective_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
+            # Identify docs missing from the input; deletion is deferred until
+            # the run is known to have succeeded
             existing_doc_ids_before = set(
                 (await self.docstore.aget_all_document_hashes()).values()
             )
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                await self.docstore.adelete_document(ref_doc_id)
+            planned.docs_to_purge.extend(sorted(doc_ids_to_delete))
 
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
+        return planned
 
-        return deduped_nodes_to_run
+    async def _aapply_planned_deletes(self, planned: _PlannedRun) -> None:
+        """
+        Apply the deletions decided at planning time. Runs only after
+        transformations have succeeded, and before the new chunks are added to
+        the vector store: the new chunks carry the same ref_doc_id as the old
+        ones, so deleting later would drop them too.
+        """
+        assert self.docstore is not None
+
+        for ref_doc_id in sorted(planned.ref_docs_to_delete):
+            await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
+
+        for ref_doc_id in planned.docs_to_purge:
+            await self.docstore.adelete_document(ref_doc_id)
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
 
     @dispatcher.span
     async def arun(
@@ -778,43 +833,27 @@ class IngestionPipeline(BaseModel):
         """
         input_nodes = self._prepare_inputs(documents, nodes)
 
-        effective_strategy = self.docstore_strategy
-        if (
-            self.docstore is not None
-            and self.vector_store is None
-            and self.docstore_strategy
-            in (DocstoreStrategy.UPSERTS, DocstoreStrategy.UPSERTS_AND_DELETE)
-        ):
-            warnings.warn(
-                f"docstore_strategy='{self.docstore_strategy.value}' requires a vector store "
-                "to apply upsert/delete semantics; falling back to 'duplicates_only' for this run. "
-                "pipeline.docstore_strategy is unchanged.",
-                UserWarning,
-                stacklevel=3,
-            )
-            effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
+        effective_strategy = self._resolve_effective_strategy()
 
-        # check if we need to dedup
+        # decide what to run (read-only); store mutations are deferred until
+        # the transformations have succeeded
+        planned: Optional[_PlannedRun] = None
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = await self._ahandle_upserts(
-                    input_nodes, store_doc_text=store_doc_text
-                )
+                planned = await self._aplan_upserts(input_nodes, effective_strategy)
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
-                nodes_to_run = await self._ahandle_duplicates(
-                    input_nodes, store_doc_text=store_doc_text
-                )
+                planned = await self._aplan_duplicates(input_nodes)
             else:
                 raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
         elif self.docstore is not None and self.vector_store is None:
-            nodes_to_run = await self._ahandle_duplicates(
-                input_nodes, store_doc_text=store_doc_text
-            )
-        else:
-            nodes_to_run = input_nodes
+            planned = await self._aplan_duplicates(input_nodes)
+
+        nodes_to_run = (
+            planned.nodes_to_run if planned is not None else list(input_nodes)
+        )
 
         if num_workers and num_workers > 1:
             num_cpus = multiprocessing.cpu_count()
@@ -866,6 +905,11 @@ class IngestionPipeline(BaseModel):
             nodes = nodes
 
         nodes = nodes or []
+
+        # transformations succeeded: apply the deferred deletions first (the
+        # new chunks share ref_doc_id with the old ones), then the writes
+        if planned is not None:
+            await self._aapply_planned_deletes(planned)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -259,7 +259,7 @@ def test_pipeline_dedup_duplicates_only() -> None:
 
 def test_pipeline_dedup_within_single_batch() -> None:
     """
-    `_handle_duplicates` should deduplicate nodes that share a hash
+    `_plan_duplicates` should deduplicate nodes that share a hash
     within a single ingestion run, not just against the docstore.
 
     Documents with identical text and metadata produce identical
@@ -298,9 +298,10 @@ def _nodes_sharing_ref_doc(ref_doc_id: str, count: int) -> list[BaseNode]:
 def test_pipeline_upserts_keep_all_nodes_per_doc() -> None:
     """
     Regression test: with the UPSERTS strategy, every node belonging to the
-    same source document must be ingested. `_handle_upserts` previously keyed a
-    dict by `ref_doc_id` and overwrote earlier nodes, so only the last chunk of
-    each document survived and the rest were silently dropped.
+    same source document must be ingested. `_plan_upserts` (formerly
+    `_handle_upserts`) previously keyed a dict by `ref_doc_id` and overwrote
+    earlier nodes, so only the last chunk of each document survived and the
+    rest were silently dropped.
     """
     nodes = _nodes_sharing_ref_doc("source-doc", 5)
     pipeline = IngestionPipeline(

--- a/llama-index-core/tests/ingestion/test_pipeline_atomicity.py
+++ b/llama-index-core/tests/ingestion/test_pipeline_atomicity.py
@@ -1,0 +1,353 @@
+"""
+Failure-atomicity coverage for IngestionPipeline.
+
+A run that fails mid-transformations must leave the docstore and the vector
+store exactly as they were, so the same inputs can be safely retried.
+"""
+
+from typing import Any, Sequence
+
+import pytest
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
+from llama_index.core.ingestion.pipeline import DocstoreStrategy, IngestionPipeline
+from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.schema import (
+    BaseNode,
+    Document,
+    NodeRelationship,
+    RelatedNodeInfo,
+    TextNode,
+    TransformComponent,
+)
+from llama_index.core.storage.docstore import SimpleDocumentStore
+from llama_index.core.vector_stores import SimpleVectorStore
+
+
+class RaisingTransform(TransformComponent):
+    def __call__(self, nodes: Sequence[BaseNode], **kwargs: Any) -> Sequence[BaseNode]:
+        raise RuntimeError("simulated mid-run failure")
+
+    async def acall(
+        self, nodes: Sequence[BaseNode], **kwargs: Any
+    ) -> Sequence[BaseNode]:
+        raise RuntimeError("simulated mid-run failure")
+
+
+class StrictDeleteVectorStore(SimpleVectorStore):
+    """
+    Rejects deleting a ref_doc_id with no stored vectors, like non-idempotent
+    real backends: repeated deletes for the same document must not happen.
+    """
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        if ref_doc_id not in self.data.text_id_to_ref_doc_id.values():
+            raise ValueError(f"cannot delete unknown ref_doc_id: {ref_doc_id}")
+        super().delete(ref_doc_id, **delete_kwargs)
+
+    async def adelete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        self.delete(ref_doc_id, **delete_kwargs)
+
+
+def _chunks_of(ref_doc_id: str, count: int) -> list[TextNode]:
+    nodes = [TextNode(text=f"updated chunk {i}", id_=f"node-{i}") for i in range(count)]
+    for node in nodes:
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+            node_id=ref_doc_id
+        )
+    return nodes
+
+
+def test_duplicates_only_failed_run_leaves_docstore_clean() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+    doc = Document(text="one sentence. another sentence.", doc_id="1")
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    with pytest.raises(RuntimeError):
+        pipeline.run(documents=[doc])
+
+    # the failed run must not have marked the document as seen
+    assert docstore.get_document_hash("1") is None
+    assert docstore.docs == {}
+
+    # a clean retry must ingest the document instead of skipping it
+    retry = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = retry.run(documents=[doc])
+    assert len(nodes) > 0
+    assert docstore.get_document_hash("1") == doc.hash
+
+
+def test_upserts_failed_rerun_preserves_old_vectors() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    pipeline.run(documents=[Document(text="old content. more text.", doc_id="1")])
+    old_hash = docstore.get_document_hash("1")
+    old_vectors = dict(vector_store.data.embedding_dict)
+    assert len(old_vectors) > 0
+
+    failing = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    with pytest.raises(RuntimeError):
+        failing.run(documents=[Document(text="new content entirely.", doc_id="1")])
+
+    # the old ingested state must survive the failed re-ingest untouched
+    # (note: top-level Documents never get ref_doc_info entries, so the hash
+    # and the vectors are the observable docstore/vector-store state here)
+    assert vector_store.data.embedding_dict == old_vectors
+    assert docstore.get_document_hash("1") == old_hash
+    assert docstore.get_node("1") is not None
+
+
+def test_upserts_success_still_replaces_old_vectors() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    pipeline.run(documents=[Document(text="old content. more text.", doc_id="1")])
+    old_ids = set(vector_store.data.embedding_dict)
+
+    pipeline.run(documents=[Document(text="new content entirely.", doc_id="1")])
+    new_ids = set(vector_store.data.embedding_dict)
+
+    # deferred deletion must still replace, not accumulate or wipe
+    assert new_ids
+    assert not (old_ids & new_ids)
+    assert (
+        docstore.get_document_hash("1")
+        == Document(text="new content entirely.", doc_id="1").hash
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_duplicates_only_failed_run_leaves_docstore_clean() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+    doc = Document(text="one sentence. another sentence.", doc_id="1")
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    with pytest.raises(RuntimeError):
+        await pipeline.arun(documents=[doc])
+
+    assert docstore.get_document_hash("1") is None
+    assert docstore.docs == {}
+
+    # a clean retry must ingest the document instead of skipping it
+    retry = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = await retry.arun(documents=[doc])
+    assert len(nodes) > 0
+    assert docstore.get_document_hash("1") == doc.hash
+
+
+@pytest.mark.asyncio
+async def test_async_upserts_failed_rerun_preserves_old_vectors() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    await pipeline.arun(
+        documents=[Document(text="old content. more text.", doc_id="1")]
+    )
+    old_hash = docstore.get_document_hash("1")
+    old_vectors = dict(vector_store.data.embedding_dict)
+    assert len(old_vectors) > 0
+
+    failing = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    with pytest.raises(RuntimeError):
+        await failing.arun(
+            documents=[Document(text="new content entirely.", doc_id="1")]
+        )
+
+    assert vector_store.data.embedding_dict == old_vectors
+    assert docstore.get_document_hash("1") == old_hash
+
+
+def test_upserts_multi_node_update_deletes_old_vectors_once() -> None:
+    """
+    Regression: when an updated document arrives as multiple nodes sharing one
+    ref_doc_id, the old entries must be deleted exactly once. Scheduling one
+    delete per node breaks non-idempotent vector backends (the second delete
+    targets a document that no longer has vectors) and would abort the run
+    after the old vectors are already gone.
+    """
+    docstore = SimpleDocumentStore()
+    vector_store = StrictDeleteVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    pipeline.run(documents=[Document(text="v1 content.", doc_id="source-doc")])
+    assert set(vector_store.data.text_id_to_ref_doc_id.values()) == {"source-doc"}
+
+    result = pipeline.run(nodes=_chunks_of("source-doc", 3))
+
+    assert len(result) == 3
+    ref_doc_ids = set(vector_store.data.text_id_to_ref_doc_id.values())
+    assert ref_doc_ids == {"source-doc"}
+    assert len(vector_store.data.text_id_to_ref_doc_id) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_upserts_multi_node_update_deletes_old_vectors_once() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = StrictDeleteVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    await pipeline.arun(documents=[Document(text="v1 content.", doc_id="source-doc")])
+
+    result = await pipeline.arun(nodes=_chunks_of("source-doc", 3))
+
+    assert len(result) == 3
+    assert set(vector_store.data.text_id_to_ref_doc_id.values()) == {"source-doc"}
+    assert len(vector_store.data.text_id_to_ref_doc_id) == 3
+
+
+def test_upserts_and_delete_failed_run_does_not_purge() -> None:
+    """
+    UPSERTS_AND_DELETE: a document missing from the input is scheduled for
+    purge, but the purge must not happen if the run fails mid-transformations.
+    """
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+    pipeline.run(
+        documents=[
+            Document(text="first document.", doc_id="docA"),
+            Document(text="second document.", doc_id="docB"),
+        ]
+    )
+    vectors_before = dict(vector_store.data.embedding_dict)
+
+    failing = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+    # docB is missing from the input AND docA changed: the failed run must
+    # neither purge docB nor drop docA's old version
+    with pytest.raises(RuntimeError):
+        failing.run(documents=[Document(text="changed first document.", doc_id="docA")])
+
+    assert docstore.get_document_hash("docA") is not None
+    assert docstore.get_document_hash("docB") is not None
+    assert vector_store.data.embedding_dict == vectors_before
+
+
+@pytest.mark.asyncio
+async def test_async_upserts_and_delete_failed_run_does_not_purge() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+    await pipeline.arun(
+        documents=[
+            Document(text="first document.", doc_id="docA"),
+            Document(text="second document.", doc_id="docB"),
+        ]
+    )
+    vectors_before = dict(vector_store.data.embedding_dict)
+
+    failing = IngestionPipeline(
+        transformations=[SentenceSplitter(), RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+    # docB is missing from the input AND docA changed: the failed run must
+    # neither purge docB nor drop docA's old version
+    with pytest.raises(RuntimeError):
+        await failing.arun(
+            documents=[Document(text="changed first document.", doc_id="docA")]
+        )
+
+    assert docstore.get_document_hash("docA") is not None
+    assert docstore.get_document_hash("docB") is not None
+    assert vector_store.data.embedding_dict == vectors_before
+
+
+@pytest.mark.asyncio
+async def test_async_upserts_success_still_replaces_old_vectors() -> None:
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    await pipeline.arun(
+        documents=[Document(text="old content. more text.", doc_id="1")]
+    )
+    old_ids = set(vector_store.data.embedding_dict)
+
+    await pipeline.arun(documents=[Document(text="new content entirely.", doc_id="1")])
+    new_ids = set(vector_store.data.embedding_dict)
+
+    assert new_ids
+    assert not (old_ids & new_ids)


### PR DESCRIPTION
# Description

`IngestionPipeline` mutates the docstore and the vector store in the decision phase, before any transformation has executed, so an error in the ingestion pipeline produces two failure modes:

Fixes #22638 
Fixes #22639 

1. **DUPLICATES_ONLY failed run poisons dedup.** `_handle_duplicates` wrote each new document's hash via `set_document_hash` during the decision phase. If the run then raised, the hash stayed behind and every retry classified the document as already ingested.
2. **UPSERTS / UPSERTS_AND_DELETE failed update loses both versions.** `_handle_upserts` deleted the old docstore entry and the old vectors as soon as a changed document was detected. If the run then raised, the old version was already gone and the new one was never written

Both bugs are caused by running non-reversible code in the decision phase, so they share one fix:

- `_handle_duplicates` / `_handle_upserts` (and their async versions) become `_plan_duplicates` / `_plan_upserts`, returning a `_PlannedRun` (nodes to run + deletions to apply). The decision phase performs no write on either store.
- Deletions are applied by `_apply_planned_deletes` only after transformations succeed, and before `vector_store.add`: the new chunks carry the same `ref_doc_id` as the old ones, so deleting after adding would wipe the new vectors (covered by the `test_upserts_success_still_replaces_old_vectors` regression guard).
- `ref_docs_to_delete` is a set: when an updated document arrives as multiple nodes sharing one `ref_doc_id`, exactly one delete per document is scheduled — `vector_store.delete` has no idempotency guarantee across backends (covered by `test_upserts_multi_node_update_deletes_old_vectors_once`, sync and async).
- Hashes for `DUPLICATES_ONLY` are now recorded in `_update_docstore` together with the other post-success writes.
- The duplicated fallback block that resolves the effective strategy is extracted into `_resolve_effective_strategy` (warning `stacklevel` bumped 3→4 for the extra frame, so it still points at the caller).

**Note on the private-helper rename `handle_` vs `plan_` can be reverted if preferred** `_handle_duplicates`/`_handle_upserts` are renamed to `_plan_duplicates`/`_plan_upserts` deliberately to match the semantic of the methods.

A run that raises mid-transformations now leaves both stores exactly as they were and can be safely retried with the same inputs.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- x ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

**Transparency**: the code was mainly generated by Claude Code and personally reviewed and tweaked by me
