### PR TITLE
fix(core): make MultiStepQueryEngine.aquery use async sub-queries

### DIFF
--- a/llama-index-core/llama_index/core/query_engine/multistep_query_engine.py
+++ b/llama-index-core/llama_index/core/query_engine/multistep_query_engine.py
@@ -100,7 +100,7 @@ class MultiStepQueryEngine(BaseQueryEngine):
         with self.callback_manager.event(
             CBEventType.QUERY, payload={EventPayload.QUERY_STR: query_bundle.query_str}
         ) as query_event:
-            nodes, source_nodes, metadata = self._query_multistep(query_bundle)
+            nodes, source_nodes, metadata = await self._aquery_multistep(query_bundle)
 
             final_response = await self._response_synthesizer.asynthesize(
                 query=query_bundle,
@@ -163,6 +163,56 @@ class MultiStepQueryEngine(BaseQueryEngine):
             for source_node in cur_response.source_nodes:
                 source_nodes.append(source_node)
             # update metadata
+            final_response_metadata["sub_qa"].append(
+                (updated_query_bundle.query_str, cur_response)
+            )
+
+            prev_reasoning += (
+                f"- {updated_query_bundle.query_str}\n- {cur_response!s}\n"
+            )
+            cur_steps += 1
+
+        nodes = [
+            NodeWithScore(node=TextNode(text=text_chunk)) for text_chunk in text_chunks
+        ]
+        return nodes, source_nodes, final_response_metadata
+
+    async def _aquery_multistep(
+        self, query_bundle: QueryBundle
+    ) -> Tuple[List[NodeWithScore], List[NodeWithScore], Dict[str, Any]]:
+        """Run query combiner asynchronously."""
+        prev_reasoning = ""
+        cur_response = None
+        should_stop = False
+        cur_steps = 0
+
+        final_response_metadata: Dict[str, Any] = {"sub_qa": []}
+
+        text_chunks = []
+        source_nodes = []
+        while not should_stop:
+            if self._num_steps is not None and cur_steps >= self._num_steps:
+                should_stop = True
+                break
+            elif should_stop:
+                break
+
+            updated_query_bundle = self._combine_queries(query_bundle, prev_reasoning)
+
+            stop_dict = {"query_bundle": updated_query_bundle}
+            if self._stop_fn(stop_dict):
+                should_stop = True
+                break
+
+            cur_response = await self._query_engine.aquery(updated_query_bundle)
+
+            cur_qa_text = (
+                f"\nQuestion: {updated_query_bundle.query_str}\n"
+                f"Answer: {cur_response!s}"
+            )
+            text_chunks.append(cur_qa_text)
+            for source_node in cur_response.source_nodes:
+                source_nodes.append(source_node)
             final_response_metadata["sub_qa"].append(
                 (updated_query_bundle.query_str, cur_response)
             )

--- a/llama-index-core/tests/query_engine/test_multistep_query_engine.py
+++ b/llama-index-core/tests/query_engine/test_multistep_query_engine.py
@@ -1,0 +1,61 @@
+"""Tests for MultiStepQueryEngine async correctness."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llama_index.core.base.response.schema import Response
+from llama_index.core.callbacks import CallbackManager
+from llama_index.core.query_engine.multistep_query_engine import MultiStepQueryEngine
+from llama_index.core.schema import QueryBundle
+
+
+def _make_engine(num_steps: int = 2) -> MultiStepQueryEngine:
+    inner_engine = MagicMock()
+    inner_engine.callback_manager = CallbackManager([])
+    resp = Response(response="sub-answer", source_nodes=[])
+    inner_engine.query.return_value = resp
+    inner_engine.aquery = AsyncMock(return_value=resp)
+
+    transform = MagicMock()
+    transform.return_value = QueryBundle(query_str="sub-question")
+
+    synth = MagicMock()
+    synth.synthesize.return_value = Response(response="final")
+    synth.asynthesize = AsyncMock(return_value=Response(response="final"))
+
+    return MultiStepQueryEngine(
+        query_engine=inner_engine,
+        query_transform=transform,
+        response_synthesizer=synth,
+        num_steps=num_steps,
+        early_stopping=True,
+    )
+
+
+def test_query_uses_sync_engine():
+    engine = _make_engine(num_steps=1)
+    result = engine.query(QueryBundle(query_str="What is X?"))
+    assert str(result) == "final"
+    engine._query_engine.query.assert_called_once()
+    engine._query_engine.aquery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_aquery_uses_async_engine():
+    """_aquery must call aquery on the inner engine, never the sync query."""
+    engine = _make_engine(num_steps=1)
+    result = await engine.aquery(QueryBundle(query_str="What is X?"))
+    assert str(result) == "final"
+    engine._query_engine.aquery.assert_awaited_once()
+    engine._query_engine.query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aquery_multi_steps_uses_async_engine():
+    """With multiple steps, every step must go through aquery."""
+    engine = _make_engine(num_steps=3)
+    result = await engine.aquery(QueryBundle(query_str="What is X?"))
+    assert str(result) == "final"
+    assert engine._query_engine.aquery.await_count == 3
+    engine._query_engine.query.assert_not_called()


### PR DESCRIPTION
Closes #22635

---

`MultiStepQueryEngine.aquery()` was silently blocking the event loop at every
decomposition step. The root cause: `_aquery()` called the synchronous helper
`_query_multistep()`, which in turn called `self._query_engine.query()` (sync)
at each iteration. No async path was exercised even when `aquery()` was used.

## Fix

Added `_aquery_multistep()` as a true async counterpart to `_query_multistep()`.
It is structurally identical to the sync version except that each sub-query goes
through `await self._query_engine.aquery()`. Updated `_aquery()` to call
`await self._aquery_multistep()` instead of the sync helper.

This mirrors the existing pattern in `SubQuestionQueryEngine`, which already
maintains separate `_query_subq` / `_aquery_subq` methods for the same reason.

## Tests

Three unit tests added in `tests/query_engine/test_multistep_query_engine.py`:

- `test_query_uses_sync_engine` — verifies `query()` calls `query()` on the
  inner engine and never touches `aquery`.
- `test_aquery_uses_async_engine` — verifies `aquery()` calls `aquery()` on
  the inner engine and never touches the sync `query`.
- `test_aquery_multi_steps_uses_async_engine` — verifies that with `num_steps=3`,
  `aquery()` invokes `aquery` exactly three times (once per step).

> This contribution was developed with AI-agent assistance (Claude Code). All
> logic, tests, and commit messages were reviewed before submission.