### PR TITLE
fix(qdrant): preserve alpha=0 in aquery() hybrid search

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/llama_index/vector_stores/qdrant/base.py
@@ -1261,7 +1261,7 @@ class QdrantVectorStore(BasePydanticVectorStore):
             return self._hybrid_fusion_fn(
                 self.parse_to_query_result(sparse_response[0].points),
                 self.parse_to_query_result(sparse_response[1].points),
-                alpha=query.alpha or 0.5,
+                alpha=query.alpha if query.alpha is not None else 0.5,
                 # NOTE: use hybrid_top_k if provided, otherwise use similarity_top_k
                 top_k=query.hybrid_top_k or query.similarity_top_k,
             )

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-qdrant"
-version = "0.10.2"
+version = "0.10.3"
 description = "llama-index vector_stores qdrant integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<3.14"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-qdrant/tests/test_vector_stores_qdrant.py
@@ -882,15 +882,55 @@ async def test_async_hybrid_vector_store_query(
         sparse_top_k=1,
         hybrid_top_k=2,
         mode=VectorStoreQueryMode.HYBRID,
+        alpha=0,
     )
-    results = await hybrid_vector_store.aquery(query)
+    with patch.object(
+        hybrid_vector_store,
+        "_hybrid_fusion_fn",
+        wraps=hybrid_vector_store._hybrid_fusion_fn,
+    ) as fusion_mock:
+        results = await hybrid_vector_store.aquery(query)
+
     assert len(results.nodes) == 2
+    assert fusion_mock.call_args.kwargs["alpha"] == 0
 
     # disable hybrid, and it should still work
     hybrid_vector_store.enable_hybrid = False
     query.mode = VectorStoreQueryMode.DEFAULT
     results = await hybrid_vector_store.aquery(query)
     assert len(results.nodes) == 1
+
+
+@pytest.mark.asyncio
+async def test_hybrid_vector_store_query_alpha_sync_async_parity(
+    hybrid_vector_store: QdrantVectorStore,
+) -> None:
+    query = VectorStoreQuery(
+        query_embedding=[0.0, 0.0],
+        query_str="test1",
+        similarity_top_k=1,
+        sparse_top_k=1,
+        hybrid_top_k=2,
+        mode=VectorStoreQueryMode.HYBRID,
+        alpha=0,
+    )
+
+    with patch.object(
+        hybrid_vector_store,
+        "_hybrid_fusion_fn",
+        wraps=hybrid_vector_store._hybrid_fusion_fn,
+    ) as sync_fusion_mock:
+        hybrid_vector_store.query(query)
+
+    with patch.object(
+        hybrid_vector_store,
+        "_hybrid_fusion_fn",
+        wraps=hybrid_vector_store._hybrid_fusion_fn,
+    ) as async_fusion_mock:
+        await hybrid_vector_store.aquery(query)
+
+    assert sync_fusion_mock.call_args.kwargs["alpha"] == query.alpha
+    assert async_fusion_mock.call_args.kwargs["alpha"] == query.alpha
 
 
 def test_vector_store_query(vector_store: QdrantVectorStore) -> None:


### PR DESCRIPTION
## Summary

- preserve `alpha=0` in Qdrant's async hybrid query path
- align `aquery()` with the sync behavior fixed in #20880
- prevent pure sparse requests from silently becoming 50/50 dense-sparse fusion
- bump the Qdrant integration patch version to `0.10.3`

## Tests

- extended the in-memory async hybrid test to assert the fusion callback receives `0`
- added sync/async alpha parity coverage
- `uv run make lint`
- `uv run -- pytest` (`30 passed, 16 skipped`)
