### PR TITLE
fix(tools-mcp): remove_model_fields erased descriptions on surviving fields

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -248,11 +248,12 @@ class McpToolSpec(
         fields_to_remove: Set[str],
         model_name: str,
     ) -> type[BaseModel]:
+        # Pass the FieldInfo through unchanged: rebuilding from (annotation, default)
+        # erased the description (and any other field metadata) on every field that
+        # survived the removal, so the LLM-facing fn_schema lost its parameter docs
+        # whenever partial params were used.
         fields = {
-            name: (
-                field.annotation,
-                field.default if field.is_required() else field.default,
-            )
+            name: (field.annotation, field)
             for name, field in model.model_fields.items()
             if name not in fields_to_remove
         }

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -777,3 +777,30 @@ async def test_aget_tools_from_mcp_url_propagates_combined_params(
     # Verify merged params
     assert add_tool.partial_params == {"a": 1.0, "user_id": "global", "b": 2.0}
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+def test_remove_model_fields_preserves_descriptions_and_defaults(client: BasicMCPClient):
+    """
+    Regression: remove_model_fields rebuilt surviving fields from only
+    (annotation, default), erasing their descriptions — so using
+    global_partial_params / partial_params_by_tool silently stripped the
+    parameter docs the LLM relies on from the remaining fields.
+    """
+    from pydantic import Field, create_model
+
+    tool_spec = McpToolSpec(client)
+    model = create_model(
+        "Tool_Schema",
+        a=(float, Field(..., description="First addend, in units")),
+        b=(float, Field(..., description="Second addend, in units")),
+        mode=(str, Field("fast", description="Rounding mode")),
+    )
+
+    trimmed = tool_spec.remove_model_fields(model, {"a"}, "Tool_Schema")
+    props = trimmed.model_json_schema()["properties"]
+
+    assert set(props) == {"b", "mode"}
+    assert props["b"]["description"] == "Second addend, in units"
+    assert props["mode"]["description"] == "Rounding mode"
+    assert props["mode"]["default"] == "fast"
+    assert trimmed.model_json_schema()["required"] == ["b"]


### PR DESCRIPTION
## Description

`McpToolSpec.remove_model_fields` rebuilds the surviving fields from only `(annotation, default)`, which discards all other field metadata. So whenever `global_partial_params` / `partial_params_by_tool` remove a field, the fields that **remain** silently lose their descriptions in the generated `fn_schema` — the parameter documentation the LLM relies on for tool calling.

Reproduction against current `main`:

```python
from pydantic import Field, create_model
M = create_model("Tool_Schema",
    a=(float, Field(..., description="First addend, in units")),
    b=(float, Field(..., description="Second addend, in units")),
    mode=(str, Field("fast", description="Rounding mode")),
)
trimmed = McpToolSpec(client).remove_model_fields(M, {"a"}, "Tool_Schema")
{k: v.get("description") for k, v in trimmed.model_json_schema()["properties"].items()}
# before this fix: {'b': None, 'mode': None}
# after this fix:  {'b': 'Second addend, in units', 'mode': 'Rounding mode'}
```

The fix passes each surviving `FieldInfo` through unchanged, which preserves descriptions, defaults, requiredness, and any `json_schema_extra`. (It also removes the pre-existing `field.default if field.is_required() else field.default` expression, whose branches were identical.)

## How Has This Been Tested?

- New regression test asserting surviving fields keep their descriptions and default, and `required` stays correct.
- Full package suite: **52 passed** under mcp 2.x on current main.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Version Bump?

- [ ] No — happy to bump if you'd like this released immediately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)