### PR TITLE
fix(tools-mcp): $defs types leak across tools through the shared cache

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -215,6 +215,11 @@ class McpToolSpec(
             A Pydantic model class.
 
         """
+        # Each call converts a self-contained schema, so start from an empty
+        # cache. Reusing it across calls let a $defs type from one tool leak
+        # into another tool that happened to define a type of the same name,
+        # silently handing the LLM the wrong parameter schema.
+        self.properties_cache = {}
         defs = schema.get("$defs", {})
 
         # Process all type definitions

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -777,3 +777,46 @@ async def test_aget_tools_from_mcp_url_propagates_combined_params(
     # Verify merged params
     assert add_tool.partial_params == {"a": 1.0, "user_id": "global", "b": 2.0}
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+def test_defs_name_collision_across_tools(client: BasicMCPClient):
+    """
+    Regression: properties_cache persisted across create_model_from_json_schema
+    calls on one spec, so two tools that each defined a $defs type of the same
+    name (e.g. "Item") with different shapes silently shared the first one's
+    model — the LLM got the wrong parameter schema for the second tool.
+    """
+    tool_spec = McpToolSpec(client)
+    schema_a = {
+        "type": "object",
+        "properties": {"item": {"$ref": "#/$defs/Item"}},
+        "required": ["item"],
+        "$defs": {
+            "Item": {
+                "type": "object",
+                "properties": {"weight_kg": {"type": "number"}},
+                "required": ["weight_kg"],
+            }
+        },
+    }
+    schema_b = {
+        "type": "object",
+        "properties": {"item": {"$ref": "#/$defs/Item"}},
+        "required": ["item"],
+        "$defs": {
+            "Item": {
+                "type": "object",
+                "properties": {"color": {"type": "string"}},
+                "required": ["color"],
+            }
+        },
+    }
+
+    model_a = tool_spec.create_model_from_json_schema(schema_a, "toolA_Schema")
+    model_b = tool_spec.create_model_from_json_schema(schema_b, "toolB_Schema")
+
+    item_a = model_a.model_fields["item"].annotation
+    item_b = model_b.model_fields["item"].annotation
+
+    assert set(item_a.model_fields) == {"weight_kg"}
+    assert set(item_b.model_fields) == {"color"}


### PR DESCRIPTION
## Description

`McpToolSpec.properties_cache` is instance-level and is never cleared between calls to `create_model_from_json_schema`. Since `to_tool_list_async` converts every tool with the same `McpToolSpec`, a `$defs` type built for one tool stays in the cache and is reused for any later tool that defines a type of the **same name** — even when the two definitions are completely different. Generic names like `Item`, `Input`, `Config`, `Params` collide constantly across independent MCP tools, so the LLM silently receives the wrong parameter schema.

Reproduction against current `main`:

```python
from llama_index.tools.mcp import McpToolSpec
spec = McpToolSpec(client=object())  # conversion never touches the client

tool_a = {"type": "object", "properties": {"item": {"$ref": "#/$defs/Item"}}, "required": ["item"],
          "$defs": {"Item": {"type": "object", "properties": {"weight_kg": {"type": "number"}}, "required": ["weight_kg"]}}}
tool_b = {"type": "object", "properties": {"item": {"$ref": "#/$defs/Item"}}, "required": ["item"],
          "$defs": {"Item": {"type": "object", "properties": {"color": {"type": "string"}}, "required": ["color"]}}}

ma = spec.create_model_from_json_schema(tool_a, "toolA_Schema")
mb = spec.create_model_from_json_schema(tool_b, "toolB_Schema")
```

```
# main
toolA 'item' fields: {'weight_kg'}
toolB 'item' fields: {'weight_kg'}   <- wrong: should be {'color'}

# with this fix
toolA 'item' fields: {'weight_kg'}
toolB 'item' fields: {'color'}
```

The fix resets `properties_cache` at the start of each `create_model_from_json_schema`. Each tool's `inputSchema` is self-contained (its own `$defs`), so there is no correct cross-tool sharing to preserve; the cache still does its real job of resolving `$ref`/recursion **within** a single schema.

## How Has This Been Tested?

- Added `test_defs_name_collision_across_tools`, which asserts the two tools keep their own `Item` shapes.
- The schema-conversion unit tests pass. The stdio-server integration tests need the live MCP test server, which I couldn't stand up in my sandbox (the server subprocess can't import `tests.schemas` — reproduces identically on unmodified `main`, so it's unrelated to this change).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)