### PR TITLE
fix(embeddings): forward Cohere Bedrock kwargs

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -522,12 +522,12 @@ class BedrockEmbedding(BaseEmbedding):
             }
             payload = [payload] if isinstance(payload, str) else payload
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
-            request_body = json.dumps(
-                {
-                    "texts": payload,
-                    "input_type": input_types[input_type],
-                }
-            )
+            cohere_body = {
+                "texts": payload,
+                "input_type": input_types[input_type],
+                **self.additional_kwargs,
+            }
+            request_body = json.dumps(cohere_body)
         else:
             raise ValueError("Provider not supported")
         return request_body

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -525,8 +525,11 @@ class BedrockEmbedding(BaseEmbedding):
             cohere_body = {
                 "texts": payload,
                 "input_type": input_types[input_type],
-                **self.additional_kwargs,
             }
+            if "output_dimension" in self.additional_kwargs:
+                cohere_body["output_dimension"] = self.additional_kwargs[
+                    "output_dimension"
+                ]
             request_body = json.dumps(cohere_body)
         else:
             raise ValueError("Provider not supported")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -144,6 +144,44 @@ class TestBedrockEmbedding(TestCase):
         bedrock_stubber.assert_no_pending_responses()
         self.assertEqual(embedding, mock_response["embeddings"][0])
 
+    def test_get_text_embedding_cohere_with_additional_kwargs(self) -> None:
+        bedrock_stubber = Stubber(self.bedrock_client)
+
+        mock_response = {"embeddings": {"float": [exp_embed]}}
+        mock_stream = BytesIO(json.dumps(mock_response).encode())
+        bedrock_stubber.add_response(
+            "invoke_model",
+            {
+                "contentType": "application/json",
+                "body": StreamingBody(mock_stream, len(json.dumps(mock_response))),
+            },
+            expected_params={
+                "accept": "application/json",
+                "body": json.dumps(
+                    {
+                        "texts": [self.exp_query],
+                        "input_type": "search_document",
+                        "output_dimension": 256,
+                    }
+                ),
+                "contentType": "application/json",
+                "modelId": Models.COHERE_EMBED_V4.value,
+            },
+        )
+
+        bedrock_embedding = BedrockEmbedding(
+            model_name=Models.COHERE_EMBED_V4,
+            client=self.bedrock_client,
+            additional_kwargs={"output_dimension": 256},
+        )
+
+        bedrock_stubber.activate()
+        embedding = bedrock_embedding.get_text_embedding(text=self.exp_query)
+        bedrock_stubber.deactivate()
+
+        bedrock_stubber.assert_no_pending_responses()
+        self.assertEqual(embedding, exp_embed)
+
     def test_get_text_embedding_batch_cohere(self) -> None:
         bedrock_stubber = Stubber(self.bedrock_client)
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock.py
@@ -172,7 +172,12 @@ class TestBedrockEmbedding(TestCase):
         bedrock_embedding = BedrockEmbedding(
             model_name=Models.COHERE_EMBED_V4,
             client=self.bedrock_client,
-            additional_kwargs={"output_dimension": 256},
+            additional_kwargs={
+                "output_dimension": 256,
+                "input_type": "unexpected-input-type",
+                "texts": ["unexpected-text"],
+                "output_dimesion": 512,
+            },
         )
 
         bedrock_stubber.activate()


### PR DESCRIPTION
## Description

Forward the supported `output_dimension` option from `additional_kwargs` when building Cohere Bedrock embedding requests.

Fixes #22648

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] New and existing unit tests pass locally

Validation run in the `llama-index-embeddings-bedrock` integration:

- `pytest tests/test_bedrock.py -q` — 13 passed
- `ruff check` on the changed source and test files — passed
- `ruff format --check` on the changed source and test files — passed
- `python -m compileall` on the integration source and tests — passed
- `git diff --check` — passed

The test uses a stubbed Bedrock client; no AWS credentials or network calls were used.

The implementation forwards only `output_dimension` for Cohere requests. Request-owned `texts` and `input_type` remain protected, and unknown keys are ignored.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] I ran formatting and lint checks on the changed files

## AI assistance

An AI coding assistant helped inspect the issue, implement the focused change, and draft the test. I reviewed the diff and understand the behavior being changed.