### PR TITLE
fix(core): avoid poisoning docstore hashes on failed ingestion

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -460,7 +460,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -695,7 +694,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -397,7 +397,18 @@ def test_pipeline_with_transform_error() -> None:
     with pytest.raises(RuntimeError):
         pipeline.run(documents=[document1])
 
-    assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore is not None
+    assert pipeline.docstore.get_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = retry_pipeline.run(documents=[document1])
+
+    assert len(nodes) == 1
+    assert pipeline.docstore.get_document_hash("1") == document1.hash
 
 
 @pytest.mark.asyncio
@@ -637,7 +648,18 @@ async def test_async_pipeline_with_transform_error() -> None:
     with pytest.raises(RuntimeError):
         await pipeline.arun(documents=[document1])
 
-    assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore is not None
+    assert await pipeline.docstore.aget_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = await retry_pipeline.arun(documents=[document1])
+
+    assert len(nodes) == 1
+    assert await pipeline.docstore.aget_document_hash("1") == document1.hash
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:


### PR DESCRIPTION
## Summary

Fixes #22638.

When `DUPLICATES_ONLY` is used, `IngestionPipeline` recorded each input node's hash before running transformations. If a transformation failed, the hash remained in the docstore even though the node was never ingested. A retry then treated the document as a duplicate and skipped it.

This change defers the synchronous and asynchronous hash persistence to the existing post-transformation docstore update path.

## Testing

- `uv run --project llama-index-core -- python -m pytest llama-index-core/tests/ingestion -q` (47 passed, 3 skipped)
- `uv run --project llama-index-core -- ruff check llama-index-core/llama_index/core/ingestion/pipeline.py llama-index-core/tests/ingestion/test_pipeline.py`
- `uv run --project llama-index-core -- ruff format --check llama-index-core/llama_index/core/ingestion/pipeline.py llama-index-core/tests/ingestion/test_pipeline.py`
- `uv run --project . mypy llama_index/core/ingestion/pipeline.py` from `llama-index-core` (no issues found)

The regression tests cover both sync and async failures, verify that no hash is persisted after the failed run, and verify that a retry succeeds and records the hash.

## AI-assisted contribution disclosure

I used OpenAI Codex to help inspect the issue, trace the existing sync/async code paths, draft the focused regression coverage, and review the patch. I reproduced the failure against the current `main` checkout, reviewed the final diff line by line, and ran the tests and static checks listed above. The submitted change is intentionally limited to the two premature hash writes and the corresponding regression assertions.

Prompt used: "Investigate issue #22638 in the current LlamaIndex checkout, reproduce the poisoned docstore hash after a failed sync and async ingestion run, make the smallest fix that preserves existing duplicate behavior, add regression tests, and run the relevant tests and static checks."
