### PR TITLE
fix(core): copy __dict__ in __getstate__ to avoid mutating live object

### DIFF
--- a/llama-index-core/llama_index/core/schema.py
+++ b/llama-index-core/llama_index/core/schema.py
@@ -124,6 +124,12 @@ class BaseComponent(BaseModel):
     def __getstate__(self) -> Dict[str, Any]:
         state = super().__getstate__()
 
+        # Pydantic v2 returns a reference to the live __dict__, not a copy.
+        # Mutating it directly strips the attribute from the running instance,
+        # so callers that use the object after pickling see AttributeError.
+        # We copy before removing so the live object is unaffected.
+        state["__dict__"] = state["__dict__"].copy()
+
         # remove attributes that are not pickleable -- kind of dangerous
         keys_to_remove = []
         for key, val in state["__dict__"].items():
@@ -140,6 +146,8 @@ class BaseComponent(BaseModel):
         keys_to_remove = []
         private_attrs = state.get("__pydantic_private__", None)
         if private_attrs:
+            state["__pydantic_private__"] = state["__pydantic_private__"].copy()
+
             for key, val in state["__pydantic_private__"].items():
                 try:
                     pickle.dumps(val)

--- a/llama-index-core/tests/schema/test_base_component.py
+++ b/llama-index-core/tests/schema/test_base_component.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 from llama_index.core.schema import BaseComponent
@@ -50,6 +50,43 @@ def test__getstate__():
         "__pydantic_fields_set__": set(),
         "__pydantic_private__": {"_text": "test private attr"},
     }
+
+
+def test__getstate__does_not_mutate_live_object():
+    """
+    __getstate__ must not strip attributes from the live instance.
+
+    Regression for GitHub issue #22578: __getstate__ was deleting from the
+    live __dict__ / __pydantic_private__ instead of from a copy, so the
+    original instance became corrupt after the call.
+    """
+
+    class MyComponent(BaseComponent):
+        fn: Any = None
+        _private_fn: Callable = PrivateAttr(default=lambda x: x)
+
+    unpickleable = lambda x: x  # noqa: E731
+    mc = MyComponent(fn=unpickleable)
+
+    # __getstate__ is what pickle calls; invoke it directly so we can verify
+    # the live object is unaffected even when the class itself can't be pickled.
+    state = mc.__getstate__()
+
+    # The serialised snapshot must NOT contain the unpickleable field.
+    assert "fn" not in state["__dict__"], (
+        "Expected unpickleable 'fn' to be stripped from the pickle snapshot"
+    )
+    assert "_private_fn" not in (state.get("__pydantic_private__") or {}), (
+        "Expected unpickleable '_private_fn' to be stripped from the pickle snapshot"
+    )
+
+    # The *live* instance must still have its attributes intact.
+    assert mc.fn is unpickleable, (
+        "__getstate__ mutated the live object and removed mc.fn"
+    )
+    assert callable(mc._private_fn), (
+        "__getstate__ mutated the live object and removed mc._private_fn"
+    )
 
 
 def test__setstate__():


### PR DESCRIPTION
Fixes #22578

## Root cause

`pydantic.BaseModel.__getstate__` (v2) returns a reference to the live `self.__dict__`, not a copy. `BaseComponent.__getstate__` then deleted unpickleable keys directly from `state["__dict__"]`, which is **the same object** as the instance's `__dict__`. Any attribute stripped during pickling was permanently removed from the source object. The next access raised `AttributeError` (or returned the default, masking the loss entirely).

The same applies to `state["__pydantic_private__"]` for private attributes.

## What changed

- In `__getstate__`, shallow-copy `state["__dict__"]` (and `state["__pydantic_private__"]` when it is non-`None`) before removing keys, so the serialised snapshot is independent of the live instance.
- Added `test__getstate__does_not_mutate_live_object` to `tests/schema/test_base_component.py` that verifies both an unpickleable model field and an unpickleable private attr remain accessible on the original object after `__getstate__` is called.

## Test evidence

```
tests/schema/test_base_component.py::test__getstate__does_not_mutate_live_object PASSED
```

All 8 tests in the file pass; pre-commit hooks (ruff, ruff-format, mypy, codespell) pass on the changed files.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.