### PR TITLE
fix(core): avoid persisting docstore hashes before ingestion

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -460,7 +460,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -695,7 +694,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -396,8 +396,18 @@ def test_pipeline_with_transform_error() -> None:
 
     with pytest.raises(RuntimeError):
         pipeline.run(documents=[document1])
-
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore.get_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+
+    nodes = retry_pipeline.run(documents=[document1])
+
+    assert len(nodes) == 1
 
 
 @pytest.mark.asyncio
@@ -638,6 +648,17 @@ async def test_async_pipeline_with_transform_error() -> None:
         await pipeline.arun(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore.get_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+
+    nodes = await retry_pipeline.arun(documents=[document1])
+
+    assert len(nodes) == 1
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:


### PR DESCRIPTION
## Summary

Fixes #22638.

Docstore hashes were persisted during duplicate detection before transformations completed successfully. If a transformation failed, the hash remained in the docstore and subsequent retries incorrectly skipped the document.

This change:
- defers sync docstore hash persistence until the normal docstore update phase
- defers async docstore hash persistence until the normal docstore update phase
- adds sync and async regression coverage for failed ingestion followed by retry

## Tests

- `uv run --no-sync pytest llama-index-core/tests/ingestion/test_pipeline.py -v`
- 26 passed
- `git diff --check`
- Ruff formatting/checks passed