### PR TITLE
docs: link the CopilotKit Channels guide from the full-stack apps page

### DIFF
--- a/docs/src/content/docs/framework/understanding/putting_it_all_together/apps/index.md
+++ b/docs/src/content/docs/framework/understanding/putting_it_all_together/apps/index.md
@@ -12,3 +12,4 @@ We provide tutorials and resources to help you get started in this area:
 - **CopilotKit + LlamaIndex:** CopilotKit is the Agentic Application Framework, an open source framework and hosted service for AI-assisted applications.
   - [CopilotKit LlamaIndex Quickstart](https://docs.copilotkit.ai/llamaindex/quickstart): A guide for how to turn your LlamaIndex Agents into an agent-native application in 10 minutes.
   - [CopilotKit <> LlamaIndex Starter](https://github.com/CopilotKit/with-llamaindex): This is a starter template for building AI agents using LlamaIndex and CopilotKit. It provides a modern Next.js application with an integrated investment analyst agent that can research stocks, analyze market data, and provide investment insights.
+  - [CopilotKit LlamaIndex Channels SDK](https://docs.copilotkit.ai/slack/llamaindex): A guide for running the same LlamaIndex agent as a bot in Slack and other messaging platforms with the CopilotKit Channels SDK.


### PR DESCRIPTION
## Description

Per feedback: instead of a dedicated page, this now just adds one link. The existing CopilotKit section on the full-stack apps page gains a bullet pointing to the [CopilotKit Channels guide for LlamaIndex](https://docs.copilotkit.ai/slack/llamaindex), which covers running the same LlamaIndex agent as a bot in Slack and other messaging platforms. The full walkthrough lives in the CopilotKit docs, where it stays current with the packages.

One line added to `docs/src/content/docs/framework/understanding/putting_it_all_together/apps/index.md`; no new pages.

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

Docs-only change: a single Markdown list item with an external link, matching the format of the surrounding bullets.

## Checklist:

- [x] I added new unit tests to cover this change — not applicable, docs only
- [x] I believe this change is already covered by existing unit tests — not applicable, docs only
