### PR TITLE
Preserve Anthropic cache usage metadata

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py
@@ -108,6 +108,21 @@ def _get_default_headers(
     return default_headers
 
 
+def _usage_metadata_from_anthropic_usage(
+    usage: Any, input_tokens: Optional[int] = None
+) -> Dict[str, Any]:
+    """Convert Anthropic usage metadata into a serializable dict."""
+    usage_metadata: Dict[str, Any] = {
+        "input_tokens": getattr(usage, "input_tokens", None) or input_tokens,
+        "output_tokens": getattr(usage, "output_tokens", None),
+    }
+    for key in ("cache_creation_input_tokens", "cache_read_input_tokens"):
+        value = getattr(usage, key, None)
+        if value is not None:
+            usage_metadata[key] = value
+    return usage_metadata
+
+
 class AnthropicTokenizer:
     def __init__(self, client, model) -> None:
         self._client = client
@@ -464,6 +479,11 @@ class Anthropic(FunctionCallingLLM):
             message=ChatMessage(
                 role=MessageRole.ASSISTANT,
                 blocks=blocks,
+                additional_kwargs={
+                    "usage": _usage_metadata_from_anthropic_usage(response.usage)
+                    if getattr(response, "usage", None)
+                    else None,
+                },
             ),
             citations=citations,
             raw=dict(response),
@@ -649,19 +669,15 @@ class Anthropic(FunctionCallingLLM):
                     if hasattr(r.message, "usage") and r.message.usage:
                         # Save input tokens for later
                         input_tokens = r.message.usage.input_tokens
-                        usage_metadata = {
-                            "input_tokens": r.message.usage.input_tokens,
-                            "output_tokens": r.message.usage.output_tokens,
-                        }
+                        usage_metadata = _usage_metadata_from_anthropic_usage(
+                            r.message.usage
+                        )
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
                     if hasattr(r, "usage") and r.usage:
-                        # Modify r.usage.input_tokens if None with saved input tokens value
-                        r.usage.input_tokens = r.usage.input_tokens or input_tokens
-                        usage_metadata = {
-                            "input_tokens": r.usage.input_tokens,
-                            "output_tokens": r.usage.output_tokens,
-                        }
+                        usage_metadata = _usage_metadata_from_anthropic_usage(
+                            r.usage, input_tokens
+                        )
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason
 
@@ -721,6 +737,11 @@ class Anthropic(FunctionCallingLLM):
             message=ChatMessage(
                 role=MessageRole.ASSISTANT,
                 blocks=blocks,
+                additional_kwargs={
+                    "usage": _usage_metadata_from_anthropic_usage(response.usage)
+                    if getattr(response, "usage", None)
+                    else None,
+                },
             ),
             citations=citations,
             raw=dict(response),
@@ -906,19 +927,15 @@ class Anthropic(FunctionCallingLLM):
                     if hasattr(r.message, "usage") and r.message.usage:
                         # Save input tokens for later
                         input_tokens = r.message.usage.input_tokens
-                        usage_metadata = {
-                            "input_tokens": r.message.usage.input_tokens,
-                            "output_tokens": r.message.usage.output_tokens,
-                        }
+                        usage_metadata = _usage_metadata_from_anthropic_usage(
+                            r.message.usage
+                        )
                 elif isinstance(r, RawMessageDeltaEvent):
                     # Update usage metadata and capture stop_reason from message_delta
                     if hasattr(r, "usage") and r.usage:
-                        # Modify r.usage.input_tokens if None with saved input tokens value
-                        r.usage.input_tokens = r.usage.input_tokens or input_tokens
-                        usage_metadata = {
-                            "input_tokens": r.usage.input_tokens,
-                            "output_tokens": r.usage.output_tokens,
-                        }
+                        usage_metadata = _usage_metadata_from_anthropic_usage(
+                            r.usage, input_tokens
+                        )
                     if hasattr(r, "delta") and hasattr(r.delta, "stop_reason"):
                         stop_reason = r.delta.stop_reason
 

--- a/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
+++ b/llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py
@@ -23,7 +23,11 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.base.llms.types import ThinkingBlock
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.anthropic import Anthropic
-from llama_index.llms.anthropic.base import AnthropicChatResponse, _get_default_headers
+from llama_index.llms.anthropic.base import (
+    AnthropicChatResponse,
+    _get_default_headers,
+    _usage_metadata_from_anthropic_usage,
+)
 from llama_index.llms.anthropic.utils import messages_to_anthropic_messages
 
 
@@ -54,6 +58,21 @@ def test_get_default_headers_preserves_default_when_no_conflict():
     headers = _get_default_headers(user_headers)
     assert headers["X-Custom"] == "value"
     assert headers["User-Agent"].startswith("llama-index/")
+
+
+def test_usage_metadata_preserves_anthropic_cache_tokens():
+    usage = MagicMock()
+    usage.input_tokens = None
+    usage.output_tokens = 8
+    usage.cache_creation_input_tokens = 12
+    usage.cache_read_input_tokens = 34
+
+    assert _usage_metadata_from_anthropic_usage(usage, input_tokens=15) == {
+        "input_tokens": 15,
+        "output_tokens": 8,
+        "cache_creation_input_tokens": 12,
+        "cache_read_input_tokens": 34,
+    }
 
 
 @pytest.mark.skipif(
@@ -704,6 +723,8 @@ def test_stream_chat_usage_and_stop_reason_mock():
     mock_first_usage = MagicMock(spec=Usage)
     mock_first_usage.input_tokens = 15
     mock_first_usage.output_tokens = 1
+    mock_first_usage.cache_creation_input_tokens = 2
+    mock_first_usage.cache_read_input_tokens = 3
 
     # Last event with final usage
     # Note that input_tokens can be None
@@ -711,6 +732,8 @@ def test_stream_chat_usage_and_stop_reason_mock():
     mock_last_usage = MagicMock(spec=Usage)
     mock_last_usage.input_tokens = None
     mock_last_usage.output_tokens = 8
+    mock_last_usage.cache_creation_input_tokens = 5
+    mock_last_usage.cache_read_input_tokens = 7
 
     mock_delta = MagicMock()
     mock_delta.stop_reason = "end_turn"
@@ -767,6 +790,8 @@ def test_stream_chat_usage_and_stop_reason_mock():
     )
     assert usage["input_tokens"] == 15
     assert usage["output_tokens"] == 8
+    assert usage["cache_creation_input_tokens"] == 5
+    assert usage["cache_read_input_tokens"] == 7
 
     # Verify stop_reason was captured
     stop_reason = last_chunk.message.additional_kwargs.get("stop_reason")
@@ -795,10 +820,14 @@ async def test_astream_chat_usage_and_stop_reason_mock():
     mock_first_usage = MagicMock(spec=Usage)
     mock_first_usage.input_tokens = 20
     mock_first_usage.output_tokens = 1
+    mock_first_usage.cache_creation_input_tokens = 4
+    mock_first_usage.cache_read_input_tokens = 6
 
     mock_last_usage = MagicMock(spec=Usage)
     mock_last_usage.input_tokens = None
     mock_last_usage.output_tokens = 12
+    mock_last_usage.cache_creation_input_tokens = 8
+    mock_last_usage.cache_read_input_tokens = 10
 
     mock_delta = MagicMock()
     mock_delta.stop_reason = "max_tokens"
@@ -853,6 +882,8 @@ async def test_astream_chat_usage_and_stop_reason_mock():
     assert usage is not None, "Usage metadata should be captured in async streaming"
     assert usage["input_tokens"] == 20
     assert usage["output_tokens"] == 12
+    assert usage["cache_creation_input_tokens"] == 8
+    assert usage["cache_read_input_tokens"] == 10
 
     # Verify stop_reason was captured
     stop_reason = last_chunk.message.additional_kwargs.get("stop_reason")


### PR DESCRIPTION
## Summary

Preserves Anthropic cache usage counters in LlamaIndex response metadata.

This adds `cache_creation_input_tokens` and `cache_read_input_tokens` to the usage metadata that is attached to Anthropic streaming responses, and also attaches usage metadata to non-streaming chat responses when Anthropic returns it.

## Why

Anthropic usage objects can include cache-specific token counters in addition to `input_tokens` and `output_tokens`. Those counters are needed by downstream observability and cost tooling to distinguish full-price input, cache writes, and cache reads.

The existing streaming path kept only `input_tokens` and `output_tokens`, so cache usage was lost even when the SDK exposed it.

## Validation

- `PYTHONPATH=llama-index-core:llama-index-integrations/llms/llama-index-llms-anthropic uv run --group dev --with anthropic pytest llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py::test_usage_metadata_preserves_anthropic_cache_tokens llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py::test_stream_chat_usage_and_stop_reason_mock llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py::test_astream_chat_usage_and_stop_reason_mock -q`
- `PYTHONPATH=llama-index-core:llama-index-integrations/llms/llama-index-llms-anthropic uv run --group dev ruff check llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py`
- `python3 -m compileall -q llama-index-integrations/llms/llama-index-llms-anthropic/llama_index/llms/anthropic/base.py llama-index-integrations/llms/llama-index-llms-anthropic/tests/test_llms_anthropic.py`
- `git diff --check`

I also ran the full Anthropic test file. The offline tests passed, but two live API tests failed for existing external reasons: one references `claude-sonnet-4-0`, which the API returned as not found, and another live structured-output test returned `tool_choice: Input should be an object`.
