### PR TITLE
fix(missing_documentation): Def `run_async_tasks` in llama-index-core/llama_index/core/a

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -82,7 +82,36 @@ def run_async_tasks(
     show_progress: bool = False,
     progress_bar_desc: str = "Running async tasks",
 ) -> List[Any]:
-    """Run a list of async tasks."""
+    """Run a list of async tasks.
+
+    Executes a list of coroutines concurrently using ``asyncio.gather``.
+    An optional progress bar (powered by ``tqdm``) can be shown while the
+    tasks are running.
+
+    Args:
+        tasks (List[Coroutine]): The coroutines to execute concurrently.
+        show_progress (bool): If ``True``, display a ``tqdm`` progress bar
+            while the tasks are running.  Defaults to ``False``.
+        progress_bar_desc (str): Description label shown on the progress bar
+            when *show_progress* is ``True``.
+            Defaults to ``"Running async tasks"``.
+
+    Returns:
+        List[Any]: A list of results in the same order as *tasks*.
+
+    Example:
+        >>> import asyncio
+        >>> from llama_index.core.async_utils import run_async_tasks
+        >>>
+        >>> async def double(x: int) -> int:
+        ...     await asyncio.sleep(0)
+        ...     return x * 2
+        >>>
+        >>> tasks = [double(i) for i in range(5)]
+        >>> results = run_async_tasks(tasks)
+        >>> print(results)
+        [0, 2, 4, 6, 8]
+    """
     tasks_to_execute: List[Any] = tasks
     if show_progress:
         try:


### PR DESCRIPTION
## TLDR

**Gap:** Def `run_async_tasks` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L80

## Changes

- `llama-index-core/llama_index/core/async_utils.py`

**Diff size:** 31 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>