### PR TITLE
fix(tools-mcp): unpack 2-tuple from streamable_http_client (mcp 2.x)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -251,7 +251,7 @@ class BasicMCPClient(ClientSession):
                 async with streamable_http_client(
                     url=self.command_or_url,
                     http_client=self.http_client,
-                ) as (read, write, _):
+                ) as (read, write):
                     async with ClientSession(
                         read,
                         write,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,4 +1,7 @@
 import os
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
 from httpx2 import AsyncClient
 import pytest
 
@@ -259,3 +262,42 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_unpacks_two_tuple():
+    received = {}
+
+    @asynccontextmanager
+    async def fake_streamable_http_client(*args, **kwargs):
+        # mcp 2.x yields (read_stream, write_stream) — exactly two values.
+        yield ("read-stream", "write-stream")
+
+    class FakeSession:
+        def __init__(self, read, write, **kwargs):
+            received["read"] = read
+            received["write"] = write
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def initialize(self):
+            return None
+
+    client = BasicMCPClient("https://example.com/mcp/", timeout=5)
+
+    with (
+        patch(
+            "llama_index.tools.mcp.client.streamable_http_client",
+            fake_streamable_http_client,
+        ),
+        patch("llama_index.tools.mcp.client.ClientSession", FakeSession),
+    ):
+        async with client._run_session() as session:
+            assert isinstance(session, FakeSession)
+
+    # The two streams from the transport are forwarded to the session in order.
+    assert received == {"read": "read-stream", "write": "write-stream"}


### PR DESCRIPTION
# Description

The mcp 2.x migration (#22515 / #22557) left one break site unfixed — item #1 of the tracking issue #22515.

In `mcp` 2.0.0, `streamable_http_client(...)` yields a **2-tuple** `(read, write)` (see `mcp/client/streamable_http.py`: `yield read_stream, write_stream`), but `client.py` still unpacked a **3-tuple**:

```python
async with streamable_http_client(...) as (read, write, _):  # expects 3, gets 2
```

PR #22557 edited the `read_timeout_seconds` line directly beneath this unpack but never touched the unpack itself, so every streamable-HTTP session raised immediately:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

Since streamable-HTTP is the recommended/most-common transport, 0.5.0 was broken out of the box for those users. The fix changes the unpack to `(read, write)`.

Fixes #22655

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Bumped `llama-index-tools-mcp` `0.5.0` → `0.5.1`.

- [x] Yes
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_streamable_http_unpacks_two_tuple`, which drives `_run_session` over a stubbed `streamable_http_client` that yields `(read, write)` and asserts both streams reach `ClientSession`. It fails on the old 3-tuple unpack (`ValueError: expected 3, got 2`) and passes with the fix, covering the streamable-HTTP transport path that previously had no test. Full suite: `52 passed` locally.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
