### PR TITLE
fix(lancedb): add pandas as runtime dependency

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/pyproject.toml
@@ -21,7 +21,6 @@ dev = [
     "types-setuptools==67.1.0.0",
     "black[jupyter]<=23.9.1,>=23.7.0",
     "codespell[toml]>=v2.2.6",
-    "pandas>=2.2.3",
     "diff-cover>=9.2.0",
     "pytest-cov>=6.1.1",
 ]
@@ -36,6 +35,7 @@ readme = "README.md"
 license = "MIT"
 dependencies = [
     "lancedb>=0.21.1",
+    "pandas>=2.2.3",
     "pylance",
     "tantivy",
     "llama-index-core>=0.13.0,<0.15",

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/uv.lock
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-lancedb/uv.lock
@@ -1008,7 +1008,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1896,6 +1896,8 @@ source = { editable = "." }
 dependencies = [
     { name = "lancedb" },
     { name = "llama-index-core" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pylance" },
     { name = "tantivy" },
 ]
@@ -1908,8 +1910,6 @@ dev = [
     { name = "ipython" },
     { name = "jupyter" },
     { name = "mypy" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
@@ -1929,6 +1929,7 @@ dev = [
 requires-dist = [
     { name = "lancedb", specifier = ">=0.21.1" },
     { name = "llama-index-core", specifier = ">=0.13.0,<0.15" },
+    { name = "pandas", specifier = ">=2.2.3" },
     { name = "pylance" },
     { name = "tantivy" },
 ]
@@ -1941,7 +1942,6 @@ dev = [
     { name = "ipython", specifier = "==8.10.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2" },
     { name = "mypy", specifier = "==0.991" },
-    { name = "pandas", specifier = ">=2.2.3" },
     { name = "pre-commit", specifier = "==3.2.0" },
     { name = "pylint", specifier = "==2.15.10" },
     { name = "pytest", specifier = "==7.2.1" },
@@ -2597,10 +2597,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2666,9 +2666,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [


### PR DESCRIPTION
Summary
llama-index-vector-stores-lancedb imports pandas at runtime (e.g. from pandas import DataFrame in base.py and .to_pandas() calls in query paths), but pandas was only declared in the dev dependency group. Installing the package in a clean environment therefore fails with ModuleNotFoundError: No module named 'pandas'.
This PR moves pandas>=2.2.3 from the dev group to the runtime dependencies in pyproject.toml and regenerates uv.lock accordingly.
Changes
- pyproject.toml: move pandas>=2.2.3 from [dependency-groups] dev to [project] dependencies
- uv.lock: regenerated with uv lock
Verification
- uv lock resolves successfully
- Package tests pass: 26 passed
Closes #22619