### PR TITLE
feat(ag-ui): support multimodal user input (images, audio, video, documents)

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -198,9 +198,22 @@ class AGUIChatWorkflow(Workflow):
             if state:
                 for msg in chat_history[::-1]:
                     if msg.role.value == "user":
-                        msg.content = DEFAULT_STATE_PROMPT.format(
-                            state=str(state), user_input=msg.content
+                        # Rebuild the blocks rather than assigning `.content`:
+                        # the content setter raises on a multi-block (e.g.
+                        # image-carrying) message, and would drop media if it
+                        # didn't. The state prompt wraps the text; every
+                        # non-text block is carried over unchanged.
+                        state_text = DEFAULT_STATE_PROMPT.format(
+                            state=str(state), user_input=msg.content or ""
                         )
+                        msg.blocks = [
+                            TextBlock(text=state_text),
+                            *[
+                                block
+                                for block in msg.blocks
+                                if not isinstance(block, TextBlock)
+                            ],
+                        ]
                         break
 
             if self.system_prompt:

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -1,4 +1,6 @@
+import base64
 import datetime
+import logging
 import re
 import uuid
 from ag_ui.core import (
@@ -11,12 +13,197 @@ from ag_ui.core import (
     ToolCall,
     FunctionCall,
 )
+from ag_ui.core.types import (
+    AudioInputContent,
+    BinaryInputContent,
+    DocumentInputContent,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    TextInputContent,
+    VideoInputContent,
+)
 from ag_ui.encoder import EventEncoder
-from typing import Union, Callable
+from typing import Any, List, Optional, Union, Callable
 
 from llama_index.core.llms import ChatMessage
+from llama_index.core.base.llms.types import (
+    AudioBlock,
+    ContentBlock,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
+
+try:  # VideoBlock landed after the 0.13 floor of this package's core range
+    from llama_index.core.base.llms.types import VideoBlock
+except ImportError:  # pragma: no cover
+    VideoBlock = None  # type: ignore[assignment,misc]
 from llama_index.core.tools import BaseTool, FunctionTool
 from llama_index.core.workflow import Event
+
+logger = logging.getLogger(__name__)
+
+
+def _source_kwargs(source: Union[InputContentDataSource, InputContentUrlSource]) -> dict:
+    """Project an AG-UI input-content source onto block constructor kwargs.
+
+    A ``data`` source carries base64 in ``value``; blocks take raw bytes. A
+    ``url`` source passes through. Returns ``{}`` for a source this converter
+    cannot read, so the caller can skip the part with a warning.
+    """
+    if isinstance(source, InputContentDataSource):
+        return {"data": base64.b64decode(source.value), "mime_type": source.mime_type}
+    if isinstance(source, InputContentUrlSource):
+        return {"url": source.value, "mime_type": source.mime_type}
+    return {}
+
+
+def _binary_part_to_block(part: BinaryInputContent) -> Optional[ContentBlock]:
+    """Convert the deprecated flat ``binary`` part, routed by MIME prefix."""
+    mime = part.mime_type or ""
+    data = base64.b64decode(part.data) if part.data else None
+    if not part.url and data is None:
+        return None
+    if mime.startswith("image/"):
+        return ImageBlock(image=data, url=part.url, image_mimetype=mime or None)
+    if mime.startswith("audio/"):
+        return AudioBlock(audio=data, url=part.url)
+    if mime.startswith("video/") and VideoBlock is not None:
+        return VideoBlock(video=data, url=part.url, video_mimetype=mime or None)
+    return DocumentBlock(
+        data=data, url=part.url, document_mimetype=mime or None, title=part.filename
+    )
+
+
+def agui_content_to_blocks(content: Union[str, List[Any]]) -> List[ContentBlock]:
+    """Convert AG-UI user-message content onto llama-index content blocks.
+
+    String content becomes a single :class:`TextBlock`. List content maps each
+    typed part (text/image/audio/video/document, plus the deprecated flat
+    ``binary`` shape) onto the corresponding block; a part this converter
+    cannot represent is skipped with a warning rather than silently stringified.
+    """
+    if isinstance(content, str):
+        return [TextBlock(text=content)]
+
+    blocks: List[ContentBlock] = []
+    for part in content:
+        if isinstance(part, TextInputContent):
+            blocks.append(TextBlock(text=part.text))
+        elif isinstance(part, ImageInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping image part with unreadable source")
+                continue
+            blocks.append(
+                ImageBlock(
+                    image=kwargs.get("data"),
+                    url=kwargs.get("url"),
+                    image_mimetype=kwargs.get("mime_type"),
+                )
+            )
+        elif isinstance(part, AudioInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping audio part with unreadable source")
+                continue
+            blocks.append(AudioBlock(audio=kwargs.get("data"), url=kwargs.get("url")))
+        elif isinstance(part, VideoInputContent):
+            if VideoBlock is None:
+                logger.warning(
+                    "Skipping video part: this llama-index-core has no VideoBlock"
+                )
+                continue
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping video part with unreadable source")
+                continue
+            blocks.append(
+                VideoBlock(
+                    video=kwargs.get("data"),
+                    url=kwargs.get("url"),
+                    video_mimetype=kwargs.get("mime_type"),
+                )
+            )
+        elif isinstance(part, DocumentInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping document part with unreadable source")
+                continue
+            blocks.append(
+                DocumentBlock(
+                    data=kwargs.get("data"),
+                    url=kwargs.get("url"),
+                    document_mimetype=kwargs.get("mime_type"),
+                )
+            )
+        elif isinstance(part, BinaryInputContent):
+            block = _binary_part_to_block(part)
+            if block is None:
+                logger.warning("Skipping binary part with no url or data")
+                continue
+            blocks.append(block)
+        else:
+            logger.warning(
+                "Skipping unrecognized content part type: %r", type(part).__name__
+            )
+    return blocks
+
+
+def _block_to_agui_part(block: ContentBlock) -> Optional[Any]:
+    """Convert one llama-index content block back onto an AG-UI input part.
+
+    The inverse of :func:`agui_content_to_blocks` for the block types it emits.
+    A block with neither bytes nor a URL (e.g. path-based) has no AG-UI wire
+    shape and returns ``None``.
+    """
+
+    def _source(
+        data: Optional[bytes], url: Optional[Any], mime: Optional[str]
+    ) -> Optional[Union[InputContentDataSource, InputContentUrlSource]]:
+        if url:
+            return InputContentUrlSource(type="url", value=str(url), mime_type=mime)
+        if data is not None:
+            return InputContentDataSource(
+                type="data",
+                value=base64.b64encode(data).decode("ascii"),
+                mime_type=mime or "application/octet-stream",
+            )
+        return None
+
+    def _bytes(block: ContentBlock, field: Optional[bytes], resolve: Callable) -> Optional[bytes]:
+        # The block classes normalize stored bytes through a base64 heuristic,
+        # so the field value is not reliably raw; resolve_*() is. Only resolved
+        # when the block has no URL — resolving a URL-backed block would fetch
+        # it over the network, and the URL passes through as-is instead.
+        if block.url or field is None:
+            return None
+        return resolve().read()
+
+    if isinstance(block, TextBlock):
+        return TextInputContent(type="text", text=block.text)
+    if isinstance(block, ImageBlock):
+        data = _bytes(block, block.image, block.resolve_image)
+        source = _source(data, block.url, block.image_mimetype)
+        return ImageInputContent(type="image", source=source) if source else None
+    if isinstance(block, AudioBlock):
+        mime = f"audio/{block.format}" if block.format else None
+        data = _bytes(block, block.audio, block.resolve_audio)
+        source = _source(data, block.url, mime)
+        return AudioInputContent(type="audio", source=source) if source else None
+    if VideoBlock is not None and isinstance(block, VideoBlock):
+        data = _bytes(block, block.video, block.resolve_video)
+        source = _source(data, block.url, block.video_mimetype)
+        return VideoInputContent(type="video", source=source) if source else None
+    if isinstance(block, DocumentBlock):
+        data = _bytes(block, block.data, block.resolve_document)
+        source = _source(data, block.url, block.document_mimetype)
+        return DocumentInputContent(type="document", source=source) if source else None
+    return None
+
+
+_STATE_TAG_RE = re.compile(r"<state>[\s\S]*?</state>")
 
 
 def llama_index_message_to_ag_ui_message(
@@ -28,8 +215,23 @@ def llama_index_message_to_ag_ui_message(
     elif (
         message.role.value == "user" and "tool_call_id" not in message.additional_kwargs
     ):
+        non_text = [b for b in message.blocks if not isinstance(b, TextBlock)]
+        if non_text:
+            # Multimodal user message: emit typed AG-UI parts, applying the
+            # state-tag cleanup to each text part.
+            parts = []
+            for block in message.blocks:
+                if isinstance(block, TextBlock):
+                    text = _STATE_TAG_RE.sub("", block.text).strip()
+                    if text:
+                        parts.append(TextInputContent(type="text", text=text))
+                    continue
+                part = _block_to_agui_part(block)
+                if part is not None:
+                    parts.append(part)
+            return UserMessage(id=msg_id, content=parts, role="user")
         content = message.content or ""
-        content = re.sub(r"<state>[\s\S]*?</state>", "", content).strip()
+        content = _STATE_TAG_RE.sub("", content).strip()
         return UserMessage(id=msg_id, content=content, role="user")
     elif message.role.value == "assistant":
         # Remove tool calls from the message
@@ -84,7 +286,9 @@ def ag_ui_message_to_llama_index_message(message: Message) -> ChatMessage:
         )
     elif isinstance(message, UserMessage):
         return ChatMessage(
-            role="user", content=message.content, additional_kwargs={"id": message.id}
+            role="user",
+            blocks=agui_content_to_blocks(message.content or ""),
+            additional_kwargs={"id": message.id},
         )
     elif isinstance(message, AssistantMessage):
         # TODO: llama-index-core needs to support tool calls on messages in a more official way

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.4"
+version = "0.4.0"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_multimodal_input.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_multimodal_input.py
@@ -1,0 +1,166 @@
+import base64
+
+from ag_ui.core import UserMessage
+from ag_ui.core.types import (
+    AudioInputContent,
+    BinaryInputContent,
+    DocumentInputContent,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    TextInputContent,
+)
+from llama_index.core.base.llms.types import (
+    AudioBlock,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+)
+from llama_index.core.llms import ChatMessage
+
+from llama_index.protocols.ag_ui.utils import (
+    ag_ui_message_to_llama_index_message,
+    agui_content_to_blocks,
+    llama_index_message_to_ag_ui_message,
+)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake image payload"
+PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
+
+
+def user_message(content) -> UserMessage:
+    return UserMessage(id="msg-1", role="user", content=content)
+
+
+def test_string_content_still_converts_to_text() -> None:
+    msg = ag_ui_message_to_llama_index_message(user_message("hello"))
+    assert msg.role.value == "user"
+    assert msg.content == "hello"
+    assert [type(b) for b in msg.blocks] == [TextBlock]
+
+
+def test_image_data_part_becomes_image_block_with_bytes() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                TextInputContent(type="text", text="what is in this image?"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=PNG_B64, mime_type="image/png"
+                    ),
+                ),
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [TextBlock, ImageBlock]
+    image = msg.blocks[1]
+    assert image.resolve_image().read() == PNG_BYTES
+    assert image.image_mimetype == "image/png"
+    # The text is still reachable through the plain-content view.
+    assert msg.content == "what is in this image?"
+
+
+def test_image_url_part_becomes_image_block_with_url() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                ImageInputContent(
+                    type="image",
+                    source=InputContentUrlSource(
+                        type="url", value="https://example.com/cat.png"
+                    ),
+                )
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [ImageBlock]
+    assert str(msg.blocks[0].url) == "https://example.com/cat.png"
+
+
+def test_audio_and_document_parts_convert() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                AudioInputContent(
+                    type="audio",
+                    source=InputContentDataSource(
+                        type="data", value=PNG_B64, mime_type="audio/mpeg"
+                    ),
+                ),
+                DocumentInputContent(
+                    type="document",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/report.pdf",
+                        mime_type="application/pdf",
+                    ),
+                ),
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [AudioBlock, DocumentBlock]
+
+
+def test_deprecated_binary_part_routes_by_mime() -> None:
+    blocks = agui_content_to_blocks(
+        [
+            BinaryInputContent(
+                type="binary", mime_type="image/jpeg", data=PNG_B64, filename="a.jpg"
+            )
+        ]
+    )
+    assert [type(b) for b in blocks] == [ImageBlock]
+
+
+def test_unreadable_parts_are_skipped_not_stringified() -> None:
+    blocks = agui_content_to_blocks(
+        [
+            TextInputContent(type="text", text="hi"),
+            # id-only binary part: nothing to read, so it must be skipped.
+            BinaryInputContent(type="binary", mime_type="image/png", id="file-123"),
+        ]
+    )
+    assert [type(b) for b in blocks] == [TextBlock]
+
+
+def test_roundtrip_multimodal_user_message() -> None:
+    original = user_message(
+        [
+            TextInputContent(type="text", text="describe this"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ]
+    )
+    li_msg = ag_ui_message_to_llama_index_message(original)
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert isinstance(back, UserMessage)
+    assert isinstance(back.content, list)
+    assert [p.type for p in back.content] == ["text", "image"]
+    assert back.content[0].text == "describe this"
+    assert base64.b64decode(back.content[1].source.value) == PNG_BYTES
+
+
+def test_text_only_user_message_roundtrips_as_string() -> None:
+    li_msg = ag_ui_message_to_llama_index_message(user_message("plain text"))
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert back.content == "plain text"
+
+
+def test_state_tag_is_stripped_from_text_part_of_multimodal_message() -> None:
+    li_msg = ChatMessage(
+        role="user",
+        blocks=[
+            TextBlock(text="<state>{'a': 1}</state>ask about the image"),
+            ImageBlock(url="https://example.com/cat.png"),
+        ],
+        additional_kwargs={"id": "msg-2"},
+    )
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert isinstance(back.content, list)
+    assert back.content[0].text == "ask about the image"
+    assert back.content[1].type == "image"

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
@@ -1,0 +1,51 @@
+"""The state prompt must not crash on (or drop media from) multimodal input.
+
+Regression test for the ``msg.content = ...`` assignment in
+``AGUIChatWorkflow``: the ``ChatMessage.content`` setter raises on a
+multi-block message, so a user message carrying an image alongside text made
+every run with non-empty state fail before the blocks-preserving rewrite.
+"""
+
+from llama_index.core.base.llms.types import ImageBlock, TextBlock
+from llama_index.core.llms import ChatMessage
+
+from llama_index.protocols.ag_ui.agent import DEFAULT_STATE_PROMPT
+
+
+def rewrite_last_user_message(chat_history, state) -> None:
+    """Mirror of the state-prompt rewrite in AGUIChatWorkflow.prepare_chat."""
+    for msg in chat_history[::-1]:
+        if msg.role.value == "user":
+            state_text = DEFAULT_STATE_PROMPT.format(
+                state=str(state), user_input=msg.content or ""
+            )
+            msg.blocks = [
+                TextBlock(text=state_text),
+                *[block for block in msg.blocks if not isinstance(block, TextBlock)],
+            ]
+            break
+
+
+def test_state_prompt_preserves_image_blocks() -> None:
+    history = [
+        ChatMessage(
+            role="user",
+            blocks=[
+                TextBlock(text="what is in this image?"),
+                ImageBlock(url="https://example.com/cat.png"),
+            ],
+        )
+    ]
+    rewrite_last_user_message(history, {"a": 1})
+    blocks = history[0].blocks
+    assert [type(b) for b in blocks] == [TextBlock, ImageBlock]
+    assert "what is in this image?" in blocks[0].text
+    assert "{'a': 1}" in blocks[0].text
+    assert str(blocks[1].url) == "https://example.com/cat.png"
+
+
+def test_state_prompt_still_works_for_text_only() -> None:
+    history = [ChatMessage(role="user", content="hello")]
+    rewrite_last_user_message(history, {"a": 1})
+    assert "hello" in history[0].content
+    assert "{'a': 1}" in history[0].content


### PR DESCRIPTION
# Description

`llama-index-protocols-ag-ui` currently drops multimodal input: an AG-UI user message whose `content` is a parts list (text + image/audio/video/document) is passed untouched into `ChatMessage(content=...)`, so media never reaches the model — and the state-prompt rewrite crashes outright on multi-block messages because the `ChatMessage.content` setter raises on them. AG-UI's protocol has supported typed multimodal input content for a while, and every other major integration (CrewAI, Strands, Agno, Pydantic AI, Agent Framework, AG2) already maps it.

This PR adds full multimodal input support:

- `agui_content_to_blocks` maps typed AG-UI parts onto llama-index content blocks (`TextBlock`/`ImageBlock`/`AudioBlock`/`VideoBlock`/`DocumentBlock`): base64 `data` sources are decoded to raw bytes, `url` sources pass through, and the deprecated flat `binary` shape is routed by MIME prefix. Unreadable parts are skipped with a warning instead of being stringified.
- The reverse direction (`llama_index_message_to_ag_ui_message`) emits typed parts for multimodal user messages, resolving block bytes via `resolve_*()` (the stored field is normalized through a base64 heuristic and is not reliably raw) and never resolving URL-backed blocks, which would fetch over the network. The `<state>` tag cleanup is applied per text part.
- The state-prompt rewrite in `AGUIChatWorkflow` rebuilds `blocks` instead of assigning `.content`, fixing the crash and preserving media blocks.
- `VideoBlock` is imported defensively — it does not exist at the `llama-index-core>=0.13.0` floor of this package's declared range.

Sequencing note: the AG-UI TypeScript client (`@ag-ui/llamaindex`) pins `maxVersion = "0.0.39"`, whose compatibility middleware flattens parts lists to text before requests reach this server. A follow-up PR to ag-ui-protocol/ag-ui removes that pin once this package is released, which is what makes the end-to-end path work.

## New Package?

- [ ] No

## Version Bump?

- [x] Yes (0.3.4 → 0.4.0)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

11 new tests across `tests/test_multimodal_input.py` (data/url sources, audio/document, deprecated binary routing, skip-not-stringify, multimodal roundtrip, state-tag stripping per part) and `tests/test_state_prompt_multimodal.py` (regression for the multi-block state-prompt crash). Full package suite passes (15/15).

Beyond unit tests: verified end-to-end over HTTP (real `RunAgentInput` JSON with camelCase wire aliases through the FastAPI router — the ImageBlock reaches the LLM with byte-identical content), and manually against OpenAI `gpt-4.1` plus the AG-UI dojo browser UI with the client pin removed (uploaded image is described correctly).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
