### PR TITLE
Fix PropertyGraphIndex async node insertion in running event loops

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -192,6 +192,10 @@ class BaseIndex(Generic[IS], ABC):
     def _insert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
         """Index-specific logic for inserting nodes to the index struct."""
 
+    async def _ainsert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
+        """Asynchronous index-specific logic for inserting nodes to the index struct."""
+        self._insert(nodes, **insert_kwargs)
+
     def insert_nodes(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
         """Insert nodes."""
         for node in nodes:
@@ -221,7 +225,7 @@ class BaseIndex(Generic[IS], ABC):
 
         with self._callback_manager.as_trace("ainsert_nodes"):
             await self.docstore.async_add_documents(nodes, allow_update=True)
-            self._insert(nodes=nodes)
+            await self._ainsert(nodes=nodes, **insert_kwargs)
             await self._storage_context.index_store.async_add_index_struct(
                 self._index_struct
             )

--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, List, Optional, Sequence, Type, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TYPE_CHECKING
 
 from llama_index.core.data_structs import IndexLPG
 from llama_index.core.base.base_retriever import BaseRetriever
@@ -209,6 +209,44 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
                 nodes, self._kg_extractors, show_progress=self._show_progress
             )
 
+        nodes, kg_nodes_to_insert, kg_rels_to_insert = self._prepare_nodes_for_insert(
+            nodes
+        )
+        if self._embed_kg_nodes:
+            self._embed_nodes(nodes, kg_nodes_to_insert)
+        self._upsert_nodes(nodes, kg_nodes_to_insert, kg_rels_to_insert)
+        return nodes
+
+    async def _ainsert_nodes(self, nodes: Sequence[BaseNode]) -> Sequence[BaseNode]:
+        """Asynchronously insert nodes to the index struct."""
+        if len(nodes) == 0:
+            return nodes
+
+        # run transformations on nodes to extract triplets
+        if self._use_async:
+            nodes = await arun_transformations(
+                nodes, self._kg_extractors, show_progress=self._show_progress
+            )
+        else:
+            nodes = run_transformations(
+                nodes, self._kg_extractors, show_progress=self._show_progress
+            )
+
+        nodes, kg_nodes_to_insert, kg_rels_to_insert = self._prepare_nodes_for_insert(
+            nodes
+        )
+        if self._embed_kg_nodes:
+            if self._use_async:
+                await self._aembed_nodes(nodes, kg_nodes_to_insert)
+            else:
+                self._embed_nodes(nodes, kg_nodes_to_insert)
+        self._upsert_nodes(nodes, kg_nodes_to_insert, kg_rels_to_insert)
+        return nodes
+
+    def _prepare_nodes_for_insert(
+        self, nodes: Sequence[BaseNode]
+    ) -> Tuple[List[BaseNode], List[LabelledNode], List[Relation]]:
+        """Prepare transformed nodes for insertion."""
         # ensure all nodes have nodes and/or relations in metadata
         assert all(
             node.metadata.get(KG_NODES_KEY) is not None
@@ -248,45 +286,82 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
         existing_node_hashes = {node.hash for node in existing_nodes}
         nodes = [node for node in nodes if node.hash not in existing_node_hashes]
 
-        # embed nodes (if needed)
-        if self._embed_kg_nodes:
-            # embed llama-index nodes
-            node_texts = [
-                node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes
-            ]
+        return nodes, kg_nodes_to_insert, kg_rels_to_insert
 
-            if self._use_async:
-                embeddings = asyncio.run(
-                    self._embed_model.aget_text_embedding_batch(
-                        node_texts, show_progress=self._show_progress
-                    )
-                )
-            else:
-                embeddings = self._embed_model.get_text_embedding_batch(
+    def _embed_nodes(
+        self, nodes: Sequence[BaseNode], kg_nodes_to_insert: List[LabelledNode]
+    ) -> None:
+        """Embed llama-index and KG nodes."""
+        # embed llama-index nodes
+        node_texts = [
+            node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes
+        ]
+
+        if self._use_async:
+            embeddings = asyncio.run(
+                self._embed_model.aget_text_embedding_batch(
                     node_texts, show_progress=self._show_progress
                 )
+            )
+        else:
+            embeddings = self._embed_model.get_text_embedding_batch(
+                node_texts, show_progress=self._show_progress
+            )
 
-            for node, embedding in zip(nodes, embeddings):
-                node.embedding = embedding
+        for node, embedding in zip(nodes, embeddings):
+            node.embedding = embedding
 
-            # embed kg nodes
-            kg_node_texts = [str(kg_node) for kg_node in kg_nodes_to_insert]
+        # embed kg nodes
+        kg_node_texts = [str(kg_node) for kg_node in kg_nodes_to_insert]
 
-            if self._use_async:
-                kg_embeddings = asyncio.run(
-                    self._embed_model.aget_text_embedding_batch(
-                        kg_node_texts, show_progress=self._show_progress
-                    )
+        if self._use_async:
+            kg_embeddings = asyncio.run(
+                self._embed_model.aget_text_embedding_batch(
+                    kg_node_texts, show_progress=self._show_progress
                 )
-            else:
-                kg_embeddings = self._embed_model.get_text_embedding_batch(
-                    kg_node_texts,
-                    show_progress=self._show_progress,
-                )
+            )
+        else:
+            kg_embeddings = self._embed_model.get_text_embedding_batch(
+                kg_node_texts,
+                show_progress=self._show_progress,
+            )
 
-            for kg_node, embedding in zip(kg_nodes_to_insert, kg_embeddings):
-                kg_node.embedding = embedding
+        for kg_node, embedding in zip(kg_nodes_to_insert, kg_embeddings):
+            kg_node.embedding = embedding
 
+    async def _aembed_nodes(
+        self, nodes: Sequence[BaseNode], kg_nodes_to_insert: List[LabelledNode]
+    ) -> None:
+        """Asynchronously embed llama-index and KG nodes."""
+        # embed llama-index nodes
+        node_texts = [
+            node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes
+        ]
+
+        embeddings = await self._embed_model.aget_text_embedding_batch(
+            node_texts, show_progress=self._show_progress
+        )
+
+        for node, embedding in zip(nodes, embeddings):
+            node.embedding = embedding
+
+        # embed kg nodes
+        kg_node_texts = [str(kg_node) for kg_node in kg_nodes_to_insert]
+
+        kg_embeddings = await self._embed_model.aget_text_embedding_batch(
+            kg_node_texts, show_progress=self._show_progress
+        )
+
+        for kg_node, embedding in zip(kg_nodes_to_insert, kg_embeddings):
+            kg_node.embedding = embedding
+
+    def _upsert_nodes(
+        self,
+        nodes: List[BaseNode],
+        kg_nodes_to_insert: List[LabelledNode],
+        kg_rels_to_insert: List[Relation],
+    ) -> None:
+        """Upsert prepared nodes and relations."""
         # if graph store doesn't support vectors, or the vector index was provided, use it
         if self.vector_store is not None and len(kg_nodes_to_insert) > 0:
             self._insert_nodes_to_vector_index(kg_nodes_to_insert)
@@ -304,8 +379,6 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
         # refresh schema if needed
         if self.property_graph_store.supports_structured_queries:
             self.property_graph_store.get_schema(refresh=True)
-
-        return nodes
 
     def _insert_nodes_to_vector_index(self, nodes: List[LabelledNode]) -> None:
         """Insert vector nodes."""
@@ -400,6 +473,10 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
     def _insert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
         """Index-specific logic for inserting nodes to the index struct."""
         self._insert_nodes(nodes)
+
+    async def _ainsert(self, nodes: Sequence[BaseNode], **insert_kwargs: Any) -> None:
+        """Asynchronous index-specific logic for inserting nodes to the index struct."""
+        await self._ainsert_nodes(nodes)
 
     @property
     def ref_doc_info(self) -> Dict[str, RefDocInfo]:

--- a/llama-index-core/tests/indices/property_graph/test_property_graph.py
+++ b/llama-index-core/tests/indices/property_graph/test_property_graph.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 from typing import Any, List
 
+import pytest
+
 from llama_index.core import PropertyGraphIndex, Document, MockEmbedding
 from llama_index.core.graph_stores.simple_labelled import SimplePropertyGraphStore
 from llama_index.core.graph_stores.types import (
@@ -66,3 +68,28 @@ def test_construction() -> None:
     index.insert_nodes(kg_extractor([]))
 
     assert index._insert_nodes_to_vector_index.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_ainsert_nodes_use_async_inside_running_event_loop() -> None:
+    graph_store = SimplePropertyGraphStore()
+    vector_store = SimpleVectorStore()
+    kg_extractor = MockKGExtractor()
+
+    index = PropertyGraphIndex.from_existing(
+        property_graph_store=graph_store,
+        vector_store=vector_store,
+        llm=MockLLM(),
+        embed_model=MockEmbedding(embed_dim=8),
+        kg_extractors=[kg_extractor],
+        use_async=True,
+    )
+
+    await index.ainsert_nodes([TextNode(text="Logan was born in Canada")])
+
+    assert len(vector_store.get("Logan")) == 8
+    assert len(vector_store.get("Canada")) == 8
+
+    kg_nodes = graph_store.get(ids=["Logan", "Canada"])
+    assert len(kg_nodes) == 2
+    assert all(kg_node.embedding is None for kg_node in kg_nodes)


### PR DESCRIPTION
## Summary

Fixes #22661.

This adds an async insertion hook to `BaseIndex` so `ainsert_nodes()` can await index-specific insertion logic instead of routing back through the synchronous `_insert()` path.

For `PropertyGraphIndex`, this adds a true async node insertion path that awaits async KG transformations and embedding batches directly when `use_async=True`, avoiding nested `asyncio.run()` calls inside an already-running event loop.

The shared preparation, embedding, and upsert steps are split out so the synchronous insertion path keeps the existing behavior while the async path can await the async operations safely.

## Tests

- [x] `uv run pytest llama-index-core/tests/indices/property_graph/test_property_graph.py -q`
- [x] `git diff --check HEAD^..HEAD`