### PR TITLE
Update Nebius integrations for Token Factory

### DIFF
--- a/docs/examples/embeddings/nebius.ipynb
+++ b/docs/examples/embeddings/nebius.ipynb
@@ -13,14 +13,14 @@
    "source": [
     "# Nebius Embeddings\n",
     "\n",
-    "This notebook demonstrates how to use [Nebius AI Studio](https://studio.nebius.ai/) Embeddings with LlamaIndex. Nebius AI Studio implements all state-of-the-art embeddings models, available for commercial use."
+    "This notebook demonstrates how to use the [Nebius Token Factory](https://tokenfactory.nebius.com/) OpenAI-compatible Embeddings API with LlamaIndex."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's install LlamaIndex and dependencies of Nebius AI Studio."
+    "First, let's install LlamaIndex and the Nebius Token Factory embeddings integration."
    ]
   },
   {
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upload your Nebius AI Studio key from system variables below or simply insert it. You can get it by registering for free at [Nebius AI Studio](https://auth.eu.nebius.com/ui/login) and issuing the key at [API Keys section](https://studio.nebius.ai/settings/api-keys)."
+    "Load your Nebius Token Factory API key from the `NEBIUS_API_KEY` environment variable. See the [Token Factory quickstart](https://docs.tokenfactory.nebius.com/quickstart) to create a key."
    ]
   },
   {
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's get embeddings using Nebius AI Studio"
+    "Now let's get embeddings using Nebius Token Factory."
    ]
   },
   {

--- a/docs/examples/embeddings/nebius.ipynb
+++ b/docs/examples/embeddings/nebius.ipynb
@@ -65,7 +65,9 @@
    "source": [
     "from llama_index.embeddings.nebius import NebiusEmbedding\n",
     "\n",
-    "embed_model = NebiusEmbedding(api_key=NEBIUS_API_KEY)"
+    "embed_model = NebiusEmbedding(\n",
+    "    api_key=NEBIUS_API_KEY, model_name=\"Qwen/Qwen3-Embedding-8B\"\n",
+    ")"
    ]
   },
   {

--- a/docs/examples/llm/nebius.ipynb
+++ b/docs/examples/llm/nebius.ipynb
@@ -13,14 +13,14 @@
    "source": [
     "# Nebius LLMs\n",
     "\n",
-    "This notebook demonstrates how to use LLMs from [Nebius AI Studio](https://studio.nebius.ai/) with LlamaIndex. Nebius AI Studio implements all state-of-the-art LLMs available for commercial use."
+    "This notebook demonstrates how to use open models from [Nebius Token Factory](https://tokenfactory.nebius.com/) with LlamaIndex through its OpenAI-compatible Chat Completions API."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's install LlamaIndex and dependencies of Nebius AI Studio."
+    "First, let's install LlamaIndex and the Nebius Token Factory integration."
    ]
   },
   {
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upload your Nebius AI Studio key from system variables below or simply insert it. You can get it by registering for free at [Nebius AI Studio](https://auth.eu.nebius.com/ui/login) and issuing the key at [API Keys section](https://studio.nebius.ai/settings/api-keys).\""
+    "Load your Nebius Token Factory API key from the `NEBIUS_API_KEY` environment variable. See the [Token Factory quickstart](https://docs.tokenfactory.nebius.com/quickstart) to create a key."
    ]
   },
   {
@@ -66,9 +66,7 @@
    "source": [
     "from llama_index.llms.nebius import NebiusLLM\n",
     "\n",
-    "llm = NebiusLLM(\n",
-    "    api_key=NEBIUS_API_KEY, model=\"meta-llama/Llama-3.3-70B-Instruct-fast\"\n",
-    ")"
+    "llm = NebiusLLM(api_key=NEBIUS_API_KEY, model=\"Qwen/Qwen3-30B-A3B-fast\")"
    ]
   },
   {

--- a/docs/examples/llm/nebius.ipynb
+++ b/docs/examples/llm/nebius.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "from llama_index.llms.nebius import NebiusLLM\n",
     "\n",
-    "llm = NebiusLLM(api_key=NEBIUS_API_KEY, model=\"Qwen/Qwen3-30B-A3B-fast\")"
+    "llm = NebiusLLM(api_key=NEBIUS_API_KEY, model=\"openai/gpt-oss-120b\")"
    ]
   },
   {

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/README.md
@@ -24,7 +24,7 @@ NEBIUS_API_KEY=your_api_key
 ```python
 from llama_index.embeddings.nebius import NebiusEmbedding
 
-embed_model = NebiusEmbedding(model_name="BAAI/bge-en-icl")
+embed_model = NebiusEmbedding(model_name="Qwen/Qwen3-Embedding-8B")
 ```
 
 #### Without environmental variables
@@ -33,7 +33,7 @@ embed_model = NebiusEmbedding(model_name="BAAI/bge-en-icl")
 from llama_index.embeddings.nebius import NebiusEmbedding
 
 embed_model = NebiusEmbedding(
-    api_key="your_api_key", model_name="BAAI/bge-en-icl"
+    api_key="your_api_key", model_name="Qwen/Qwen3-Embedding-8B"
 )
 ```
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/README.md
@@ -1,8 +1,8 @@
-# LlamaIndex Embeddings Integration: [Nebius AI Studio](https://studio.nebius.ai/)
+# LlamaIndex Embeddings Integration: [Nebius Token Factory](https://tokenfactory.nebius.com/)
 
 ## Overview
 
-Integrate with Nebius AI Studio API, which provides access to open-source state-of-the-art text embeddings models.
+Integrate with the OpenAI-compatible Embeddings API in Nebius Token Factory, which provides access to open-source text embedding models.
 
 ## Installation
 
@@ -36,6 +36,11 @@ embed_model = NebiusEmbedding(
     api_key="your_api_key", model_name="BAAI/bge-en-icl"
 )
 ```
+
+The integration defaults to `https://api.tokenfactory.nebius.com/v1`. You can
+set `api_base` explicitly to target a Dedicated Endpoint or another compatible
+deployment. See the [Token Factory model list](https://docs.tokenfactory.nebius.com/models)
+for currently available model IDs.
 
 ### Launching
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/base.py
@@ -12,7 +12,7 @@ from llama_index.embeddings.nebius.utils import (
 from llama_index.embeddings.openai import OpenAIEmbedding
 
 DEFAULT_API_BASE = "https://api.tokenfactory.nebius.com/v1"
-DEFAULT_MODEL = "BAAI/bge-en-icl"
+DEFAULT_MODEL = "Qwen/Qwen3-Embedding-8B"
 
 
 class NebiusEmbedding(OpenAIEmbedding):
@@ -20,7 +20,7 @@ class NebiusEmbedding(OpenAIEmbedding):
     Nebius class for embeddings.
 
     Args:
-        model (str): Model for embedding. Defaults to "BAAI/bge-en-icl"
+        model (str): Model for embedding. Defaults to "Qwen/Qwen3-Embedding-8B"
 
     """
 

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/base.py
@@ -11,7 +11,7 @@ from llama_index.embeddings.nebius.utils import (
 )
 from llama_index.embeddings.openai import OpenAIEmbedding
 
-DEFAULT_API_BASE = "https://api.studio.nebius.ai/v1"
+DEFAULT_API_BASE = "https://api.tokenfactory.nebius.com/v1"
 DEFAULT_MODEL = "BAAI/bge-en-icl"
 
 
@@ -28,8 +28,8 @@ class NebiusEmbedding(OpenAIEmbedding):
         default_factory=dict, description="Additional kwargs for the OpenAI API."
     )
 
-    api_key: str = Field(description="The Nebius AI Studio API key.")
-    api_base: str = Field(description="The base URL for Nebius AI Studio API.")
+    api_key: str = Field(description="The Nebius Token Factory API key.")
+    api_base: str = Field(description="The base URL for Nebius Token Factory API.")
     api_version: str = Field(description="The version for OpenAI API.")
 
     def __init__(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/utils.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/llama_index/embeddings/nebius/utils.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 from llama_index.core.base.llms.generic_utils import get_from_param_or_env
 
-DEFAULT_API_BASE = "https://api.studio.nebius.ai/v1"
+DEFAULT_API_BASE = "https://api.tokenfactory.nebius.com/v1"
 DEFAULT_NEBIUS_API_VERSION = ""
 
 
@@ -12,13 +12,12 @@ def resolve_nebius_credentials(
     api_version: Optional[str] = None,
 ) -> Tuple[Optional[str], str, str]:
     """
-    "Resolve Nebius AI Studio credentials.
+    Resolve Nebius Token Factory credentials.
 
     The order of precedence is:
     1. param
     2. env
-    3. openai module
-    4. default
+    3. default
     """
     # resolve from param or env
     api_key = get_from_param_or_env("api_key", api_key, "NEBIUS_API_KEY", "")

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 [project]
 name = "llama-index-embeddings-nebius"
 version = "0.5.1"
-description = "llama-index embeddings Nebius AI Studio integration"
+description = "llama-index embeddings Nebius Token Factory integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/tests/test_embeddings_nebius.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/tests/test_embeddings_nebius.py
@@ -1,7 +1,42 @@
+import json
+
+import httpx
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.embeddings.nebius import NebiusEmbedding
+from llama_index.embeddings.nebius.base import DEFAULT_API_BASE
 
 
-def test_embedding_class():
-    emb = NebiusEmbedding(model_name="per_aspera", api_key="ad_astra")
-    assert isinstance(emb, BaseEmbedding)
+def test_embedding_class() -> None:
+    embedding = NebiusEmbedding(model_name="BAAI/bge-en-icl", api_key="test-key")
+    assert isinstance(embedding, BaseEmbedding)
+
+
+def test_embedding_uses_token_factory_endpoint_and_openai_request_shape() -> None:
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url == f"{DEFAULT_API_BASE}/embeddings"
+        assert request.headers["authorization"] == "Bearer test-key"
+
+        payload = json.loads(request.content)
+        assert payload == {
+            "input": ["Everyone loves justice"],
+            "model": "BAAI/bge-en-icl",
+            "encoding_format": "base64",
+        }
+
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [{"object": "embedding", "embedding": [0.1, 0.2], "index": 0}],
+                "model": payload["model"],
+                "usage": {"prompt_tokens": 3, "total_tokens": 3},
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    embedding = NebiusEmbedding(api_key="test-key", http_client=http_client)
+
+    result = embedding.get_text_embedding("Everyone loves justice")
+
+    assert result == [0.1, 0.2]

--- a/llama-index-integrations/embeddings/llama-index-embeddings-nebius/tests/test_embeddings_nebius.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-nebius/tests/test_embeddings_nebius.py
@@ -7,7 +7,9 @@ from llama_index.embeddings.nebius.base import DEFAULT_API_BASE
 
 
 def test_embedding_class() -> None:
-    embedding = NebiusEmbedding(model_name="BAAI/bge-en-icl", api_key="test-key")
+    embedding = NebiusEmbedding(
+        model_name="Qwen/Qwen3-Embedding-8B", api_key="test-key"
+    )
     assert isinstance(embedding, BaseEmbedding)
 
 
@@ -20,7 +22,7 @@ def test_embedding_uses_token_factory_endpoint_and_openai_request_shape() -> Non
         payload = json.loads(request.content)
         assert payload == {
             "input": ["Everyone loves justice"],
-            "model": "BAAI/bge-en-icl",
+            "model": "Qwen/Qwen3-Embedding-8B",
             "encoding_format": "base64",
         }
 

--- a/llama-index-integrations/llms/llama-index-llms-nebius/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/README.md
@@ -24,7 +24,7 @@ NEBIUS_API_KEY=your_api_key
 ```python
 from llama_index.llms.nebius import NebiusLLM
 
-llm = NebiusLLM(model="Qwen/Qwen3-30B-A3B-fast")
+llm = NebiusLLM(model="openai/gpt-oss-120b")
 ```
 
 #### Without environmental variables
@@ -32,7 +32,7 @@ llm = NebiusLLM(model="Qwen/Qwen3-30B-A3B-fast")
 ```python
 from llama_index.llms.nebius import NebiusLLM
 
-llm = NebiusLLM(api_key="your_api_key", model="Qwen/Qwen3-30B-A3B-fast")
+llm = NebiusLLM(api_key="your_api_key", model="openai/gpt-oss-120b")
 ```
 
 The integration defaults to `https://api.tokenfactory.nebius.com/v1`. You can

--- a/llama-index-integrations/llms/llama-index-llms-nebius/README.md
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/README.md
@@ -1,8 +1,8 @@
-# LlamaIndex Llms Integration: [Nebius AI Studio](https://studio.nebius.ai/)
+# LlamaIndex LLMs Integration: [Nebius Token Factory](https://tokenfactory.nebius.com/)
 
 ## Overview
 
-Integrate with Nebius AI Studio API, which provides access to open-source state-of-the-art large language models (LLMs).
+Integrate with the OpenAI-compatible Chat Completions API in Nebius Token Factory, which provides access to open-source large language models (LLMs).
 
 ## Installation
 
@@ -24,7 +24,7 @@ NEBIUS_API_KEY=your_api_key
 ```python
 from llama_index.llms.nebius import NebiusLLM
 
-llm = NebiusLLM(model="meta-llama/Meta-Llama-3.1-70B-Instruct-fast")
+llm = NebiusLLM(model="Qwen/Qwen3-30B-A3B-fast")
 ```
 
 #### Without environmental variables
@@ -32,10 +32,13 @@ llm = NebiusLLM(model="meta-llama/Meta-Llama-3.1-70B-Instruct-fast")
 ```python
 from llama_index.llms.nebius import NebiusLLM
 
-llm = NebiusLLM(
-    api_key="your_api_key", model="meta-llama/Meta-Llama-3.1-70B-Instruct-fast"
-)
+llm = NebiusLLM(api_key="your_api_key", model="Qwen/Qwen3-30B-A3B-fast")
 ```
+
+The integration defaults to `https://api.tokenfactory.nebius.com/v1`. You can
+set `api_base` explicitly to target a Dedicated Endpoint or another compatible
+deployment. See the [Token Factory model list](https://docs.tokenfactory.nebius.com/models)
+for currently available model IDs.
 
 ### Launching
 

--- a/llama-index-integrations/llms/llama-index-llms-nebius/llama_index/llms/nebius/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/llama_index/llms/nebius/base.py
@@ -22,7 +22,7 @@ class NebiusLLM(OpenAILike):
         # os.environ["NEBIUS_API_KEY"] = "your api key"
 
         llm = NebiusLLM(
-            model="Qwen/Qwen3-30B-A3B-fast", api_key="your_api_key"
+            model="openai/gpt-oss-120b", api_key="your_api_key"
         )
 
         resp = llm.complete("Who is Paul Graham?")

--- a/llama-index-integrations/llms/llama-index-llms-nebius/llama_index/llms/nebius/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/llama_index/llms/nebius/base.py
@@ -4,12 +4,12 @@ from typing import Any, Optional
 from llama_index.llms.openai_like import OpenAILike
 
 
-DEFAULT_API_BASE = "https://api.studio.nebius.ai/v1"
+DEFAULT_API_BASE = "https://api.tokenfactory.nebius.com/v1"
 
 
 class NebiusLLM(OpenAILike):
     """
-    Nebius AI Studio LLM class.
+    Nebius Token Factory LLM class.
 
     Examples:
         `pip install llama-index-llms-nebius`
@@ -22,7 +22,7 @@ class NebiusLLM(OpenAILike):
         # os.environ["NEBIUS_API_KEY"] = "your api key"
 
         llm = NebiusLLM(
-            model="mistralai/Mixtral-8x7B-Instruct-v0.1", api_key="your_api_key"
+            model="Qwen/Qwen3-30B-A3B-fast", api_key="your_api_key"
         )
 
         resp = llm.complete("Who is Paul Graham?")

--- a/llama-index-integrations/llms/llama-index-llms-nebius/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 [project]
 name = "llama-index-llms-nebius"
 version = "0.3.0"
-description = "llama-index llms Nebius AI Studio integration"
+description = "llama-index llms Nebius Token Factory integration"
 authors = [{name = "Akim Tsvigun", email = "aktsvigun@nebius.com"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"

--- a/llama-index-integrations/llms/llama-index-llms-nebius/tests/test_llms_nebius.py
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/tests/test_llms_nebius.py
@@ -19,7 +19,7 @@ def test_chat_uses_token_factory_endpoint_and_openai_request_shape() -> None:
         assert request.headers["authorization"] == "Bearer test-key"
 
         payload = json.loads(request.content)
-        assert payload["model"] == "Qwen/Qwen3-30B-A3B-fast"
+        assert payload["model"] == "openai/gpt-oss-120b"
         assert payload["messages"] == [{"role": "user", "content": "Hello"}]
         assert payload["stream"] is False
 
@@ -47,7 +47,7 @@ def test_chat_uses_token_factory_endpoint_and_openai_request_shape() -> None:
 
     http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
     llm = NebiusLLM(
-        model="Qwen/Qwen3-30B-A3B-fast",
+        model="openai/gpt-oss-120b",
         api_key="test-key",
         http_client=http_client,
     )

--- a/llama-index-integrations/llms/llama-index-llms-nebius/tests/test_llms_nebius.py
+++ b/llama-index-integrations/llms/llama-index-llms-nebius/tests/test_llms_nebius.py
@@ -1,7 +1,57 @@
+import json
+
+import httpx
 from llama_index.core.base.llms.base import BaseLLM
+from llama_index.core.llms import ChatMessage, MessageRole
 from llama_index.llms.nebius import NebiusLLM
+from llama_index.llms.nebius.base import DEFAULT_API_BASE
 
 
-def test_llm_class():
-    names_of_base_classes = [b.__name__ for b in NebiusLLM.__mro__]
+def test_llm_class() -> None:
+    names_of_base_classes = [base.__name__ for base in NebiusLLM.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_chat_uses_token_factory_endpoint_and_openai_request_shape() -> None:
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url == f"{DEFAULT_API_BASE}/chat/completions"
+        assert request.headers["authorization"] == "Bearer test-key"
+
+        payload = json.loads(request.content)
+        assert payload["model"] == "Qwen/Qwen3-30B-A3B-fast"
+        assert payload["messages"] == [{"role": "user", "content": "Hello"}]
+        assert payload["stream"] is False
+
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": payload["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Hi!"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    llm = NebiusLLM(
+        model="Qwen/Qwen3-30B-A3B-fast",
+        api_key="test-key",
+        http_client=http_client,
+    )
+
+    response = llm.chat([ChatMessage(role=MessageRole.USER, content="Hello")])
+
+    assert response.message.content == "Hi!"


### PR DESCRIPTION
## What changed

- move the existing Nebius LLM and embeddings integrations from the retired AI Studio default to `https://api.tokenfactory.nebius.com/v1`
- update package metadata, READMEs, and notebooks to use Nebius Token Factory naming and current examples
- add deterministic HTTP transport tests for the exact Chat Completions and Embeddings endpoint, authorization header, and OpenAI-compatible request bodies
- replace retired examples and the embedding package default with current catalog IDs: `openai/gpt-oss-120b` and `Qwen/Qwen3-Embedding-8B`

## Why

Nebius AI Studio evolved into Nebius Token Factory, but both published LlamaIndex packages still defaulted to the former `api.studio.nebius.ai` host. Users relying on the default were therefore sent to a legacy endpoint, while the existing tests only checked class inheritance and could not detect endpoint regressions.

This updates the two existing packages; it does not add a new integration package or change the integration to the Responses API.

## Impact

`NebiusLLM` continues to use OpenAI-compatible Chat Completions and `NebiusEmbedding` continues to use OpenAI-compatible Embeddings. Explicit `api_base` values remain supported for Dedicated Endpoints and other compatible deployments.

## Validation

- LLM package: `uv run --locked pytest -q` (2 passed)
- embeddings package: `uv run --locked pytest -q` (2 passed)
- repository pre-commit suite on all 11 changed files (passed, including ruff, mypy, notebook formatting, codespell, and TOML validation)
- notebook JSON validation with `jq empty`
- public `models_info` catalog lookup confirming both example IDs on 2026-08-13

AI assistance was used to prepare the small mechanical URL/branding updates and mocked request tests. The resulting diff was reviewed and validated with the checks above.
