### PR TITLE
fix: McpToolSpec resource-template tools bind the wrong URI (stale variable / UnboundLocalError) and were never callable

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -1,10 +1,28 @@
 import asyncio
 import logging
+import re
 from typing import Any, Callable, Dict, List, Optional, Set
+from urllib.parse import quote
 
 from mcp.client.session import ClientSession
 from mcp.types import Resource
 from pydantic import BaseModel, create_model
+from pydantic.fields import FieldInfo
+
+_SIMPLE_TEMPLATE_VAR = re.compile(r"\{([^{}]+)\}")
+
+
+def _simple_template_variables(uri_template: str) -> Optional[List[str]]:
+    """
+    Variable names of an RFC 6570 level-1 template (simple ``{var}``
+    expansion only), in order of first appearance. Returns None when the
+    template uses operators or forms beyond level 1 (``{+var}``, ``{x,y}``,
+    ...), which this integration does not support.
+    """
+    names = _SIMPLE_TEMPLATE_VAR.findall(uri_template)
+    if all(name.isidentifier() for name in names):
+        return list(dict.fromkeys(names))
+    return None
 
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
@@ -123,6 +141,24 @@ class McpToolSpec(
 
         return async_resource_fn
 
+    def _create_resource_template_fn(
+        self, uri_template: str, var_names: List[str]
+    ) -> Callable:
+        """
+        Create a resource call function for an MCP resource template. The
+        returned function substitutes its keyword arguments into the
+        template (RFC 6570 simple expansion: values are percent-encoded)
+        and reads the resulting URI.
+        """
+
+        async def async_resource_fn(**kwargs):
+            uri = uri_template
+            for name in var_names:
+                uri = uri.replace("{" + name + "}", quote(str(kwargs[name]), safe=""))
+            return await self.client.read_resource(uri)
+
+        return async_resource_fn
+
     async def to_tool_list_async(self) -> List[FunctionTool]:
         """
         Asynchronous method to convert MCP tools to FunctionTool objects.
@@ -173,16 +209,55 @@ class McpToolSpec(
         if self.include_resources:
             resources_list = await self.fetch_resources()
             for resource in resources_list:
-                if hasattr(resource, "uri"):
-                    uri = resource.uri
-                elif hasattr(resource, "template"):
-                    uri = resource.template
-                fn = self._create_resource_fn(uri)
+                uri = getattr(resource, "uri", None)
+                fn_schema: Optional[type[BaseModel]] = None
+                if uri is not None:
+                    fn = self._create_resource_fn(str(uri))
+                else:
+                    # mcp.types.ResourceTemplate: the URI lives on
+                    # ``uri_template`` and contains ``{var}`` placeholders
+                    # the caller must fill in.
+                    uri_template = getattr(resource, "uri_template", None)
+                    if uri_template is None:
+                        logging.warning(
+                            "Skipping resource %r: it has neither a `uri` nor a "
+                            "`uri_template` attribute.",
+                            resource.name,
+                        )
+                        continue
+                    template_vars = _simple_template_variables(str(uri_template))
+                    if template_vars is None:
+                        logging.warning(
+                            "Skipping resource template %r: %r uses RFC 6570 "
+                            "features beyond simple {var} expansion.",
+                            resource.name,
+                            str(uri_template),
+                        )
+                        continue
+                    fn = self._create_resource_template_fn(
+                        str(uri_template), template_vars
+                    )
+                    fn_schema = create_model(
+                        f"{resource.name.replace('/', '_')}_Schema",
+                        **{
+                            var: (
+                                str,
+                                FieldInfo(
+                                    description=(
+                                        f"Value substituted for {{{var}}} in the "
+                                        f"resource URI template {uri_template!s}"
+                                    )
+                                ),
+                            )
+                            for var in template_vars
+                        },
+                    )
                 function_tool_list.append(
                     FunctionTool.from_defaults(
                         async_fn=fn,
                         name=resource.name.replace("/", "_"),
                         description=resource.description,
+                        fn_schema=fn_schema,
                     )
                 )
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -777,3 +777,113 @@ async def test_aget_tools_from_mcp_url_propagates_combined_params(
     # Verify merged params
     assert add_tool.partial_params == {"a": 1.0, "user_id": "global", "b": 2.0}
     assert update_user_tool.partial_params == {"a": 1.0, "user_id": "global"}
+
+
+class _FakeResourceSession:
+    """Duck-typed session: static resources and/or resource templates,
+    recording every read_resource call."""
+
+    def __init__(self, with_static: bool = True, with_template: bool = True):
+        import mcp.types as mt
+
+        self._mt = mt
+        self.with_static = with_static
+        self.with_template = with_template
+        self.read_calls: list = []
+
+    async def list_tools(self):
+        return self._mt.ListToolsResult(tools=[])
+
+    async def list_resources(self):
+        resources = []
+        if self.with_static:
+            resources.append(
+                self._mt.Resource(
+                    name="static_notes",
+                    uri="file:///static/notes.txt",
+                    description="a static resource",
+                )
+            )
+        return self._mt.ListResourcesResult(resources=resources)
+
+    async def list_resource_templates(self):
+        templates = []
+        if self.with_template:
+            templates.append(
+                self._mt.ResourceTemplate(
+                    name="user_profile",
+                    uriTemplate="users://{user_id}/profile",
+                    description="per-user profile resource",
+                )
+            )
+        return self._mt.ListResourceTemplatesResult(resourceTemplates=templates)
+
+    async def read_resource(self, uri):
+        self.read_calls.append(str(uri))
+        return self._mt.ReadResourceResult(
+            contents=[
+                self._mt.TextResourceContents(uri="file:///x", text="content")
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_resource_template_tool_reads_its_own_uri_not_a_stale_one():
+    """A template tool must never read the URI of the previous static
+    resource in the loop (regression: `uri` variable leaked across
+    iterations because ResourceTemplate has no `uri`/`template` attribute)."""
+    session = _FakeResourceSession(with_static=True, with_template=True)
+    spec = McpToolSpec(client=session, include_resources=True)
+    tools = await spec.to_tool_list_async()
+
+    template_tool = next(t for t in tools if t.metadata.name == "user_profile")
+    await template_tool.acall(user_id="42")
+
+    assert session.read_calls[-1] == "users://42/profile"
+    assert "file:///static/notes.txt" not in session.read_calls
+
+
+@pytest.mark.asyncio
+async def test_templates_only_server_does_not_crash():
+    """Regression: a server exposing only resource templates raised
+    UnboundLocalError from to_tool_list_async."""
+    session = _FakeResourceSession(with_static=False, with_template=True)
+    spec = McpToolSpec(client=session, include_resources=True)
+    tools = await spec.to_tool_list_async()
+    assert [t.metadata.name for t in tools] == ["user_profile"]
+
+
+@pytest.mark.asyncio
+async def test_template_tool_exposes_template_variables_as_params():
+    """The template tool's schema must surface the template variables so an
+    LLM can supply them."""
+    session = _FakeResourceSession(with_static=False, with_template=True)
+    spec = McpToolSpec(client=session, include_resources=True)
+    tools = await spec.to_tool_list_async()
+
+    schema = tools[0].metadata.fn_schema.model_json_schema()
+    assert "user_id" in schema.get("properties", {})
+    assert "user_id" in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_template_substitution_percent_encodes_values():
+    """RFC 6570 simple expansion percent-encodes reserved characters."""
+    session = _FakeResourceSession(with_static=False, with_template=True)
+    spec = McpToolSpec(client=session, include_resources=True)
+    tools = await spec.to_tool_list_async()
+
+    await tools[0].acall(user_id="a/b c")
+    assert session.read_calls[-1] == "users://a%2Fb%20c/profile"
+
+
+@pytest.mark.asyncio
+async def test_static_resource_tool_unchanged():
+    """Static resources keep their existing no-argument read behavior."""
+    session = _FakeResourceSession(with_static=True, with_template=False)
+    spec = McpToolSpec(client=session, include_resources=True)
+    tools = await spec.to_tool_list_async()
+
+    static_tool = next(t for t in tools if t.metadata.name == "static_notes")
+    await static_tool.acall()
+    assert session.read_calls[-1] == "file:///static/notes.txt"


### PR DESCRIPTION
## Description

`McpToolSpec(include_resources=True)` is broken for the resource-template half of the feature, in two ways:

**1. Template tools bind to the wrong URI (or crash).** `mcp.types.ResourceTemplate` has no `template` attribute — its URI lives on `uri_template` — and it has no `uri` either. So in `to_tool_list_async`:

```python
if hasattr(resource, "uri"):
    uri = resource.uri
elif hasattr(resource, "template"):
    uri = resource.template     # <- attribute never exists
fn = self._create_resource_fn(uri)
```

neither branch assigns `uri` for a template. If the server also has at least one static resource, every template-named tool is silently built with the **stale `uri` from the previous static resource** — the agent reads a different resource's content under a plausible tool name. If the server exposes *only* templates, `to_tool_list_async` raises `UnboundLocalError`.

Verified with hasattr probes: `ResourceTemplate` has neither `template` nor `uri` under mcp 2.x (this package pins `mcp>=2.0.0,<3`; same under 1.x).

**2. Even with the right URI, template tools were never callable.** The URI still contains `{var}` placeholders and `_create_resource_fn` wraps a **no-argument** `read_resource(uri)` — reading a literal `users://{user_id}/profile` can't work. Templates are the "dynamic resources" this feature advertises (added in #19307, which introduced the `hasattr(resource, "template")` branch — closest existing report is #19211, which covered a different aspect).

## Fix

- Read the URI from the attribute that exists: `uri` for static resources, `uri_template` for templates.
- Give template tools their template variables as **required string parameters** (`fn_schema` via `create_model`), substituted with RFC 6570 simple expansion (values percent-encoded) before `read_resource`.
- Templates using RFC 6570 features beyond simple `{var}` expansion (operators like `{+var}`, `{x,y}`) are skipped with a warning — previously they crashed or misbound; full RFC 6570 support can come separately if anyone needs it.
- Static resource tools are unchanged (covered by a regression test).

## Repro

```python
class FakeSession:  # duck-typed ClientSession
    async def list_resources(self):  # one static resource
        ...
    async def list_resource_templates(self):  # one template: users://{user_id}/profile
        ...

spec = McpToolSpec(client=session, include_resources=True)
tools = await spec.to_tool_list_async()
# before: the 'user_profile' tool reads file:///static/notes.txt (the static resource!)
# before (templates only): UnboundLocalError
# after:  tools[user_profile].acall(user_id="42") reads users://42/profile
```

## Testing

Five new tests in `tests/test_tools_mcp.py`, all running against a duck-typed session (no server subprocess needed):

- template tool reads **its own** substituted URI, never the stale static one
- templates-only server no longer crashes
- template variables surface as required params in the tool schema
- substituted values are percent-encoded (`a/b c` → `a%2Fb%20c`)
- static resource tools unchanged

Test suite: **52 passed on `main`, 57 passed on this branch, zero failures** (`uv run --no-sync -- pytest tests -q` in `llama-index-tools-mcp`, re-run 2026-09-16 against `main` at `fd4a517`). The 5 new tests are exactly the delta.

_Correction: an earlier revision of this section reported "41 failed" on both branches. That was an artifact of the sandbox the PR was first prepared in, where the stdio test-server subprocess could not import `mcp`. It was never a property of this change, and the suite is fully green in a normal checkout._

