### PR TITLE
fix(mcp): support streamable HTTP client with mcp 2

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -251,7 +251,7 @@ class BasicMCPClient(ClientSession):
                 async with streamable_http_client(
                     url=self.command_or_url,
                     http_client=self.http_client,
-                ) as (read, write, _):
+                ) as (read, write):
                     async with ClientSession(
                         read,
                         write,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,4 +1,6 @@
 import os
+from contextlib import asynccontextmanager
+
 from httpx2 import AsyncClient
 import pytest
 
@@ -168,6 +170,48 @@ async def test_use_provided_http_client():
 
 
 @pytest.mark.asyncio
+async def test_streamable_http_client_two_streams(monkeypatch):
+    read_stream = AsyncMock()
+    write_stream = AsyncMock()
+
+    class MockStreamableHTTPClient:
+        async def __aenter__(self):
+            return read_stream, write_stream
+
+        async def __aexit__(self, *args):
+            pass
+
+    class MockClientSession:
+        def __init__(self, read, write, **kwargs):
+            assert read is read_stream
+            assert write is write_stream
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def initialize(self):
+            pass
+
+    monkeypatch.setattr(
+        "llama_index.tools.mcp.client.streamable_http_client",
+        lambda **kwargs: MockStreamableHTTPClient(),
+    )
+    monkeypatch.setattr(
+        "llama_index.tools.mcp.client.ClientSession",
+        MockClientSession,
+    )
+
+    client = BasicMCPClient("https://example.com/mcp")
+
+    session = await anext(client._run_session())
+
+    assert isinstance(session, MockClientSession)
+
+
+@pytest.mark.asyncio
 async def test_use_provided_http_client_with_oauth():
     """Test the use of a provided HTTP client."""
     # Create client with OAuth
@@ -223,6 +267,44 @@ async def test_image_return_value(client: BasicMCPClient):
     # Check that we got image data back
     assert isinstance(result, types.CallToolResult)
     assert len(result.content[0].data) > 0
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_client_two_streams(monkeypatch):
+    read_stream = object()
+    write_stream = object()
+
+    @asynccontextmanager
+    async def mock_streamable_http_client(**kwargs):
+        yield read_stream, write_stream
+
+    class MockClientSession:
+        def __init__(self, read, write, **kwargs):
+            assert read is read_stream
+            assert write is write_stream
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def initialize(self):
+            pass
+
+    monkeypatch.setattr(
+        "llama_index.tools.mcp.client.streamable_http_client",
+        mock_streamable_http_client,
+    )
+    monkeypatch.setattr(
+        "llama_index.tools.mcp.client.ClientSession",
+        MockClientSession,
+    )
+
+    client = BasicMCPClient("https://example.com/mcp")
+
+    async with client._run_session() as session:
+        assert isinstance(session, MockClientSession)
 
 
 def test_enable_sse():


### PR DESCRIPTION
Summary

Fixes #22655.

The mcp>=2.0.0 migration changed streamable_http_client() to yield a 2-tuple:

(read, write)

However, BasicMCPClient._run_session() was still unpacking the result as a 3-tuple:

(read, write, _)

This caused Streamable HTTP sessions to fail with:

ValueError: not enough values to unpack (expected 3, got 2)

Changes
Updated the Streamable HTTP transport to correctly unpack the 2-tuple returned by MCP 2.x.
Added a regression test covering the MCP 2.x two-stream contract.
Testing
Targeted regression test passes: test_streamable_http_client_two_streams
Ruff formatting check passes.
Git diff whitespace check passes.

The broader test_client.py suite was also attempted, but the test-server setup currently has unrelated tests.schemas import failures. These failures are outside the scope of this change.