### PR TITLE
docs: fix 'beacuse' typo in ingestion_gdrive notebook

### DIFF
--- a/docs/examples/ingestion/ingestion_gdrive.ipynb
+++ b/docs/examples/ingestion/ingestion_gdrive.ipynb
@@ -456,7 +456,7 @@
    "id": "768505db-02ee-4929-a8e7-1ee127356c98",
    "metadata": {},
    "source": [
-    "Notice how only one node is ingested. This is beacuse only one document changed, while the other documents stayed the same. This means that we only need to re-transform and re-embed one document!"
+    "Notice how only one node is ingested. This is because only one document changed, while the other documents stayed the same. This means that we only need to re-transform and re-embed one document!"
    ]
   },
   {


### PR DESCRIPTION
Fix the misspelling of \eacuse\ in the markdown cell of \docs/examples/ingestion/ingestion_gdrive.ipynb\.

Doc-only change.