### PR TITLE
fix(core): honor explicit max_outputs=0 in multi selectors

### DIFF
--- a/llama-index-core/llama_index/core/selectors/llm_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/llm_selectors.py
@@ -200,7 +200,7 @@ class LLMMultiSelector(BaseSelector):
     ) -> SelectorResult:
         # prepare input
         context_list = _build_choices_text(choices)
-        max_outputs = self._max_outputs or len(choices)
+        max_outputs = self._max_outputs if self._max_outputs is not None else len(choices)
 
         prediction = self._llm.predict(
             prompt=self._prompt,
@@ -219,7 +219,7 @@ class LLMMultiSelector(BaseSelector):
     ) -> SelectorResult:
         # prepare input
         context_list = _build_choices_text(choices)
-        max_outputs = self._max_outputs or len(choices)
+        max_outputs = self._max_outputs if self._max_outputs is not None else len(choices)
 
         prediction = await self._llm.apredict(
             prompt=self._prompt,

--- a/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
+++ b/llama-index-core/llama_index/core/selectors/pydantic_selectors.py
@@ -139,7 +139,7 @@ class PydanticMultiSelector(BaseSelector):
     ) -> SelectorResult:
         # prepare input
         context_list = _build_choices_text(choices)
-        max_outputs = self._max_outputs or len(choices)
+        max_outputs = self._max_outputs if self._max_outputs is not None else len(choices)
 
         # predict
         prediction = self._selector_program(

--- a/llama-index-core/tests/selectors/test_llm_selectors.py
+++ b/llama-index-core/tests/selectors/test_llm_selectors.py
@@ -51,3 +51,17 @@ def test_llm_multi_selector_max_choices(patch_llm_predictor) -> None:
 
     result = selector.select(choices, query)
     assert result.inds == [0, 1]
+
+
+def test_llm_multi_selector_zero_max_outputs(patch_llm_predictor) -> None:
+    selector = LLMMultiSelector.from_defaults(max_outputs=0)
+
+    choices = [
+        "apple",
+        "pear",
+        "peach",
+    ]
+    query = "what is the best fruit?"
+
+    result = selector.select(choices, query)
+    assert result.inds == []


### PR DESCRIPTION
## Summary

`LLMMultiSelector` / `PydanticMultiSelector` swallow an explicit `max_outputs=0` because of `self._max_outputs or len(choices)`: a falsy zero falls back to the number of choices, so requesting zero outputs actually returns all choices.

This is the same class of falsy-zero bug as `similarity_top_k=0` (see #22508): when `max_outputs` is `None` it should mean "no limit", but an explicit `0` is a valid request for no outputs and must be preserved.

## Changes

- `llama-index-core/llama_index/core/selectors/llm_selectors.py`: use `is not None` check in both `_select` and `_aselect`
- `llama-index-core/llama_index/core/selectors/pydantic_selectors.py`: same fix in `_select`
- `llama-index-core/tests/selectors/test_llm_selectors.py`: regression test asserting `max_outputs=0` yields no selections (fails before the fix: returns `[0, 1, 2]`)

## Verification

`pytest tests/selectors/test_llm_selectors.py` — 4 passed locally (before fix: 1 failed).
