### PR TITLE
fix: WholeSiteReader treats a look-alike domain as in-scope

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/whole_site/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/whole_site/base.py
@@ -1,6 +1,7 @@
 import time
 import warnings
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from llama_index.core.readers.base import BaseReader
 from llama_index.core.schema import Document
@@ -65,6 +66,24 @@ class WholeSiteReader(BaseReader):
     def clean_url(self, url):
         return url.split("#")[0]
 
+    def is_in_scope(self, href: str) -> bool:
+        """
+        Whether href is on the same origin as prefix and under its path.
+
+        A plain `href.startswith(self.prefix)` also matches a link like
+        "https://example.com.evil.com/..." against a prefix of
+        "https://example.com", since that's just string containment.
+        Comparing scheme and host separately closes that without changing
+        behavior for the documented usage (a prefix ending in "/").
+        """
+        prefix_parts = urlparse(self.prefix)
+        href_parts = urlparse(href)
+        return (
+            href_parts.scheme == prefix_parts.scheme
+            and href_parts.netloc == prefix_parts.netloc
+            and href.startswith(self.prefix)
+        )
+
     def restart_driver(self):
         self.driver.quit()
         self.driver = self.setup_driver()
@@ -127,7 +146,7 @@ class WholeSiteReader(BaseReader):
 
                     for href in links:
                         try:
-                            if href.startswith(self.prefix) and href not in added_urls:
+                            if self.is_in_scope(href) and href not in added_urls:
                                 urls_to_visit.append((href, next_depth))
                                 added_urls.add(href)
                         except Exception:

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_whole_site.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_whole_site.py
@@ -1,0 +1,55 @@
+from llama_index.readers.web import WholeSiteReader
+
+
+class FakeDriver:
+    """Stands in for the real Selenium webdriver.Chrome, driven by a fixed link graph."""
+
+    def __init__(self, graph):
+        self.graph = graph
+        self.current = None
+
+    def get(self, url):
+        self.current = url
+
+    def quit(self):
+        pass
+
+
+def _make_reader(prefix: str, graph: dict) -> WholeSiteReader:
+    reader = WholeSiteReader(prefix=prefix, driver=FakeDriver(graph))
+    reader.extract_content = lambda: reader.driver.graph[reader.driver.current][0]
+    reader.extract_links = lambda: reader.driver.graph[reader.driver.current][1]
+    return reader
+
+
+def test_look_alike_domain_is_not_crawled():
+    """
+    A prefix of https://example.com must not match https://example.com.evil.com,
+    since that is a different origin, not a substring match.
+    """
+    prefix = "https://example.com"
+    lookalike = "https://example.com.evil.com/harvest"
+    graph = {
+        f"{prefix}/home": ("home", [lookalike]),
+        lookalike: ("attacker page", []),
+    }
+
+    docs = _make_reader(prefix, graph).load_data(f"{prefix}/home")
+    visited = {d.extra_info["URL"] for d in docs}
+
+    assert visited == {f"{prefix}/home"}
+
+
+def test_same_origin_links_are_still_crawled():
+    """Normal same-origin crawling behavior must be unaffected by the scope fix."""
+    prefix = "https://example.com/"
+    start = "https://example.com/index"
+    graph = {
+        start: ("index", ["https://example.com/about"]),
+        "https://example.com/about": ("about", []),
+    }
+
+    docs = _make_reader(prefix, graph).load_data(start)
+    visited = {d.extra_info["URL"] for d in docs}
+
+    assert visited == set(graph.keys())


### PR DESCRIPTION
## Summary

`WholeSiteReader.load_data()` decides whether to follow a link with `href.startswith(self.prefix)`, plain string containment rather than a real host check. A prefix of `https://example.com` also matches `https://example.com.evil.com/...`, so a page under the configured domain that links out to a similarly-named domain gets crawled as if it were part of the site.

## Root cause

Fixed with a new `is_in_scope()` method that compares `urlparse` scheme and netloc separately before falling back to the existing prefix check, so the documented usage (a prefix ending in `/`) behaves the same as before.

## Current-main audit

Rechecked against `main@eb8cf2c`, this line is still present and unfixed. No open issue or PR (checked WholeSiteReader, prefix, subdomain, crawl scope) covers this.

## Validation

Two tests added to `tests/test_whole_site.py`. `test_look_alike_domain_is_not_crawled` fails on unpatched code and passes with this change, confirmed by reverting just the fix and rerunning. `test_same_origin_links_are_still_crawled` pins the documented normal usage and passes either way, stated plainly rather than implied as a second regression test.

Full package suite: 40 passed, 5 skipped. ruff check and ruff format --check both clean.

AI assistance was used to help draft and verify this fix. I reproduced the bug, reviewed the diff, and ran all tests myself before opening this.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] I added new unit tests to cover this change

## Suggested Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods