### PR TITLE
fix(core): safely dump raw model in agent workflows and events to guard against KeyError

### DIFF
--- a/llama-index-core/llama_index/core/agent/workflow/base_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/base_agent.py
@@ -76,6 +76,24 @@ WORKFLOW_KWARGS = (
 )
 
 
+def _safe_model_dump(raw: Any) -> Any:
+    """
+    Safely serialize a Pydantic model or return the raw object unchanged.
+
+    Guards against response objects whose custom __getattr__ raises KeyError or other
+    non-AttributeError exceptions during isinstance(raw, BaseModel) checks.
+    """
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, BaseModel):
+            return raw.model_dump()
+    except Exception:
+        pass
+    return raw
+
+
+
 def get_default_llm() -> LLM:
     return Settings.llm
 
@@ -321,11 +339,7 @@ class BaseWorkflowAgent(
             response_stream = await target_llm.astream_chat(llm_input)
             last_response = None
             async for last_response in response_stream:
-                raw = (
-                    last_response.raw.model_dump()
-                    if isinstance(last_response.raw, BaseModel)
-                    else last_response.raw
-                )
+                raw = _safe_model_dump(last_response.raw)
                 if ctx.is_running:
                     ctx.write_event_to_stream(
                         AgentStream(

--- a/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/codeact_agent.py
@@ -4,7 +4,10 @@ import uuid
 from typing import Awaitable, Callable, List, Sequence, Union, Optional, Tuple
 
 from llama_index.core.agent.workflow.agent_context import AgentContext
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from llama_index.core.agent.workflow.base_agent import (
+    BaseWorkflowAgent,
+    _safe_model_dump,
+)
 from llama_index.core.agent.workflow.workflow_events import (
     AgentInput,
     AgentOutput,
@@ -12,7 +15,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     ToolCallResult,
 )
 from llama_index.core.base.llms.types import ChatResponse
-from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.llms.llm import ToolSelection, LLM
 from llama_index.core.llms.function_calling import FunctionCallingLLM
@@ -236,11 +239,7 @@ class CodeActAgent(BaseWorkflowAgent):
             full_response_text += delta
 
             # Create a raw object for the event stream
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = _safe_model_dump(last_chat_response.raw)
 
             # Write delta to the event stream
             ctx.write_event_to_stream(
@@ -336,11 +335,7 @@ class CodeActAgent(BaseWorkflowAgent):
         await ctx.store.set(self.scratchpad_key, scratchpad)
 
         # Create the raw object for the output
-        raw = (
-            chat_response.raw.model_dump()
-            if isinstance(chat_response.raw, BaseModel)
-            else chat_response.raw
-        )
+        raw = _safe_model_dump(chat_response.raw)
 
         return AgentOutput(
             response=message,

--- a/llama-index-core/llama_index/core/agent/workflow/function_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/function_agent.py
@@ -1,7 +1,10 @@
 from typing import List, Optional, Sequence
 
 from llama_index.core.agent.workflow.agent_context import AgentContext
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from llama_index.core.agent.workflow.base_agent import (
+    BaseWorkflowAgent,
+    _safe_model_dump,
+)
 from llama_index.core.agent.workflow.workflow_events import (
     AgentInput,
     AgentOutput,
@@ -9,7 +12,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     ToolCallResult,
 )
 from llama_index.core.base.llms.types import ChatResponse
-from llama_index.core.bridge.pydantic import BaseModel, Field
+from llama_index.core.bridge.pydantic import Field
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import BaseMemory
 from llama_index.core.tools import AsyncBaseTool
@@ -78,11 +81,7 @@ class FunctionAgent(BaseWorkflowAgent):
             tool_calls = self.llm.get_tool_calls_from_response(  # type: ignore
                 last_chat_response, error_on_no_tool_call=False
             )
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = _safe_model_dump(last_chat_response.raw)
             ctx.write_event_to_stream(
                 AgentStream(
                     delta=last_chat_response.delta or "",
@@ -133,11 +132,7 @@ class FunctionAgent(BaseWorkflowAgent):
         scratchpad.append(last_chat_response.message)
         await ctx.store.set(self.scratchpad_key, scratchpad)
 
-        raw = (
-            last_chat_response.raw.model_dump()
-            if isinstance(last_chat_response.raw, BaseModel)
-            else last_chat_response.raw
-        )
+        raw = _safe_model_dump(last_chat_response.raw)
         return AgentOutput(
             response=last_chat_response.message,
             tool_calls=tool_calls or [],

--- a/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
+++ b/llama-index-core/llama_index/core/agent/workflow/multi_agent_workflow.py
@@ -25,6 +25,7 @@ from llama_index.core.agent.workflow.base_agent import (
     DEFAULT_AGENT_DESCRIPTION,
     DEFAULT_MAX_ITERATIONS,
     _get_waiting_for_event_exception,
+    _safe_model_dump,
 )
 from llama_index.core.agent.workflow.prompts import DEFAULT_EARLY_STOPPING_PROMPT
 from llama_index.core.agent.workflow.function_agent import FunctionAgent
@@ -322,11 +323,7 @@ class AgentWorkflow(Workflow, PromptMixin, metaclass=AgentWorkflowMeta):
             response_stream = await agent.llm.astream_chat(llm_input)
             last_response = None
             async for last_response in response_stream:
-                raw = (
-                    last_response.raw.model_dump()
-                    if isinstance(last_response.raw, BaseModel)
-                    else last_response.raw
-                )
+                raw = _safe_model_dump(last_response.raw)
                 if ctx.is_running:
                     ctx.write_event_to_stream(
                         AgentStream(

--- a/llama-index-core/llama_index/core/agent/workflow/react_agent.py
+++ b/llama-index-core/llama_index/core/agent/workflow/react_agent.py
@@ -11,7 +11,10 @@ from llama_index.core.agent.react.types import (
     ResponseReasoningStep,
 )
 from llama_index.core.agent.workflow.agent_context import AgentContext
-from llama_index.core.agent.workflow.base_agent import BaseWorkflowAgent
+from llama_index.core.agent.workflow.base_agent import (
+    BaseWorkflowAgent,
+    _safe_model_dump,
+)
 from llama_index.core.agent.workflow.workflow_events import (
     AgentInput,
     AgentOutput,
@@ -19,7 +22,7 @@ from llama_index.core.agent.workflow.workflow_events import (
     ToolCallResult,
 )
 from llama_index.core.base.llms.types import ChatResponse, TextBlock
-from llama_index.core.bridge.pydantic import BaseModel, Field, model_validator
+from llama_index.core.bridge.pydantic import Field, model_validator
 from llama_index.core.llms import ChatMessage
 from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.memory import BaseMemory
@@ -95,11 +98,7 @@ class ReActAgent(BaseWorkflowAgent):
         # We initialize it so it's valid even when 'response' is empty
         last_chat_response = ChatResponse(message=ChatMessage())
         async for last_chat_response in response:
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = _safe_model_dump(last_chat_response.raw)
             # some code paths (namely react agent via llm.predict_and_call for non function calling llms) pass through a context without starting the workflow.
             # They do so in order to conform to the interface, and share state between tools, however the events are discarded and not exposed to the caller,
             # so just don't write events if the context is not running.
@@ -173,11 +172,7 @@ class ReActAgent(BaseWorkflowAgent):
                 "Thought: <what you are thinking>\n"
                 "Answer: <your final response to the user>"
             )
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = _safe_model_dump(last_chat_response.raw)
 
             return AgentOutput(
                 response=last_chat_response.message,
@@ -208,11 +203,7 @@ class ReActAgent(BaseWorkflowAgent):
                 "```\n"
             )
 
-            raw = (
-                last_chat_response.raw.model_dump()
-                if isinstance(last_chat_response.raw, BaseModel)
-                else last_chat_response.raw
-            )
+            raw = _safe_model_dump(last_chat_response.raw)
             # Return with retry messages to let the LLM fix the error
             return AgentOutput(
                 response=last_chat_response.message,
@@ -229,11 +220,7 @@ class ReActAgent(BaseWorkflowAgent):
         await ctx.store.set(self.reasoning_key, current_reasoning)
 
         # If response step, we're done
-        raw = (
-            last_chat_response.raw.model_dump()
-            if isinstance(last_chat_response.raw, BaseModel)
-            else last_chat_response.raw
-        )
+        raw = _safe_model_dump(last_chat_response.raw)
         if reasoning_step.is_done:
             return AgentOutput(
                 response=last_chat_response.message,

--- a/llama-index-core/llama_index/core/instrumentation/events/llm.py
+++ b/llama-index-core/llama_index/core/instrumentation/events/llm.py
@@ -143,14 +143,17 @@ class LLMCompletionInProgressEvent(BaseEvent):
         return "LLMCompletionInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            return self.model_copy(
-                update={
-                    "response": self.response.model_copy(
-                        update={"raw": self.response.raw.model_dump()}
-                    )
-                }
-            ).model_dump(**kwargs)
+        try:
+            if isinstance(self.response.raw, BaseModel):
+                return self.model_copy(
+                    update={
+                        "response": self.response.model_copy(
+                            update={"raw": self.response.raw.model_dump()}
+                        )
+                    }
+                ).model_dump(**kwargs)
+        except Exception:
+            pass
         return super().model_dump(**kwargs)
 
 
@@ -173,14 +176,17 @@ class LLMCompletionEndEvent(BaseEvent):
         return "LLMCompletionEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            return self.model_copy(
-                update={
-                    "response": self.response.model_copy(
-                        update={"raw": self.response.raw.model_dump()}
-                    )
-                }
-            ).model_dump(**kwargs)
+        try:
+            if isinstance(self.response.raw, BaseModel):
+                return self.model_copy(
+                    update={
+                        "response": self.response.model_copy(
+                            update={"raw": self.response.raw.model_dump()}
+                        )
+                    }
+                ).model_dump(**kwargs)
+        except Exception:
+            pass
         return super().model_dump(**kwargs)
 
 
@@ -225,14 +231,17 @@ class LLMChatInProgressEvent(BaseEvent):
         return "LLMChatInProgressEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if isinstance(self.response.raw, BaseModel):
-            return self.model_copy(
-                update={
-                    "response": self.response.model_copy(
-                        update={"raw": self.response.raw.model_dump()}
-                    )
-                }
-            ).model_dump(**kwargs)
+        try:
+            if isinstance(self.response.raw, BaseModel):
+                return self.model_copy(
+                    update={
+                        "response": self.response.model_copy(
+                            update={"raw": self.response.raw.model_dump()}
+                        )
+                    }
+                ).model_dump(**kwargs)
+        except Exception:
+            pass
         return super().model_dump(**kwargs)
 
 
@@ -255,12 +264,16 @@ class LLMChatEndEvent(BaseEvent):
         return "LLMChatEndEvent"
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:
-        if self.response is not None and isinstance(self.response.raw, BaseModel):
-            return self.model_copy(
-                update={
-                    "response": self.response.model_copy(
-                        update={"raw": self.response.raw.model_dump()}
-                    )
-                }
-            ).model_dump(**kwargs)
+        if self.response is not None:
+            try:
+                if isinstance(self.response.raw, BaseModel):
+                    return self.model_copy(
+                        update={
+                            "response": self.response.model_copy(
+                                update={"raw": self.response.raw.model_dump()}
+                            )
+                        }
+                    ).model_dump(**kwargs)
+            except Exception:
+                pass
         return super().model_dump(**kwargs)

--- a/llama-index-core/pyproject.toml
+++ b/llama-index-core/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 
 [project]
 name = "llama-index-core"
-version = "0.14.23"
+version = "0.14.24"
 description = "Interface between LLMs and your data"
 authors = [{name = "Jerry Liu", email = "jerry@llamaindex.ai"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-core/tests/agent/workflow/test_safe_model_dump.py
+++ b/llama-index-core/tests/agent/workflow/test_safe_model_dump.py
@@ -1,0 +1,177 @@
+import pytest
+from typing import Sequence, Any
+from pydantic import BaseModel, Field
+
+from llama_index.core.workflow import Context
+from llama_index.core.agent.workflow.base_agent import _safe_model_dump
+from llama_index.core.agent.workflow import ReActAgent
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    CompletionResponse,
+    MessageRole,
+)
+from llama_index.core.instrumentation.events.llm import (
+    LLMChatEndEvent,
+    LLMChatInProgressEvent,
+    LLMCompletionEndEvent,
+    LLMCompletionInProgressEvent,
+)
+from llama_index.core.memory import ChatMemoryBuffer
+
+
+class DashScopeLikeResponse(dict):
+    """
+    Simulates dashscope.api_entities.dashscope_response.DashScopeResponse
+    where __getattr__ raises KeyError instead of AttributeError for missing attributes.
+    """
+
+    def __getattr__(self, attr: str) -> Any:
+        return self[attr]
+
+
+class SampleModel(BaseModel):
+    foo: str = Field(default="bar")
+
+
+def test_safe_model_dump():
+    # 1. DashScope-like response with faulty __getattr__
+    dashscope_raw = DashScopeLikeResponse({"status_code": 200, "output": {"text": "hello"}})
+    res = _safe_model_dump(dashscope_raw)
+    assert res == dashscope_raw
+    assert isinstance(res, DashScopeLikeResponse)
+
+    # 2. Pydantic BaseModel
+    model_raw = SampleModel(foo="test")
+    res = _safe_model_dump(model_raw)
+    assert res == {"foo": "test"}
+
+    # 3. Primitives and None
+    assert _safe_model_dump(None) is None
+    assert _safe_model_dump({"a": 1}) == {"a": 1}
+    assert _safe_model_dump("text") == "text"
+    assert _safe_model_dump(123) == 123
+
+
+def test_instrumentation_events_with_dashscope_like_raw():
+    dashscope_raw = DashScopeLikeResponse({"status_code": 200, "output": {"text": "hello"}})
+
+    # LLMCompletionInProgressEvent
+    event1 = LLMCompletionInProgressEvent(
+        prompt="test",
+        response=CompletionResponse(text="output", raw=dashscope_raw),
+    )
+    dumped1 = event1.model_dump()
+    assert dumped1["response"]["raw"] == dashscope_raw
+
+    # LLMCompletionEndEvent
+    event2 = LLMCompletionEndEvent(
+        prompt="test",
+        response=CompletionResponse(text="output", raw=dashscope_raw),
+    )
+    dumped2 = event2.model_dump()
+    assert dumped2["response"]["raw"] == dashscope_raw
+
+    # LLMChatInProgressEvent
+    event3 = LLMChatInProgressEvent(
+        messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+        response=ChatResponse(message=ChatMessage(role=MessageRole.ASSISTANT, content="hi"), raw=dashscope_raw),
+    )
+    dumped3 = event3.model_dump()
+    assert dumped3["response"]["raw"] == dashscope_raw
+
+    # LLMChatEndEvent
+    event4 = LLMChatEndEvent(
+        messages=[ChatMessage(role=MessageRole.USER, content="hi")],
+        response=ChatResponse(message=ChatMessage(role=MessageRole.ASSISTANT, content="hi"), raw=dashscope_raw),
+    )
+    dumped4 = event4.model_dump()
+    assert dumped4["response"]["raw"] == dashscope_raw
+
+
+from llama_index.core.llms.llm import LLM
+from llama_index.core.base.llms.types import LLMMetadata
+
+
+class DashScopeMockLLM(LLM):
+    """Mock LLM returning DashScopeLikeResponse in raw."""
+
+    @property
+    def metadata(self) -> LLMMetadata:
+        return LLMMetadata(is_function_calling_model=False)
+
+    async def achat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        raw = DashScopeLikeResponse({"status_code": 200, "output": {"text": "Thought: none\nAnswer: 42"}})
+        return ChatResponse(
+            message=ChatMessage(role=MessageRole.ASSISTANT, content="Thought: none\nAnswer: 42"),
+            raw=raw,
+        )
+
+    async def astream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any):
+        raw = DashScopeLikeResponse({"status_code": 200, "output": {"text": "Thought: none\nAnswer: 42"}})
+
+        async def gen():
+            yield ChatResponse(
+                message=ChatMessage(role=MessageRole.ASSISTANT, content="Thought: none\nAnswer: 42"),
+                delta="Thought: none\nAnswer: 42",
+                raw=raw,
+            )
+
+        return gen()
+
+    def chat(self, messages: Sequence[ChatMessage], **kwargs: Any) -> ChatResponse:
+        return ChatResponse(message=ChatMessage(role=MessageRole.ASSISTANT, content="Thought: none\nAnswer: 42"))
+
+    def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        return CompletionResponse(text="Thought: none\nAnswer: 42")
+
+    def stream_chat(self, messages: Sequence[ChatMessage], **kwargs: Any):
+        raise NotImplementedError
+
+    def stream_complete(self, prompt: str, **kwargs: Any):
+        raise NotImplementedError
+
+    async def acomplete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
+        return CompletionResponse(text="Thought: none\nAnswer: 42")
+
+    async def astream_complete(self, prompt: str, **kwargs: Any):
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_react_agent_with_dashscope_like_raw():
+    llm = DashScopeMockLLM()
+    agent = ReActAgent(llm=llm, tools=[])
+    ctx = Context(agent)
+    memory = ChatMemoryBuffer.from_defaults()
+
+    output = await agent.take_step(
+        ctx=ctx,
+        llm_input=[ChatMessage(role=MessageRole.USER, content="What is 20 + 22?")],
+        tools=[],
+        memory=memory,
+    )
+
+    assert output.response.content == "Thought: none\nAnswer: 42"
+    assert isinstance(output.raw, DashScopeLikeResponse)
+    assert output.raw["status_code"] == 200
+
+
+@pytest.mark.asyncio
+async def test_react_agent_streaming_with_dashscope_like_raw():
+    llm = DashScopeMockLLM()
+    agent = ReActAgent(llm=llm, tools=[], streaming=True)
+    ctx = Context(agent)
+    memory = ChatMemoryBuffer.from_defaults()
+
+    output = await agent.take_step(
+        ctx=ctx,
+        llm_input=[ChatMessage(role=MessageRole.USER, content="What is 20 + 22?")],
+        tools=[],
+        memory=memory,
+    )
+
+    assert output.response.content == "Thought: none\nAnswer: 42"
+    assert isinstance(output.raw, DashScopeLikeResponse)
+    assert output.raw["status_code"] == 200
+


### PR DESCRIPTION
# Description

Fixes #18694

When using `ReActAgent`, `FunctionAgent`, `CodeActAgent`, or `MultiAgentWorkflow` with LLMs whose response objects implement a custom `__getattr__` that delegates to `__getitem__` (raising `KeyError` instead of `AttributeError` for non-existent attributes, e.g. DashScope's `DashScopeResponse`), calling `isinstance(raw, BaseModel)` triggers Pydantic's internal `hasattr(instance, '__pydantic_validator__')` inspection.

In Python versions <= 3.12, `hasattr()` only catches `AttributeError`. When a non-standard response wrapper raises `KeyError`, `hasattr` does not catch it and the uncaught `KeyError: '__pydantic_validator__'` / `KeyError: '__pydantic_decorators__'` propagates, crashing the agent workflow step.

### Solution
1. Introduced a defensive `_safe_model_dump` helper function in `llama_index/core/agent/workflow/base_agent.py` that safely calls `.model_dump()` if the object is a Pydantic `BaseModel` and falls back cleanly to the raw response object without crashing on unexpected exceptions during attribute/instance checks.
2. Replaced raw `isinstance(..., BaseModel)` / `.model_dump()` extraction with `_safe_model_dump` across `ReActAgent`, `FunctionAgent`, `CodeActAgent`, and `MultiAgentWorkflow`.
3. Defensively protected raw model dumping in LLM instrumentation events (`LLMCompletionInProgressEvent`, `LLMCompletionEndEvent`, `LLMChatInProgressEvent`, `LLMChatEndEvent`).
4. Bumped version in `llama-index-core/pyproject.toml` to `0.14.24`.
5. Added unit and regression tests in `test_safe_model_dump.py` verifying behavior on DashScope-like dictionary responses, Pydantic models, and agent streaming / step execution.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

- Added regression tests in `llama-index-core/tests/agent/workflow/test_safe_model_dump.py` verifying `_safe_model_dump`, instrumentation events, and `ReActAgent` (sync & streaming) with DashScope-like dictionary responses.
- Verified test suite passes locally with `pytest`.
- Ran `ruff check` on all touched files with 0 errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
