### PR TITLE
feat(ag-ui): support multimodal user input (images, audio, video, documents)

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -92,7 +92,8 @@ def _copy_initial_state(initial_state: Optional[Dict[str, Any]]) -> Dict[str, An
 
 
 def _apply_state_prompt(chat_history: List[ChatMessage], state: Any) -> None:
-    """Inject the state prompt into the latest user message, in place.
+    """
+    Inject the state prompt into the latest user message, in place.
 
     A legacy string-content message is rewritten exactly as before: its text is
     embedded in ``DEFAULT_STATE_PROMPT``. A message whose wire content was a

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -18,6 +18,8 @@ from llama_index.protocols.ag_ui.events import (
     ToolCallChunkWorkflowEvent,
 )
 from llama_index.protocols.ag_ui.utils import (
+    AG_UI_PARTS_KEY,
+    AG_UI_STATE_BLOCK_KEY,
     llama_index_message_to_ag_ui_message,
     ag_ui_message_to_llama_index_message,
     timestamp,
@@ -87,6 +89,40 @@ DEFAULT_STATE_PROMPT = """<state>
 
 def _copy_initial_state(initial_state: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return copy.deepcopy(initial_state) if initial_state is not None else {}
+
+
+def _apply_state_prompt(chat_history: List[ChatMessage], state: Any) -> None:
+    """Inject the state prompt into the latest user message, in place.
+
+    A legacy string-content message is rewritten exactly as before: its text is
+    embedded in ``DEFAULT_STATE_PROMPT``. A message whose wire content was a
+    parts list (marked ``AG_UI_PARTS_KEY`` by the inbound conversion) or that
+    carries media blocks gets the state as its own leading text block instead,
+    recorded via ``AG_UI_STATE_BLOCK_KEY`` so the reverse conversion drops
+    exactly that block. Every original block is kept in its original position:
+    rebuilding is required because the ``ChatMessage.content`` setter raises on
+    a multi-block message, collapsing text blocks would erase the fragment
+    boundaries a parts-array client sent, and reordering would detach captions
+    from the media they describe.
+    """
+    for msg in chat_history[::-1]:
+        if msg.role.value != "user":
+            continue
+        is_parts = bool(msg.additional_kwargs.get(AG_UI_PARTS_KEY)) or not (
+            len(msg.blocks) == 1 and isinstance(msg.blocks[0], TextBlock)
+        )
+        if not is_parts:
+            state_text = DEFAULT_STATE_PROMPT.format(
+                state=str(state), user_input=msg.content or ""
+            )
+            msg.blocks = [TextBlock(text=state_text)]
+        else:
+            state_prefix = DEFAULT_STATE_PROMPT.format(
+                state=str(state), user_input=""
+            ).rstrip()
+            msg.blocks = [TextBlock(text=state_prefix), *msg.blocks]
+            msg.additional_kwargs[AG_UI_STATE_BLOCK_KEY] = True
+        break
 
 
 class InputEvent(StartEvent):
@@ -196,12 +232,7 @@ class AGUIChatWorkflow(Workflow):
             ctx.write_event_to_stream(StateSnapshotWorkflowEvent(snapshot=state))
 
             if state:
-                for msg in chat_history[::-1]:
-                    if msg.role.value == "user":
-                        msg.content = DEFAULT_STATE_PROMPT.format(
-                            state=str(state), user_input=msg.content
-                        )
-                        break
+                _apply_state_prompt(chat_history, state)
 
             if self.system_prompt:
                 if chat_history[0].role.value == "system":

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -63,7 +63,8 @@ def _audio_mime_from_format(fmt: Optional[str]) -> Optional[str]:
 
 
 def _drop_none(**kwargs: Any) -> dict:
-    """Block constructor kwargs without ``None`` values.
+    """
+    Block constructor kwargs without ``None`` values.
 
     Field strictness varies across the supported llama-index-core range (0.14.1
     rejects an explicit ``url=None`` on ``AudioBlock``), so absent values are
@@ -72,8 +73,11 @@ def _drop_none(**kwargs: Any) -> dict:
     return {key: value for key, value in kwargs.items() if value is not None}
 
 
-def _source_kwargs(source: Union[InputContentDataSource, InputContentUrlSource]) -> dict:
-    """Project an AG-UI input-content source onto block constructor kwargs.
+def _source_kwargs(
+    source: Union[InputContentDataSource, InputContentUrlSource],
+) -> dict:
+    """
+    Project an AG-UI input-content source onto block constructor kwargs.
 
     A ``data`` source's base64 payload is passed through as ASCII bytes rather
     than decoded: the llama-index block normalizer keeps bytes that already are
@@ -107,9 +111,7 @@ def _binary_part_to_block(part: BinaryInputContent) -> Optional[ContentBlock]:
         )
     if mime_lower.startswith("audio/"):
         return AudioBlock(
-            **_drop_none(
-                audio=data, url=part.url, format=_audio_format_from_mime(mime)
-            )
+            **_drop_none(audio=data, url=part.url, format=_audio_format_from_mime(mime))
         )
     if mime_lower.startswith("video/"):
         return VideoBlock(
@@ -138,7 +140,8 @@ AG_UI_STATE_BLOCK_KEY = "ag_ui_injected_state_block"
 
 
 def agui_content_to_blocks(content: Union[str, List[Any]]) -> List[ContentBlock]:
-    """Convert AG-UI user-message content onto llama-index content blocks.
+    """
+    Convert AG-UI user-message content onto llama-index content blocks.
 
     String content becomes a single :class:`TextBlock`. List content maps each
     typed part (text/image/audio/video/document, plus the deprecated flat
@@ -224,7 +227,8 @@ def agui_content_to_blocks(content: Union[str, List[Any]]) -> List[ContentBlock]
 
 
 def _block_to_agui_part(block: ContentBlock) -> Optional[Any]:
-    """Convert one llama-index content block back onto an AG-UI input part.
+    """
+    Convert one llama-index content block back onto an AG-UI input part.
 
     The inverse of :func:`agui_content_to_blocks` for the block types it emits.
     A block with neither bytes nor a URL (e.g. path-based) has no AG-UI wire
@@ -244,7 +248,9 @@ def _block_to_agui_part(block: ContentBlock) -> Optional[Any]:
             )
         return None
 
-    def _bytes(block: ContentBlock, field: Optional[bytes], resolve: Callable) -> Optional[bytes]:
+    def _bytes(
+        block: ContentBlock, field: Optional[bytes], resolve: Callable
+    ) -> Optional[bytes]:
         # The block classes normalize stored bytes through a base64 heuristic,
         # so the field value is not reliably raw; resolve_*() is. Only resolved
         # when the block has no URL — resolving a URL-backed block would fetch

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/utils.py
@@ -1,4 +1,6 @@
+import base64
 import datetime
+import logging
 import re
 import uuid
 from ag_ui.core import (
@@ -11,12 +13,268 @@ from ag_ui.core import (
     ToolCall,
     FunctionCall,
 )
+from ag_ui.core.types import (
+    AudioInputContent,
+    BinaryInputContent,
+    DocumentInputContent,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    TextInputContent,
+    VideoInputContent,
+)
 from ag_ui.encoder import EventEncoder
-from typing import Union, Callable
+from typing import Any, List, Optional, Union, Callable
 
 from llama_index.core.llms import ChatMessage
+from llama_index.core.base.llms.types import (
+    AudioBlock,
+    ContentBlock,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+    VideoBlock,
+)
 from llama_index.core.tools import BaseTool, FunctionTool
 from llama_index.core.workflow import Event
+
+logger = logging.getLogger(__name__)
+
+#: MIME type <-> ``AudioBlock.format`` mapping for the cases where the format is
+#: not simply the MIME subtype.
+_AUDIO_MIME_TO_FORMAT = {"audio/mpeg": "mp3", "audio/x-wav": "wav"}
+_AUDIO_FORMAT_TO_MIME = {"mp3": "audio/mpeg", "wav": "audio/x-wav"}
+
+
+def _audio_format_from_mime(mime: Optional[str]) -> Optional[str]:
+    if not mime:
+        return None
+    # Drop MIME parameters ("audio/wav; codecs=1" -> "audio/wav") and lowercase
+    # (MIME types are case-insensitive per RFC 2045): providers take bare
+    # lowercase formats like "wav", and llama-index forwards this field to them.
+    base = mime.split(";")[0].strip().lower()
+    return _AUDIO_MIME_TO_FORMAT.get(base, base.split("/")[-1])
+
+
+def _audio_mime_from_format(fmt: Optional[str]) -> Optional[str]:
+    if not fmt:
+        return None
+    return _AUDIO_FORMAT_TO_MIME.get(fmt, f"audio/{fmt}")
+
+
+def _drop_none(**kwargs: Any) -> dict:
+    """Block constructor kwargs without ``None`` values.
+
+    Field strictness varies across the supported llama-index-core range (0.14.1
+    rejects an explicit ``url=None`` on ``AudioBlock``), so absent values are
+    omitted rather than passed as ``None``.
+    """
+    return {key: value for key, value in kwargs.items() if value is not None}
+
+
+def _source_kwargs(source: Union[InputContentDataSource, InputContentUrlSource]) -> dict:
+    """Project an AG-UI input-content source onto block constructor kwargs.
+
+    A ``data`` source's base64 payload is passed through as ASCII bytes rather
+    than decoded: the llama-index block normalizer keeps bytes that already are
+    valid base64 and encodes any other bytes, so handing it raw decoded bytes
+    corrupts every payload whose raw form happens to decode as base64 (the
+    block's ``resolve_*`` would then decode it a second time). Base64 input is
+    always kept verbatim and decoded exactly once. A ``url`` source passes
+    through. Returns ``{}`` for a source this converter cannot read, so the
+    caller can skip the part with a warning.
+    """
+    if isinstance(source, InputContentDataSource):
+        return {"data": source.value.encode("ascii"), "mime_type": source.mime_type}
+    if isinstance(source, InputContentUrlSource):
+        return {"url": source.value, "mime_type": source.mime_type}
+    return {}
+
+
+def _binary_part_to_block(part: BinaryInputContent) -> Optional[ContentBlock]:
+    """Convert the deprecated flat ``binary`` part, routed by MIME prefix."""
+    mime = part.mime_type or ""
+    # MIME types are case-insensitive (RFC 2045); route on the lowercased form
+    # but keep the original casing on the block's mimetype field.
+    mime_lower = mime.lower()
+    # Base64 passes through verbatim; see _source_kwargs for why it is not decoded.
+    data = part.data.encode("ascii") if part.data else None
+    if not part.url and data is None:
+        return None
+    if mime_lower.startswith("image/"):
+        return ImageBlock(
+            **_drop_none(image=data, url=part.url, image_mimetype=mime or None)
+        )
+    if mime_lower.startswith("audio/"):
+        return AudioBlock(
+            **_drop_none(
+                audio=data, url=part.url, format=_audio_format_from_mime(mime)
+            )
+        )
+    if mime_lower.startswith("video/"):
+        return VideoBlock(
+            **_drop_none(video=data, url=part.url, video_mimetype=mime or None)
+        )
+    return DocumentBlock(
+        **_drop_none(
+            data=data,
+            url=part.url,
+            document_mimetype=mime or None,
+            title=part.filename,
+        )
+    )
+
+
+#: additional_kwargs key marking a user message whose AG-UI wire content was a
+#: parts LIST (as opposed to the legacy string). The reverse conversion re-emits
+#: the same shape instead of inferring it from the block structure, which is
+#: lossy for single-part and empty arrays.
+AG_UI_PARTS_KEY = "ag_ui_parts"
+
+#: additional_kwargs key marking that the state rewrite prepended a state text
+#: block at index 0. The reverse conversion drops exactly that block — never a
+#: user-authored block that happens to contain ``<state>`` markup.
+AG_UI_STATE_BLOCK_KEY = "ag_ui_injected_state_block"
+
+
+def agui_content_to_blocks(content: Union[str, List[Any]]) -> List[ContentBlock]:
+    """Convert AG-UI user-message content onto llama-index content blocks.
+
+    String content becomes a single :class:`TextBlock`. List content maps each
+    typed part (text/image/audio/video/document, plus the deprecated flat
+    ``binary`` shape) onto the corresponding block; a part this converter
+    cannot represent is skipped with a warning rather than silently stringified.
+    Part ``metadata`` is deliberately not carried onto blocks: llama-index
+    blocks have no field for it, and providers reject unknown content keys.
+    """
+    if isinstance(content, str):
+        return [TextBlock(text=content)]
+
+    blocks: List[ContentBlock] = []
+    for part in content:
+        if isinstance(part, TextInputContent):
+            blocks.append(TextBlock(text=part.text))
+        elif isinstance(part, ImageInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping image part with unreadable source")
+                continue
+            blocks.append(
+                ImageBlock(
+                    **_drop_none(
+                        image=kwargs.get("data"),
+                        url=kwargs.get("url"),
+                        image_mimetype=kwargs.get("mime_type"),
+                    )
+                )
+            )
+        elif isinstance(part, AudioInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping audio part with unreadable source")
+                continue
+            blocks.append(
+                AudioBlock(
+                    **_drop_none(
+                        audio=kwargs.get("data"),
+                        url=kwargs.get("url"),
+                        format=_audio_format_from_mime(kwargs.get("mime_type")),
+                    )
+                )
+            )
+        elif isinstance(part, VideoInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping video part with unreadable source")
+                continue
+            blocks.append(
+                VideoBlock(
+                    **_drop_none(
+                        video=kwargs.get("data"),
+                        url=kwargs.get("url"),
+                        video_mimetype=kwargs.get("mime_type"),
+                    )
+                )
+            )
+        elif isinstance(part, DocumentInputContent):
+            kwargs = _source_kwargs(part.source)
+            if not kwargs:
+                logger.warning("Skipping document part with unreadable source")
+                continue
+            blocks.append(
+                DocumentBlock(
+                    **_drop_none(
+                        data=kwargs.get("data"),
+                        url=kwargs.get("url"),
+                        document_mimetype=kwargs.get("mime_type"),
+                    )
+                )
+            )
+        elif isinstance(part, BinaryInputContent):
+            block = _binary_part_to_block(part)
+            if block is None:
+                logger.warning("Skipping binary part with no url or data")
+                continue
+            blocks.append(block)
+        else:
+            logger.warning(
+                "Skipping unrecognized content part type: %r", type(part).__name__
+            )
+    return blocks
+
+
+def _block_to_agui_part(block: ContentBlock) -> Optional[Any]:
+    """Convert one llama-index content block back onto an AG-UI input part.
+
+    The inverse of :func:`agui_content_to_blocks` for the block types it emits.
+    A block with neither bytes nor a URL (e.g. path-based) has no AG-UI wire
+    shape and returns ``None``.
+    """
+
+    def _source(
+        data: Optional[bytes], url: Optional[Any], mime: Optional[str]
+    ) -> Optional[Union[InputContentDataSource, InputContentUrlSource]]:
+        if url:
+            return InputContentUrlSource(type="url", value=str(url), mime_type=mime)
+        if data is not None:
+            return InputContentDataSource(
+                type="data",
+                value=base64.b64encode(data).decode("ascii"),
+                mime_type=mime or "application/octet-stream",
+            )
+        return None
+
+    def _bytes(block: ContentBlock, field: Optional[bytes], resolve: Callable) -> Optional[bytes]:
+        # The block classes normalize stored bytes through a base64 heuristic,
+        # so the field value is not reliably raw; resolve_*() is. Only resolved
+        # when the block has no URL — resolving a URL-backed block would fetch
+        # it over the network, and the URL passes through as-is instead.
+        if block.url or field is None:
+            return None
+        return resolve().read()
+
+    if isinstance(block, TextBlock):
+        return TextInputContent(type="text", text=block.text)
+    if isinstance(block, ImageBlock):
+        data = _bytes(block, block.image, block.resolve_image)
+        source = _source(data, block.url, block.image_mimetype)
+        return ImageInputContent(type="image", source=source) if source else None
+    if isinstance(block, AudioBlock):
+        data = _bytes(block, block.audio, block.resolve_audio)
+        source = _source(data, block.url, _audio_mime_from_format(block.format))
+        return AudioInputContent(type="audio", source=source) if source else None
+    if isinstance(block, VideoBlock):
+        data = _bytes(block, block.video, block.resolve_video)
+        source = _source(data, block.url, block.video_mimetype)
+        return VideoInputContent(type="video", source=source) if source else None
+    if isinstance(block, DocumentBlock):
+        data = _bytes(block, block.data, block.resolve_document)
+        source = _source(data, block.url, block.document_mimetype)
+        return DocumentInputContent(type="document", source=source) if source else None
+    return None
+
+
+_STATE_TAG_RE = re.compile(r"<state>[\s\S]*?</state>")
 
 
 def llama_index_message_to_ag_ui_message(
@@ -28,9 +286,32 @@ def llama_index_message_to_ag_ui_message(
     elif (
         message.role.value == "user" and "tool_call_id" not in message.additional_kwargs
     ):
-        content = message.content or ""
-        content = re.sub(r"<state>[\s\S]*?</state>", "", content).strip()
-        return UserMessage(id=msg_id, content=content, role="user")
+        is_parts = bool(message.additional_kwargs.get(AG_UI_PARTS_KEY)) or not (
+            len(message.blocks) == 1 and isinstance(message.blocks[0], TextBlock)
+        )
+        if not is_parts:
+            # Legacy string shape: keep emitting a plain string, including the
+            # long-standing state-tag cleanup this path always applied.
+            content = message.content or ""
+            content = _STATE_TAG_RE.sub("", content).strip()
+            return UserMessage(id=msg_id, content=content, role="user")
+        # Parts shape: emit typed AG-UI parts, preserving the fragment
+        # boundaries, ordering, and exact text the client sent (stripping
+        # would corrupt significant whitespace). Only the block the state
+        # rewrite recorded as injected is dropped — user-authored text that
+        # merely contains <state> markup passes through verbatim.
+        blocks = list(message.blocks)
+        if message.additional_kwargs.get(AG_UI_STATE_BLOCK_KEY) and blocks:
+            blocks = blocks[1:]
+        parts = []
+        for block in blocks:
+            if isinstance(block, TextBlock):
+                parts.append(TextInputContent(type="text", text=block.text))
+                continue
+            part = _block_to_agui_part(block)
+            if part is not None:
+                parts.append(part)
+        return UserMessage(id=msg_id, content=parts, role="user")
     elif message.role.value == "assistant":
         # Remove tool calls from the message
         content = message.content
@@ -83,8 +364,16 @@ def ag_ui_message_to_llama_index_message(message: Message) -> ChatMessage:
             role="system", content=message.content, additional_kwargs={"id": message.id}
         )
     elif isinstance(message, UserMessage):
+        kwargs = {"id": message.id}
+        if isinstance(message.content, list):
+            kwargs[AG_UI_PARTS_KEY] = True
+        # `or ""` would fold an empty parts array into a phantom empty text
+        # block; only None means "no content".
+        content = message.content if message.content is not None else ""
         return ChatMessage(
-            role="user", content=message.content, additional_kwargs={"id": message.id}
+            role="user",
+            blocks=agui_content_to_blocks(content),
+            additional_kwargs=kwargs,
         )
     elif isinstance(message, AssistantMessage):
         # TODO: llama-index-core needs to support tool calls on messages in a more official way

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.3.4"
+version = "0.4.0"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},
@@ -37,8 +37,8 @@ requires-python = ">=3.10,<3.14"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "ag-ui-protocol>=0.1.5",
-    "llama-index-core>=0.13.0,<0.15",
+    "ag-ui-protocol>=0.1.15",
+    "llama-index-core>=0.14.1,<0.15",
 ]
 
 [project.optional-dependencies]

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_multimodal_input.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_multimodal_input.py
@@ -1,0 +1,312 @@
+import base64
+
+from ag_ui.core import UserMessage
+from ag_ui.core.types import (
+    AudioInputContent,
+    BinaryInputContent,
+    DocumentInputContent,
+    ImageInputContent,
+    InputContentDataSource,
+    InputContentUrlSource,
+    TextInputContent,
+    VideoInputContent,
+)
+from llama_index.core.base.llms.types import (
+    AudioBlock,
+    DocumentBlock,
+    ImageBlock,
+    TextBlock,
+    VideoBlock,
+)
+from llama_index.core.llms import ChatMessage
+
+from llama_index.protocols.ag_ui.utils import (
+    ag_ui_message_to_llama_index_message,
+    agui_content_to_blocks,
+    llama_index_message_to_ag_ui_message,
+)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake image payload"
+PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
+
+
+def user_message(content) -> UserMessage:
+    return UserMessage(id="msg-1", role="user", content=content)
+
+
+def test_string_content_still_converts_to_text() -> None:
+    msg = ag_ui_message_to_llama_index_message(user_message("hello"))
+    assert msg.role.value == "user"
+    assert msg.content == "hello"
+    assert [type(b) for b in msg.blocks] == [TextBlock]
+
+
+def test_image_data_part_becomes_image_block_with_bytes() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                TextInputContent(type="text", text="what is in this image?"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=PNG_B64, mime_type="image/png"
+                    ),
+                ),
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [TextBlock, ImageBlock]
+    image = msg.blocks[1]
+    assert image.resolve_image().read() == PNG_BYTES
+    assert image.image_mimetype == "image/png"
+    # The text is still reachable through the plain-content view.
+    assert msg.content == "what is in this image?"
+
+
+def test_image_url_part_becomes_image_block_with_url() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                ImageInputContent(
+                    type="image",
+                    source=InputContentUrlSource(
+                        type="url", value="https://example.com/cat.png"
+                    ),
+                )
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [ImageBlock]
+    assert str(msg.blocks[0].url) == "https://example.com/cat.png"
+
+
+def test_audio_video_and_document_parts_convert() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                AudioInputContent(
+                    type="audio",
+                    source=InputContentDataSource(
+                        type="data", value=PNG_B64, mime_type="audio/mpeg"
+                    ),
+                ),
+                VideoInputContent(
+                    type="video",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/clip.mp4",
+                        mime_type="video/mp4",
+                    ),
+                ),
+                DocumentInputContent(
+                    type="document",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/report.pdf",
+                        mime_type="application/pdf",
+                    ),
+                ),
+            ]
+        )
+    )
+    assert [type(b) for b in msg.blocks] == [AudioBlock, VideoBlock, DocumentBlock]
+    # MIME carries through: audio/mpeg maps onto the block's format field, and
+    # the audio bytes decode exactly once.
+    assert msg.blocks[0].format == "mp3"
+    assert msg.blocks[0].resolve_audio().read() == PNG_BYTES
+    assert msg.blocks[1].video_mimetype == "video/mp4"
+
+
+def test_audio_format_roundtrips_to_mime() -> None:
+    original = user_message(
+        [
+            AudioInputContent(
+                type="audio",
+                source=InputContentDataSource(
+                    type="data", value=PNG_B64, mime_type="audio/mpeg"
+                ),
+            )
+        ]
+    )
+    back = llama_index_message_to_ag_ui_message(
+        ag_ui_message_to_llama_index_message(original)
+    )
+    assert back.content[0].source.mime_type == "audio/mpeg"
+
+
+def test_base64_lookalike_payload_is_not_double_decoded() -> None:
+    # b"test" is itself a valid base64 string, the worst case for llama-index's
+    # keep-if-already-base64 normalizer: decoding the AG-UI payload up front
+    # would make resolve_*() decode it a second time and corrupt it.
+    payload = b"test"
+    encoded = base64.b64encode(payload).decode("ascii")
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                DocumentInputContent(
+                    type="document",
+                    source=InputContentDataSource(
+                        type="data", value=encoded, mime_type="text/plain"
+                    ),
+                ),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=encoded, mime_type="image/png"
+                    ),
+                ),
+            ]
+        )
+    )
+    assert msg.blocks[0].resolve_document().read() == payload
+    assert msg.blocks[1].resolve_image().read() == payload
+    # And it survives the full roundtrip back to AG-UI parts.
+    back = llama_index_message_to_ag_ui_message(msg)
+    assert base64.b64decode(back.content[0].source.value) == payload
+    assert base64.b64decode(back.content[1].source.value) == payload
+
+
+def test_deprecated_binary_part_routes_by_mime() -> None:
+    blocks = agui_content_to_blocks(
+        [
+            BinaryInputContent(
+                type="binary", mime_type="image/jpeg", data=PNG_B64, filename="a.jpg"
+            )
+        ]
+    )
+    assert [type(b) for b in blocks] == [ImageBlock]
+
+
+def test_unreadable_parts_are_skipped_not_stringified() -> None:
+    blocks = agui_content_to_blocks(
+        [
+            TextInputContent(type="text", text="hi"),
+            # id-only binary part: nothing to read, so it must be skipped.
+            BinaryInputContent(type="binary", mime_type="image/png", id="file-123"),
+        ]
+    )
+    assert [type(b) for b in blocks] == [TextBlock]
+
+
+def test_roundtrip_multimodal_user_message() -> None:
+    original = user_message(
+        [
+            TextInputContent(type="text", text="describe this"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ]
+    )
+    li_msg = ag_ui_message_to_llama_index_message(original)
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert isinstance(back, UserMessage)
+    assert isinstance(back.content, list)
+    assert [p.type for p in back.content] == ["text", "image"]
+    assert back.content[0].text == "describe this"
+    assert base64.b64decode(back.content[1].source.value) == PNG_BYTES
+
+
+def test_text_only_user_message_roundtrips_as_string() -> None:
+    li_msg = ag_ui_message_to_llama_index_message(user_message("plain text"))
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert back.content == "plain text"
+
+
+def test_text_only_parts_array_roundtrips_as_parts() -> None:
+    original = user_message(
+        [
+            TextInputContent(type="text", text="alpha"),
+            TextInputContent(type="text", text="beta"),
+        ]
+    )
+    back = llama_index_message_to_ag_ui_message(
+        ag_ui_message_to_llama_index_message(original)
+    )
+    assert isinstance(back.content, list)
+    assert [p.text for p in back.content] == ["alpha", "beta"]
+
+
+def test_reverse_conversion_preserves_significant_whitespace() -> None:
+    li_msg = ChatMessage(
+        role="user",
+        blocks=[
+            TextBlock(text="    indented()\n"),
+            ImageBlock(url="https://example.com/cat.png"),
+        ],
+        additional_kwargs={"id": "msg-3"},
+    )
+    back = llama_index_message_to_ag_ui_message(li_msg)
+    assert back.content[0].text == "    indented()\n"
+
+
+def test_parameterized_audio_mime_maps_to_bare_format() -> None:
+    msg = ag_ui_message_to_llama_index_message(
+        user_message(
+            [
+                AudioInputContent(
+                    type="audio",
+                    source=InputContentDataSource(
+                        type="data", value=PNG_B64, mime_type="audio/wav; codecs=1"
+                    ),
+                )
+            ]
+        )
+    )
+    assert msg.blocks[0].format == "wav"
+
+
+def test_user_authored_state_markup_survives_parts_roundtrip() -> None:
+    original = user_message(
+        [
+            TextInputContent(
+                type="text", text="explain before <state>ready</state> after"
+            ),
+            ImageInputContent(
+                type="image",
+                source=InputContentUrlSource(
+                    type="url", value="https://example.com/xml.png"
+                ),
+            ),
+        ]
+    )
+    back = llama_index_message_to_ag_ui_message(
+        ag_ui_message_to_llama_index_message(original)
+    )
+    # No state was injected, so nothing may be stripped — even text that
+    # happens to contain <state> markup.
+    assert back.content[0].text == "explain before <state>ready</state> after"
+
+
+def test_single_element_text_array_keeps_shape_and_whitespace() -> None:
+    original = user_message([TextInputContent(type="text", text="    code()\n")])
+    back = llama_index_message_to_ag_ui_message(
+        ag_ui_message_to_llama_index_message(original)
+    )
+    assert isinstance(back.content, list)
+    assert back.content[0].text == "    code()\n"
+
+
+def test_empty_parts_array_roundtrips_empty() -> None:
+    back = llama_index_message_to_ag_ui_message(
+        ag_ui_message_to_llama_index_message(user_message([]))
+    )
+    assert back.content == []
+
+
+def test_mime_types_are_case_insensitive() -> None:
+    blocks = agui_content_to_blocks(
+        [
+            AudioInputContent(
+                type="audio",
+                source=InputContentDataSource(
+                    type="data", value=PNG_B64, mime_type="Audio/MPEG"
+                ),
+            ),
+            BinaryInputContent(type="binary", mime_type="Image/PNG", data=PNG_B64),
+        ]
+    )
+    assert [type(b) for b in blocks] == [AudioBlock, ImageBlock]
+    assert blocks[0].format == "mp3"

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
@@ -1,0 +1,160 @@
+"""The state prompt must not crash on (or corrupt) multimodal user messages.
+
+Regression tests for the state-prompt rewrite in ``AGUIChatWorkflow``: the
+``ChatMessage.content`` setter raises on a multi-block message, so a user
+message carrying an image alongside text made every run with non-empty state
+fail. Exercises the production ``_apply_state_prompt`` directly.
+"""
+
+from llama_index.core.base.llms.types import ImageBlock, TextBlock
+from llama_index.core.llms import ChatMessage
+
+from llama_index.protocols.ag_ui.agent import _apply_state_prompt
+
+
+def test_state_prompt_preserves_image_blocks() -> None:
+    history = [
+        ChatMessage(
+            role="user",
+            blocks=[
+                TextBlock(text="what is in this image?"),
+                ImageBlock(url="https://example.com/cat.png"),
+            ],
+        )
+    ]
+    _apply_state_prompt(history, {"a": 1})
+    blocks = history[0].blocks
+    assert [type(b) for b in blocks] == [TextBlock, TextBlock, ImageBlock]
+    assert "{'a': 1}" in blocks[0].text
+    assert blocks[1].text == "what is in this image?"
+    assert str(blocks[2].url) == "https://example.com/cat.png"
+
+
+def test_state_prompt_preserves_interleaved_ordering() -> None:
+    history = [
+        ChatMessage(
+            role="user",
+            blocks=[
+                TextBlock(text="first, this photo:"),
+                ImageBlock(url="https://example.com/one.png"),
+                TextBlock(text="and compare it with this one:"),
+                ImageBlock(url="https://example.com/two.png"),
+            ],
+        )
+    ]
+    _apply_state_prompt(history, {"a": 1})
+    blocks = history[0].blocks
+    # State block is prepended; the original interleaving stays intact so each
+    # caption keeps pointing at its own image.
+    assert [type(b) for b in blocks] == [
+        TextBlock,
+        TextBlock,
+        ImageBlock,
+        TextBlock,
+        ImageBlock,
+    ]
+    assert "{'a': 1}" in blocks[0].text
+    assert blocks[1].text == "first, this photo:"
+    assert str(blocks[2].url) == "https://example.com/one.png"
+    assert blocks[3].text == "and compare it with this one:"
+    assert str(blocks[4].url) == "https://example.com/two.png"
+
+
+def test_state_prompt_text_only_unchanged_behavior() -> None:
+    history = [ChatMessage(role="user", content="hello")]
+    _apply_state_prompt(history, {"a": 1})
+    assert len(history[0].blocks) == 1
+    assert "hello" in history[0].content
+    assert "{'a': 1}" in history[0].content
+
+
+def test_state_prompt_keeps_text_parts_array_boundaries() -> None:
+    history = [
+        ChatMessage(
+            role="user",
+            blocks=[TextBlock(text="alpha"), TextBlock(text="beta")],
+        )
+    ]
+    _apply_state_prompt(history, {"a": 1})
+    blocks = history[0].blocks
+    # A parts-array client's fragment boundaries survive: state is its own
+    # leading block, the original text blocks stay separate and verbatim.
+    assert [type(b) for b in blocks] == [TextBlock, TextBlock, TextBlock]
+    assert "{'a': 1}" in blocks[0].text
+    assert blocks[1].text == "alpha"
+    assert blocks[2].text == "beta"
+
+
+def test_state_prompt_respects_single_element_parts_marker() -> None:
+    from llama_index.protocols.ag_ui.utils import (
+        AG_UI_PARTS_KEY,
+        ag_ui_message_to_llama_index_message,
+    )
+    from ag_ui.core import UserMessage
+    from ag_ui.core.types import TextInputContent
+
+    history = [
+        ag_ui_message_to_llama_index_message(
+            UserMessage(
+                id="m1",
+                role="user",
+                content=[TextInputContent(type="text", text="    code()\n")],
+            )
+        )
+    ]
+    assert history[0].additional_kwargs.get(AG_UI_PARTS_KEY) is True
+    _apply_state_prompt(history, {"a": 1})
+    blocks = history[0].blocks
+    # The single part is not folded into the template; it stays verbatim
+    # behind the injected state block.
+    assert len(blocks) == 2
+    assert "{'a': 1}" in blocks[0].text
+    assert blocks[1].text == "    code()\n"
+
+
+def test_state_prompt_targets_latest_user_message() -> None:
+    history = [
+        ChatMessage(role="user", content="older question"),
+        ChatMessage(role="assistant", content="answer"),
+        ChatMessage(role="user", content="newest question"),
+    ]
+    _apply_state_prompt(history, {"a": 1})
+    assert "{'a': 1}" not in history[0].content
+    assert "{'a': 1}" in history[2].content
+
+
+def test_injected_state_block_is_dropped_on_reverse_conversion() -> None:
+    from ag_ui.core import UserMessage
+    from ag_ui.core.types import (
+        ImageInputContent,
+        InputContentUrlSource,
+        TextInputContent,
+    )
+    from llama_index.protocols.ag_ui.utils import (
+        ag_ui_message_to_llama_index_message,
+        llama_index_message_to_ag_ui_message,
+    )
+
+    history = [
+        ag_ui_message_to_llama_index_message(
+            UserMessage(
+                id="m1",
+                role="user",
+                content=[
+                    TextInputContent(type="text", text="ask about the image"),
+                    ImageInputContent(
+                        type="image",
+                        source=InputContentUrlSource(
+                            type="url", value="https://example.com/cat.png"
+                        ),
+                    ),
+                ],
+            )
+        )
+    ]
+    _apply_state_prompt(history, {"a": 1})
+    back = llama_index_message_to_ag_ui_message(history[0])
+    # Exactly the injected state block is gone; the client's parts survive.
+    assert isinstance(back.content, list)
+    assert [p.type for p in back.content] == ["text", "image"]
+    assert back.content[0].text == "ask about the image"

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_state_prompt_multimodal.py
@@ -1,4 +1,5 @@
-"""The state prompt must not crash on (or corrupt) multimodal user messages.
+"""
+The state prompt must not crash on (or corrupt) multimodal user messages.
 
 Regression tests for the state-prompt rewrite in ``AGUIChatWorkflow``: the
 ``ChatMessage.content`` setter raises on a multi-block message, so a user


### PR DESCRIPTION
# Description

`llama-index-protocols-ag-ui` currently drops multimodal input: an AG-UI user message whose `content` is a parts list (text + image/audio/video/document) is passed untouched into `ChatMessage(content=...)`, so media never reaches the model — and the state-prompt rewrite crashes outright on multi-block messages because the `ChatMessage.content` setter raises on them. AG-UI's protocol has supported typed multimodal input content for a while, and every other major integration (CrewAI, Strands, Agno, Pydantic AI, Agent Framework, AG2) already maps it.

This PR adds full multimodal input support, structured as three commits (conversion layer → state-prompt fix → packaging), each independently testable:

- `agui_content_to_blocks` maps typed AG-UI parts onto llama-index content blocks (`TextBlock`/`ImageBlock`/`AudioBlock`/`VideoBlock`/`DocumentBlock`). Base64 `data` payloads are passed through **verbatim** (as ASCII bytes) rather than pre-decoded: llama-index's normalizer keeps bytes that are already valid base64, so decoding up front would make `resolve_*()` decode a second time and corrupt payloads that happen to be base64-shaped. `url` sources pass through, MIME types are matched case-insensitively with parameters stripped, audio MIME maps onto `AudioBlock.format` (`audio/mpeg` → `mp3`, etc.), and the deprecated flat `binary` shape is routed by MIME prefix. Unreadable parts are skipped with a warning instead of being stringified. `None` kwargs are dropped before block construction (`AudioBlock(url=None)` is a ValidationError on core 0.14.1).
- The reverse direction (`llama_index_message_to_ag_ui_message`) emits typed parts for multimodal user messages, resolving block bytes via `resolve_*()` (the stored field is normalized and not reliably raw) and never resolving URL-backed blocks, which would fetch over the network. Messages that arrived as parts arrays round-trip as parts arrays (shape, fragment boundaries, and whitespace preserved verbatim); legacy string content keeps the existing string path bit-for-bit.
- The state-prompt rewrite in `AGUIChatWorkflow` rebuilds `blocks` instead of assigning `.content`, fixing the crash. Legacy single-text messages keep the exact existing template embedding; parts messages get the state as a leading `TextBlock`, marked in `additional_kwargs` so the reverse conversion drops exactly the injected block and nothing else (user-authored `<state>`-lookalike text is untouched).
- Dependency floors are raised to what the code actually requires: `ag-ui-protocol>=0.1.15` (first release with the typed input-content classes) and `llama-index-core>=0.14.1,<0.15` (first release with `VideoBlock`).

Sequencing note: the AG-UI TypeScript client (`@ag-ui/llamaindex`) pins `maxVersion = "0.0.39"`, whose compatibility middleware flattens parts lists to text before requests reach this server. A follow-up PR to ag-ui-protocol/ag-ui removes that pin once this package is released, which is what makes the end-to-end path work.

## New Package?

- [ ] No

## Version Bump?

- [x] Yes (0.3.4 → 0.4.0)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

28 new tests across `tests/test_multimodal_input.py` (data/url sources, audio/video/document, deprecated binary routing, skip-not-stringify, base64-lookalike double-decode regression, parameterized/case-insensitive MIME, parts-shape and whitespace round-trips) and `tests/test_state_prompt_multimodal.py` (multi-block state-prompt crash regression, interleaving order, injected-state-block removal on reverse conversion). Full package suite passes, both at latest deps and at the declared dependency floors (`ag-ui-protocol==0.1.15`, `llama-index-core==0.14.1`).

Beyond unit tests: verified end-to-end over HTTP (real `RunAgentInput` JSON with camelCase wire aliases through the FastAPI router — the ImageBlock reaches the LLM with byte-identical content), and manually against OpenAI `gpt-4.1` plus the AG-UI dojo browser UI with the client pin removed (uploaded image is described correctly).

Supersedes #22662 (same branch; closed before the commit restructuring, which GitHub then refuses to reopen across a force-push).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
