### PR TITLE
docs: add an agent discovery example using MCP

### DIFF
--- a/docs/examples/tools/agent_discovery.ipynb
+++ b/docs/examples/tools/agent_discovery.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Discovering Agents with MCP\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/run-llama/llama_index/blob/main/docs/examples/tools/agent_discovery.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "Most agent examples start from a tool or service you already know about. This one starts from a task and *no* candidates: the agent queries a public registry to find out, at runtime, which third-party agents can do the job.\n",
+    "\n",
+    "The registry used here is [Aidress](https://api.aidress.ai), which exposes its lookups over MCP. Because the agents that discovery turns up are ones you have never worked with, the registry also returns trust data for each candidate \u2014 a trust score, whether the agent is verified, how many transactions it has completed, and any flags \u2014 so the agent can vet a candidate before recommending it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-tools-mcp llama-index-llms-openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to the registry\n",
+    "\n",
+    "The registry exposes read-only lookups alongside tools that mutate registry state, such as registering an agent or proxying a paid call. Discovery needs only the read-only subset, so `allowed_tools` keeps the agent from reaching the rest.\n",
+    "\n",
+    "The read-only lookups are public and need no credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.mcp import BasicMCPClient, aget_tools_from_mcp_url\n",
+    "\n",
+    "REGISTRY_URL = \"https://api.aidress.ai/mcp/sse\"\n",
+    "\n",
+    "READ_ONLY_TOOLS = [\n",
+    "    # Discovery: find candidates by capability, or page through the whole registry.\n",
+    "    \"match_agents\",\n",
+    "    \"list_registry\",\n",
+    "    # Due diligence on a candidate that discovery surfaced.\n",
+    "    \"verify_agent\",\n",
+    "    \"get_agent\",\n",
+    "    \"protocol_reference\",\n",
+    "]\n",
+    "\n",
+    "client = BasicMCPClient(REGISTRY_URL)\n",
+    "tools = await aget_tools_from_mcp_url(\n",
+    "    REGISTRY_URL, client=client, allowed_tools=READ_ONLY_TOOLS\n",
+    ")\n",
+    "\n",
+    "print(f\"{len(tools)} tools available:\")\n",
+    "for tool in tools:\n",
+    "    print(f\"  - {tool.metadata.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discovering candidates for a task\n",
+    "\n",
+    "Now give an agent the tools and a task, without naming a single counterparty. It has to find out who exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.agent.workflow import FunctionAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "\n",
+    "agent = FunctionAgent(\n",
+    "    name=\"Agent Discovery Assistant\",\n",
+    "    description=\"Finds third-party agents that can do a task, and vets them.\",\n",
+    "    llm=OpenAI(model=\"gpt-4o\"),\n",
+    "    tools=tools,\n",
+    "    system_prompt=(\n",
+    "        \"You find third-party agents that can do a task the user needs done. \"\n",
+    "        \"Start by searching the registry for agents offering the required \"\n",
+    "        \"capability, and report what you found: how many candidates there are \"\n",
+    "        \"and what each one does. Then, because the user has not worked with any \"\n",
+    "        \"of them before, check each candidate's trust score, whether it is \"\n",
+    "        \"verified, how many transactions it has completed, and any flags. Close \"\n",
+    "        \"with the candidate you would pick and the evidence behind the choice. \"\n",
+    "        \"Report only the values the tools return; never invent an agent or a score.\"\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "response = await agent.run(\n",
+    "    \"I need a web research task done, but I don't know which agents offer that. \"\n",
+    "    \"Find the ones that do, then tell me which of them I can trust with the job.\"\n",
+    ")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The registry holds real third-party agents, so the candidates and their numbers change over time \u2014 nothing above is hard-coded, and rerunning this may surface a different set."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# Description

Adds `docs/examples/tools/agent_discovery.ipynb`, an example of **agent discovery over MCP**: the agent starts from a task with no known counterparties and queries a public registry at runtime to find out which third-party agents can do the job.

The existing MCP notebooks (`mcp.ipynb`, `mcp_agent_tools.ipynb`) connect to a server whose tools the author already knew about, which is the usual case. This one covers the other case — the candidate set is not known until the agent asks. Because the agents discovery returns are ones the user has never worked with, the notebook then vets each candidate on the trust data the registry returns (trust score, verified status, completed transaction count, flags) before recommending one.

Nothing is hard-coded: the registry holds real third-party agents, so the candidates and their numbers change between runs.

It uses the existing `llama-index-tools-mcp` package as-is — `BasicMCPClient` plus `aget_tools_from_mcp_url` with `allowed_tools`. No new package, no dependency changes, no code outside `docs/`. The registry exposes tools that mutate registry state alongside its read-only lookups, so `allowed_tools` restricts the agent to the five read-only ones; the lookups are public and need no credentials.

One note on transport, since it may look like an odd choice: the notebook connects over SSE rather than streamable HTTP. That is deliberate — streamable HTTP currently raises `ValueError: not enough values to unpack (expected 3, got 2)` in `llama-index-tools-mcp` 0.5.0 under `mcp` 2.x, which is #22655 with fixes already open in #22659, #22670 and #22672. I did not include a fix here, since three are already in flight and a fourth would only add review load. Once one lands, this notebook works unchanged against the streamable-HTTP endpoint too.

Fixes # (issue) — N/A, no issue.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — documentation only, no package touched.

## Type of Change

- [x] This change requires a documentation update (it *is* the documentation change)

## How Has This Been Tested?

Documentation-only, so there is no unit test to add. I verified the notebook's code against the live endpoint rather than asserting it works:

- The connection cell was executed **verbatim** from the committed notebook — extracted from the `.ipynb` and run in IPython so the top-level `await` is exercised as it would be in a notebook kernel. It printed the expected five tools:

  ```
  5 tools available:
    - verify_agent
    - match_agents
    - get_agent
    - protocol_reference
    - list_registry
  ```

- The registry exposes 16 tools; `allowed_tools` correctly narrows that to the 5 read-only ones, confirmed against the live server.
- A live `match_agents` call for "web research" returned 8 real candidates with their trust data, which is what the agent cell reasons over:

  ```
  agent_exa_ai              trust=76  verified=True  tx=14
  agent_parallel_ai         trust=72  verified=True  tx=16
  agent_ydc_index_io        trust=75  verified=True  tx=1
  ```

- `nbformat.validate()` passes, and `black` (jupyter extra) leaves the notebook unchanged.

The final agent cell requires an OpenAI key at runtime, as every agent notebook in this directory does. I'll follow up with its output in a comment.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests — docs-only change; no package code touched.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — not applicable to a docs notebook
- [x] New and existing unit tests pass locally with my changes — no package code changed
- [ ] I ran `uv run make format; uv run make lint` — I ran `black` with the jupyter extra on the notebook (clean) rather than the full-repo lint, since the diff is a single `docs/` file. Happy to run the full stack if you'd like it on the record.

---

**Disclosure, per the "How to Use AI when Contributing" guidance:** this notebook was written with AI assistance. Every claim in it was checked against the live service rather than assumed — the transport bug above was found that way, not read about — and the connection cell was executed verbatim as committed. I'm one of the authors of the registry it connects to, so the example is written around the SDK pattern rather than the service, and it uses only public, unauthenticated endpoints. If you'd rather this not live in the docs, that's entirely your call.
