### PR TITLE
docs: fix TypeScript and JavaScript capitalization

### DIFF
--- a/docs/src/content/docs/framework/index.md
+++ b/docs/src/content/docs/framework/index.md
@@ -92,7 +92,7 @@ For more complex applications, our lower-level APIs allow advanced users to cust
 
 ## Getting Started
 
-LlamaIndex is available in Python (these docs) and [Typescript](https://ts.llamaindex.ai/). If you're not sure where to start, we recommend reading [how to read these docs](/python/framework/getting_started/reading) which will point you to the right place based on your experience level.
+LlamaIndex is available in Python (these docs) and [TypeScript](https://ts.llamaindex.ai/). If you're not sure where to start, we recommend reading [how to read these docs](/python/framework/getting_started/reading) which will point you to the right place based on your experience level.
 
 ### 30 second quickstart
 
@@ -140,7 +140,7 @@ Need help? Have a feature suggestion? Join the LlamaIndex community:
   - [LlamaIndex Python Github](https://github.com/run-llama/llama_index)
   - [Python Docs](https://docs.llamaindex.ai/) (what you're reading now)
   - [LlamaIndex on PyPi](https://pypi.org/project/llama-index/)
-- LlamaIndex.TS (Typescript/Javascript package):
+- LlamaIndex.TS (TypeScript/JavaScript package):
   - [LlamaIndex.TS Github](https://github.com/run-llama/LlamaIndexTS)
   - [TypeScript Docs](https://ts.llamaindex.ai/)
   - [LlamaIndex.TS on npm](https://www.npmjs.com/package/llamaindex)

--- a/docs/src/content/docs/framework/javascript/_meta.yml
+++ b/docs/src/content/docs/framework/javascript/_meta.yml
@@ -1,2 +1,2 @@
-label: Javascript
+label: JavaScript
 collapsed: true

--- a/docs/src/content/docs/framework/module_guides/mcp/index.md
+++ b/docs/src/content/docs/framework/module_guides/mcp/index.md
@@ -28,7 +28,7 @@ With LlamaIndex, there are a number of ways you can use MCP servers, which allow
 
 - **Use existing MCP servers tools with LlamaIndex workflows**: Get data from external resources that are served via existing MCP servers.
 - **Serve LlamaIndex workflows as MCP servers**: You can convert your own custom LlamaIndex workflows to MCP servers.
-- **Use LlamaCloud services within LlamaIndex workflows**: Run one of our MCP servers (both in Python and Typescript) that serve LlamaCloud functionality such as LlamaExtract or LlamaParse, within any other application that communicates with MCP servers, including LlamaIndex workflows
+- **Use LlamaCloud services within LlamaIndex workflows**: Run one of our MCP servers (both in Python and TypeScript) that serve LlamaCloud functionality such as LlamaExtract or LlamaParse, within any other application that communicates with MCP servers, including LlamaIndex workflows
 
 ## Next Steps
 

--- a/docs/src/content/docs/framework/understanding/putting_it_all_together/apps/fullstack_app_guide.md
+++ b/docs/src/content/docs/framework/understanding/putting_it_all_together/apps/fullstack_app_guide.md
@@ -280,7 +280,7 @@ Check out the complete `flask_demo.py` and `index_server.py` scripts in the [rep
 
 ## React Frontend
 
-Generally, React and Typescript are one of the most popular libraries and languages for writing webapps today. This guide will assume you are familiar with how these tools work, because otherwise this guide will triple in length :smile:.
+Generally, React and TypeScript are one of the most popular libraries and languages for writing webapps today. This guide will assume you are familiar with how these tools work, because otherwise this guide will triple in length :smile:.
 
 In the [repository](https://github.com/logan-markewich/llama_index_starter_pack/tree/main/flask_react), the frontend code is organized inside of the `react_frontend` folder.
 


### PR DESCRIPTION
## Summary
Fixed incorrect capitalization of "Typescript" → "TypeScript" and "Javascript" → "JavaScript" in the documentation for consistency with official branding.

## Changes
- Updated several documentation files to use the correct capitalization of TypeScript and JavaScript.