### PR TITLE
fix(core): keep retrieval metrics within [0, 1] when ids repeat

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -13,6 +13,17 @@ from typing_extensions import assert_never
 _AGG_FUNC: Dict[str, Callable] = {"mean": np.mean, "median": np.median, "max": np.max}
 
 
+def _unique_ids(ids: List[str]) -> List[str]:
+    """
+    Drop repeated ids, keeping the first occurrence.
+
+    An id identifies a document, so a document listed twice is still one
+    document. The metrics below already compare ids through sets, and counting
+    a repeat as a second document lets the bounded metrics score above 1.0.
+    """
+    return list(dict.fromkeys(ids))
+
+
 class HitRate(BaseRetrievalMetric):
     """
     Hit rate metric: Compute hit rate with two calculation options.
@@ -70,8 +81,10 @@ class HitRate(BaseRetrievalMetric):
         if self.use_granular_hit_rate:
             # Granular HitRate calculation: Calculate all hits and divide by the number of expected docs
             expected_set = set(expected_ids)
-            hits = sum(1 for doc_id in retrieved_ids if doc_id in expected_set)
-            score = hits / len(expected_ids) if expected_ids else 0.0
+            hits = sum(
+                1 for doc_id in _unique_ids(retrieved_ids) if doc_id in expected_set
+            )
+            score = hits / len(expected_set) if expected_set else 0.0
         else:
             # Default HitRate calculation: Check if there is a single hit
             is_hit = any(id in expected_ids for id in retrieved_ids)
@@ -139,7 +152,7 @@ class MRR(BaseRetrievalMetric):
             expected_set = set(expected_ids)
             reciprocal_rank_sum = 0.0
             relevant_docs_count = 0
-            for index, doc_id in enumerate(retrieved_ids):
+            for index, doc_id in enumerate(_unique_ids(retrieved_ids)):
                 if doc_id in expected_set:
                     relevant_docs_count += 1
                     reciprocal_rank_sum += 1.0 / (index + 1)
@@ -324,7 +337,7 @@ class AveragePrecision(BaseRetrievalMetric):
         expected_set = set(expected_ids)
 
         relevant_count, total_precision = 0, 0.0
-        for i, retrieved_id in enumerate(retrieved_ids, start=1):
+        for i, retrieved_id in enumerate(_unique_ids(retrieved_ids), start=1):
             if retrieved_id in expected_set:
                 relevant_count += 1
                 total_precision += relevant_count / i
@@ -415,12 +428,12 @@ class NDCG(BaseRetrievalMetric):
 
         dcg = sum(
             discounted_gain(rel=docid in expected_set, i=i, mode=mode)
-            for i, docid in enumerate(retrieved_ids, start=1)
+            for i, docid in enumerate(_unique_ids(retrieved_ids), start=1)
         )
 
         idcg = sum(
             discounted_gain(rel=True, i=i, mode=mode)
-            for i in range(1, len(expected_ids) + 1)
+            for i in range(1, len(expected_set) + 1)
         )
 
         ndcg_score = dcg / idcg

--- a/llama-index-core/tests/evaluation/test_metrics.py
+++ b/llama-index-core/tests/evaluation/test_metrics.py
@@ -245,3 +245,51 @@ def test_exceptions(expected_ids, retrieved_ids, use_granular):
     with pytest.raises(ValueError):
         ndcg = NDCG()
         ndcg.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+
+
+def _granular_hit_rate() -> HitRate:
+    hit_rate = HitRate()
+    hit_rate.use_granular_hit_rate = True
+    return hit_rate
+
+
+def _granular_mrr() -> MRR:
+    mrr = MRR()
+    mrr.use_granular_mrr = True
+    return mrr
+
+
+# A document retrieved twice is still one retrieved document, so repeating an id
+# must not move a bounded metric past 1.0.
+@pytest.mark.parametrize(
+    ("metric", "expected_result"),
+    [
+        (_granular_hit_rate(), 2 / 2),
+        (_granular_mrr(), (1 / 1 + 1 / 2) / 2),
+        (Precision(), 2 / 2),
+        (Recall(), 2 / 2),
+        (AveragePrecision(), (1 / 1 + 2 / 2) / 2),
+        (NDCG(), 1.0),
+    ],
+)
+def test_repeated_retrieved_id_does_not_inflate_score(metric, expected_result):
+    expected_ids = ["id1", "id2"]
+    result = metric.compute(
+        expected_ids=expected_ids, retrieved_ids=["id1", "id1", "id2"]
+    )
+
+    assert result.score == pytest.approx(expected_result)
+    assert result.score <= 1.0
+
+    deduplicated = metric.compute(
+        expected_ids=expected_ids, retrieved_ids=["id1", "id2"]
+    )
+    assert result.score == pytest.approx(deduplicated.score)
+
+
+# The DCG side of NDCG compares ids through a set, so the ideal DCG has to be
+# built from the same de-duplicated ground truth.
+def test_ndcg_perfect_retrieval_with_repeated_expected_id():
+    result = NDCG().compute(expected_ids=["id1", "id1"], retrieved_ids=["id1"])
+
+    assert result.score == pytest.approx(1.0)


### PR DESCRIPTION
# Description

`HitRate` (granular), `MRR` (granular), `AveragePrecision` and `NDCG` walk `retrieved_ids` position by position while testing membership against a set built from `expected_ids`. A document that appears twice in the ranking is therefore counted as two retrieved documents, and these bounded metrics go past their own maximum:

```python
from llama_index.core.evaluation.retrieval.metrics import AveragePrecision, HitRate, NDCG

hit_rate = HitRate()
hit_rate.use_granular_hit_rate = True

hit_rate.compute(expected_ids=["id1"], retrieved_ids=["id1", "id1"]).score  # 2.0
AveragePrecision().compute(expected_ids=["id1"], retrieved_ids=["id1", "id1"]).score  # 2.0
NDCG().compute(expected_ids=["id1"], retrieved_ids=["id1", "id1"]).score  # 1.63
```

Duplicate ids are not exotic input: fusion and multi-query retrievers merge several rankings, so a node reachable from more than one of them arrives more than once. A score above 1.0 also silently breaks anything that aggregates these metrics — a mean over a dataset stops being comparable across runs.

NDCG has the mirror image of the same problem. Its DCG term de-duplicates `expected_ids` through a set, while its ideal DCG is summed over the raw list, so a repeat in the ground truth inflates the denominator and a perfect retrieval scores below 1:

```python
NDCG().compute(expected_ids=["id1", "id1"], retrieved_ids=["id1"]).score  # 0.61
```

This PR drops repeated ids from `retrieved_ids`, keeping the first occurrence, and builds the ideal DCG from the de-duplicated ground truth. `Precision` and `Recall` already compared sets on both sides, so they are unchanged and stay consistent with the rest.

Rankings without duplicates score exactly as before — the existing metric tests pass untouched.

Fixes # (no issue; found while evaluating a retriever whose fused ranking repeated a node)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_repeated_retrieved_id_does_not_inflate_score` covers the six metrics, asserting both the exact expected value and that a repeated id scores the same as the de-duplicated ranking. `test_ndcg_perfect_retrieval_with_repeated_expected_id` covers the ground-truth side. Five of them fail on `main` and pass with this change; the rest of `tests/evaluation` passes unchanged.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the formatter and linter over the changed files

Disclosure: I used AI assistance while investigating and writing this change. I reproduced the behaviour, reviewed the code, and take responsibility for it.
