### PR TITLE
fix(core): penalize MMR candidates against every selected result

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -2,7 +2,7 @@
 
 import heapq
 import math
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 from llama_index.core.base.embeddings.base import similarity as default_similarity_fn
@@ -134,6 +134,8 @@ def get_top_k_mmr_embeddings(
             score = similarity * threshold
 
     results: List[Tuple[Any, Any]] = []
+    # Largest similarity between a candidate and any result already selected.
+    max_overlap_with_results: Dict[Any, float] = {}
 
     embedding_length = len(embeddings or [])
     similarity_top_k_count = similarity_top_k or embedding_length
@@ -152,14 +154,19 @@ def get_top_k_mmr_embeddings(
                 embeddings[embed_map[embed_id]],
                 embeddings[full_embed_map[recent_embedding_id]],
             )
-            if (
-                threshold * embed_similarity[embed_id]
-                - ((1 - threshold) * overlap_with_recent)
-                > score
-            ):
-                score = threshold * embed_similarity[embed_id] - (
-                    (1 - threshold) * overlap_with_recent
-                )
+            # A candidate is redundant if it repeats any result already selected,
+            # not only the one selected last, so carry the largest overlap seen.
+            overlap_with_results = max(
+                overlap_with_recent,
+                max_overlap_with_results.get(embed_id, -math.inf),
+            )
+            max_overlap_with_results[embed_id] = overlap_with_results
+
+            candidate_score = threshold * embed_similarity[embed_id] - (
+                (1 - threshold) * overlap_with_results
+            )
+            if candidate_score > score:
+                score = candidate_score
                 high_score_id = embed_id
 
     result_similarities = [s for s, _ in results]

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -108,3 +108,34 @@ def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
         query_embedding, embeddings, similarity_top_k=2
     )
     assert unset_ids == [0, 1]
+
+
+def test_get_top_k_mmr_embeddings_penalizes_every_selected_result() -> None:
+    """
+    A candidate is redundant if it repeats any result already selected.
+
+    The penalty was measured against the result selected last, so a near
+    duplicate of an earlier result stopped being penalised as soon as an
+    unrelated result was selected after it, and came back in the ranking.
+    """
+    query_embedding = [1.0, 0.0, 0.0, 0.0]
+    embeddings = [
+        [0.90, 0.44, 0.00, 0.00],  # A: the most relevant result
+        [0.88, 0.47, 0.00, 0.00],  # a near-duplicate of A
+        [0.70, 0.00, 0.71, 0.00],  # B: selected next, unrelated to A
+        [0.65, 0.00, 0.00, 0.76],  # C: unrelated to both A and B
+    ]
+
+    result_similarities, result_ids = get_top_k_mmr_embeddings(
+        query_embedding,
+        embeddings,
+        embedding_ids=["A", "A_duplicate", "B", "C"],
+        mmr_threshold=0.5,
+        similarity_top_k=3,
+    )
+
+    # Once B is selected in between, the duplicate is still redundant with A.
+    assert result_ids == ["A", "B", "C"]
+
+    # The scores are the MMR scores of the picks, so they never increase.
+    assert result_similarities == sorted(result_similarities, reverse=True)


### PR DESCRIPTION
# Description

`get_top_k_mmr_embeddings` discounts each candidate by its similarity to the result that was selected **immediately before it**, rather than to every result selected so far:

```python
overlap_with_recent = similarity_fn(
    embeddings[embed_map[embed_id]],
    embeddings[full_embed_map[recent_embedding_id]],
)
```

So the penalty is forgotten as soon as another result is selected. A near-duplicate of an earlier result stops looking redundant the moment an unrelated result is picked in between, and comes back into the ranking — which is the one thing MMR exists to prevent.

```python
from llama_index.core.indices.query.embedding_utils import get_top_k_mmr_embeddings

query = [1.0, 0.0, 0.0, 0.0]
embeddings = [
    [0.90, 0.44, 0.00, 0.00],   # A
    [0.88, 0.47, 0.00, 0.00],   # near-duplicate of A
    [0.70, 0.00, 0.71, 0.00],   # B, unrelated to A
    [0.65, 0.00, 0.00, 0.76],   # C, unrelated to both
]

get_top_k_mmr_embeddings(
    query, embeddings, embedding_ids=["A", "A_duplicate", "B", "C"],
    mmr_threshold=0.5, similarity_top_k=3,
)
# main:      (['A', 'B', 'A_duplicate'], scores 0.4492, 0.0357, 0.1314)
# this PR:   (['A', 'B', 'C'],           scores 0.4492, 0.0357, 0.0330)
```

The returned scores show the same problem from another angle. Each is measured against a different document, so they are not comparable to one another and the list is not ordered by them: on `main` the third pick scores 0.13 against a second pick of 0.04. Anything downstream that treats these as node scores — a similarity cutoff, a rerank, a UI that displays them — is reading numbers that are not on one scale.

This PR carries the largest similarity a candidate has with any result already selected, which is the standard MMR formulation. The overlap is still computed once per candidate per round, so the number of `similarity_fn` calls is unchanged.

The existing tests pin scores for rankings where the running maximum happens to equal the similarity with the most recent result, so they pass untouched.

Fixes # (no issue; found while reading the MMR implementation)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_get_top_k_mmr_embeddings_penalizes_every_selected_result` uses the case above: it fails on `main` (the duplicate is returned third) and passes with this change. It also asserts the returned scores are non-increasing. The existing `tests/indices/query` tests pass unchanged.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the formatter and linter over the changed files

Disclosure: I used AI assistance while investigating and writing this change. I reproduced the behaviour, reviewed the code, and take responsibility for it.
