### PR TITLE
fix(core): stop counting image nodes as text in multi-modal retrieval eval

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/evaluator.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/evaluator.py
@@ -84,9 +84,11 @@ class MultiModalRetrieverEvaluator(BaseRetrievalEvaluator):
 
         for scored_node in retrieved_nodes:
             node = scored_node.node
+            # `ImageNode` subclasses `TextNode`, so the image check has to come
+            # first for the two modes to stay separate.
             if isinstance(node, ImageNode):
                 image_nodes.append(node)
-            if isinstance(node, TextNode):
+            elif isinstance(node, TextNode):
                 text_nodes.append(node)
 
         if mode == "text":

--- a/llama-index-core/tests/evaluation/test_retrieval_evaluator.py
+++ b/llama-index-core/tests/evaluation/test_retrieval_evaluator.py
@@ -1,0 +1,38 @@
+from typing import List
+
+import pytest
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.evaluation.retrieval.evaluator import (
+    MultiModalRetrieverEvaluator,
+)
+from llama_index.core.schema import ImageNode, NodeWithScore, QueryBundle, TextNode
+
+
+class MockMultiModalRetriever(BaseRetriever):
+    """Retriever returning one text node and one image node."""
+
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return [
+            NodeWithScore(node=TextNode(id_="text-1", text="a text chunk")),
+            NodeWithScore(
+                node=ImageNode(id_="image-1", text="a caption", image="fake-b64")
+            ),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_multi_modal_evaluator_keeps_the_two_modes_separate() -> None:
+    """
+    `ImageNode` subclasses `TextNode`, so an image node satisfies both
+    `isinstance` checks. Evaluating in text mode used to score the retriever on
+    image nodes as well, which is the opposite of what this evaluator is for.
+    """
+    evaluator = MultiModalRetrieverEvaluator.from_metric_names(
+        ["mrr", "hit_rate"], retriever=MockMultiModalRetriever()
+    )
+
+    text_ids, _ = await evaluator._aget_retrieved_ids_and_texts("query", "text")
+    image_ids, _ = await evaluator._aget_retrieved_ids_and_texts("query", "image")
+
+    assert text_ids == ["text-1"]
+    assert image_ids == ["image-1"]


### PR DESCRIPTION
# Description

`MultiModalRetrieverEvaluator._aget_retrieved_ids_and_texts` splits the retrieved nodes into an image list and a text list with two independent checks:

```python
if isinstance(node, ImageNode):
    image_nodes.append(node)
if isinstance(node, TextNode):
    text_nodes.append(node)
```

`ImageNode` subclasses `TextNode`, so every image node satisfies both and lands in both lists. Evaluating with `mode="text"` therefore scores the retriever on the image nodes as well:

```python
evaluator = MultiModalRetrieverEvaluator.from_metric_names(
    ["mrr", "hit_rate"], retriever=retriever  # returns one TextNode + one ImageNode
)
await evaluator._aget_retrieved_ids_and_texts("query", "text")
# main:    (['text-1', 'image-1'], ...)
# this PR: (['text-1'], ...)
```

This evaluator exists to measure image and text retrieval separately — that is how the [multi-modal RAG evaluation notebook](https://github.com/run-llama/llama_index/blob/main/docs/examples/evaluation/multi_modal/multi_modal_rag_evaluation.ipynb) presents it — so the text-mode numbers are the ones this distorts. An image node whose id is not in the text ground truth counts as a miss and drags precision and MRR down; one that happens to be in it counts as a hit for the wrong modality.

Checking `ImageNode` first and making the text branch an `elif` keeps each node in one mode. `mode="image"` is unaffected.

Fixes # (no issue; found while reading the retrieval evaluators)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`tests/evaluation/test_retrieval_evaluator.py` drives the evaluator with a mock retriever that returns one text node and one image node, and asserts each mode returns only its own node. It fails on `main` and passes with this change.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the formatter and linter over the changed files

Disclosure: I used AI assistance while investigating and writing this change. I reproduced the behaviour, reviewed the code, and take responsibility for it.
