### PR TITLE
fix(core): FunctionTool evaluates Field(default_factory=...) once per tool instead of per call

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -139,14 +139,34 @@ class FunctionTool(AsyncBaseTool):
 
         self.partial_params = partial_params or {}
 
-        # Extract actual default values from FieldInfo defaults so they are
-        # applied when the function is called without those arguments.
-        self._field_defaults: Dict[str, Any] = {}
+        # Keep the FieldInfo rather than a materialized value: a
+        # ``default_factory`` must run per call, not once per tool, or every
+        # call shares one object (and one uuid/timestamp).
+        self._field_default_infos: Dict[str, FieldInfo] = {}
+        self._positional_param_names: List[str] = []
         for param in sig.parameters.values():
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                self._positional_param_names.append(param.name)
             if isinstance(param.default, FieldInfo) and not param.default.is_required():
-                self._field_defaults[param.name] = param.default.get_default(
-                    call_default_factory=True
-                )
+                self._field_default_infos[param.name] = param.default
+
+    @property
+    def _field_defaults(self) -> Dict[str, Any]:
+        """Defaults for FieldInfo params, re-resolved on every access."""
+        return {
+            name: info.get_default(call_default_factory=True)
+            for name, info in self._field_default_infos.items()
+        }
+
+    def _defaults_for_call(self, args: Tuple[Any, ...]) -> Dict[str, Any]:
+        """Field defaults, minus any parameter already supplied positionally."""
+        defaults = self._field_defaults
+        for name in self._positional_param_names[: len(args)]:
+            defaults.pop(name, None)
+        return defaults
 
     def _run_sync_callback(self, result: Any) -> CallbackReturn:
         """
@@ -334,7 +354,7 @@ class FunctionTool(AsyncBaseTool):
 
     def call(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """Sync Call."""
-        all_kwargs = {**self._field_defaults, **self.partial_params, **kwargs}
+        all_kwargs = {**self._defaults_for_call(args), **self.partial_params, **kwargs}
         if self.requires_context and self.ctx_param_name is not None:
             if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")
@@ -373,7 +393,7 @@ class FunctionTool(AsyncBaseTool):
 
     async def acall(self, *args: Any, **kwargs: Any) -> ToolOutput:
         """Async Call."""
-        all_kwargs = {**self._field_defaults, **self.partial_params, **kwargs}
+        all_kwargs = {**self._defaults_for_call(args), **self.partial_params, **kwargs}
         if self.requires_context and self.ctx_param_name is not None:
             if self.ctx_param_name not in all_kwargs:
                 raise ValueError("Context is required for this tool")

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -603,3 +603,78 @@ def test_function_tool_output_document_and_text_blocks() -> None:
     assert isinstance(tool_output.blocks[0], DocumentBlock)
     assert isinstance(tool_output.blocks[1], TextBlock)
     assert tool_output.content == "Summary of the document"
+
+
+def test_field_default_factory_runs_per_call_not_per_tool() -> None:
+    """pydantic's contract is that default_factory is evaluated per use.
+
+    The defaults were materialized once in __init__, so every call reused a
+    single value — ids/timestamps froze for the life of the process.
+    """
+    from uuid import uuid4
+
+    def start_job(
+        name: str, job_id: str = Field(default_factory=lambda: uuid4().hex)
+    ) -> str:
+        return job_id
+
+    tool = FunctionTool.from_defaults(fn=start_job)
+    ids = {str(tool.call(name=n).raw_output) for n in ("a", "b", "c")}
+    assert len(ids) == 3
+
+
+@pytest.mark.asyncio
+async def test_field_default_factory_runs_per_call_async() -> None:
+    """acall shares the same default resolution as call."""
+    from uuid import uuid4
+
+    def start_job(
+        name: str, job_id: str = Field(default_factory=lambda: uuid4().hex)
+    ) -> str:
+        return job_id
+
+    tool = FunctionTool.from_defaults(fn=start_job)
+    first = str((await tool.acall(name="a")).raw_output)
+    second = str((await tool.acall(name="b")).raw_output)
+    assert first != second
+
+
+def test_mutable_field_default_is_not_shared_between_calls() -> None:
+    """A default_factory=list must hand each call its own container.
+
+    Previously one list was built at construction and reused, so a tool that
+    appended to it accumulated state across unrelated calls.
+    """
+
+    def collect(item: str, acc: List[str] = Field(default_factory=list)) -> List[str]:
+        acc.append(item)
+        return acc
+
+    tool = FunctionTool.from_defaults(fn=collect)
+    assert tool.call(item="apple").raw_output == ["apple"]
+    assert tool.call(item="pear").raw_output == ["pear"]
+
+
+def test_field_default_does_not_break_positional_calls() -> None:
+    """A Field-defaulted param passed positionally must not also arrive as a
+    keyword — that raised TypeError: got multiple values for argument.
+    """
+
+    def greet(name: str, greeting: str = Field(default="hi")) -> str:
+        return f"{greeting} {name}"
+
+    tool = FunctionTool.from_defaults(fn=greet)
+    assert tool.call("bob").content == "hi bob"
+    assert tool.call("bob", "yo").content == "yo bob"
+    assert tool.call("bob", greeting="hey").content == "hey bob"
+
+
+def test_plain_field_default_still_applied() -> None:
+    """Regression guard for the original Field(default=...) behavior."""
+
+    def get_weather(location: Optional[str] = Field(default="Berlin")) -> str:
+        return f"weather in {location}"
+
+    tool = FunctionTool.from_defaults(get_weather)
+    assert tool.call().content == "weather in Berlin"
+    assert tool.call(location="Munich").content == "weather in Munich"


### PR DESCRIPTION
## Description

`FunctionTool.__init__` materializes every `FieldInfo` default up front:

```python
self._field_defaults[param.name] = param.default.get_default(call_default_factory=True)
```

`call_default_factory=True` **invokes** the factory — once, at tool-construction time. `call()`/`acall()` then splat that frozen dict into every invocation. Pydantic's contract is that `default_factory` runs *per use*, precisely so fresh/mutable values aren't shared; here it runs per *tool*.

Three consequences, all verified:

**1. Factories freeze to one value for the life of the process.**

```python
def start_job(name: str, job_id: str = Field(default_factory=lambda: uuid4().hex)) -> str:
    return job_id
```
```
call 1 : a -> ef2d3849a9554b7e9a9d2517e94bde81
call 2 : b -> ef2d3849a9554b7e9a9d2517e94bde81
acall 3: c -> ef2d3849a9554b7e9a9d2517e94bde81
distinct job_ids across 3 calls: 1 (expected 3)
```
Request ids, timestamps and nonces silently collapse to a single value.

**2. Mutable defaults are shared, so state leaks between unrelated calls.**

```python
def collect(item: str, acc: list = Field(default_factory=list)) -> list:
    acc.append(item); return acc
```
```
call 1: ['apple']
call 2: ['apple', 'pear']
call 3: ['apple', 'pear', 'fig']
```
The same dict backs both `call` and `acall`, and the tool object is typically shared across agent sessions in a process.

**3. Positional calls raise.** Because the defaults are splatted as keywords:

```
tool.call("bob", "yo")  ->  TypeError: greet() got multiple values for argument 'greeting'
# (one positional arg is fine: tool.call("bob") returns "hi bob")
```

## Fix

Keep the `FieldInfo` rather than a materialized value and resolve defaults per call, dropping any parameter that arrived positionally. `_field_defaults` is preserved as a property (same name, now re-resolved on access) so anything reading it keeps working.

This is a regression from #20839, which added `_field_defaults` to make plain `Field(default=...)` work and didn't consider factories — plain defaults are unaffected here and still covered by `test_function_tool_field_default`.

## Testing

Five tests added to `tests/tools/test_base.py`. Verified they are genuinely red before the change — reverting only `function_tool.py` and re-running:

```
FAILED test_field_default_factory_runs_per_call_not_per_tool
FAILED test_field_default_factory_runs_per_call_async
FAILED test_mutable_field_default_is_not_shared_between_calls
FAILED test_field_default_does_not_break_positional_calls
4 failed
```
and green with it (`4 passed`). The fifth is a regression guard on the original `Field(default=...)` behavior.

`tests/tools/`: **68 passed, 4 skipped**.

