### PR TITLE
fix(core): default CohereRerankRelevancyMetric to a live model

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -437,7 +437,7 @@ class CohereRerankRelevancyMetric(BaseRetrievalMetric):
 
     def __init__(
         self,
-        model: str = "rerank-english-v2.0",
+        model: str = "rerank-v3.5",
         api_key: Optional[str] = None,
     ):
         try:

--- a/llama-index-core/tests/evaluation/test_metrics.py
+++ b/llama-index-core/tests/evaluation/test_metrics.py
@@ -1,8 +1,10 @@
+import inspect
 from math import log2
 
 import pytest
 from llama_index.core.evaluation.retrieval.metrics import (
     AveragePrecision,
+    CohereRerankRelevancyMetric,
     HitRate,
     MRR,
     NDCG,
@@ -245,3 +247,16 @@ def test_exceptions(expected_ids, retrieved_ids, use_granular):
     with pytest.raises(ValueError):
         ndcg = NDCG()
         ndcg.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+
+
+# Cohere shut these down on 2025-04-30, so a default pointing at either one
+# makes CohereRerankRelevancyMetric() fail on every request.
+SHUT_DOWN_COHERE_RERANK_MODELS = {"rerank-english-v2.0", "rerank-multilingual-v2.0"}
+
+
+def test_cohere_rerank_relevancy_default_model_is_not_shut_down():
+    # Read the default off the signature so the test needs neither the cohere
+    # package nor an API key, both of which the constructor requires.
+    default = inspect.signature(CohereRerankRelevancyMetric).parameters["model"].default
+    assert default not in SHUT_DOWN_COHERE_RERANK_MODELS
+    assert default == "rerank-v3.5"


### PR DESCRIPTION

Fixes #22693

`CohereRerankRelevancyMetric` defaulted to `rerank-english-v2.0`, which Cohere shut down on 2025-04-30, so retrieval evaluation using the default fails.

https://docs.cohere.com/docs/deprecations

| model | shut down | replacement |
|---|---|---|
| `rerank-english-v2.0` | 2025-04-30 | `rerank-v3.5` |

The integrations copy at `llama-index-postprocessor-cohere-rerank/.../base.py:67` was already moved to `rerank-english-v3.0`, so this is the core copy catching up. Used `rerank-v3.5` since that is the replacement Cohere names.
