### PR TITLE
fix(missing_documentation): Def `run_coro_in_thread` in llama-index-core/llama_index/cor

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -52,6 +52,25 @@ def asyncio_run(coro: Coroutine) -> Any:
             ctx = contextvars.copy_context()
 
             def run_coro_in_thread() -> Any:
+                """Run *coro* in a brand-new event loop on the current thread.
+
+                Creates a fresh :class:`asyncio.AbstractEventLoop`, installs it
+                as the running loop for this thread, executes *coro* to
+                completion while propagating the caller's
+                :mod:`contextvars` context, then closes the loop.
+
+                Returns:
+                    Any: The value returned by *coro*.
+
+                Example:
+                    >>> import asyncio
+                    >>> async def _add(x: int, y: int) -> int:
+                    ...     return x + y
+                    >>> # asyncio_run() calls run_coro_in_thread() internally
+                    >>> # when an event loop is already running:
+                    >>> result = asyncio_run(_add(1, 2))
+                    >>> assert result == 3
+                """
                 new_loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(new_loop)
                 try:


### PR DESCRIPTION
## TLDR

**Gap:** Def `run_coro_in_thread` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example [BLOCKED:Verify rejected: The docstring example redefines `run_coro_in_thread` inside itself, which is confusing and would shadow the function it's supposed to

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L54

## Changes

- `llama-index-core/llama_index/core/async_utils.py`

**Diff size:** 19 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>