### PR TITLE
fix(missing_documentation): Def `get_asyncio_module` in llama-index-core/llama_index/cor

### DIFF
--- a/llama-index-core/llama_index/core/async_utils.py
+++ b/llama-index-core/llama_index/core/async_utils.py
@@ -12,6 +12,36 @@ dispatcher = instrument.get_dispatcher(__name__)
 
 
 def get_asyncio_module(show_progress: bool = False) -> Any:
+    """Return the appropriate asyncio-compatible module based on progress display preference.
+
+    When ``show_progress`` is ``True`` the function returns
+    :class:`tqdm.asyncio.tqdm_asyncio`, which wraps standard asyncio gather
+    calls with a ``tqdm`` progress bar.  Otherwise the built-in
+    :mod:`asyncio` module is returned unchanged.
+
+    Args:
+        show_progress (bool):
+            If ``True``, return ``tqdm.asyncio.tqdm_asyncio`` so that callers
+            can display a progress bar while awaiting coroutines.
+            Defaults to ``False``.
+
+    Returns:
+        Any:
+            Either ``tqdm.asyncio.tqdm_asyncio`` (when *show_progress* is
+            ``True``) or the standard :mod:`asyncio` module.
+
+    Example:
+        >>> import asyncio
+        >>> module = get_asyncio_module(show_progress=False)
+        >>> module is asyncio
+        True
+
+        >>> # With progress bar enabled (requires tqdm):
+        >>> # module = get_asyncio_module(show_progress=True)
+        >>> # from tqdm.asyncio import tqdm_asyncio
+        >>> # module is tqdm_asyncio  # True
+
+    """
     if show_progress:
         from tqdm.asyncio import tqdm_asyncio
 


### PR DESCRIPTION
## TLDR

**Gap:** Def `get_asyncio_module` in llama-index-core/llama_index/core/async_utils.py has no docstring — add parameter docs, return type, and example

**Wedge type:** `missing_documentation`

**Issue:** https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/async_utils.py#L14

## Changes

- `llama-index-core/llama_index/core/async_utils.py`

**Diff size:** 30 lines across 1 file(s)

## Pre-submission checklist

- [x] Minimal change — touches at most 3 files
- [x] Tests updated (if test suite present)
- [x] No CI/CD, Dockerfile, or lock file modifications
- [x] Diff reviewed for secrets

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>