### PR TITLE
fix(llama-dev): disable nltk import-security hook in package test runs

### DIFF
--- a/llama-dev/llama_dev/test/__init__.py
+++ b/llama-dev/llama_dev/test/__init__.py
@@ -412,12 +412,19 @@ def _pytest(
     if cov:
         pytest_cmd += ["--cov=.", "--cov-report=xml"]
 
+    # nltk >=3.10.1 installs an import-time security hook (nltk/inisec.py)
+    # that blocks imports resolving inside the CWD subtree. The per-package
+    # virtualenv lives at <package>/.venv, so site-packages sits inside the
+    # CWD and every nltk-importing package fails at collection with
+    # "Blocked import of regex from current working directory". PYTHONSAFEPATH
+    # does not help (the hook checks path geometry, not sys.path entries);
+    # nltk's own escape hatch is this environment variable.
     return subprocess.run(
         pytest_cmd,
         cwd=package_path,
         text=True,
         capture_output=True,
-        env=env,
+        env={**env, "NLTK_DISABLE_IMPORT_SECURITY": "1"},
         timeout=300,  # 5 minute timeout per package
     )
 

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -129,6 +130,16 @@ def test_workers_parameter(
     runner = CliRunner()
     runner.invoke(cli, ["test", "--base-ref", "main", "--workers", "16"])
     mock_pool.assert_called_once_with(max_workers=16)
+
+
+@mock.patch("llama_dev.test.subprocess.run")
+def test_pytest_disables_nltk_import_security(mock_run):
+    """nltk's inisec hook false-positives on venvs inside the package cwd."""
+    mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+    _pytest(Path("/fake/package"), {"PATH": "/bin"}, cov=False)
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["NLTK_DISABLE_IMPORT_SECURITY"] == "1"
+    assert kwargs["env"]["PATH"] == "/bin"
 
 
 @mock.patch("llama_dev.test.find_all_packages")

--- a/llama-dev/tests/test/test_test.py
+++ b/llama-dev/tests/test/test_test.py
@@ -134,7 +134,7 @@ def test_workers_parameter(
 
 @mock.patch("llama_dev.test.subprocess.run")
 def test_pytest_disables_nltk_import_security(mock_run):
-    """nltk's inisec hook false-positives on venvs inside the package cwd."""
+    """The nltk inisec hook false-positives on venvs inside the package cwd."""
     mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
     _pytest(Path("/fake/package"), {"PATH": "/bin"}, cov=False)
     _, kwargs = mock_run.call_args


### PR DESCRIPTION
# Description

The unit-test matrix fails at collection for any package that imports nltk with this error:

    nltk/inisec.py:128: in find_spec
        raise ImportError(
    ImportError: Blocked import of regex from current working directory for security reasons. Use '-P' or set PYTHONSAFEPATH to prevent Python from searching the current working directory.

Root cause: nltk 3.10.1+ installs an import-time security hook (nltk/inisec.py, CWE-427 mitigation) that blocks imports whose resolved location falls inside the CWD subtree. llama-dev runs each package's pytest with cwd=<package> and keeps the virtualenv at <package>/.venv, so site-packages sits inside the CWD. When a package imports nltk, nltk imports regex, which resolves inside the CWD subtree, and the hook blocks it.

I reproduced this locally: a virtualenv inside the package directory with nltk 3.10.1 fails on a plain "import nltk", and PYTHONSAFEPATH=1 does not help, because the hook compares path geometry rather than sys.path entries. NLTK_DISABLE_IMPORT_SECURITY=1, the escape hatch nltk ships for exactly this situation, restores the import.

This PR sets that variable only for the pytest subprocess in llama-dev, so the guard stays active everywhere else.

Alternatives considered: relocating each package venv outside the package directory (UV_PROJECT_ENVIRONMENT) keeps the hook intact but invalidates every CI cache and changes local developer workflows; pinning nltk does not help because the hook lives in the nltk line that will eventually land in these lockfiles anyway.

# Test Plan

New regression test test_pytest_disables_nltk_import_security asserts the pytest subprocess receives NLTK_DISABLE_IMPORT_SECURITY=1 while preserving the rest of the environment. llama-dev's suite passes locally except five pre-existing failures that also occur on a clean main checkout (test_coverage_failures, test_install_failures, test_skip_failures_no_tests, test_skip_failures_unsupported_python, test_success).
