### PR TITLE
fix(core): build the VectorMemoryBlock session filter per call instead of mutating query_kwargs

### DIFF
--- a/llama-index-core/llama_index/core/memory/memory_blocks/vector.py
+++ b/llama-index-core/llama_index/core/memory/memory_blocks/vector.py
@@ -120,25 +120,28 @@ class VectorMemoryBlock(BaseMemoryBlock[str]):
         if not query_text:
             return ""
 
-        # Handle filtering by session_id
+        # Handle filtering by session_id.
+        # The session filter is built per call: the same block instance can be
+        # shared by memories with different session ids, so it must never be
+        # written back into self.query_kwargs (nor into a caller-owned
+        # MetadataFilters), or the first session's id would be reused forever.
+        query_kwargs = {**self.query_kwargs}
         if session_id is not None:
             filter = MetadataFilter(key="session_id", value=session_id)
-            if "filters" in self.query_kwargs and isinstance(
-                self.query_kwargs["filters"], MetadataFilters
-            ):
+            existing_filters = query_kwargs.get("filters")
+            if isinstance(existing_filters, MetadataFilters):
                 # only add session_id filter if it does not exist in the filters list
-                session_id_filter_exists = False
-                for metadata_filter in self.query_kwargs["filters"].filters:
-                    if (
-                        isinstance(metadata_filter, MetadataFilter)
-                        and metadata_filter.key == "session_id"
-                    ):
-                        session_id_filter_exists = True
-                        break
+                session_id_filter_exists = any(
+                    isinstance(metadata_filter, MetadataFilter)
+                    and metadata_filter.key == "session_id"
+                    for metadata_filter in existing_filters.filters
+                )
                 if not session_id_filter_exists:
-                    self.query_kwargs["filters"].filters.append(filter)
+                    query_kwargs["filters"] = existing_filters.model_copy(
+                        update={"filters": [*existing_filters.filters, filter]}
+                    )
             else:
-                self.query_kwargs["filters"] = MetadataFilters(filters=[filter])
+                query_kwargs["filters"] = MetadataFilters(filters=[filter])
 
         # Create and execute the query
         query_embedding = await self.embed_model.aget_query_embedding(query_text)
@@ -146,7 +149,7 @@ class VectorMemoryBlock(BaseMemoryBlock[str]):
             query_str=query_text,
             query_embedding=query_embedding,
             similarity_top_k=self.similarity_top_k,
-            **self.query_kwargs,
+            **query_kwargs,
         )
 
         results = await self.vector_store.aquery(query)
@@ -180,12 +183,18 @@ class VectorMemoryBlock(BaseMemoryBlock[str]):
             if not text:
                 continue
 
-            # special case for session_id
-            if "session_id" in message.additional_kwargs:
-                session_id = message.additional_kwargs.pop("session_id")
+            # special case for session_id: it is stored as node metadata rather
+            # than embedded in the text, but read it without mutating the
+            # caller's message
+            additional_kwargs = {
+                key: value
+                for key, value in message.additional_kwargs.items()
+                if key != "session_id"
+            }
+            session_id = message.additional_kwargs.get("session_id", session_id)
 
-            if message.additional_kwargs:
-                text += f"\nAdditional Info: ({message.additional_kwargs!s})"
+            if additional_kwargs:
+                text += f"\nAdditional Info: ({additional_kwargs!s})"
 
             text = f"<message role='{message.role.value}'>{text}</message>"
             texts.append(text)

--- a/llama-index-core/tests/memory/blocks/test_vector.py
+++ b/llama-index-core/tests/memory/blocks/test_vector.py
@@ -9,6 +9,8 @@ from llama_index.core.prompts import RichPromptTemplate
 from llama_index.core.schema import BaseNode, TextNode, NodeWithScore
 from llama_index.core.vector_stores.types import (
     BasePydanticVectorStore,
+    MetadataFilter,
+    MetadataFilters,
     VectorStoreQuery,
     VectorStoreQueryResult,
 )
@@ -23,6 +25,7 @@ class MockVectorStore(BasePydanticVectorStore):
     def __init__(self):
         super().__init__()
         self._nodes = {}
+        self._queries = []
 
     @property
     def client(self) -> Any:
@@ -31,6 +34,11 @@ class MockVectorStore(BasePydanticVectorStore):
     @property
     def nodes(self) -> Dict[str, BaseNode]:
         return self._nodes
+
+    @property
+    def queries(self) -> List[VectorStoreQuery]:
+        """Queries received by this store, in order."""
+        return self._queries
 
     def add(self, nodes: Sequence[BaseNode], **kwargs: Any) -> List[str]:
         """Add nodes to vector store."""
@@ -52,6 +60,8 @@ class MockVectorStore(BasePydanticVectorStore):
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
         """Query vector store."""
+        self._queries.append(query)
+
         # For simplicity, return all nodes
         nodes = list(self._nodes.values())
         if query.similarity_top_k and len(nodes) > query.similarity_top_k:
@@ -285,3 +295,97 @@ async def test_format_template(
     # Check that the result contains our custom prefix
     assert result.startswith("Relevant context:")
     assert "capital of France is Paris" in result
+
+
+def _session_filters(query: VectorStoreQuery) -> List[str]:
+    """Get the values of every session_id filter attached to a query."""
+    if query.filters is None:
+        return []
+    return [
+        metadata_filter.value
+        for metadata_filter in query.filters.filters
+        if isinstance(metadata_filter, MetadataFilter)
+        and metadata_filter.key == "session_id"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_id_filter_is_per_call(vector_memory_block: VectorMemoryBlock):
+    """A block shared across sessions must filter on the session id of each call."""
+    messages = [ChatMessage(role="user", content="Tell me about Paris.")]
+
+    await vector_memory_block.aget(messages=messages, session_id="session-a")
+    await vector_memory_block.aget(messages=messages, session_id="session-b")
+
+    queries = vector_memory_block.vector_store.queries
+    assert len(queries) == 2
+    assert _session_filters(queries[0]) == ["session-a"]
+    assert _session_filters(queries[1]) == ["session-b"]
+
+    # the session filter must not be persisted on the block itself
+    assert "filters" not in vector_memory_block.query_kwargs
+
+
+@pytest.mark.asyncio
+async def test_session_id_filter_does_not_mutate_query_kwargs(
+    mock_vector_store: MockVectorStore, mock_embedding: MockEmbedding
+):
+    """User-supplied filters are left untouched when the session filter is added."""
+    user_filters = MetadataFilters(filters=[MetadataFilter(key="topic", value="paris")])
+    memory_block = VectorMemoryBlock(
+        vector_store=mock_vector_store,
+        embed_model=mock_embedding,
+        query_kwargs={"filters": user_filters},
+    )
+
+    messages = [ChatMessage(role="user", content="Tell me about Paris.")]
+    await memory_block.aget(messages=messages, session_id="session-a")
+
+    # the query carries both the user filter and the session filter
+    query_filters = mock_vector_store.queries[0].filters
+    assert [(f.key, f.value) for f in query_filters.filters] == [
+        ("topic", "paris"),
+        ("session_id", "session-a"),
+    ]
+
+    # but the caller's MetadataFilters object is unchanged
+    assert [(f.key, f.value) for f in user_filters.filters] == [("topic", "paris")]
+    assert memory_block.query_kwargs["filters"] is user_filters
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_id_filter_is_not_overridden(
+    mock_vector_store: MockVectorStore, mock_embedding: MockEmbedding
+):
+    """An explicitly configured session_id filter takes precedence."""
+    memory_block = VectorMemoryBlock(
+        vector_store=mock_vector_store,
+        embed_model=mock_embedding,
+        query_kwargs={
+            "filters": MetadataFilters(
+                filters=[MetadataFilter(key="session_id", value="pinned")]
+            )
+        },
+    )
+
+    messages = [ChatMessage(role="user", content="Tell me about Paris.")]
+    await memory_block.aget(messages=messages, session_id="session-a")
+
+    assert _session_filters(mock_vector_store.queries[0]) == ["pinned"]
+
+
+@pytest.mark.asyncio
+async def test_put_does_not_mutate_message_additional_kwargs(
+    vector_memory_block: VectorMemoryBlock,
+):
+    """Putting messages must not strip session_id from the caller's messages."""
+    message = ChatMessage(role="user", content="Hello!")
+
+    await vector_memory_block.aput(messages=[message], session_id="session-a")
+
+    assert message.additional_kwargs["session_id"] == "session-a"
+
+    # session_id is stored as node metadata, not embedded in the node text
+    node = next(iter(vector_memory_block.vector_store.nodes.values()))
+    assert node.metadata["session_id"] == "session-a"
+    assert "Additional Info" not in node.text


### PR DESCRIPTION
## Description

`VectorMemoryBlock._aget()` built the `session_id` metadata filter by mutating `self.query_kwargs`. Since `Memory` calls `memory_block.aget(..., session_id=self.session_id)` on every retrieval, the first session id a block instance ever saw was written into `self.query_kwargs["filters"]` — and the "only add if it does not already exist" guard from #19427 then prevented it from ever being updated.

A `VectorMemoryBlock` shared across sessions therefore kept filtering on the first session's id: session B retrieved session A's messages and none of its own, defeating the multi-tenant filtering added in #18730. Passing your own `MetadataFilters` via `query_kwargs` was also mutated in place.

This builds the filter per call instead:

- `_aget()` works on a shallow copy of `query_kwargs`, and extends caller-supplied `MetadataFilters` with `model_copy(update=...)` rather than appending to the caller's list. Nothing is written back to the block or to the caller's object.
- An explicitly configured `session_id` filter still takes precedence, so the behavior #19427 intended is preserved.
- `_aput()` reads `session_id` from `message.additional_kwargs` instead of `pop()`-ing it, so storing messages no longer strips the key off the caller's live `ChatMessage` objects. `session_id` is still kept out of the embedded `Additional Info` text and still stored as node metadata.

Fixes #22701

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four tests in `llama-index-core/tests/memory/blocks/test_vector.py`, with the mock vector store now recording the queries it receives:

- `test_session_id_filter_is_per_call` — two `aget()` calls on one block with different session ids produce filters for `session-a` then `session-b`, and nothing is persisted onto the block.
- `test_session_id_filter_does_not_mutate_query_kwargs` — the query carries both the user filter and the session filter, while the caller's `MetadataFilters` object is unchanged.
- `test_explicit_session_id_filter_is_not_overridden` — a `session_id` filter configured in `query_kwargs` still wins (guards the #19427 behavior).
- `test_put_does_not_mutate_message_additional_kwargs` — `aput()` leaves `session_id` on the caller's message and still records it as node metadata without embedding it in the text.

The first three fail on `main` and pass with this change; the fourth documents behavior that must not regress.

```
$ uv run -- pytest tests/memory/ -q
85 passed
```

`uv run make lint` passes (ruff, ruff-format, mypy, codespell).

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
