### PR TITLE
fix(core): FunctionTool.call() returns an un-awaited coroutine as a successful result when fn and async_fn are both async

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -93,7 +93,15 @@ class FunctionTool(AsyncBaseTool):
         self._real_fn = fn or async_fn
         if async_fn is not None:
             self._async_fn = async_fn
-            self._fn = fn or async_to_sync(async_fn)
+            if fn is None:
+                self._fn = async_to_sync(async_fn)
+            elif inspect.iscoroutinefunction(fn):
+                # A coroutine function in the sync slot has to be driven to
+                # completion; calling it directly only builds a coroutine
+                # object, which call() would hand back as a successful result.
+                self._fn = async_to_sync(fn)
+            else:
+                self._fn = fn
         else:
             assert fn is not None
             if inspect.iscoroutinefunction(fn):

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -2,12 +2,13 @@
 
 import contextvars
 import json
-from typing import List, Optional
+from typing import Coroutine, List, Optional
 
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import TextBlock, ImageBlock, DocumentBlock, VideoBlock
 from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
 from llama_index.core.schema import Document, TextNode
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow import Context
@@ -603,3 +604,66 @@ def test_function_tool_output_document_and_text_blocks() -> None:
     assert isinstance(tool_output.blocks[0], DocumentBlock)
     assert isinstance(tool_output.blocks[1], TextBlock)
     assert tool_output.content == "Summary of the document"
+
+
+def test_async_fn_in_both_slots_does_not_return_a_coroutine() -> None:
+    """A coroutine function passed as `fn` alongside `async_fn` was called
+    without being awaited, so `call()` reported success and handed the LLM
+    '<coroutine object ...>' as the tool's content.
+    """
+
+    async def get_weather(city: str) -> str:
+        return f"It is sunny in {city}"
+
+    tool = FunctionTool.from_defaults(fn=get_weather, async_fn=get_weather)
+    output = tool.call(city="Paris")
+
+    assert output.is_error is False
+    assert output.content == "It is sunny in Paris"
+    assert not isinstance(output.raw_output, Coroutine)
+
+
+def test_tool_spec_tuple_form_with_async_method_is_awaited() -> None:
+    """BaseToolSpec's ("sync_name", "async_name") form passes the first entry
+    as `fn` with no coroutine check, so an async method reached the same bug
+    without anyone calling from_defaults directly.
+    """
+
+    class WeatherSpec(BaseToolSpec):
+        spec_functions = [("get_weather", "get_weather")]
+
+        async def get_weather(self, city: str) -> str:
+            return f"It is sunny in {city}"
+
+    tool = WeatherSpec().to_tool_list()[0]
+    assert tool.call(city="Paris").content == "It is sunny in Paris"
+
+
+@pytest.mark.asyncio
+async def test_async_fn_in_both_slots_acall_unchanged() -> None:
+    """The async path was always correct and must stay that way."""
+
+    async def get_weather(city: str) -> str:
+        return f"It is sunny in {city}"
+
+    tool = FunctionTool.from_defaults(fn=get_weather, async_fn=get_weather)
+    assert (await tool.acall(city="Paris")).content == "It is sunny in Paris"
+
+
+def test_sync_fn_with_async_fn_still_uses_sync_fn() -> None:
+    """When `fn` really is synchronous it must still be used verbatim for
+    call(), not routed through the event loop.
+    """
+    calls: List[str] = []
+
+    def sync_impl(city: str) -> str:
+        calls.append("sync")
+        return f"sync {city}"
+
+    async def async_impl(city: str) -> str:
+        calls.append("async")
+        return f"async {city}"
+
+    tool = FunctionTool.from_defaults(fn=sync_impl, async_fn=async_impl)
+    assert tool.call(city="Paris").content == "sync Paris"
+    assert calls == ["sync"]


### PR DESCRIPTION
## Description

`FunctionTool.__init__` only unwraps a coroutine `fn` on the branch where `async_fn` is absent:

```python
if async_fn is not None:
    self._async_fn = async_fn
    self._fn = fn or async_to_sync(async_fn)   # <- no iscoroutinefunction(fn) check
else:
    ...
    if inspect.iscoroutinefunction(fn):
        self._fn = async_to_sync(fn)
```

So when **both** arguments are given and `fn` happens to be async, `self._fn` stays the raw coroutine function. `call()` does `raw_output = self._fn(...)`, which merely *creates* a coroutine object — the function body never runs.

Nothing catches it. `_parse_tool_output` falls through to `TextBlock(text=str(raw_output))`, so the tool reports **success** and the LLM receives:

```
is_error : False
content  : '<coroutine object get_weather at 0x107a55540>'
```

A silent wrong answer presented as a correct one is the worst shape for this failure — the agent has no way to know. The `RuntimeWarning: coroutine ... was never awaited` arrives later from the GC, detached from the call site, and a user-supplied `callback` can't compensate because it is handed the same coroutine object.

**Reachable without writing `from_defaults` by hand.** `BaseToolSpec.to_tool_list()` supports the tuple spec form `("sync_name", "async_name")` and passes `fn=getattr(self, spec[0])` with no coroutine check, so an async method in the first slot hits this directly:

```python
class WeatherSpec(BaseToolSpec):
    spec_functions = [("get_weather", "get_weather")]
    async def get_weather(self, city: str) -> str: ...

WeatherSpec().to_tool_list()[0].call(city="Paris")
# before: '<coroutine object WeatherSpec.get_weather at 0x10b7b56c0>'
# after:  'It is sunny in Paris'
```

Each argument **alone** already worked (`fn=` only and `async_fn=` only both return the real value) — only the combination was broken.

## Fix

In the `async_fn is not None` branch, route a coroutine `fn` through `async_to_sync` the same way the other branch already does. A genuinely synchronous `fn` is still used verbatim.

## Testing

Four tests added to `tests/tools/test_base.py`. Verified genuinely red before the change by reverting only `function_tool.py`:

```
FAILED test_async_fn_in_both_slots_does_not_return_a_coroutine
FAILED test_tool_spec_tuple_form_with_async_method_is_awaited
2 failed, 2 passed
```

and `4 passed` with it. The two that pass either way are deliberate regression guards: `acall` was always correct and must stay so, and a sync `fn` must still be called directly rather than routed through the event loop.

`tests/tools/`: **67 passed, 4 skipped**.

Independent of my #22688 (same file, different lines) — I verified the two branches merge cleanly.
