### PR TITLE
fix(core): delete every dropped document in UPSERTS_AND_DELETE, not just one per content hash

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -493,10 +493,11 @@ class IngestionPipeline(BaseModel):
                 continue  # document exists and is unchanged, so skip it
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
-            # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                self.docstore.get_all_document_hashes().values()
-            )
+            # Identify missing docs and delete them from docstore and vector store.
+            # Read the ids directly: get_all_document_hashes() is keyed by hash,
+            # so documents sharing identical content collapse onto one entry and
+            # the ones that dropped out would never be deleted.
+            existing_doc_ids_before = self.docstore.get_all_document_ids()
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:
                 self.docstore.delete_document(ref_doc_id)
@@ -729,10 +730,11 @@ class IngestionPipeline(BaseModel):
                 continue  # document exists and is unchanged, so skip it
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
-            # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                (await self.docstore.aget_all_document_hashes()).values()
-            )
+            # Identify missing docs and delete them from docstore and vector store.
+            # Read the ids directly: get_all_document_hashes() is keyed by hash,
+            # so documents sharing identical content collapse onto one entry and
+            # the ones that dropped out would never be deleted.
+            existing_doc_ids_before = await self.docstore.aget_all_document_ids()
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:
                 await self.docstore.adelete_document(ref_doc_id)

--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -1,7 +1,7 @@
 """Document store."""
 
 import asyncio
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.storage.docstore.types import BaseDocumentStore, RefDocInfo
@@ -666,4 +666,30 @@ class KVDocumentStore(BaseDocumentStore):
                 await self._kvstore.aget_all(collection=self._metadata_collection)
             ).items()
             if (doc_hash := doc.get("doc_hash"))
+        }
+
+    def get_all_document_ids(self) -> Set[str]:
+        """
+        Get the ids of all documents that have a stored hash.
+
+        Read straight off the metadata collection so that documents sharing
+        identical content -- and therefore an identical hash -- each keep their
+        own id, which the hash-keyed mapping cannot express.
+        """
+        return {
+            doc_id
+            for doc_id, doc in (
+                self._kvstore.get_all(collection=self._metadata_collection)
+            ).items()
+            if doc.get("doc_hash")
+        }
+
+    async def aget_all_document_ids(self) -> Set[str]:
+        """Async version of ``get_all_document_ids``."""
+        return {
+            doc_id
+            for doc_id, doc in (
+                await self._kvstore.aget_all(collection=self._metadata_collection)
+            ).items()
+            if doc.get("doc_hash")
         }

--- a/llama-index-core/llama_index/core/storage/docstore/types.py
+++ b/llama-index-core/llama_index/core/storage/docstore/types.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Sequence, overload
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, overload
 
 import fsspec
 from dataclasses_json import DataClassJsonMixin
@@ -103,6 +103,21 @@ class BaseDocumentStore(ABC):
 
     @abstractmethod
     async def aget_all_document_hashes(self) -> Dict[str, str]: ...
+
+    def get_all_document_ids(self) -> Set[str]:
+        """
+        Get the ids of all documents that have a stored hash.
+
+        Prefer this over ``get_all_document_hashes()`` when the doc ids are what
+        is needed: that mapping is keyed by hash, so documents sharing identical
+        content collapse onto a single entry and all but one of their ids are
+        lost.
+        """
+        return set(self.docs.keys())
+
+    async def aget_all_document_ids(self) -> Set[str]:
+        """Async version of ``get_all_document_ids``."""
+        return self.get_all_document_ids()
 
     # ==== Ref Docs =====
     @abstractmethod

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -665,3 +665,52 @@ async def test_docstore_strategy_not_mutated_on_arun_without_vector_store() -> N
             await pipeline.arun(documents=[Document.example()])
 
         assert pipeline.docstore_strategy is strategy
+
+
+def _upserts_and_delete_pipeline() -> IngestionPipeline:
+    return IngestionPipeline(
+        transformations=[SentenceSplitter(chunk_size=512), MockEmbedding(embed_dim=8)],
+        docstore=SimpleDocumentStore(),
+        vector_store=SimpleVectorStore(),
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+
+
+def test_upserts_and_delete_removes_docs_sharing_a_hash() -> None:
+    """Docs with identical content must each be deleted once they drop out."""
+    pipeline = _upserts_and_delete_pipeline()
+
+    # two distinct documents that happen to have identical content, and so
+    # identical hashes
+    pipeline.run(
+        documents=[
+            Document(id_="doc-a", text="shared boilerplate text"),
+            Document(id_="doc-b", text="shared boilerplate text"),
+        ]
+    )
+    assert set(pipeline.docstore.docs.keys()) == {"doc-a", "doc-b"}
+
+    # neither is supplied any more, so both must be removed
+    pipeline.run(documents=[Document(id_="doc-c", text="totally new content")])
+
+    assert set(pipeline.docstore.docs.keys()) == {"doc-c"}
+    assert len(pipeline.vector_store.data.embedding_dict) == 1
+
+
+@pytest.mark.asyncio
+async def test_aupserts_and_delete_removes_docs_sharing_a_hash() -> None:
+    """Async twin of test_upserts_and_delete_removes_docs_sharing_a_hash."""
+    pipeline = _upserts_and_delete_pipeline()
+
+    await pipeline.arun(
+        documents=[
+            Document(id_="doc-a", text="shared boilerplate text"),
+            Document(id_="doc-b", text="shared boilerplate text"),
+        ]
+    )
+    assert set(pipeline.docstore.docs.keys()) == {"doc-a", "doc-b"}
+
+    await pipeline.arun(documents=[Document(id_="doc-c", text="totally new content")])
+
+    assert set(pipeline.docstore.docs.keys()) == {"doc-c"}
+    assert len(pipeline.vector_store.data.embedding_dict) == 1

--- a/llama-index-core/tests/storage/docstore/test_simple_docstore.py
+++ b/llama-index-core/tests/storage/docstore/test_simple_docstore.py
@@ -152,3 +152,43 @@ def test_docstore_delete_all_ref_doc_nodes() -> None:
     assert docstore._kvstore.get("d1", docstore._node_collection) is None
     assert docstore._kvstore.get("d1", docstore._metadata_collection) is None
     assert docstore._kvstore.get("d1", docstore._ref_doc_collection) is None
+
+
+def test_get_all_document_ids_keeps_docs_sharing_a_hash() -> None:
+    """Identical content collapses the hash-keyed map, but not the id set."""
+    docstore = SimpleDocumentStore()
+    doc_a = Document(id_="doc-a", text="same content")
+    doc_b = Document(id_="doc-b", text="same content")
+    docstore.add_documents([doc_a, doc_b])
+
+    assert doc_a.hash == doc_b.hash
+    # the hash-keyed mapping can only represent one of them
+    assert len(docstore.get_all_document_hashes()) == 1
+
+    assert docstore.get_all_document_ids() == {"doc-a", "doc-b"}
+
+
+@pytest.mark.asyncio
+async def test_aget_all_document_ids_keeps_docs_sharing_a_hash() -> None:
+    """Async twin of test_get_all_document_ids_keeps_docs_sharing_a_hash."""
+    docstore = SimpleDocumentStore()
+    docstore.add_documents(
+        [
+            Document(id_="doc-a", text="same content"),
+            Document(id_="doc-b", text="same content"),
+        ]
+    )
+
+    assert len(await docstore.aget_all_document_hashes()) == 1
+    assert await docstore.aget_all_document_ids() == {"doc-a", "doc-b"}
+
+
+def test_get_all_document_ids_excludes_deleted_docs() -> None:
+    docstore = SimpleDocumentStore()
+    docstore.add_documents(
+        [Document(id_="doc-a", text="one"), Document(id_="doc-b", text="two")]
+    )
+    assert docstore.get_all_document_ids() == {"doc-a", "doc-b"}
+
+    docstore.delete_document("doc-a")
+    assert docstore.get_all_document_ids() == {"doc-b"}


### PR DESCRIPTION
# Description

`DocstoreStrategy.UPSERTS_AND_DELETE` silently failed to delete documents whenever two documents shared identical content.

`_handle_upserts()` derived "every doc currently in the docstore" from `get_all_document_hashes().values()`. That mapping is keyed by **hash**, so documents with identical content collapse onto one entry and all but one of their ids are lost. The lost ids never reached `doc_ids_to_delete`, so those documents stayed in the docstore *and* the vector store permanently and kept being retrieved after being removed from the source. `_ahandle_upserts()` had the same defect.

Identical content under distinct doc ids is common in practice — boilerplate pages, licence headers, the same file ingested under two paths.

The hash-keyed shape of `get_all_document_hashes()` is load-bearing elsewhere: `_handle_duplicates()` relies on hash-keyed lookups for content dedup, and #19362 deliberately made that a single KV round trip. So rather than change that public method's return shape, this adds a dedicated id accessor:

- `BaseDocumentStore.get_all_document_ids()` / `aget_all_document_ids()` — returns `Set[str]`. Concrete, not abstract, with a `set(self.docs.keys())` default so existing third-party subclasses keep working without changes.
- `KVDocumentStore` overrides both to read ids straight off the metadata collection, keeping the single-round-trip property #19362 introduced. Every docstore backend in this repo (azure, couchbase, duckdb, dynamodb, elasticsearch, firestore, gel, mongodb, postgres, redis, tablestore, simple) subclasses `KVDocumentStore`, so they all inherit the efficient version.
- `_handle_upserts()` / `_ahandle_upserts()` now use it.

No public method changes shape and no existing behavior changes, so this is not a breaking change.

Fixes #22706

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Five tests, all of which fail on `main` and pass with this change:

`tests/ingestion/test_pipeline.py`
- `test_upserts_and_delete_removes_docs_sharing_a_hash` — ingest two same-content docs, then a run containing neither; both must leave the docstore and the vector store.
- `test_aupserts_and_delete_removes_docs_sharing_a_hash` — async twin.

`tests/storage/docstore/test_simple_docstore.py`
- `test_get_all_document_ids_keeps_docs_sharing_a_hash` — asserts the hash map collapses to one entry while the id set keeps both.
- `test_aget_all_document_ids_keeps_docs_sharing_a_hash` — async twin.
- `test_get_all_document_ids_excludes_deleted_docs` — deleted docs drop out of the id set.

```
$ uv run -- pytest tests/ingestion tests/storage tests/indices -q
396 passed, 3 skipped
```

`uv run make lint` passes (ruff, ruff-format, mypy, codespell).

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
