### PR TITLE
fix(instrumentation): avoid mutable dispatcher defaults

### DIFF
--- a/llama-index-instrumentation/pyproject.toml
+++ b/llama-index-instrumentation/pyproject.toml
@@ -7,7 +7,7 @@ dev = ["pytest>=8.4.0", "pytest-asyncio>=1.0.0", "pytest-cov>=6.1.1"]
 
 [project]
 name = "llama-index-instrumentation"
-version = "0.5.0"
+version = "0.5.1"
 description = "Instrumentation and Observability for LlamaIndex"
 license = "MIT"
 readme = "README.md"

--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers if event_handlers is not None else [],
+            span_handlers=span_handlers if span_handlers is not None else [],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,

--- a/llama-index-instrumentation/tests/test_dispatcher.py
+++ b/llama-index-instrumentation/tests/test_dispatcher.py
@@ -35,6 +35,18 @@ value_error = ValueError("value error")
 cancelled_error = CancelledError("cancelled error")
 
 
+def test_dispatcher_handler_defaults_are_not_mutable() -> None:
+    signature = inspect.signature(Dispatcher.__init__)
+
+    assert signature.parameters["event_handlers"].default is None
+    assert signature.parameters["span_handlers"].default is None
+
+    first = Dispatcher()
+    second = Dispatcher()
+    assert first.event_handlers is not second.event_handlers
+    assert first.span_handlers is not second.span_handlers
+
+
 class _TestStartEvent(BaseEvent):
     @classmethod
     def class_name(cls):

--- a/llama-index-instrumentation/uv.lock
+++ b/llama-index-instrumentation/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-instrumentation"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "deprecated" },


### PR DESCRIPTION
Fixes #22705

## Summary

Replace the mutable list defaults in `Dispatcher.__init__` with `None`, then allocate fresh handler lists for each instance.

The public behavior is unchanged for callers that pass lists explicitly, while omitted handler arguments can no longer share mutable default objects.

The instrumentation package version is bumped from 0.5.0 to 0.5.1 and the lockfile is updated accordingly.

## Tests

- Added a regression test that checks the signature defaults and independent instance lists
- Focused regression: 1 passed
- Dispatcher suite excluding the pre-existing Windows timing-sensitive test: 33 passed
- Ruff check and format check pass
- `git diff --check` passes

The full dispatcher file has one unrelated timing assertion that remains flaky on this Windows machine (`test_aevent_concurrent_handlers`); it failed unchanged before and after this patch.

This contribution was prepared with AI assistance and manually reviewed.