### PR TITLE
fix: defer upsert deletes until the transformations succeed

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -10,7 +10,7 @@ from functools import partial
 from hashlib import sha256
 from itertools import repeat
 from pathlib import Path
-from typing import Any, Generator, List, Optional, Sequence, Union
+from typing import Any, Generator, List, Optional, Sequence, Tuple, Union
 
 from fsspec import AbstractFileSystem
 
@@ -470,41 +470,82 @@ class IngestionPipeline(BaseModel):
         self,
         nodes: Sequence[BaseNode],
     ) -> Sequence[BaseNode]:
-        """Handle docstore upserts by checking hashes and ids."""
+        """
+        Handle docstore upserts by checking hashes and ids.
+
+        Deletes eagerly. `run` uses `_plan_upserts` instead, so a failing
+        transformation cannot destroy the previous version.
+        """
+        nodes_to_run, ref_doc_ids_to_delete, doc_ids_to_delete = self._plan_upserts(
+            nodes
+        )
+        self._apply_upsert_deletes(ref_doc_ids_to_delete, doc_ids_to_delete)
+        return nodes_to_run
+
+    def _plan_upserts(
+        self,
+        nodes: Sequence[BaseNode],
+    ) -> Tuple[Sequence[BaseNode], List[str], List[str]]:
+        """
+        Find the nodes to run, plus the ref doc ids and doc ids they supersede.
+
+        Nothing is deleted here, so a failed transformation cannot lose the
+        previous version. See `_apply_upsert_deletes`.
+        """
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        ref_doc_ids_to_delete: List[str] = []
+        superseded: set[str] = set()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
+            if ref_doc_id in superseded:
+                # deleting used to happen here, so the lookup below missed and
+                # the node was kept; keep it, or sibling nodes get dropped
+                deduped_nodes_to_run.append(node)
+                continue
             existing_hash = self.docstore.get_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
+                ref_doc_ids_to_delete.append(ref_doc_id)
+                superseded.add(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
+        doc_ids_to_delete: List[str] = []
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
             existing_doc_ids_before = set(
                 self.docstore.get_all_document_hashes().values()
             )
-            doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                self.docstore.delete_document(ref_doc_id)
+            doc_ids_to_delete = list(existing_doc_ids_before - doc_ids_from_nodes)
 
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
+        return deduped_nodes_to_run, ref_doc_ids_to_delete, doc_ids_to_delete
 
-        return deduped_nodes_to_run
+    def _apply_upsert_deletes(
+        self,
+        ref_doc_ids_to_delete: Sequence[str],
+        doc_ids_to_delete: Sequence[str],
+    ) -> None:
+        """Remove data superseded by a successful run."""
+        assert self.docstore is not None
+
+        for ref_doc_id in ref_doc_ids_to_delete:
+            self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
+
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
+
+        for ref_doc_id in doc_ids_to_delete:
+            self.docstore.delete_document(ref_doc_id)
+
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
 
     @staticmethod
     def _node_batcher(
@@ -588,12 +629,18 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        ref_doc_ids_to_delete: List[str] = []
+        doc_ids_to_delete: List[str] = []
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = self._handle_upserts(input_nodes)
+                (
+                    nodes_to_run,
+                    ref_doc_ids_to_delete,
+                    doc_ids_to_delete,
+                ) = self._plan_upserts(input_nodes)
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
                 nodes_to_run = self._handle_duplicates(input_nodes)
             else:
@@ -646,6 +693,10 @@ class IngestionPipeline(BaseModel):
             )
 
         nodes = nodes or []
+
+        # transformations succeeded, so the old data can go
+        if self.docstore is not None:
+            self._apply_upsert_deletes(ref_doc_ids_to_delete, doc_ids_to_delete)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]
@@ -706,41 +757,85 @@ class IngestionPipeline(BaseModel):
         nodes: Sequence[BaseNode],
         store_doc_text: bool = True,
     ) -> Sequence[BaseNode]:
-        """Handle docstore upserts by checking hashes and ids."""
+        """
+        Handle docstore upserts by checking hashes and ids.
+
+        Deletes eagerly. `arun` uses `_aplan_upserts` instead, so a failing
+        transformation cannot destroy the previous version.
+        """
+        (
+            nodes_to_run,
+            ref_doc_ids_to_delete,
+            doc_ids_to_delete,
+        ) = await self._aplan_upserts(nodes, store_doc_text=store_doc_text)
+        await self._aapply_upsert_deletes(ref_doc_ids_to_delete, doc_ids_to_delete)
+        return nodes_to_run
+
+    async def _aplan_upserts(
+        self,
+        nodes: Sequence[BaseNode],
+        store_doc_text: bool = True,
+    ) -> Tuple[Sequence[BaseNode], List[str], List[str]]:
+        """
+        Find the nodes to run, plus the ref doc ids and doc ids they supersede.
+
+        Nothing is deleted here, so a failed transformation cannot lose the
+        previous version. See `_aapply_upsert_deletes`.
+        """
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        ref_doc_ids_to_delete: List[str] = []
+        superseded: set[str] = set()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
+            if ref_doc_id in superseded:
+                # deleting used to happen here, so the lookup below missed and
+                # the node was kept; keep it, or sibling nodes get dropped
+                deduped_nodes_to_run.append(node)
+                continue
             existing_hash = await self.docstore.aget_document_hash(ref_doc_id)
             if not existing_hash:
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
+                ref_doc_ids_to_delete.append(ref_doc_id)
+                superseded.add(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
 
+        doc_ids_to_delete: List[str] = []
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
             existing_doc_ids_before = set(
                 (await self.docstore.aget_all_document_hashes()).values()
             )
-            doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                await self.docstore.adelete_document(ref_doc_id)
+            doc_ids_to_delete = list(existing_doc_ids_before - doc_ids_from_nodes)
 
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
+        return deduped_nodes_to_run, ref_doc_ids_to_delete, doc_ids_to_delete
 
-        return deduped_nodes_to_run
+    async def _aapply_upsert_deletes(
+        self,
+        ref_doc_ids_to_delete: Sequence[str],
+        doc_ids_to_delete: Sequence[str],
+    ) -> None:
+        """Remove data superseded by a successful run."""
+        assert self.docstore is not None
+
+        for ref_doc_id in ref_doc_ids_to_delete:
+            await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
+
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
+
+        for ref_doc_id in doc_ids_to_delete:
+            await self.docstore.adelete_document(ref_doc_id)
+
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
 
     @dispatcher.span
     async def arun(
@@ -795,12 +890,18 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        ref_doc_ids_to_delete: List[str] = []
+        doc_ids_to_delete: List[str] = []
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = await self._ahandle_upserts(
+                (
+                    nodes_to_run,
+                    ref_doc_ids_to_delete,
+                    doc_ids_to_delete,
+                ) = await self._aplan_upserts(
                     input_nodes, store_doc_text=store_doc_text
                 )
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
@@ -866,6 +967,10 @@ class IngestionPipeline(BaseModel):
             nodes = nodes
 
         nodes = nodes or []
+
+        # transformations succeeded, so the old data can go
+        if self.docstore is not None:
+            await self._aapply_upsert_deletes(ref_doc_ids_to_delete, doc_ids_to_delete)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -317,6 +317,80 @@ def test_pipeline_upserts_keep_all_nodes_per_doc() -> None:
     )
 
 
+class _RaisingTransform(TransformComponent):
+    def __call__(self, nodes: Sequence[BaseNode], **kwargs: Any) -> Sequence[BaseNode]:
+        raise RuntimeError("transform failed")
+
+    async def acall(
+        self, nodes: Sequence[BaseNode], **kwargs: Any
+    ) -> Sequence[BaseNode]:
+        raise RuntimeError("transform failed")
+
+
+def _upsert_pipeline(
+    docstore: SimpleDocumentStore,
+    vector_store: SimpleVectorStore,
+    transformations: Sequence[TransformComponent],
+) -> IngestionPipeline:
+    return IngestionPipeline(
+        transformations=list(transformations),
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+
+
+def test_pipeline_upserts_keep_existing_vectors_when_transform_fails() -> None:
+    """
+    Regression test: the old vectors were deleted before the transformations
+    ran, so a failure left the document with no vectors at all.
+    """
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    _upsert_pipeline(
+        docstore, vector_store, [SentenceSplitter(), MockEmbedding(embed_dim=8)]
+    ).run(documents=[Document(text="original text", doc_id="1")])
+
+    embeddings_before = dict(vector_store.data.embedding_dict)
+    assert embeddings_before, "the first run should have stored vectors"
+
+    # same doc id, new content, so the hash changes and the old data is superseded
+    with pytest.raises(RuntimeError):
+        _upsert_pipeline(
+            docstore, vector_store, [SentenceSplitter(), _RaisingTransform()]
+        ).run(documents=[Document(text="updated text", doc_id="1")])
+
+    assert vector_store.data.embedding_dict == embeddings_before, (
+        "a failed run must not delete the previous version's vectors"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_upserts_keep_existing_vectors_when_transform_fails() -> (
+    None
+):
+    """Async counterpart of the test above."""
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    await _upsert_pipeline(
+        docstore, vector_store, [SentenceSplitter(), MockEmbedding(embed_dim=8)]
+    ).arun(documents=[Document(text="original text", doc_id="1")])
+
+    embeddings_before = dict(vector_store.data.embedding_dict)
+    assert embeddings_before, "the first run should have stored vectors"
+
+    with pytest.raises(RuntimeError):
+        await _upsert_pipeline(
+            docstore, vector_store, [SentenceSplitter(), _RaisingTransform()]
+        ).arun(documents=[Document(text="updated text", doc_id="1")])
+
+    assert vector_store.data.embedding_dict == embeddings_before, (
+        "a failed run must not delete the previous version's vectors"
+    )
+
+
 @pytest.mark.skipif(cpu_count() < 2, reason="requires at least 2 CPUs")
 def test_pipeline_parallel_cache_populated() -> None:
     num_workers = 2


### PR DESCRIPTION
With `DocstoreStrategy.UPSERTS`, `_handle_upserts` deleted a document's previous data as soon as it saw a changed hash, before the transformations ran. A failing transformation then left the document with no vectors at all: the old ones were already gone and the new ones were never written.

`_handle_upserts` now returns the ids to remove instead of removing them, and `_apply_upsert_deletes` runs them once the transformations have succeeded, immediately before the new nodes are written. Same change on the async path.

Deleting eagerly also meant a second node sharing a ref doc id found no hash on its own lookup and was kept, so `_handle_upserts` tracks the ref docs it has already superseded to keep those sibling nodes.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [ ] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
