### PR TITLE
fix: update CohereRerankRelevancyMetric default to rerank-v3.5

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -437,7 +437,7 @@ class CohereRerankRelevancyMetric(BaseRetrievalMetric):
 
     def __init__(
         self,
-        model: str = "rerank-english-v2.0",
+        model: str = "rerank-v3.5",
         api_key: Optional[str] = None,
     ):
         try:

--- a/llama-index-core/tests/evaluation/test_metrics.py
+++ b/llama-index-core/tests/evaluation/test_metrics.py
@@ -1,8 +1,10 @@
+import inspect
 from math import log2
 
 import pytest
 from llama_index.core.evaluation.retrieval.metrics import (
     AveragePrecision,
+    CohereRerankRelevancyMetric,
     HitRate,
     MRR,
     NDCG,
@@ -245,3 +247,14 @@ def test_exceptions(expected_ids, retrieved_ids, use_granular):
     with pytest.raises(ValueError):
         ndcg = NDCG()
         ndcg.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+
+
+def test_cohere_rerank_relevancy_default_model() -> None:
+    """
+    The default Cohere rerank model must be one that Cohere still serves.
+
+    `rerank-english-v2.0` was shut down on 2025-04-30, so the default
+    constructor path failed. Cohere's documented replacement is `rerank-v3.5`.
+    """
+    signature = inspect.signature(CohereRerankRelevancyMetric.__init__)
+    assert signature.parameters["model"].default == "rerank-v3.5"


### PR DESCRIPTION
## Summary

`CohereRerankRelevancyMetric()` defaulted to `rerank-english-v2.0`, which Cohere **shut down on 2025-04-30**. Requests to shut-down models fail, so the default constructor path did not work at all.

Fixes #22693

## Evidence

From [Cohere's deprecations page](https://docs.cohere.com/docs/deprecations) (2024-12-02: Rerank v2.0):

| Shutdown Date | Deprecated Model | Recommended Replacement |
| --- | --- | --- |
| 2025-04-30 | `rerank-english-v2.0` | `rerank-v3.5` |
| 2025-04-30 | `rerank-multilingual-v2.0` | `rerank-v3.5` |

## Change

`llama-index-core/llama_index/core/evaluation/retrieval/metrics.py`

```diff
     def __init__(
         self,
-        model: str = rerank-english-v2.0,
+        model: str = rerank-v3.5,
         api_key: Optional[str] = None,
     ):
```

This was the only occurrence of `rerank-english-v2.0` in the repository.

## Why `rerank-v3.5` and not `rerank-english-v3.0`

The `llama-index-postprocessor-cohere-rerank` integration already moved to `rerank-english-v3.0`, so matching it would also have been reasonable. I went with `rerank-v3.5` because it is the replacement Cohere names explicitly for the entire Rerank v2.0 family, and it is multilingual rather than English-only. Happy to switch to `rerank-english-v3.0` instead if you would rather keep the two packages identical.

## Tests

Added `test_cohere_rerank_relevancy_default_model` to `llama-index-core/tests/evaluation/test_metrics.py`. It reads the default via `inspect.signature`, so it needs neither the `cohere` package nor an API key.

Verified the test is meaningful, not just green:

- passes with the fix applied
- **fails** when the default is reverted to `rerank-english-v2.0`
- full file: `43 passed`