### PR TITLE
fix: UPSERTS_AND_DELETE never deletes docs sharing a content hash

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -494,9 +494,7 @@ class IngestionPipeline(BaseModel):
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                self.docstore.get_all_document_hashes().values()
-            )
+            existing_doc_ids_before = self.docstore.get_all_document_ids()
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:
                 self.docstore.delete_document(ref_doc_id)
@@ -730,9 +728,7 @@ class IngestionPipeline(BaseModel):
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                (await self.docstore.aget_all_document_hashes()).values()
-            )
+            existing_doc_ids_before = await self.docstore.aget_all_document_ids()
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:
                 await self.docstore.adelete_document(ref_doc_id)

--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -1,7 +1,7 @@
 """Document store."""
 
 import asyncio
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.storage.docstore.types import BaseDocumentStore, RefDocInfo
@@ -666,4 +666,24 @@ class KVDocumentStore(BaseDocumentStore):
                 await self._kvstore.aget_all(collection=self._metadata_collection)
             ).items()
             if (doc_hash := doc.get("doc_hash"))
+        }
+
+    def get_all_document_ids(self) -> Set[str]:
+        """Get the ids of every document that has a stored hash."""
+        return {
+            doc_id
+            for doc_id, doc in (
+                self._kvstore.get_all(collection=self._metadata_collection)
+            ).items()
+            if doc.get("doc_hash")
+        }
+
+    async def aget_all_document_ids(self) -> Set[str]:
+        """Get the ids of every document that has a stored hash."""
+        return {
+            doc_id
+            for doc_id, doc in (
+                await self._kvstore.aget_all(collection=self._metadata_collection)
+            ).items()
+            if doc.get("doc_hash")
         }

--- a/llama-index-core/llama_index/core/storage/docstore/types.py
+++ b/llama-index-core/llama_index/core/storage/docstore/types.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Sequence, overload
+from typing import Any, Dict, List, Literal, Optional, Sequence, Set, overload
 
 import fsspec
 from dataclasses_json import DataClassJsonMixin
@@ -103,6 +103,24 @@ class BaseDocumentStore(ABC):
 
     @abstractmethod
     async def aget_all_document_hashes(self) -> Dict[str, str]: ...
+
+    def get_all_document_ids(self) -> Set[str]:
+        """
+        Get the ids of every document that has a stored hash.
+
+        `get_all_document_hashes` is keyed by hash, so documents sharing
+        identical content collapse into a single entry and their ids are lost.
+        Callers that need the full set of ids should use this instead.
+
+        This default derives ids from `get_all_document_hashes` and therefore
+        inherits that collapsing. Subclasses that can enumerate ids directly
+        should override it.
+        """
+        return set(self.get_all_document_hashes().values())
+
+    async def aget_all_document_ids(self) -> Set[str]:
+        """Async version of `get_all_document_ids`."""
+        return set((await self.aget_all_document_hashes()).values())
 
     # ==== Ref Docs =====
     @abstractmethod

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -665,3 +665,53 @@ async def test_docstore_strategy_not_mutated_on_arun_without_vector_store() -> N
             await pipeline.arun(documents=[Document.example()])
 
         assert pipeline.docstore_strategy is strategy
+
+
+def _upserts_and_delete_pipeline(docstore: SimpleDocumentStore) -> IngestionPipeline:
+    return IngestionPipeline(
+        transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=SimpleVectorStore(),
+        docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
+    )
+
+
+def test_pipeline_upserts_and_delete_removes_docs_sharing_a_hash() -> None:
+    """Docs sharing a content hash must still be deleted once they leave the source."""
+    docstore = SimpleDocumentStore()
+    pipeline = _upserts_and_delete_pipeline(docstore)
+
+    pipeline.run(
+        documents=[
+            Document(text="duplicate content", id_="doc_a"),
+            Document(text="duplicate content", id_="doc_b"),
+        ]
+    )
+    assert docstore.get_all_document_ids() == {"doc_a", "doc_b"}
+
+    pipeline.run(documents=[Document(text="brand new content", id_="doc_c")])
+
+    assert docstore.get_all_document_ids() == {"doc_c"}, (
+        "documents sharing a content hash must not survive deletion"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apipeline_upserts_and_delete_removes_docs_sharing_a_hash() -> None:
+    """Async counterpart of ``test_pipeline_upserts_and_delete_removes_docs_sharing_a_hash``."""
+    docstore = SimpleDocumentStore()
+    pipeline = _upserts_and_delete_pipeline(docstore)
+
+    await pipeline.arun(
+        documents=[
+            Document(text="duplicate content", id_="doc_a"),
+            Document(text="duplicate content", id_="doc_b"),
+        ]
+    )
+    assert await docstore.aget_all_document_ids() == {"doc_a", "doc_b"}
+
+    await pipeline.arun(documents=[Document(text="brand new content", id_="doc_c")])
+
+    assert await docstore.aget_all_document_ids() == {"doc_c"}, (
+        "documents sharing a content hash must not survive deletion"
+    )

--- a/llama-index-core/tests/storage/docstore/test_simple_docstore.py
+++ b/llama-index-core/tests/storage/docstore/test_simple_docstore.py
@@ -152,3 +152,30 @@ def test_docstore_delete_all_ref_doc_nodes() -> None:
     assert docstore._kvstore.get("d1", docstore._node_collection) is None
     assert docstore._kvstore.get("d1", docstore._metadata_collection) is None
     assert docstore._kvstore.get("d1", docstore._ref_doc_collection) is None
+
+
+def test_get_all_document_ids_keeps_docs_sharing_a_hash() -> None:
+    docstore = SimpleDocumentStore()
+    docstore.add_documents(
+        [
+            Document(text="duplicate content", id_="d1"),
+            Document(text="duplicate content", id_="d2"),
+        ]
+    )
+
+    assert len(docstore.get_all_document_hashes()) == 1
+    assert docstore.get_all_document_ids() == {"d1", "d2"}
+
+
+@pytest.mark.asyncio
+async def test_aget_all_document_ids_keeps_docs_sharing_a_hash() -> None:
+    docstore = SimpleDocumentStore()
+    await docstore.async_add_documents(
+        [
+            Document(text="duplicate content", id_="d1"),
+            Document(text="duplicate content", id_="d2"),
+        ]
+    )
+
+    assert len(await docstore.aget_all_document_hashes()) == 1
+    assert await docstore.aget_all_document_ids() == {"d1", "d2"}


### PR DESCRIPTION
## Summary

`DocstoreStrategy.UPSERTS_AND_DELETE` silently fails to delete documents whenever two documents share identical content. The stale document survives in both the docstore and the vector store.

Fixes #22706

## Reproduction

```python
docstore = SimpleDocumentStore()
pipeline = IngestionPipeline(
    transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
    docstore=docstore,
    vector_store=SimpleVectorStore(),
    docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
)

pipeline.run(documents=[
    Document(id_="doc_a", text="duplicate content"),
    Document(id_="doc_b", text="duplicate content"),
])

# both docs leave the source set, so both should be deleted
pipeline.run(documents=[Document(id_="doc_c", text="brand new content")])
```

| | before | after |
| --- | --- | --- |
| remaining ids | `['doc_a', 'doc_c']` | `['doc_c']` |

`doc_a` was never deleted.

## Root cause

`get_all_document_hashes()` returns a dict **keyed by hash**:

```python
return {doc_hash: doc_id for doc_id, doc in ...}
```

Two documents with identical content produce the same `doc_hash`, so the second overwrites the first and one id is lost. `_handle_upserts` then derived the existing-id set from that dict's `.values()`:

```python
existing_doc_ids_before = set(self.docstore.get_all_document_hashes().values())
doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
```

The collapsed id is absent from `existing_doc_ids_before`, so it can never appear in `doc_ids_to_delete`. Observed directly in the repro above:

```
docstore.docs keys        : ['doc_a', 'doc_b']     <- both stored
get_all_document_hashes() : {hash: 'doc_b'}        <- doc_a collapsed
```

Present in both `_handle_upserts` and `_ahandle_upserts`.

## Why not the simpler options

I tried these first; recording why they do not work:

- **Re-key `get_all_document_hashes()` to `{doc_id: doc_hash}`** - `_handle_duplicates` relies on the keys being hashes (`if node.hash not in existing_hashes`). The two callers want opposite orientations.
- **Use `get_all_ref_doc_info()`** - returns `{}` for top-level `Document`s, which have no `ref_doc_id`. Confirmed empty in the repro.
- **Use `docstore.docs.keys()`** - there is no async counterpart on `BaseDocumentStore`, and with `store_text=False` the node collection is skipped entirely while metadata is still written, so ids would be missed.

## Change

Adds `get_all_document_ids()` / `aget_all_document_ids()`:

- On `BaseDocumentStore` as **concrete** methods (not abstract), so existing third-party docstores keep working unchanged. The default delegates to `get_all_document_hashes()` and documents that it inherits the collapsing.
- Overridden in `KVDocumentStore` to enumerate the metadata collection directly, which is both non-lossy and cheaper than the current inversion.

Both upsert paths now use the new accessor.

## Tests

- `test_pipeline_upserts_and_delete_removes_docs_sharing_a_hash` + async counterpart
- `test_get_all_document_ids_keeps_docs_sharing_a_hash` + async counterpart

Verified the tests are meaningful rather than merely green: with only the `pipeline.py` change reverted, the two pipeline tests **fail** and the two docstore tests still pass, which is the expected split.

Regression sweep: `tests/storage/ tests/ingestion/ tests/indices/` -> **395 passed, 3 skipped**.