### PR TITLE
fix(core): keep separators at end of text splits

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -36,7 +36,7 @@ def split_text_keep_separator(text: str, separator: str) -> List[str]:
 
     """
     parts = text.split(separator)
-    result = [separator + s if i > 0 else s for i, s in enumerate(parts)]
+    result = [s + separator if i < len(parts) - 1 else s for i, s in enumerate(parts)]
     return [s for s in result if s]
 
 

--- a/llama-index-core/tests/node_parser/test_text_utils.py
+++ b/llama-index-core/tests/node_parser/test_text_utils.py
@@ -1,0 +1,19 @@
+from llama_index.core.node_parser.text.utils import split_text_keep_separator
+
+
+def test_split_text_keep_separator_appends_separator() -> None:
+    text = "Hello. World. Bye."
+
+    assert split_text_keep_separator(text, ".") == [
+        "Hello.",
+        " World.",
+        " Bye.",
+    ]
+
+
+def test_split_text_keep_separator_preserves_text_with_consecutive_separators() -> None:
+    text = "a..b"
+    chunks = split_text_keep_separator(text, ".")
+
+    assert chunks == ["a.", ".", "b"]
+    assert "".join(chunks) == text


### PR DESCRIPTION
## Summary

Fix `split_text_keep_separator` so each separator remains at the end of the
segment it terminates, matching the function's documented behavior.

## What changed

The helper previously prepended the separator to every segment after the first.
For example, splitting `"Hello. World. Bye."` on `"."` returned:

```text
["Hello", ". World", ". Bye", "."]
```

The helper now returns:

```text
["Hello.", " World.", " Bye."]
```

The change preserves lossless reassembly, including consecutive separators, and
adds focused regression coverage for both cases.

## Verification

- `pytest tests/node_parser/test_text_utils.py`
- `pytest tests/text_splitter/test_sentence_splitter.py`
- `ruff check` on the changed files
