### PR TITLE
fix: handle mmr_threshold=0 and None score in fusion retriever

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -115,7 +115,7 @@ def get_top_k_mmr_embeddings(
     A mmr_threshold of 1 will check similarity the query and ignore previous results.
 
     """
-    threshold = mmr_threshold or 0.5
+    threshold = mmr_threshold if mmr_threshold is not None else 0.5
     similarity_fn = similarity_fn or default_similarity_fn
 
     if embedding_ids is None or embedding_ids == []:

--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -183,9 +183,9 @@ class QueryFusionRetriever(BaseRetriever):
                 if max_score == min_score:
                     node_with_score.score = 1.0 if max_score > 0 else 0.0
                 else:
-                    node_with_score.score = (node_with_score.score - min_score) / (
-                        max_score - min_score
-                    )
+                    node_with_score.score = (
+                        (node_with_score.score or 0.0) - min_score
+                    ) / (max_score - min_score)
                 # Scale by the weight of the retriever
                 retriever_idx = query_tuple[1]
                 existing_score = node_with_score.score or 0.0


### PR DESCRIPTION
This PR addresses: handle mmr_threshold=0 and None score in fusion retriever