### PR TITLE
fix(node_parser): support scalar JSON values in JSONNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/file/json.py
+++ b/llama-index-core/llama_index/core/node_parser/file/json.py
@@ -78,7 +78,10 @@ class JSONNodeParser(NodeParser):
                     )
                 )
         else:
-            raise ValueError("JSON is invalid")
+            lines = [*self._depth_first_yield(data, 0, [])]
+            json_nodes.extend(
+                build_nodes_from_splits(["\n".join(lines)], node, id_func=self.id_func)
+            )
 
         return json_nodes
 

--- a/llama-index-core/tests/node_parser/test_json.py
+++ b/llama-index-core/tests/node_parser/test_json.py
@@ -41,3 +41,17 @@ def test_split_invalid_json() -> None:
     input_text = Document(text='{"name": "John", "age": 30,}')
     result = json_splitter.get_nodes_from_documents([input_text])
     assert result == []
+
+
+def test_split_scalar_json() -> None:
+    json_splitter = JSONNodeParser()
+
+    for text, expected in [
+        ('"hello"', "hello"),
+        ("123", "123"),
+        ("true", "True"),
+        ("null", "None"),
+    ]:
+        result = json_splitter.get_nodes_from_documents([Document(text=text)])
+        assert len(result) == 1
+        assert result[0].text == expected


### PR DESCRIPTION
# Description

Handles valid scalar JSON documents (strings, numbers, booleans, null) in `JSONNodeParser.get_nodes_from_node()` instead of raising `ValueError("JSON is invalid")`.

Per RFC 8259, scalar JSON values are valid top-level JSON structures. This fix parses them via `_depth_first_yield()` into single text nodes while preserving existing dictionary and list parsing behavior.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_split_scalar_json` in `tests/node_parser/test_json.py`. Ran `pytest tests/node_parser/test_json.py` (6 passed).

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes