### PR TITLE
fix(eval): update CohereRerankRelevancyMetric default model from retired rerank-english-v2.0 to v3.0

### DIFF
--- a/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
+++ b/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py
@@ -437,7 +437,7 @@ class CohereRerankRelevancyMetric(BaseRetrievalMetric):
 
     def __init__(
         self,
-        model: str = "rerank-english-v2.0",
+        model: str = "rerank-english-v3.0",
         api_key: Optional[str] = None,
     ):
         try:

--- a/llama-index-core/tests/evaluation/test_metrics.py
+++ b/llama-index-core/tests/evaluation/test_metrics.py
@@ -1,8 +1,10 @@
+import inspect
 from math import log2
 
 import pytest
 from llama_index.core.evaluation.retrieval.metrics import (
     AveragePrecision,
+    CohereRerankRelevancyMetric,
     HitRate,
     MRR,
     NDCG,
@@ -245,3 +247,14 @@ def test_exceptions(expected_ids, retrieved_ids, use_granular):
     with pytest.raises(ValueError):
         ndcg = NDCG()
         ndcg.compute(expected_ids=expected_ids, retrieved_ids=retrieved_ids)
+
+
+def test_cohere_rerank_metric_default_model_not_retired():
+    """Default model must not be the retired rerank-english-v2.0 (Cohere EOL April 2025)."""
+    sig = inspect.signature(CohereRerankRelevancyMetric.__init__)
+    default_model = sig.parameters["model"].default
+    assert default_model != "rerank-english-v2.0", (
+        "rerank-english-v2.0 was retired by Cohere in April 2025 and returns HTTP 404; "
+        "the default must be updated to an active model such as rerank-english-v3.0."
+    )
+    assert default_model == "rerank-english-v3.0"


### PR DESCRIPTION
## Summary

Fixes #22693

`CohereRerankRelevancyMetric` defaults to `rerank-english-v2.0`, which Cohere **retired in April 2025**. Any user who calls:

```python
metric = CohereRerankRelevancyMetric()   # no model= arg
```

gets an HTTP 404 from the Cohere API. This is a silent foot-gun — the class instantiates fine but fails at evaluation time.

## Root Cause / Motivation

The default was set at initial authoring and never updated to track Cohere's model lifecycle. The companion class `CohereRerank` (in `llama-index-integrations/postprocessor/`) already uses `rerank-english-v3.0` as its default (see `base.py:65`). This change brings the evaluation metric into alignment.

## Changes

| File | Change |
|------|--------|
| `llama-index-core/llama_index/core/evaluation/retrieval/metrics.py` | `model: str = "rerank-english-v2.0"` → `"rerank-english-v3.0"` in `CohereRerankRelevancyMetric.__init__` |
| `llama-index-core/tests/evaluation/test_metrics.py` | Added `test_cohere_rerank_metric_default_model_not_retired` — pure-introspection test, **no Cohere API key required** |

## Testing

The new test uses `inspect.signature()` to assert the default value without instantiating the class or importing `cohere`:

```python
def test_cohere_rerank_metric_default_model_not_retired():
    sig = inspect.signature(CohereRerankRelevancyMetric.__init__)
    default_model = sig.parameters["model"].default
    assert default_model != "rerank-english-v2.0"
    assert default_model == "rerank-english-v3.0"
```

This runs in CI without credentials and prevents silent regression if the default is changed to another retired model in the future.

## Impact

- **No breaking change** — callers who already pass `model=` explicitly are unaffected.
- **Fixes silent 404s** for anyone using the default.
- Aligns with the postprocessor's existing `rerank-english-v3.0` default, creating one consistent default across the codebase.