### PR TITLE
fix(bedrock): forward additional_kwargs in Cohere request body

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -527,12 +527,12 @@ class BedrockEmbedding(BaseEmbedding):
             }
             payload = [payload] if isinstance(payload, str) else payload
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
-            request_body = json.dumps(
-                {
-                    "texts": payload,
-                    "input_type": input_types[input_type],
-                }
-            )
+            cohere_body_request = {
+                "texts": payload,
+                "input_type": input_types[input_type],
+            }
+            cohere_body_request.update(self.additional_kwargs)
+            request_body = json.dumps(cohere_body_request)
         else:
             raise ValueError("Provider not supported")
         return request_body

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
@@ -95,6 +95,20 @@ def test_non_empty_payload_still_builds_request_body():
         embedding._get_provider()
 
 
+def test_cohere_request_body_includes_additional_kwargs():
+    """additional_kwargs (e.g. output_dimension) must reach the Cohere request body."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    embedding = BedrockEmbedding(
+        model_name="cohere.embed-v4:0",
+        client=bedrock_client,
+        additional_kwargs={"output_dimension": 256},
+    )
+
+    body = embedding._get_request_body("cohere", ["hello"], "text")
+    assert '"output_dimension": 256' in body
+    assert '"texts"' in body and '"input_type"' in body
+
+
 @pytest.mark.parametrize(
     ("model_name", "expected_provider"),
     [


### PR DESCRIPTION
Fixes run-llama/llama_index#22648

## Summary
`BedrockEmbedding._get_request_body` reads `self.additional_kwargs` for Amazon/Titan models (`dimensions`, `normalize`) but silently dropped them for Cohere models. This made it impossible to set `output_dimension` for Cohere Embed v4 (`cohere.embed-v4:0`), which always returned the default dimension.

Now the Cohere request body is merged with `self.additional_kwargs`, so `output_dimension` (and any other Cohere-supported kwarg) is forwarded to Bedrock.

## Test
Added `test_cohere_request_body_includes_additional_kwargs` verifying `output_dimension` appears in the serialized request body.
