### PR TITLE
fix(mcp): unpack 2-tuple from streamable_http_client for mcp 2.x

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -251,7 +251,7 @@ class BasicMCPClient(ClientSession):
                 async with streamable_http_client(
                     url=self.command_or_url,
                     http_client=self.http_client,
-                ) as (read, write, _):
+                ) as (read, write):
                     async with ClientSession(
                         read,
                         write,


### PR DESCRIPTION
Fixes run-llama/llama_index#22655

## Summary
`llama-index-tools-mcp` 0.5.0 migrated to the mcp 2.x SDK, but `client.py` still unpacks `streamable_http_client(...)` as a 3-tuple `(read, write, _)`. In mcp 2.0.0 the context manager yields a 2-tuple `(read, write)`, so every streamable-HTTP session crashes with a ValueError during unpacking.

Changed the unpack to `(read, write)`, matching the mcp 2.x API.

## Verification
- `client.py` parses cleanly.
- This is the exact break site listed as item #1 in the tracking issue #22515.
