### PR TITLE
fix(instrumentation): avoid mutable default args in Dispatcher.__init__

### DIFF
--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers or [],
+            span_handlers=span_handlers or [],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,


### PR DESCRIPTION
Fixes run-llama/llama_index#22705

## Summary
`Dispatcher.__init__` used mutable list defaults (`event_handlers=[]`, `span_handlers=[]`), the classic Python `B006` footgun. In instrumentation this is especially risky because event/span handlers are meant to be isolated per dispatcher instance.

Changed the defaults to `None` and initialized fresh lists in the body (`event_handlers or []`), per the reporter's suggested fix.
