### PR TITLE
fix(ag-ui): do not persist frontend tool results server-side

### DIFF
--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/llama_index/protocols/ag_ui/agent.py
@@ -426,8 +426,13 @@ class AGUIChatWorkflow(Workflow):
             if tool_result.tool_name not in all_frontend_names
         ]
 
+        # Only backend tool results are persisted server-side. Frontend tool
+        # results are supplied by the client on the callback run (AG-UI
+        # contract): emitting a server-side result for a frontend tool call
+        # marks it as already resolved, so the client never executes its
+        # handler.
         new_tool_messages = []
-        for tool_result in [*backend_tool_calls, *frontend_tool_calls]:
+        for tool_result in backend_tool_calls:
             new_tool_messages.append(
                 ChatMessage(
                     role="tool",

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-protocols-ag-ui"
-version = "0.4.0"
+version = "0.4.1"
 description = "llama-index protocols AG-UI integration"
 authors = [
     {name = "Logan Markewich", email = "logan@runllama.ai"},

--- a/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_frontend_tool_messages.py
+++ b/llama-index-integrations/protocols/llama-index-protocols-ag-ui/tests/test_frontend_tool_messages.py
@@ -17,7 +17,13 @@ async def frontend_show(message: str) -> str:
     return ""
 
 
-def test_frontend_tool_calls_are_persisted_as_tool_messages() -> None:
+def test_frontend_tool_results_are_not_persisted_server_side() -> None:
+    """
+    Backend tool calls get a server-side tool reply; frontend tool calls
+    must not — their results arrive from the client on the callback run.
+    A server-side reply marks the call resolved and the client never runs
+    its handler (regression: dojo change_background stopped firing).
+    """
     backend_tool_call_id = "call_backend_calc"
     frontend_tool_call_id = "call_frontend_show"
 
@@ -106,4 +112,5 @@ def test_frontend_tool_calls_are_persisted_as_tool_messages() -> None:
         backend_tool_call_id,
         frontend_tool_call_id,
     }
-    assert claimed_tool_call_ids <= replied_tool_call_ids
+    assert backend_tool_call_id in replied_tool_call_ids
+    assert frontend_tool_call_id not in replied_tool_call_ids


### PR DESCRIPTION
# Description

Frontend tool calls stopped working for AG-UI clients: since the 0.3.x line, `AGUIChatWorkflow.aggregate_tool_results` has persisted frontend tool stub outputs as `role=tool` messages in chat history, so the `MESSAGES_SNAPSHOT` delivered every frontend tool call with a result already attached. Per the AG-UI contract, a tool call that arrives with a result is resolved — so clients never executed their frontend tool handlers. (Concrete symptom: the AG-UI dojo's `change_background` demo shows the tool call as done but the handler never fires. 0.2.x behaved correctly.)

This PR restores backend-only persistence, matching 0.2.x and the AG-UI contract: frontend tool results are supplied by the client on the callback run (the workflow already stops with `StopEvent` to wait for exactly that). Backend tool behavior is unchanged.

The regression test added in #22678 asserted the broken behavior (`claimed_tool_call_ids <= replied_tool_call_ids` for all calls including frontend); it now asserts that backend calls get a server-side reply and frontend calls do not.

## New Package?

- [ ] No

## Version Bump?

- [x] Yes (0.4.0 → 0.4.1)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Full package suite passes (28 tests). Also verified end-to-end against the AG-UI dojo: with this fix the frontend tool call arrives without a server-side result, the client executes its handler (background changes), and the callback run completes with the client-supplied tool result.