### PR TITLE
test(core): add polarity test cases for SemanticSimilarityEvaluator

### DIFF
--- a/llama-index-core/tests/evaluation/test_semantic_similarity.py
+++ b/llama-index-core/tests/evaluation/test_semantic_similarity.py
@@ -1,0 +1,96 @@
+import math
+from typing import Any, Dict, List
+
+import pytest
+from llama_index.core.base.embeddings.base import BaseEmbedding
+from llama_index.core.evaluation import SemanticSimilarityEvaluator
+
+
+class FixedEmbedding(BaseEmbedding):
+    """
+    Embedding model that returns a pre-set vector for each known text.
+
+    Lets a test pin the exact cosine similarity between two texts without
+    depending on a real embedding model.
+    """
+
+    text_to_vector: Dict[str, List[float]]
+
+    def __init__(self, text_to_vector: Dict[str, List[float]], **kwargs: Any) -> None:
+        super().__init__(text_to_vector=text_to_vector, **kwargs)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "FixedEmbedding"
+
+    def _get_vector(self, text: str) -> List[float]:
+        return self.text_to_vector[text]
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return self._get_vector(query)
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._get_vector(query)
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return self._get_vector(text)
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return self._get_vector(text)
+
+
+def _vector_at_cosine(target_cosine: float) -> List[float]:
+    """A 2D unit vector whose cosine similarity to [1, 0] is target_cosine."""
+    return [target_cosine, math.sqrt(1 - target_cosine**2)]
+
+
+@pytest.mark.asyncio
+async def test_reversed_meaning_can_pass_at_default_threshold() -> None:
+    """
+    Cosine similarity does not track correctness: a wording-preserving
+    reversal of the reference's meaning can still score above the default
+    0.8 threshold. See https://github.com/run-llama/llama_index/issues/22729.
+    """
+    reference = (
+        "Withhold the study drug from any participant who reports chest tightness."
+    )
+    response = (
+        "Administer the study drug to any participant who reports chest tightness."
+    )
+
+    embed_model = FixedEmbedding(
+        text_to_vector={
+            reference: [1.0, 0.0],
+            response: _vector_at_cosine(0.96),
+        }
+    )
+    evaluator = SemanticSimilarityEvaluator(embed_model=embed_model)
+
+    result = await evaluator.aevaluate(response=response, reference=reference)
+
+    assert result.score == pytest.approx(0.96)
+    assert result.passing is True
+
+
+@pytest.mark.asyncio
+async def test_faithful_low_overlap_restatement_can_fail_at_default_threshold() -> None:
+    """
+    The mirror-image blind spot: a correct restatement that shares little
+    wording with the reference can score below the default 0.8 threshold.
+    See https://github.com/run-llama/llama_index/issues/22729.
+    """
+    reference = "Retry the request at most three times."
+    response = "Give the call up to three attempts, then stop."
+
+    embed_model = FixedEmbedding(
+        text_to_vector={
+            reference: [1.0, 0.0],
+            response: _vector_at_cosine(0.76),
+        }
+    )
+    evaluator = SemanticSimilarityEvaluator(embed_model=embed_model)
+
+    result = await evaluator.aevaluate(response=response, reference=reference)
+
+    assert result.score == pytest.approx(0.76)
+    assert result.passing is False


### PR DESCRIPTION
Closes #22729

## Summary

`SemanticSimilarityEvaluator` grades a generated answer by cosine similarity to a reference, passing at `similarity_threshold=0.8` (default). As reported in #22729, cosine similarity is not correlated with answer correctness in two directions:

1. A wording-preserving reversal of the reference's meaning (negation, scope inversion, etc.) shares most tokens with the reference and can score **above** the threshold even though it is wrong.
2. A faithful restatement in fresh wording shares few tokens with the reference and can score **below** the threshold even though it is correct.

The evaluator's test suite previously had no coverage of either case, so this blind spot was invisible to CI. This PR adds two tests that pin down and document the current (limitation-exhibiting) behavior, per the issue's proposal, using a small `FixedEmbedding` test double that returns a pre-set vector per input text so the exact cosine similarity between a pair is controlled deterministically (no network/API calls, no real embedding model needed):

- `test_reversed_meaning_can_pass_at_default_threshold`: a reversed-meaning pair at cosine 0.96 → `passing=True`.
- `test_faithful_low_overlap_restatement_can_fail_at_default_threshold`: a correct, low-overlap restatement at cosine 0.76 → `passing=False`.

This is a test-only change; no production code is modified. It documents a known boundary of threshold-based cosine similarity rather than attempting to "fix" it, since (as the issue notes) no cosine threshold can distinguish these cases in general.

## Test plan

Ran the new tests, and confirmed they fail without the corresponding evaluator behavior by flipping the `passing` comparison operator locally and re-running (reverted before committing):

```
$ python -m pytest tests/evaluation/test_semantic_similarity.py -v
tests/evaluation/test_semantic_similarity.py::test_reversed_meaning_can_pass_at_default_threshold PASSED
tests/evaluation/test_semantic_similarity.py::test_faithful_low_overlap_restatement_can_fail_at_default_threshold PASSED
2 passed in 0.03s
```

Also ran the full `tests/evaluation/` suite to check for regressions:

```
$ python -m pytest tests/evaluation/ -v
49 passed, 4 warnings in 1.05s
```

Ran `ruff check` and `ruff format --check` on the new file; both pass.

## AI assistance disclosure

This PR was drafted with AI assistance (Claude Code), per the repo's [CONTRIBUTING.md AI guidelines](../CONTRIBUTING.md#how-to-use-ai-when-contributing). The change is a small, self-contained addition of test cases; it was verified by running the new tests, confirming they fail on the inverted logic, and running the full evaluation test suite plus lint checks locally as shown above.
