### PR TITLE
feat(tools): add M2MCent ToolSpec for 1,000+ AI Agent Micro-Services on Base Mainnet

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-m2mcent/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-m2mcent/README.md
@@ -1,0 +1,27 @@
+# LlamaIndex M2MCent ToolSpec
+
+This tool spec enables LlamaIndex agents to query and execute **1,005 autonomous MCP micro-services** via the **M2MCent Gateway** (`https://api.m2mcent.com`) monetized via **x402 V2 on Base Mainnet**.
+
+## Usage
+
+```python
+from llama_index.tools.m2mcent import M2MCentToolSpec
+from llama_index.core.agent import ReActAgent
+from llama_index.llms.openai import OpenAI
+
+# 1. Initialize M2MCent ToolSpec
+m2mcent_spec = M2MCentToolSpec(base_url="https://api.m2mcent.com")
+tools = m2mcent_spec.to_tool_list()
+
+# 2. Attach tools to your autonomous agent
+agent = ReActAgent.from_tools(tools, llm=OpenAI(model="gpt-4o"), verbose=True)
+
+# 3. Query or execute tasks
+response = agent.chat("Search for a smart contract audit tool in M2MCent and analyze this Solidity snippet.")
+print(response)
+```
+
+## Features
+- **1,005 Specialized Agent Tools:** Finance, security, bioinformatics, 3D, logistics, smart contracts.
+- **x402 V2 Micropayment Protocol:** Trustless USDC settlement on Base Mainnet (`0xDb48F51A2de8F4a80CD1d0BAdcd18E847734A74a`).
+- **Semantic Discovery:** Real-time keyword & domain search across the entire 1,005 micro-service catalog.

--- a/llama-index-integrations/tools/llama-index-tools-m2mcent/llama_index/tools/m2mcent/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-m2mcent/llama_index/tools/m2mcent/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.m2mcent.base import M2MCentToolSpec
+
+__all__ = ["M2MCentToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-m2mcent/llama_index/tools/m2mcent/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-m2mcent/llama_index/tools/m2mcent/base.py
@@ -1,0 +1,68 @@
+"""
+M2MCent ToolSpec for LlamaIndex / LlamaHub
+Enables autonomous AI agents in LlamaIndex to query, execute, and settle payments for 1,005 specialized tools via x402 on Base Mainnet.
+"""
+
+from typing import Any, Dict, List, Optional
+import requests
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+class M2MCentToolSpec(BaseToolSpec):
+    """
+    M2MCent Monolithic MCP & Agentic API Gateway ToolSpec.
+    Provides 1,005 micro-services across finance, security, biotech, 3D, and IoT.
+    Settled trustlessly via x402 V2 micropayments in USDC on Base Mainnet.
+    """
+
+    spec_functions = [
+        "search_tools",
+        "get_tool_info",
+        "execute_tool"
+    ]
+
+    def __init__(self, base_url: str = "https://api.m2mcent.com", auth_token: Optional[str] = None):
+        self.base_url = base_url.rstrip("/")
+        self.auth_token = auth_token
+
+    def search_tools(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """
+        Search available M2MCent micro-services by keyword or semantic domain.
+        
+        Args:
+            query: The domain, keyword, or action to search for (e.g., 'credit-risk', 'uniswap', 'solidity').
+            limit: Maximum number of tools to return.
+        """
+        resp = requests.get(f"{self.base_url}/api/v1/search", params={"q": query, "limit": limit})
+        if resp.status_code == 200:
+            return resp.json().get("results", [])
+        return []
+
+    def get_tool_info(self, tool_id: str) -> Dict[str, Any]:
+        """
+        Retrieve schema, price, and payment challenge for a specific M2MCent tool.
+        
+        Args:
+            tool_id: Unique slug of the tool (e.g., 'credit-risk-mcp').
+        """
+        resp = requests.get(f"{self.base_url}/{tool_id}/server-card.json")
+        if resp.status_code == 200:
+            return resp.json()
+        return {"error": "Tool not found", "status": resp.status_code}
+
+    def execute_tool(self, tool_id: str, payload: Dict[str, Any], payment_signature: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Execute an M2MCent tool with payload and optional x402 payment signature.
+        
+        Args:
+            tool_id: Unique slug of the tool.
+            payload: JSON input payload matching the tool schema.
+            payment_signature: Base64-encoded EIP-3009 authorization signature on Base Mainnet.
+        """
+        headers = {"Content-Type": "application/json"}
+        if payment_signature:
+            headers["Payment-Signature"] = payment_signature
+        elif self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        resp = requests.post(f"{self.base_url}/{tool_id}/api/process", json=payload, headers=headers)
+        return resp.json()

--- a/llama-index-integrations/tools/llama-index-tools-m2mcent/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-m2mcent/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "llama-index-tools-m2mcent"
+version = "0.1.0"
+description = "LlamaIndex ToolSpec integration for M2MCent MCP 1000 micro-services network on Base Mainnet"
+authors = ["Evozim <contact@m2mcent.com>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "llama_index"}]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+llama-index-core = "^0.10.0"
+requests = "^2.28.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"


### PR DESCRIPTION
## Description
This PR adds `llama-index-tools-m2mcent`, an integration enabling LlamaIndex autonomous agents to query and execute **1,005 micro-services** via the M2MCent MCP API Gateway (`https://api.m2mcent.com`) monetized via **x402 V2** on **Base Mainnet**.

## Features
- **1,005 Specialized Agent Tools:** Finance, security, bioinformatics, 3D spatial, IoT, logistics.
- **x402 V2 Micropayment Settlement:** Trustless USDC payment challenge handling on Base Mainnet (`0xDb48F51A2de8F4a80CD1d0BAdcd18E847734A74a`).
- **Standard ToolSpec:** Inherits from `BaseToolSpec` with methods: `search_tools`, `get_tool_info`, and `execute_tool`.

## Usage
```python
from llama_index.tools.m2mcent import M2MCentToolSpec
from llama_index.core.agent import ReActAgent

m2mcent_spec = M2MCentToolSpec(base_url="https://api.m2mcent.com")
tools = m2mcent_spec.to_tool_list()
```
