### PR TITLE
fix(core): fix MetadataFilters and node_ids scoping in MultiModalVectorStoreIndex

### DIFF
--- a/llama-index-core/llama_index/core/indices/multi_modal/base.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/base.py
@@ -132,9 +132,13 @@ class MultiModalVectorStoreIndex(VectorStoreIndex):
         return self._is_text_vector_store_empty
 
     def as_retriever(self, **kwargs: Any) -> MultiModalVectorIndexRetriever:
+        node_ids = kwargs.pop("node_ids", None)
+        if node_ids is None and self.index_struct and self.index_struct.nodes_dict:
+            node_ids = list(self.index_struct.nodes_dict.values())
+
         return MultiModalVectorIndexRetriever(
             self,
-            node_ids=list(self.index_struct.nodes_dict.values()),
+            node_ids=node_ids,
             **kwargs,
         )
 

--- a/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
+++ b/llama-index-core/llama_index/core/indices/multi_modal/retriever.py
@@ -56,8 +56,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         image_similarity_top_k: int = DEFAULT_SIMILARITY_TOP_K,
         vector_store_query_mode: VectorStoreQueryMode = VectorStoreQueryMode.DEFAULT,
         filters: Optional[MetadataFilters] = None,
+        image_filters: Optional[MetadataFilters] = None,
         alpha: Optional[float] = None,
         node_ids: Optional[List[str]] = None,
+        image_node_ids: Optional[List[str]] = None,
         doc_ids: Optional[List[str]] = None,
         sparse_top_k: Optional[int] = None,
         callback_manager: Optional[CallbackManager] = None,
@@ -79,8 +81,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         self._vector_store_query_mode = VectorStoreQueryMode(vector_store_query_mode)
         self._alpha = alpha
         self._node_ids = node_ids
+        self._image_node_ids = image_node_ids
         self._doc_ids = doc_ids
         self._filters = filters
+        self._image_filters = image_filters
         self._sparse_top_k = sparse_top_k
 
         self._kwargs: Dict[str, Any] = kwargs.get("vector_store_kwargs", {})
@@ -107,17 +111,26 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         self._image_similarity_top_k = image_similarity_top_k
 
     def _build_vector_store_query(
-        self, query_bundle_with_embeddings: QueryBundle, similarity_top_k: int
+        self,
+        query_bundle_with_embeddings: QueryBundle,
+        similarity_top_k: int,
+        is_image_query: bool = False,
     ) -> VectorStoreQuery:
+        node_ids = self._image_node_ids if is_image_query else self._node_ids
+        filters = (
+            self._image_filters
+            if (is_image_query and self._image_filters is not None)
+            else self._filters
+        )
         return VectorStoreQuery(
             query_embedding=query_bundle_with_embeddings.embedding,
             similarity_top_k=similarity_top_k,
-            node_ids=self._node_ids,
+            node_ids=node_ids,
             doc_ids=self._doc_ids,
             query_str=query_bundle_with_embeddings.query_str,
             mode=self._vector_store_query_mode,
             alpha=self._alpha,
-            filters=self._filters,
+            filters=filters,
             sparse_top_k=self._sparse_top_k,
         )
 
@@ -153,7 +166,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                         )
                     )
             return self._get_nodes_with_embeddings(
-                query_bundle, self._similarity_top_k, self._vector_store
+                query_bundle,
+                self._similarity_top_k,
+                self._vector_store,
+                is_image_query=False,
             )
         else:
             return []
@@ -176,7 +192,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                     )
                 )
             return self._get_nodes_with_embeddings(
-                query_bundle, self._image_similarity_top_k, self._image_vector_store
+                query_bundle,
+                self._image_similarity_top_k,
+                self._image_vector_store,
+                is_image_query=True,
             )
         else:
             return []
@@ -200,7 +219,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                     query_bundle.embedding_image[0]
                 )
             return self._get_nodes_with_embeddings(
-                query_bundle, self._image_similarity_top_k, self._image_vector_store
+                query_bundle,
+                self._image_similarity_top_k,
+                self._image_vector_store,
+                is_image_query=True,
             )
         else:
             return []
@@ -219,16 +241,24 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         query_bundle_with_embeddings: QueryBundle,
         similarity_top_k: int,
         vector_store: BasePydanticVectorStore,
+        is_image_query: bool = False,
     ) -> List[NodeWithScore]:
         query = self._build_vector_store_query(
-            query_bundle_with_embeddings, similarity_top_k
+            query_bundle_with_embeddings,
+            similarity_top_k,
+            is_image_query=is_image_query,
         )
         query_result = vector_store.query(query, **self._kwargs)
-        return self._build_node_list_from_query_result(query_result)
+        return self._build_node_list_from_query_result(
+            query_result, vector_store=vector_store
+        )
 
     def _build_node_list_from_query_result(
-        self, query_result: VectorStoreQueryResult
+        self,
+        query_result: VectorStoreQueryResult,
+        vector_store: Optional[BasePydanticVectorStore] = None,
     ) -> List[NodeWithScore]:
+        target_store = vector_store if vector_store is not None else self._vector_store
         if query_result.nodes is None:
             # NOTE: vector store does not keep text and returns node indices.
             # Need to recover all nodes from docstore
@@ -239,7 +269,13 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                 )
             assert isinstance(self._index.index_struct, IndexDict)
             node_ids = [
-                self._index.index_struct.nodes_dict[idx] for idx in query_result.ids
+                self._index.index_struct.nodes_dict[idx]
+                if (
+                    self._index.index_struct
+                    and idx in self._index.index_struct.nodes_dict
+                )
+                else idx
+                for idx in query_result.ids
             ]
             nodes = self._docstore.get_nodes(node_ids)
             query_result.nodes = nodes
@@ -248,8 +284,13 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
             # Only need to recover image or index nodes from docstore
             for i in range(len(query_result.nodes)):
                 source_node = query_result.nodes[i].source_node
-                if (not self._vector_store.stores_text) or (
-                    source_node is not None and source_node.node_type != ObjectType.TEXT
+                if (
+                    (target_store is not None and not target_store.stores_text)
+                    or (
+                        source_node is not None
+                        and source_node.node_type != ObjectType.TEXT
+                    )
+                    or isinstance(query_result.nodes[i], ImageNode)
                 ):
                     node_id = query_result.nodes[i].node_id
                     if self._docstore.document_exists(node_id):
@@ -297,7 +338,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                     )
                 )
             return await self._aget_nodes_with_embeddings(
-                query_bundle, self._similarity_top_k, self._vector_store
+                query_bundle,
+                self._similarity_top_k,
+                self._vector_store,
+                is_image_query=False,
             )
         else:
             return []
@@ -322,7 +366,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                     )
                 )
             return await self._aget_nodes_with_embeddings(
-                query_bundle, self._image_similarity_top_k, self._image_vector_store
+                query_bundle,
+                self._image_similarity_top_k,
+                self._image_vector_store,
+                is_image_query=True,
             )
         else:
             return []
@@ -339,12 +386,17 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
         query_bundle_with_embeddings: QueryBundle,
         similarity_top_k: int,
         vector_store: BasePydanticVectorStore,
+        is_image_query: bool = False,
     ) -> List[NodeWithScore]:
         query = self._build_vector_store_query(
-            query_bundle_with_embeddings, similarity_top_k
+            query_bundle_with_embeddings,
+            similarity_top_k,
+            is_image_query=is_image_query,
         )
         query_result = await vector_store.aquery(query, **self._kwargs)
-        return self._build_node_list_from_query_result(query_result)
+        return self._build_node_list_from_query_result(
+            query_result, vector_store=vector_store
+        )
 
     async def _aimage_to_image_retrieve(
         self,
@@ -361,7 +413,10 @@ class MultiModalVectorIndexRetriever(MultiModalRetriever):
                     )
                 )
             return await self._aget_nodes_with_embeddings(
-                query_bundle, self._image_similarity_top_k, self._image_vector_store
+                query_bundle,
+                self._image_similarity_top_k,
+                self._image_vector_store,
+                is_image_query=True,
             )
         else:
             return []

--- a/llama-index-core/tests/indices/multi_modal/test_retriever.py
+++ b/llama-index-core/tests/indices/multi_modal/test_retriever.py
@@ -1,0 +1,192 @@
+import pytest
+from typing import List
+from llama_index.core import MockEmbedding
+from llama_index.core.embeddings import MockMultiModalEmbedding
+from llama_index.core.indices import MultiModalVectorStoreIndex
+from llama_index.core.schema import ImageNode, TextNode
+from llama_index.core.vector_stores.types import (
+    FilterOperator,
+    MetadataFilter,
+    MetadataFilters,
+)
+
+BASE64_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+
+
+def _get_mock_embed_models():
+    embed_model_text = MockEmbedding(embed_dim=4)
+    embed_model_image = MockMultiModalEmbedding(embed_dim=4)
+    return embed_model_text, embed_model_image
+
+
+def test_image_only_retriever_with_metadata_filters():
+    """Test image-to-image and text-to-image retrieval on image-only index with metadata filters."""
+    embed_model_text, embed_model_image = _get_mock_embed_models()
+
+    nodes: List[ImageNode] = [
+        ImageNode(
+            image=BASE64_PNG,
+            id_="img_1",
+            metadata={"category": "cat", "tag": "cute"},
+        ),
+        ImageNode(
+            image=BASE64_PNG,
+            id_="img_2",
+            metadata={"category": "dog", "tag": "cute"},
+        ),
+        ImageNode(
+            image=BASE64_PNG,
+            id_="img_3",
+            metadata={"category": "cat", "tag": "funny"},
+        ),
+    ]
+
+    index = MultiModalVectorStoreIndex(
+        nodes=nodes,
+        image_embed_model=embed_model_image,
+        embed_model=embed_model_text,
+    )
+
+    # Filter for category == "cat"
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="category", operator=FilterOperator.EQ, value="cat")
+        ]
+    )
+
+    retriever = index.as_retriever(filters=filters, image_similarity_top_k=5)
+
+    # Image-to-image retrieval
+    img_results = retriever.image_to_image_retrieve(BASE64_PNG)
+    assert len(img_results) == 2
+    for res in img_results:
+        assert isinstance(res.node, ImageNode)
+        assert res.node.metadata["category"] == "cat"
+    assert {res.node.node_id for res in img_results} == {"img_1", "img_3"}
+
+    # Text-to-image retrieval
+    text_to_img_results = retriever.text_to_image_retrieve("a photo of a cat")
+    assert len(text_to_img_results) == 2
+    for res in text_to_img_results:
+        assert isinstance(res.node, ImageNode)
+        assert res.node.metadata["category"] == "cat"
+
+
+def test_multimodal_retriever_mixed_with_filters():
+    """Test retrieval on mixed text + image index with shared and modality-specific filters."""
+    embed_model_text, embed_model_image = _get_mock_embed_models()
+
+    text_nodes = [
+        TextNode(
+            text="Cat fact: cats sleep a lot.",
+            id_="txt_1",
+            metadata={"species": "feline"},
+        ),
+        TextNode(
+            text="Dog fact: dogs bark.", id_="txt_2", metadata={"species": "canine"}
+        ),
+    ]
+    image_nodes = [
+        ImageNode(image=BASE64_PNG, id_="img_1", metadata={"species": "feline"}),
+        ImageNode(image=BASE64_PNG, id_="img_2", metadata={"species": "canine"}),
+    ]
+
+    index = MultiModalVectorStoreIndex(
+        nodes=text_nodes + image_nodes,
+        image_embed_model=embed_model_image,
+        embed_model=embed_model_text,
+    )
+
+    # Shared filter for species == "feline"
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="species", operator=FilterOperator.EQ, value="feline")
+        ]
+    )
+
+    retriever = index.as_retriever(
+        filters=filters,
+        similarity_top_k=5,
+        image_similarity_top_k=5,
+    )
+
+    # Combined retrieve
+    results = retriever.retrieve("feline info")
+    assert len(results) == 2
+    node_ids = {r.node.node_id for r in results}
+    assert node_ids == {"txt_1", "img_1"}
+    for r in results:
+        assert r.node.metadata["species"] == "feline"
+
+    # Modality-specific filters (image_filters overriding filters for images)
+    image_filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key="species", operator=FilterOperator.EQ, value="canine")
+        ]
+    )
+    retriever_custom = index.as_retriever(
+        filters=filters,
+        image_filters=image_filters,
+        similarity_top_k=5,
+        image_similarity_top_k=5,
+    )
+
+    # Text retrieve should still use filters (feline), text-to-image should use image_filters (canine)
+    txt_res = retriever_custom.text_retrieve("info")
+    assert len(txt_res) == 1
+    assert txt_res[0].node.node_id == "txt_1"
+
+    img_res = retriever_custom.text_to_image_retrieve("info")
+    assert len(img_res) == 1
+    assert img_res[0].node.node_id == "img_2"
+
+
+@pytest.mark.asyncio
+async def test_async_multimodal_retriever_with_filters():
+    """Test async retrieval methods on MultiModalVectorIndexRetriever with filters."""
+    embed_model_text, embed_model_image = _get_mock_embed_models()
+
+    text_nodes = [
+        TextNode(text="Elephant text", id_="txt_1", metadata={"type": "wild"}),
+        TextNode(text="Dog text", id_="txt_2", metadata={"type": "pet"}),
+    ]
+    image_nodes = [
+        ImageNode(image=BASE64_PNG, id_="img_1", metadata={"type": "wild"}),
+        ImageNode(image=BASE64_PNG, id_="img_2", metadata={"type": "pet"}),
+    ]
+
+    index = MultiModalVectorStoreIndex(
+        nodes=text_nodes + image_nodes,
+        image_embed_model=embed_model_image,
+        embed_model=embed_model_text,
+    )
+
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key="type", operator=FilterOperator.EQ, value="wild")]
+    )
+
+    retriever = index.as_retriever(
+        filters=filters,
+        similarity_top_k=5,
+        image_similarity_top_k=5,
+    )
+
+    # Async image-to-image
+    i2i_res = await retriever.aimage_to_image_retrieve(BASE64_PNG)
+    assert len(i2i_res) == 1
+    assert i2i_res[0].node.node_id == "img_1"
+
+    # Async text-to-image
+    t2i_res = await retriever.atext_to_image_retrieve("wild elephant")
+    assert len(t2i_res) == 1
+    assert t2i_res[0].node.node_id == "img_1"
+
+    # Async text
+    txt_res = await retriever.atext_retrieve("wild elephant")
+    assert len(txt_res) == 1
+    assert txt_res[0].node.node_id == "txt_1"
+
+    # Async combined
+    all_res = await retriever.aretrieve("wild animals")
+    assert len(all_res) == 2
+    assert {r.node.node_id for r in all_res} == {"txt_1", "img_1"}


### PR DESCRIPTION
# Description

Fixes #15165

In `MultiModalVectorStoreIndex` and `MultiModalVectorIndexRetriever`:
1. `MultiModalVectorStoreIndex.as_retriever()` automatically passed `node_ids=list(self.index_struct.nodes_dict.values())` to `MultiModalVectorIndexRetriever`. Because `self.index_struct.nodes_dict` only tracks text nodes, on image-only indexes this passed `node_ids=[]`, and on mixed text+image indexes it passed only text node IDs.
2. During image retrieval (`image_to_image_retrieve` and `text_to_image_retrieve`), `_build_vector_store_query` attached `self._node_ids` to the image vector store query. The underlying vector store (e.g. `SimpleVectorStore`) pre-filtered by `node_ids in set(query.node_ids)`, which dropped all image nodes (returning 0 results) and prevented `MetadataFilters` from matching image nodes.
3. In addition, `MultiModalVectorIndexRetriever` lacked parameters for distinct `image_filters` and `image_node_ids`, and `_build_node_list_from_query_result` checked `stores_text` against the text vector store rather than the target store.

### Changes:
- **`MultiModalVectorStoreIndex.as_retriever`**: Only populate `node_ids` when not provided in `kwargs` and `self.index_struct.nodes_dict` is non-empty.
- **`MultiModalVectorIndexRetriever`**:
  - Add `image_filters` and `image_node_ids` to `__init__`.
  - Update `_build_vector_store_query` to route `node_ids` and `filters`/`image_filters` based on whether the query targets text or images (`is_image_query`).
  - Update `_text_retrieve`, `_atext_retrieve`, `_text_to_image_retrieve`, `_atext_to_image_retrieve`, `_image_to_image_retrieve`, and `_aimage_to_image_retrieve` to pass `is_image_query`.
  - Update `_build_node_list_from_query_result` to accept `vector_store` context and correctly handle `ImageNode` docstore recovery.
- **Unit Tests**:
  - Added unit test suite in `tests/indices/multi_modal/test_retriever.py` covering:
    - Image-only index retrieval with `MetadataFilters` (`image_to_image_retrieve` and `text_to_image_retrieve`).
    - Mixed text + image index with shared and modality-specific `image_filters`.
    - Async multi-modal retrieval methods with filters.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] No (llama-index-core update)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change (`tests/indices/multi_modal/test_retriever.py`)
- [x] Ran all multi-modal chat engine and vector store retriever tests (22 passed)
- [x] Ran `uv run ruff check` and `uv run ruff format --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
