### PR TITLE
docs: clarify separator placement in text utility

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/utils.py
+++ b/llama-index-core/llama_index/core/node_parser/text/utils.py
@@ -25,14 +25,14 @@ def truncate_text(text: str, text_splitter: TextSplitter) -> str:
 
 def split_text_keep_separator(text: str, separator: str) -> List[str]:
     """
-    Split text with separator and keep the separator at the end of each split.
+    Split text with separator and keep the separator at the beginning of each split after the first.
 
     Args:
         text (str): The text to split.
         separator (str): The separator to split on.
 
     Returns:
-        List[str]: List of text segments with separators preserved at the end of each split.
+        List[str]: List of text segments with separators preserved at the beginning of each split after the first.
 
     """
     parts = text.split(separator)

--- a/llama-index-core/tests/text_splitter/test_sentence_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_sentence_splitter.py
@@ -2,6 +2,7 @@ from typing import List
 
 import tiktoken
 from llama_index.core.node_parser.text import SentenceSplitter
+from llama_index.core.node_parser.text.utils import split_text_keep_separator
 from llama_index.core.schema import Document, MetadataMode, TextNode
 
 
@@ -13,6 +14,15 @@ def test_paragraphs() -> None:
     sentence_split = sentence_text_splitter.split_text(text)
     assert sentence_split[0] == " ".join(["foo"] * 15)
     assert sentence_split[1] == " ".join(["bar"] * 15)
+
+
+def test_split_text_keep_separator_preserves_lossless_reconstruction() -> None:
+    text = "a..b."
+
+    chunks = split_text_keep_separator(text, ".")
+
+    assert chunks == ["a", ".", ".b", "."]
+    assert "".join(chunks) == text
 
 
 def test_start_end_char_idx() -> None:


### PR DESCRIPTION
## Related Issue

Fixes #22704

## Proposed Changes

The split_text_keep_separator implementation prepends separators to every split after the first, but its docstring described separators as trailing. This PR updates the docstring to describe the existing behavior and adds a regression test covering consecutive separators and lossless reconstruction.

## How did you test it?

- python -c ... isolated execution of split_text_keep_separator: passed (['a', '.', '.b', '.'] and lossless reconstruction).
- python -m pytest llama-index-core/tests/text_splitter/test_sentence_splitter.py::test_split_text_keep_separator_preserves_lossless_reconstruction -q: blocked by missing llama_index_instrumentation in the local environment.

## Notes for the reviewer

No runtime behavior changes; this preserves compatibility with existing chunk boundaries.

This PR was fully generated with an AI assistant. I reviewed the changes and ran the relevant isolated regression check.

## Checklist

- [x] I have read the contributors guidelines and code of conduct.
- [x] I have added a unit test.
- [x] I have used a conventional commit title.
- [x] I have documented the change.
- [ ] Full local pytest suite could not run because the workspace dependency llama_index_instrumentation is not installed.