### PR TITLE
fix(core): validate streamed chat-with-tools responses at stream end (#22721)

### DIFF
--- a/llama-index-core/llama_index/core/llms/function_calling.py
+++ b/llama-index-core/llama_index/core/llms/function_calling.py
@@ -108,8 +108,27 @@ class FunctionCallingLLM(LLM):
             tool_required=tool_required,
             **kwargs,
         )
-        # TODO: no validation for streaming outputs
-        return self.stream_chat(**chat_kwargs)
+        response_gen = self.stream_chat(**chat_kwargs)
+
+        def gen() -> ChatResponseGen:
+            last_response: Optional[ChatResponse] = None
+            for last_response in response_gen:
+                yield last_response
+
+            # streamed responses accumulate, so once the stream is exhausted the
+            # last response carries the full message and can get the same
+            # validation as the non-streaming path. Validation is expected to
+            # mutate the response in place (e.g. force_single_tool_call), which
+            # consumers holding a reference to the final response will observe.
+            if last_response is not None:
+                self._validate_chat_with_tools_response(
+                    last_response,
+                    tools,
+                    allow_parallel_tool_calls=allow_parallel_tool_calls,
+                    **kwargs,
+                )
+
+        return gen()
 
     async def astream_chat_with_tools(
         self,
@@ -131,8 +150,24 @@ class FunctionCallingLLM(LLM):
             tool_required=tool_required,
             **kwargs,
         )
-        # TODO: no validation for streaming outputs
-        return await self.astream_chat(**chat_kwargs)
+        response_gen = await self.astream_chat(**chat_kwargs)
+
+        async def gen() -> ChatResponseAsyncGen:
+            last_response: Optional[ChatResponse] = None
+            async for last_response in response_gen:
+                yield last_response
+
+            # see stream_chat_with_tools: validate the fully accumulated
+            # response once the stream is exhausted
+            if last_response is not None:
+                self._validate_chat_with_tools_response(
+                    last_response,
+                    tools,
+                    allow_parallel_tool_calls=allow_parallel_tool_calls,
+                    **kwargs,
+                )
+
+        return gen()
 
     def _prepare_chat_with_tools_compat(
         self,

--- a/llama-index-core/tests/llms/test_function_calling.py
+++ b/llama-index-core/tests/llms/test_function_calling.py
@@ -5,6 +5,7 @@ import pytest
 from llama_index.core.base.llms.types import (
     ChatMessage,
     ChatResponse,
+    ChatResponseAsyncGen,
     ChatResponseGen,
     CompletionResponse,
     LLMMetadata,
@@ -98,6 +99,48 @@ class MockFunctionCallingLLMWithoutToolRequired(MockFunctionCallingLLM):
         return {"messages": []}
 
 
+class MockStreamingFunctionCallingLLM(MockFunctionCallingLLM):
+    """Mock LLM that streams cumulative responses and records validation calls."""
+
+    def __init__(
+        self,
+        tool_selection: List[ToolSelection],
+        stream_responses: List[ChatResponse],
+    ):
+        super().__init__(tool_selection)
+        self._stream_responses = stream_responses
+        self._validated: List[ChatResponse] = []
+
+    def stream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseGen:
+        def gen() -> ChatResponseGen:
+            yield from self._stream_responses
+
+        return gen()
+
+    async def astream_chat(
+        self, messages: Sequence[ChatMessage], **kwargs: Any
+    ) -> ChatResponseAsyncGen:
+        async def gen() -> ChatResponseAsyncGen:
+            for response in self._stream_responses:
+                yield response
+
+        return gen()
+
+    def _validate_chat_with_tools_response(
+        self,
+        response: ChatResponse,
+        tools: Sequence["BaseTool"],
+        allow_parallel_tool_calls: bool = False,
+        **kwargs: Any,
+    ) -> ChatResponse:
+        self._validated.append(response)
+        # mimic in-place normalization such as force_single_tool_call
+        response.message.additional_kwargs["validated"] = True
+        return response
+
+
 class Person(BaseModel):
     name: str = Field(description="Person name")
 
@@ -152,6 +195,99 @@ async def test_apredict_and_call_throws_if_error_on_tool(
     llm = MockFunctionCallingLLM([person_tool_selection])
     with pytest.raises(ValueError):
         await llm.apredict_and_call(tools=[person_tool], error_on_tool_error=True)
+
+
+@pytest.fixture()
+def stream_responses() -> List[ChatResponse]:
+    # streaming responses are cumulative: each chunk carries the full message
+    # so far plus the new delta
+    return [
+        ChatResponse(message=ChatMessage(role="assistant", content="foo"), delta="foo"),
+        ChatResponse(
+            message=ChatMessage(role="assistant", content="foobar"), delta="bar"
+        ),
+    ]
+
+
+def test_stream_chat_with_tools_validates_final_response(
+    person_tool: FunctionTool,
+    person_tool_selection: ToolSelection,
+    stream_responses: List[ChatResponse],
+) -> None:
+    """Test that the final streamed response gets validated once the stream is exhausted."""
+    llm = MockStreamingFunctionCallingLLM([person_tool_selection], stream_responses)
+
+    chunks = list(llm.stream_chat_with_tools(tools=[person_tool]))
+
+    assert chunks == stream_responses
+    assert llm._validated == [stream_responses[-1]]
+    # in-place changes made by validation are visible on the final response
+    assert chunks[-1].message.additional_kwargs.get("validated") is True
+    # intermediate chunks are passed through untouched
+    assert "validated" not in chunks[0].message.additional_kwargs
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_with_tools_validates_final_response(
+    person_tool: FunctionTool,
+    person_tool_selection: ToolSelection,
+    stream_responses: List[ChatResponse],
+) -> None:
+    """Test that the async streaming path validates the final response."""
+    llm = MockStreamingFunctionCallingLLM([person_tool_selection], stream_responses)
+
+    response_gen = await llm.astream_chat_with_tools(tools=[person_tool])
+    chunks = [chunk async for chunk in response_gen]
+
+    assert chunks == stream_responses
+    assert llm._validated == [stream_responses[-1]]
+    assert chunks[-1].message.additional_kwargs.get("validated") is True
+
+
+def test_stream_chat_with_tools_partial_consumption_skips_validation(
+    person_tool: FunctionTool,
+    person_tool_selection: ToolSelection,
+    stream_responses: List[ChatResponse],
+) -> None:
+    """Test that validation only runs when the stream is fully consumed."""
+    llm = MockStreamingFunctionCallingLLM([person_tool_selection], stream_responses)
+
+    response_gen = llm.stream_chat_with_tools(tools=[person_tool])
+    next(response_gen)
+    response_gen.close()
+
+    assert llm._validated == []
+
+
+def test_stream_chat_with_tools_empty_stream(
+    person_tool: FunctionTool, person_tool_selection: ToolSelection
+) -> None:
+    """Test that an empty stream neither errors nor validates."""
+    llm = MockStreamingFunctionCallingLLM([person_tool_selection], [])
+
+    assert list(llm.stream_chat_with_tools(tools=[person_tool])) == []
+    assert llm._validated == []
+
+
+def test_stream_chat_with_tools_validation_error_raised_at_stream_end(
+    person_tool: FunctionTool,
+    person_tool_selection: ToolSelection,
+    stream_responses: List[ChatResponse],
+) -> None:
+    """Test that a raising validator surfaces the error when the stream ends."""
+    llm = MockStreamingFunctionCallingLLM([person_tool_selection], stream_responses)
+
+    with patch.object(
+        llm,
+        "_validate_chat_with_tools_response",
+        side_effect=ValueError("invalid tool call"),
+    ):
+        response_gen = llm.stream_chat_with_tools(tools=[person_tool])
+        chunks = [next(response_gen), next(response_gen)]
+        with pytest.raises(ValueError, match="invalid tool call"):
+            next(response_gen)
+
+    assert chunks == stream_responses
 
 
 def test_tool_required_compatibility_without_support(


### PR DESCRIPTION
Fixes #22721

## Problem

`stream_chat_with_tools` / `astream_chat_with_tools` returned the raw stream with a literal `# TODO: no validation for streaming outputs` (`function_calling.py` L111/L134), while the non-streaming paths run `_validate_chat_with_tools_response`. Every override of that hook in the repo (openai, anthropic, bedrock-converse, mistralai, ollama, vertex, litellm, …) normalizes in place via `force_single_tool_call` when `allow_parallel_tool_calls=False` — so streaming callers silently skipped that normalization. No integration overrides the streaming entry points themselves, so a base-class fix covers all of them.

## Approach

Keep the outer methods eager (prepare + start the stream at call time, preserving error timing); return a wrapper generator that yields every chunk through untouched, and — since streamed `ChatResponse`s are cumulative — runs the same validation on the final response once the stream is exhausted, before `StopIteration`/`StopAsyncIteration` reaches the consumer. Fail-at-end because a partial response can't be meaningfully validated, and existing validators mutate rather than raise. Consumers that hold the last chunk and use it after the loop (e.g. `function_agent.py::_get_streaming_response`) observe the validated form; partially consumed streams (`break`/`close`) skip validation, unchanged from today; empty streams are guarded.

## Tests

New `tests/llms/test_function_calling.py` cases: sync validate-at-end, async validate-at-end, partial-consumption skips validation, empty stream, raising validator surfaces at the stream boundary.

- `uv run -- pytest tests/llms/test_function_calling.py -v` → 11 passed
- `uv run -- pytest tests/llms/ tests/program/ tests/agent/ -q` → 172 passed, 3 skipped
- `uv run pre-commit run --files <changed files>` → all hooks passed

## AI disclosure (per CONTRIBUTING.md)

Prepared with AI assistance (Claude Code). I reviewed the change, and verification was done by running the test suites above; the design (validate-at-end, after-yield, in-place-mutation reliance) was checked against all in-repo consumers of the streaming entry points.