### PR TITLE
fix(embeddings): use asyncio_run in HuggingFaceInferenceAPIEmbedding sync methods

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/llama_index/embeddings/huggingface_api/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/llama_index/embeddings/huggingface_api/base.py
@@ -8,6 +8,7 @@ from huggingface_hub import (
     model_info,
 )
 from huggingface_hub.hf_api import ModelInfo
+from llama_index.core.async_utils import asyncio_run
 from llama_index.core.base.embeddings.base import (
     BaseEmbedding,
     Embedding,
@@ -173,33 +174,28 @@ class HuggingFaceInferenceAPIEmbedding(BaseEmbedding):  # type: ignore[misc]
         """
         Embed the input query synchronously.
 
-        NOTE: a new asyncio event loop is created internally for this.
+        NOTE: This is safe to call from within a running event loop
+        (e.g. Jupyter/ipykernel or an async web handler).
         """
-        return asyncio.run(self._aget_query_embedding(query))
+        return asyncio_run(self._aget_query_embedding(query))
 
     def _get_text_embedding(self, text: str) -> Embedding:
         """
         Embed the text query synchronously.
 
-        NOTE: a new asyncio event loop is created internally for this.
+        NOTE: This is safe to call from within a running event loop
+        (e.g. Jupyter/ipykernel or an async web handler).
         """
-        return asyncio.run(self._aget_text_embedding(text))
+        return asyncio_run(self._aget_text_embedding(text))
 
     def _get_text_embeddings(self, texts: List[str]) -> List[Embedding]:
         """
         Embed the input sequence of text synchronously and in parallel.
 
-        NOTE: a new asyncio event loop is created internally for this.
+        NOTE: This is safe to call from within a running event loop
+        (e.g. Jupyter/ipykernel or an async web handler).
         """
-        loop = asyncio.new_event_loop()
-        try:
-            tasks = [
-                loop.create_task(self._aget_text_embedding(text)) for text in texts
-            ]
-            loop.run_until_complete(asyncio.wait(tasks))
-        finally:
-            loop.close()
-        return [task.result() for task in tasks]
+        return asyncio_run(self._aget_text_embeddings(texts))
 
     async def _aget_query_embedding(self, query: str) -> Embedding:
         return await self._async_embed_single(

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-embeddings-huggingface-api"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index embeddings huggingface api integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/tests/test_hf_inference.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-huggingface-api/tests/test_hf_inference.py
@@ -1,7 +1,10 @@
+import asyncio
+from typing import List, Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
+from llama_index.core.base.embeddings.base import Embedding
 from llama_index.embeddings.huggingface_api.base import HuggingFaceInferenceAPIEmbedding
 from llama_index.embeddings.huggingface_api.pooling import Pooling
 
@@ -97,6 +100,45 @@ class TestHuggingFaceInferenceAPIEmbeddings:
             == raw_single_embedding
         )
         mock_feature_extraction.assert_awaited_once_with("test")
+
+    def test_sync_embed_methods_inside_running_event_loop(
+        self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding
+    ) -> None:
+        """
+        Sync embed methods must work when called from within a running event loop.
+
+        Regression test for https://github.com/run-llama/llama_index/issues/22744:
+        a bare ``asyncio.run()`` in the sync methods raised
+        ``RuntimeError: asyncio.run() cannot be called from a running event loop``
+        in Jupyter/ipykernel cells and async web handlers.
+        """
+        raw_single_embedding = np.random.default_rng().random(1024, dtype=np.float32)
+
+        async def call_sync_methods() -> Tuple[Embedding, Embedding, List[Embedding]]:
+            query_embedding = hf_inference_api_embedding.get_query_embedding("query")
+            text_embedding = hf_inference_api_embedding.get_text_embedding("text")
+            batch_embeddings = hf_inference_api_embedding.get_text_embedding_batch(
+                ["first", "second"]
+            )
+            return query_embedding, text_embedding, batch_embeddings
+
+        with patch.object(
+            hf_inference_api_embedding._async_client,
+            "feature_extraction",
+            AsyncMock(return_value=raw_single_embedding),
+        ):
+            query_embedding, text_embedding, batch_embeddings = asyncio.run(
+                call_sync_methods()
+            )
+
+        for embedding in (query_embedding, text_embedding, *batch_embeddings):
+            assert isinstance(embedding, list)
+            assert len(embedding) == 1024
+            assert np.all(
+                np.array(embedding, dtype=raw_single_embedding.dtype)
+                == raw_single_embedding
+            )
+        assert len(batch_embeddings) == 2
 
     def test_serialization(
         self, hf_inference_api_embedding: HuggingFaceInferenceAPIEmbedding


### PR DESCRIPTION
Fixes #22744

## Description

The sync embed methods of `HuggingFaceInferenceAPIEmbedding` used bare `asyncio.run()` (`_get_query_embedding`, `_get_text_embedding`) and `asyncio.new_event_loop()` + `run_until_complete()` (`_get_text_embeddings`), which raise `RuntimeError: asyncio.run() cannot be called from a running event loop` / "Cannot run the event loop while another loop is running" before any network I/O when called from Jupyter/ipykernel or an async web handler.

All three sync methods now delegate through `llama_index.core.async_utils.asyncio_run`, which detects a running loop and executes the coroutine in a separate thread — the same guard pattern applied in the #22661 fix. The sync batch path now shares the async batch implementation (one bulk request) instead of maintaining a separate N-parallel-tasks code path, so sync and async behavior stay aligned.

## Version Bump

Yes — `llama-index-embeddings-huggingface-api` 0.5.0 → 0.5.1

## New Package?

No

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New unit test `test_sync_embed_methods_inside_running_event_loop` exercises all three public sync methods from inside `asyncio.run()` with a mocked `AsyncInferenceClient`: it fails on `main` with the exact `RuntimeError` from the issue and passes with this fix. Full package suite: `pytest tests/` → 7 passed. `ruff format` + `ruff check` clean on changed files.

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.