### PR TITLE
fix(core): reject document number 0 and negatives in choice-select parsing

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -146,7 +146,7 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
-        if answer_num > num_choices:
+        if answer_num < 1 or answer_num > num_choices:
             continue
         answer_nums.append(answer_num)
         # extract just the first digits after the colon.

--- a/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
@@ -102,8 +102,16 @@ class LLMRerank(BaseNodePostprocessor):
             raw_response, len(nodes_batch)
         )
         choice_idxs = [int(choice) - 1 for choice in raw_choices]
-        choice_nodes = [nodes_batch[idx] for idx in choice_idxs]
-        relevances = relevances or [1.0 for _ in choice_nodes]
+        valid_mask = [0 <= idx < len(nodes_batch) for idx in choice_idxs]
+        choice_nodes = [
+            nodes_batch[idx] for idx, valid in zip(choice_idxs, valid_mask) if valid
+        ]
+        if relevances:
+            relevances = [
+                relevance for relevance, valid in zip(relevances, valid_mask) if valid
+            ]
+        else:
+            relevances = [1.0 for _ in choice_nodes]
         return [
             NodeWithScore(node=node, score=relevance)
             for node, relevance in zip(choice_nodes, relevances)

--- a/llama-index-core/tests/indices/test_utils.py
+++ b/llama-index-core/tests/indices/test_utils.py
@@ -34,3 +34,12 @@ def test_default_parse_choice_select_answer_fn(answer):
     answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
     assert answer_nums == [2, 4]
     assert answer_relevances == [8, 6]
+
+
+def test_default_parse_choice_select_answer_fn_rejects_zero_and_negative():
+    from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
+
+    answer = "Doc: 0, Relevance: 9\nDoc: -2, Relevance: 9\nDoc: 2, Relevance: 8"
+    answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 3)
+    assert answer_nums == [2]
+    assert answer_relevances == [8]

--- a/llama-index-core/tests/postprocessor/test_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_llm_rerank.py
@@ -166,6 +166,26 @@ async def test_llm_rerank__async() -> None:
     assert result_nodes[2].node.get_content() == "Test3"
 
 
+def test_llm_rerank_ignores_out_of_range_choices() -> None:
+    """A choice number outside 1..len(nodes_batch) must not wrap around via negative indexing."""
+    nodes = [
+        TextNode(text="DOC_A"),
+        TextNode(text="DOC_B"),
+        TextNode(text="DOC_C"),
+    ]
+
+    def bad_parse_fn(answer: str, num_choices: int):
+        # Simulates a custom parser (or a buggy LLM) that lets 0 and negatives through.
+        return [0, -2, 2], [9.0, 9.0, 8.0]
+
+    llm_rerank = LLMRerank(parse_choice_select_answer_fn=bad_parse_fn)
+    result_nodes = llm_rerank._parse_raw_response("unused", nodes)
+
+    assert len(result_nodes) == 1
+    assert result_nodes[0].node.get_content() == "DOC_B"
+    assert result_nodes[0].score == 8.0
+
+
 @patch.object(
     MockLLM,
     "chat",


### PR DESCRIPTION
# Description

Fixes #22743.

`default_parse_choice_select_answer_fn` (`llama-index-core/llama_index/core/indices/utils.py`) validated only the upper bound of the document number an LLM returns:

```python
if answer_num > num_choices:
    continue
```

`0` and negative numbers passed straight through. `LLMRerank._parse_raw_response` then does `int(choice) - 1` and indexes the node batch with the result, so Python's negative indexing turned an out-of-range low number into a silent wrap-around to the wrong document instead of an error — e.g. `Doc: 0` maps to index `-1` (the *last* node in the batch) and `Doc: -2` maps to index `-3`.

## Fix

1. **`indices/utils.py`** — made the guard two-sided: `if answer_num < 1 or answer_num > num_choices: continue`.
2. **`postprocessor/llm_rerank.py`** — added a defensive bounds filter in `_parse_raw_response`. `parse_choice_select_answer_fn` is user-overridable via the `LLMRerank` constructor, so it cannot be assumed a custom parser validates its own output. The filter keeps `choice_idxs` and `relevances` paired by applying the same validity mask to both lists (rather than filtering only the index list), so a dropped out-of-range choice doesn't shift the pairing between the remaining nodes and their relevance scores.

## New Package?

- [x] No

## Version Bump?

- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added:
- `test_default_parse_choice_select_answer_fn_rejects_zero_and_negative` in `tests/indices/test_utils.py` — asserts `Doc: 0` and `Doc: -2` are skipped and only the valid `Doc: 2` is kept.
- `test_llm_rerank_ignores_out_of_range_choices` in `tests/postprocessor/test_llm_rerank.py` — feeds `LLMRerank` a custom `parse_choice_select_answer_fn` returning `[0, -2, 2]` (simulating a parser/LLM that lets invalid numbers through) and asserts only the valid choice (`DOC_B`) is returned, instead of wrapping around to `DOC_C`/`DOC_A`.

Both new tests were confirmed to fail against the pre-fix code (via `git checkout HEAD~1 -- <file>`, restoring after):

```
FAILED tests/indices/test_utils.py::test_default_parse_choice_select_answer_fn_rejects_zero_and_negative - assert [0, -2, 2] == [2]
FAILED tests/postprocessor/test_llm_rerank.py::test_llm_rerank_ignores_out_of_range_choices - AssertionError: assert 3 == 1
```

After the fix, full suite for the touched packages:

```
$ uv run -- pytest tests/postprocessor/ tests/indices/ -q
316 passed, 2 skipped, 16 warnings in 5.37s
```

`ruff check` and `ruff format --check` on all changed files: clean. Pre-commit hooks (ruff, ruff-format, mypy, prettier, codespell, etc.) all passed on commit.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI assistance disclosure

This change was written with AI assistance (Claude). I reviewed the diff, verified the bounds-filter logic preserves index/relevance pairing (rather than naively filtering only the index list, which would have silently misaligned scores with nodes), and confirmed both new tests fail without the fix and pass with it.

## Note on related PRs

This is not a duplicate of #22404, #21920, or #22252, which all address a different, orthogonal defect in the same function (the `answer_nums`/`answer_relevances` length desync when a relevance fails to parse). None of those PRs touches the lower-bound check — confirmed by reading their diffs before starting this fix.
