### PR TITLE
fix(core): respect zero vector similarity threshold

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py
@@ -186,7 +186,7 @@ class VectorContextRetriever(BasePGRetriever):
         assert len(triplets) == len(new_scores)
 
         # filter by similarity score
-        if self._similarity_score:
+        if self._similarity_score is not None:
             filtered_data = [
                 (triplet, score)
                 for triplet, score in zip(triplets, new_scores)
@@ -258,7 +258,7 @@ class VectorContextRetriever(BasePGRetriever):
         assert len(triplets) == len(new_scores)
 
         # filter by similarity score
-        if self._similarity_score:
+        if self._similarity_score is not None:
             filtered_data = [
                 (triplet, score)
                 for triplet, score in zip(triplets, new_scores)

--- a/llama-index-core/tests/indices/property_graph/test_sub_retrievers.py
+++ b/llama-index-core/tests/indices/property_graph/test_sub_retrievers.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from llama_index.core import MockEmbedding
+from llama_index.core.graph_stores.types import (
+    EntityNode,
+    PropertyGraphStore,
+    Relation,
+)
+from llama_index.core.indices.property_graph.sub_retrievers.vector import (
+    VectorContextRetriever,
+)
+from llama_index.core.schema import QueryBundle
+
+
+def _mock_vector_graph_store() -> MagicMock:
+    low_left = EntityNode(name="low-left")
+    low_right = EntityNode(name="low-right")
+    high_left = EntityNode(name="high-left")
+    high_right = EntityNode(name="high-right")
+    low_relation = Relation(
+        label="low-relation", source_id=low_left.id, target_id=low_right.id
+    )
+    high_relation = Relation(
+        label="high-relation", source_id=high_left.id, target_id=high_right.id
+    )
+    nodes = [low_left, low_right, high_left, high_right]
+    scores = [-0.4, -0.2, 0.1, 0.3]
+    triplets = [
+        (low_left, low_relation, low_right),
+        (high_left, high_relation, high_right),
+    ]
+
+    graph_store = MagicMock(spec=PropertyGraphStore)
+    graph_store.supports_vector_queries = True
+    graph_store.vector_query.return_value = (nodes, scores)
+    graph_store.get_rel_map.return_value = triplets
+    graph_store.avector_query.return_value = (nodes, scores)
+    graph_store.aget_rel_map.return_value = triplets
+    return graph_store
+
+
+def _zero_threshold_retriever(
+    graph_store: PropertyGraphStore,
+) -> VectorContextRetriever:
+    return VectorContextRetriever(
+        graph_store=graph_store,
+        embed_model=MockEmbedding(embed_dim=1),
+        include_text=False,
+        similarity_score=0.0,
+    )
+
+
+def test_vector_context_retriever_applies_zero_threshold() -> None:
+    retriever = _zero_threshold_retriever(_mock_vector_graph_store())
+
+    results = retriever.retrieve_from_graph(QueryBundle("query", embedding=[1.0]))
+
+    assert [result.score for result in results] == [0.3]
+
+
+@pytest.mark.asyncio
+async def test_vector_context_retriever_applies_zero_threshold_async() -> None:
+    retriever = _zero_threshold_retriever(_mock_vector_graph_store())
+
+    results = await retriever.aretrieve_from_graph(
+        QueryBundle("query", embedding=[1.0])
+    )
+
+    assert [result.score for result in results] == [0.3]


### PR DESCRIPTION
# Description

`VectorContextRetriever.similarity_score` is documented as the minimum score
to retrieve. A configured value of `0.0` was treated as if no threshold had
been supplied because both the synchronous and asynchronous paths used a
truthiness check. As a result, triplets with negative similarity scores were
still returned.

This change treats every non-`None` value as a configured threshold and adds
sync and async regression coverage. It does not change the public API or add
dependencies.

Issue: N/A. I searched open and closed issues and pull requests for this zero
threshold behavior and found no existing report or implementation.

## Reproduction

The regression uses two triplets whose resulting scores are `-0.2` and `0.3`
with `similarity_score=0.0`.

Before the production change, both tests failed because the retriever returned
`[0.3, -0.2]` instead of `[0.3]`. With this change, both sync and async paths
return only the non-negative result.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — this updates `llama-index-core`, which the template exempts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Commands and results:

- `.venv/bin/pytest tests/indices/property_graph/test_sub_retrievers.py -q`
  — 2 passed
- `.venv/bin/pytest tests/indices/property_graph tests/graph_stores/test_simple_lpg.py -q`
  — 32 passed
- `pre-commit run --files llama-index-core/llama_index/core/indices/property_graph/sub_retrievers/vector.py llama-index-core/tests/indices/property_graph/test_sub_retrievers.py`
  — all hooks passed, including ruff, ruff-format, mypy, prettier, and codespell

The pytest runs emitted only existing `pytest-asyncio` deprecation warnings
under Python 3.14.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing related unit tests pass locally with my changes
- [x] I ran the repository pre-commit checks for every changed file

## AI Assistance

OpenAI Codex assisted with investigation, implementation, duplicate checking,
and test execution. I reviewed and understood the complete change, verified
the failing behavior before the fix, and confirmed the test results above.
