### PR TITLE
fix(core): handle empty SimpleChatStore deletions

### DIFF
--- a/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/simple_chat_store.py
@@ -65,15 +65,14 @@ class SimpleChatStore(BaseChatStore):
         """Delete specific message for a key."""
         if key not in self.store:
             return None
-        if idx >= len(self.store[key]):
+        messages = self.store[key]
+        if not -len(messages) <= idx < len(messages):
             return None
-        return self.store[key].pop(idx)
+        return messages.pop(idx)
 
     def delete_last_message(self, key: str) -> Optional[ChatMessage]:
         """Delete last message for a key."""
-        if key not in self.store:
-            return None
-        return self.store[key].pop()
+        return self.delete_message(key, -1)
 
     def get_keys(self) -> List[str]:
         """Get all keys."""

--- a/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
+++ b/llama-index-core/tests/storage/chat_store/test_simple_chat_store.py
@@ -78,6 +78,27 @@ def test_delete_chat_message_idx() -> None:
     ]
 
 
+def test_delete_chat_message_out_of_bounds() -> None:
+    """Test deleting a message with an out-of-bounds negative index."""
+    chat_store = SimpleChatStore()
+    chat_store.add_message("user1", ChatMessage(role="user", content="hello"))
+
+    assert chat_store.delete_message("user1", -2) is None
+    assert chat_store.get_messages("user1") == [
+        ChatMessage(role="user", content="hello"),
+    ]
+
+
+def test_delete_last_chat_message_from_empty_history() -> None:
+    """Test deleting the last message from an existing empty history."""
+    chat_store = SimpleChatStore()
+    message = ChatMessage(role="user", content="hello")
+    chat_store.add_message("user1", message)
+
+    assert chat_store.delete_last_message("user1") == message
+    assert chat_store.delete_last_message("user1") is None
+
+
 def test_persist_non_ascii_unescaped(tmp_path: Path) -> None:
     """Test that non-ascii content is persisted as-is, not as unicode escapes."""
     chat_store = SimpleChatStore()


### PR DESCRIPTION
# Description

`SimpleChatStore.delete_message()` currently handles indexes past the positive end of a history, but an out-of-bounds negative index reaches `list.pop()` and raises `IndexError` even though the public API returns `Optional[ChatMessage]`. The same gap makes a second `delete_last_message()` call raise after the only message has been removed, because the history key remains present with an empty list.

This change validates both sides of the Python list-index range before deleting a message and routes `delete_last_message()` through that shared safe path. Valid positive and negative indexes keep their existing behavior, while missing messages now consistently return `None`, matching the other chat-store implementations.

No new dependencies are required.

**AI assistance disclosure:** OpenAI Codex helped identify the edge cases and draft the focused implementation and tests. I reviewed the behavior against `BaseChatStore` and the other chat-store backends, understand the change, and verified it locally.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core` is exempt)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

The regression tests cover an out-of-bounds negative index and repeated deletion after a one-message history becomes empty. Before the fix they fail with `IndexError: pop index out of range` and `IndexError: pop from empty list`; after the fix, the complete `llama-index-core/tests/storage` suite passes with 47 tests.

The repository pre-commit hooks also pass on both changed files, including Ruff formatting/linting, mypy, Prettier, and codespell.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally with my changes
