### PR TITLE
fix(core): restore token-by-token streaming for default Refine program

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -344,6 +344,16 @@ class Refine(BaseSynthesizer):
             except (ValidationError, ValueError, TypeError) as e:
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
+            if (
+                isinstance(program, DefaultRefineProgram)
+                and program._output_cls is None
+            ):
+                # Plain-text streaming has no fields to disambiguate, so stream
+                # tokens directly instead of buffering behind the "wait for the
+                # full structured object" machinery below.
+                return program._llm.stream(
+                    program._prompt, **program_kwargs, **response_kwargs
+                )
             try:
                 structured_response_gen = program.stream_call(
                     **program_kwargs,
@@ -394,6 +404,16 @@ class Refine(BaseSynthesizer):
             except (ValidationError, ValueError, TypeError) as e:
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
+            if (
+                isinstance(program, DefaultRefineProgram)
+                and program._output_cls is None
+            ):
+                # Plain-text streaming has no fields to disambiguate, so stream
+                # tokens directly instead of buffering behind the "wait for the
+                # full structured object" machinery below.
+                return await program._llm.astream(
+                    program._prompt, **program_kwargs, **response_kwargs
+                )
             try:
                 structured_response_gen = await program.astream_call(
                     **program_kwargs,

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -46,7 +46,7 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -57,7 +57,7 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -122,7 +122,7 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -133,7 +133,7 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -54,7 +54,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -65,7 +65,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -77,7 +77,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     num_iters = 0
     for _ in response.response_gen:
         num_iters += 1
-    assert num_iters == 1
+    assert num_iters > 1
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])
@@ -112,7 +112,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -123,7 +123,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -135,7 +135,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     num_iters = 0
     async for _ in response.async_response_gen():
         num_iters += 1
-    assert num_iters == 1
+    assert num_iters > 1
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -553,6 +553,38 @@ class TestRefine:
             assert llm.last_called_chat_function == []
             assert llm.last_chat_messages is None
 
+    def test_synthesize__streaming_default_refine_program_yields_incrementally(
+        self, llm_case: LLMCase, nodes: list[NodeWithScore]
+    ) -> None:
+        """
+        Regression test for https://github.com/run-llama/llama_index/issues/22749:
+        the default (non-structured, non-filtering) refine program must stream
+        tokens as they arrive instead of buffering the whole answer behind a
+        single chunk.
+        """
+        llm = llm_case.llm
+        llm.max_tokens = 10
+        synthesizer = Refine(llm=llm, streaming=True)
+        response = synthesizer.synthesize(query="test", nodes=nodes[:1])
+        assert isinstance(response, StreamingResponse)
+        chunks = list(response.response_gen)
+        assert len(chunks) > 1
+        assert "".join(chunks) == " ".join(["text"] * 10)
+
+    @pytest.mark.asyncio
+    async def test_asynthesize__streaming_default_refine_program_yields_incrementally(
+        self, llm_case: LLMCase, nodes: list[NodeWithScore]
+    ) -> None:
+        """Async counterpart of the regression test above."""
+        llm = llm_case.llm
+        llm.max_tokens = 10
+        synthesizer = Refine(llm=llm, streaming=True)
+        response = await synthesizer.asynthesize(query="test", nodes=nodes[:1])
+        assert isinstance(response, AsyncStreamingResponse)
+        chunks = [chunk async for chunk in response.async_response_gen()]
+        assert len(chunks) > 1
+        assert "".join(chunks) == " ".join(["text"] * 10)
+
     def test_synthesize__structured_answer_filtering_default_text_completion_refine_program(
         self,
         llm_case: LLMCase,


### PR DESCRIPTION
## Problem

Closes #22749.

Since 0.14.0, `ContextChatEngine`, `CondenseQuestionChatEngine`, and
`CondensePlusContextChatEngine` don't stream — `stream_chat`/`astream_chat`
return a response whose generator yields the *entire* answer as a single
chunk instead of incrementally.

### Root cause

`llama-index-core/llama_index/core/response_synthesizers/refine.py`'s
`DefaultRefineProgram.stream_call`/`astream_call` (added in #21374, the
multimodal synthesis refactor) always fully drain the LLM's token stream
into a local `answer` string before yielding a single
`StructuredRefineResponse` — there is no per-token `yield` in the loop:

```python
for token in self._llm.stream(self._prompt, **kwds):
    answer += token
yield StructuredRefineResponse(answer=answer.strip(), query_satisfied=True)
```

`Refine._update_response`/`_aupdate_response` then defer to
`_get_attribute_from_object_generator`, which is designed to wait for a
structured object to be fully streamed before trusting any of its fields
(needed for JSON/structured outputs, where field order isn't guaranteed) —
so it also only ever emits the `answer` attribute once, at the end.

For the plain (non-structured, non-filtering) case used by the default
chat engines, there's no such ambiguity — the answer text is always
"complete so far" — so this buffering is unnecessary and regresses the
pre-0.14 behavior, where `Refine` called `self._llm.stream(...)` directly
and exposed the raw per-token generator (see `v0.13.6`'s
`_give_response_single`).

## Fix

In `Refine._update_response`/`_aupdate_response`, when the program is the
plain `DefaultRefineProgram` (no `output_cls`, i.e. no structured
answer/filtering in play), stream directly from `self._llm` instead of
going through the structured-object buffering path. Structured/filtering
streaming (`structured_answer_filtering=True` or `output_cls` set) is
untouched.

## Test plan

Added a regression test in `test_refine.py` that fails without the fix
(single big chunk instead of many small ones), and updated two chat-engine
tests that had baked in the buggy "exactly 1 chunk" behavior as an
assertion (`test_context.py`, `test_condense_plus_context.py`) to assert
real streaming (`> 1` chunks) instead.

Verified the added test fails against the pre-fix source
(`git checkout HEAD~1 -- llama_index/core/response_synthesizers/refine.py`)
and passes after restoring the fix:

```
$ uv run -- pytest tests/response_synthesizers/test_refine.py -k yields_incrementally -v
# before fix:
FAILED ...test_synthesize__streaming_default_refine_program_yields_incrementally[non chat model] - AssertionError: assert 1 > 1
FAILED ...test_synthesize__streaming_default_refine_program_yields_incrementally[chat model] - AssertionError: assert 1 > 1
FAILED ...test_asynthesize__streaming_default_refine_program_yields_incrementally[non chat model] - AssertionError: assert 1 > 1
FAILED ...test_asynthesize__streaming_default_refine_program_yields_incrementally[chat model] - AssertionError: assert 1 > 1

# after fix:
4 passed
```

Full suite after the fix:

```
$ uv run -- pytest tests/response_synthesizers/ tests/chat_engine/ -q
165 passed

$ uv run -- pytest tests/ -q
1487 passed, 22 skipped, 6 xfailed
```

Lint:

```
$ uv run ruff check llama_index/core/response_synthesizers/refine.py
All checks passed!
$ uv run ruff format --check llama_index/core/response_synthesizers/refine.py
1 file already formatted
```

## AI disclosure

This change (root-cause analysis, fix, and tests) was written with AI
assistance (Claude Code). I reviewed the diff, traced the regression back
to #21374 by bisecting the refine.py history, and verified the fix against
the full `llama-index-core` test suite plus a new failing-before/passing-
after regression test, per the repo's AI contribution guidelines.
