### PR TITLE
fix(openai): don't discard explicit temperature for O1 models in OpenAIResponses

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -303,8 +303,10 @@ class OpenAI(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # O1 models only support the default temperature; only override it
+        # when the caller left it at the default, so an explicit value is
+        # never silently discarded.
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         if not is_chatcomp_api_supported(model):

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -314,8 +314,10 @@ class OpenAIResponses(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # O1 models only support the default temperature; only override it
+        # when the caller left it at the default, so an explicit value is
+        # never silently discarded.
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         super().__init__(

--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.7.10"
+version = "0.7.11"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -630,6 +630,20 @@ def test_reasoning_effort_not_passed_for_non_o1_models():
     assert "reasoning_effort" not in kwargs
 
 
+def test_o1_model_keeps_explicit_temperature():
+    """An explicit temperature passed for an O1 model must not be overwritten."""
+    model_name = next(iter(O1_MODELS))
+    llm = OpenAI(model=model_name, temperature=0.5, api_key="test-key")
+    assert llm.temperature == 0.5
+
+
+def test_o1_model_defaults_temperature_to_one():
+    """Without an explicit temperature, O1 models still default to 1.0."""
+    model_name = next(iter(O1_MODELS))
+    llm = OpenAI(model=model_name, api_key="test-key")
+    assert llm.temperature == 1.0
+
+
 def test_reasoning_effort_none_default():
     """Test that reasoning_effort defaults to None and is not passed."""
     model_name = "o1-mini"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -64,6 +64,33 @@ def test_init_and_properties(default_responses_llm):
     assert metadata.is_chat_model is True
 
 
+def test_o1_model_keeps_explicit_temperature():
+    """An explicit temperature passed for an O1 model must not be overwritten."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            model = next(iter(O1_MODELS))
+            llm = OpenAIResponses(
+                model=model,
+                temperature=0.5,
+                api_key="fake-api-key",
+            )
+
+    assert llm.temperature == 0.5
+
+
+def test_o1_model_defaults_temperature_to_one():
+    """Without an explicit temperature, O1 models still default to 1.0."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            model = next(iter(O1_MODELS))
+            llm = OpenAIResponses(
+                model=model,
+                api_key="fake-api-key",
+            )
+
+    assert llm.temperature == 1.0
+
+
 def test_get_model_name():
     """Test different model name formats are properly handled."""
     with patch("llama_index.llms.openai.responses.SyncOpenAI"):


### PR DESCRIPTION
# Description

Both `OpenAIResponses.__init__()` (`responses.py`) and `OpenAI.__init__()`
(`base.py`) unconditionally force `temperature=1.0` for any model in
`O1_MODELS`, silently discarding whatever value the caller passed in —
there is no warning, no log, no raised exception, the value is just lost:

```python
# TODO: Temp forced to 1.0 for o1
if model in O1_MODELS:
    temperature = 1.0
```

This runs before `super().__init__()`, so an explicit `temperature=0.5`
passed by the caller is replaced with `1.0` with no indication anything
happened. The issue thread confirms both classes are affected identically
and asks for a single PR fixing both.

This PR applies the reporter's suggested minimal, non-breaking fix to
**both** `base.py` and `responses.py`: only apply the O1 override when the
caller left `temperature` at its default (`DEFAULT_TEMPERATURE`), so an
explicitly-provided value is respected while O1 models still default to
`1.0` when the caller didn't specify one.

```python
if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
    temperature = 1.0
```

Fixes #22751

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (`llama-index-llms-openai` 0.7.10 → 0.7.11)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_o1_model_keeps_explicit_temperature` and
`test_o1_model_defaults_temperature_to_one` to both
`tests/test_openai_responses.py` (for `OpenAIResponses`) and
`tests/test_openai.py` (for `OpenAI`).

Verified the new `base.py` regression test fails on the pre-fix code
(`git checkout HEAD~1 -- .../base.py` then re-run):

```
tests/test_openai.py::test_o1_model_keeps_explicit_temperature FAILED
E       AssertionError: assert 1.0 == 0.5
tests/test_openai.py::test_o1_model_defaults_temperature_to_one PASSED
1 failed, 1 passed, 31 deselected in 1.90s
```

And passes after re-applying the fix, along with the full package suite:

```
$ uv run -- pytest tests/
116 passed, 14 skipped, 7 warnings in 9.29s
```

`ruff check` and `ruff format --check` both pass on the changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` (ruff check/format) to appease the lint gods

---
This change was authored with AI assistance (Claude).
