### PR TITLE
fix(core): preserve token streaming in refine chat engines

### DIFF
--- a/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -158,6 +158,10 @@ class DefaultRefineProgram(BasePydanticProgram):
                 answer += token
             yield StructuredRefineResponse(answer=answer.strip(), query_satisfied=True)
 
+    def _stream_answer(self, *args: Any, **kwds: Any) -> Generator[str, None, None]:
+        """Stream the unstructured answer without buffering it first."""
+        return self._llm.stream(self._prompt, **kwds)
+
     async def astream_call(
         self, *args: Any, **kwds: Any
     ) -> AsyncGenerator[StructuredRefineResponse, None]:
@@ -198,6 +202,12 @@ class DefaultRefineProgram(BasePydanticProgram):
                     )
 
         return gen()
+
+    async def _astream_answer(
+        self, *args: Any, **kwds: Any
+    ) -> AsyncGenerator[str, None]:
+        """Stream the unstructured answer without buffering it first."""
+        return await self._llm.astream(self._prompt, **kwds)
 
 
 class Refine(BaseSynthesizer):
@@ -345,6 +355,15 @@ class Refine(BaseSynthesizer):
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
             try:
+                if (
+                    not self._structured_answer_filtering
+                    and isinstance(program, DefaultRefineProgram)
+                    and program._output_cls is None
+                ):
+                    return program._stream_answer(
+                        **program_kwargs,
+                        **response_kwargs,
+                    )
                 structured_response_gen = program.stream_call(
                     **program_kwargs,
                     **response_kwargs,
@@ -395,6 +414,15 @@ class Refine(BaseSynthesizer):
                 logger.warning(f"Structured response error: {e}", exc_info=True)
         elif self._streaming:
             try:
+                if (
+                    not self._structured_answer_filtering
+                    and isinstance(program, DefaultRefineProgram)
+                    and program._output_cls is None
+                ):
+                    return await program._astream_answer(
+                        **program_kwargs,
+                        **response_kwargs,
+                    )
                 structured_response_gen = await program.astream_call(
                     **program_kwargs,
                     **response_kwargs,

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -46,7 +46,7 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -57,7 +57,7 @@ def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -122,7 +122,7 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -133,7 +133,7 @@ async def test_chat_astream(chat_engine: CondensePlusContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)

--- a/llama-index-core/tests/chat_engine/test_condense_question.py
+++ b/llama-index-core/tests/chat_engine/test_condense_question.py
@@ -1,5 +1,8 @@
 from unittest.mock import Mock
 
+import pytest
+
+from llama_index.core import MockEmbedding
 from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.base.response.schema import Response, StreamingResponse
@@ -8,6 +11,19 @@ from llama_index.core.chat_engine.condense_question import (
 )
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.memory import ChatMemoryBuffer
+from llama_index.core.indices import VectorStoreIndex
+from llama_index.core.schema import Document
+
+
+@pytest.fixture()
+def retriever_chat_engine() -> CondenseQuestionChatEngine:
+    llm = MockLLM()
+    index = VectorStoreIndex.from_documents(
+        [Document.example()], embed_model=MockEmbedding(embed_dim=3)
+    )
+    return CondenseQuestionChatEngine.from_defaults(
+        query_engine=index.as_query_engine(llm=llm), llm=llm
+    )
 
 
 def test_condense_question_chat_engine(patch_llm_predictor) -> None:
@@ -71,3 +87,20 @@ def test_stream_chat_history_write_completes_on_early_exit() -> None:
     assert len(engine.chat_history) == 2
     assert engine.chat_history[0].role == MessageRole.USER
     assert engine.chat_history[1].role == MessageRole.ASSISTANT
+
+
+def test_stream_chat_yields_incremental_tokens(
+    retriever_chat_engine: CondenseQuestionChatEngine,
+) -> None:
+    response = retriever_chat_engine.stream_chat("Hello!")
+
+    assert sum(1 for _ in response.response_gen) > 1
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_yields_incremental_tokens(
+    retriever_chat_engine: CondenseQuestionChatEngine,
+) -> None:
+    response = await retriever_chat_engine.astream_chat("Hello!")
+
+    assert sum([1 async for _ in response.async_response_gen()]) > 1

--- a/llama-index-core/tests/chat_engine/test_context.py
+++ b/llama-index-core/tests/chat_engine/test_context.py
@@ -54,7 +54,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -65,7 +65,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     for _ in response.response_gen:
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -77,7 +77,7 @@ def test_chat_stream(chat_engine: ContextChatEngine):
     num_iters = 0
     for _ in response.response_gen:
         num_iters += 1
-    assert num_iters == 1
+    assert num_iters > 1
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])
@@ -112,7 +112,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert len(chat_engine.chat_history) == 2
@@ -123,7 +123,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     async for _ in response.async_response_gen():
         num_iters += 1
 
-    assert num_iters == 1
+    assert num_iters > 1
     assert SYSTEM_PROMPT in str(response)
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
@@ -135,7 +135,7 @@ async def test_chat_astream(chat_engine: ContextChatEngine):
     num_iters = 0
     async for _ in response.async_response_gen():
         num_iters += 1
-    assert num_iters == 1
+    assert num_iters > 1
     assert str(q) in str(response)
     assert len(chat_engine.chat_history) == 2
     assert str(q) in str(chat_engine.chat_history[0])

--- a/llama-index-core/tests/response_synthesizers/test_refine.py
+++ b/llama-index-core/tests/response_synthesizers/test_refine.py
@@ -69,6 +69,10 @@ class QuerySatisfiedCase(BaseModel):
     expected_last_llm_message_prefix: str
 
 
+class CustomOutput(BaseModel):
+    value: str
+
+
 class LLMCase(BaseModel):
     llm: MockLLMWithChatMemoryOfLastCall
     chat_function: str | None = None
@@ -552,6 +556,123 @@ class TestRefine:
         else:
             assert llm.last_called_chat_function == []
             assert llm.last_chat_messages is None
+
+    def test_synthesize__streaming_default_refine_program_does_not_buffer_tokens(
+        self,
+    ) -> None:
+        llm = MockLLM()
+
+        def stream_complete(
+            *args: Any, **kwargs: Any
+        ) -> Generator[CompletionResponse, None, None]:
+            for text, delta in (
+                ("hel", "hel"),
+                ("hello", "lo"),
+                ("hello world", " world"),
+            ):
+                yield CompletionResponse(text=text, delta=delta)
+
+        with patch.object(MockLLM, "stream_complete", side_effect=stream_complete):
+            response = Refine(llm=llm, streaming=True).synthesize(
+                query="test",
+                nodes=[NodeWithScore(node=TextNode(text="context"))],
+            )
+
+        assert isinstance(response, StreamingResponse)
+        assert list(response.response_gen) == ["hel", "lo", " world"]
+
+    @pytest.mark.asyncio
+    async def test_asynthesize__streaming_default_refine_program_does_not_buffer_tokens(
+        self,
+    ) -> None:
+        llm = MockLLM()
+
+        async def astream_complete(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[CompletionResponse, None]:
+            for text, delta in (
+                ("hel", "hel"),
+                ("hello", "lo"),
+                ("hello world", " world"),
+            ):
+                yield CompletionResponse(text=text, delta=delta)
+
+        with patch.object(MockLLM, "astream_complete", side_effect=astream_complete):
+            response = await Refine(llm=llm, streaming=True).asynthesize(
+                query="test",
+                nodes=[NodeWithScore(node=TextNode(text="context"))],
+            )
+
+        assert isinstance(response, AsyncStreamingResponse)
+        assert [token async for token in response.async_response_gen()] == [
+            "hel",
+            "lo",
+            " world",
+        ]
+
+    def test_update_response__streaming_output_cls_uses_structured_stream(self) -> None:
+        llm = MockLLM()
+        program = DefaultRefineProgram(
+            prompt=MagicMock(), llm=llm, output_cls=CustomOutput
+        )
+        synthesizer = Refine(llm=llm, streaming=True, output_cls=CustomOutput)
+
+        with (
+            patch.object(
+                program,
+                "stream_call",
+                return_value=iter(
+                    [
+                        StructuredRefineResponse(
+                            answer='{"value":"ok"}', query_satisfied=True
+                        )
+                    ]
+                ),
+            ) as stream_call,
+            patch.object(
+                program,
+                "_stream_answer",
+                side_effect=AssertionError("unstructured path must not be used"),
+            ),
+        ):
+            response = synthesizer._update_response(program, {}, {})
+
+        assert response is not None
+        assert list(cast(Generator[str, None, None], response)) == ['{"value":"ok"}']
+        stream_call.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_aupdate_response__streaming_output_cls_uses_structured_stream(
+        self,
+    ) -> None:
+        llm = MockLLM()
+        program = DefaultRefineProgram(
+            prompt=MagicMock(), llm=llm, output_cls=CustomOutput
+        )
+        synthesizer = Refine(llm=llm, streaming=True, output_cls=CustomOutput)
+
+        async def structured_stream() -> AsyncGenerator[StructuredRefineResponse, None]:
+            yield StructuredRefineResponse(
+                answer='{"value":"ok"}', query_satisfied=True
+            )
+
+        with (
+            patch.object(
+                program, "astream_call", return_value=structured_stream()
+            ) as astream_call,
+            patch.object(
+                program,
+                "_astream_answer",
+                side_effect=AssertionError("unstructured path must not be used"),
+            ),
+        ):
+            response = await synthesizer._aupdate_response(program, {}, {})
+
+        assert response is not None
+        assert [token async for token in cast(AsyncGenerator[str, None], response)] == [
+            '{"value":"ok"}'
+        ]
+        astream_call.assert_awaited_once_with()
 
     def test_synthesize__structured_answer_filtering_default_text_completion_refine_program(
         self,


### PR DESCRIPTION
## Description

Fixes #22749.

The default `Refine` program buffered the entire LLM response whenever streaming was enabled, so `ContextChatEngine`, `CondenseQuestionChatEngine`, and `CondensePlusContextChatEngine` emitted one complete answer instead of incremental tokens. Unstructured streaming now passes through the underlying LLM token generator. Structured answer filtering and `output_cls` responses keep their existing structured streaming behavior.

## Version Bump?

Not required for `llama-index-core`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

- Added synchronous and asynchronous regression tests for unbuffered default `Refine` streaming and preservation of the `output_cls` path.
- Added or strengthened streaming assertions for all three chat engines named in #22749.
- Targeted suite: 70 passed.
- Full `llama-index-core` suite: 1460 passed, 39 skipped, 6 xfailed, and 13 unrelated `SimpleDirectoryReader` failures because this checkout lives below a hidden `.tmp` directory and those tests exclude hidden paths.
- Ruff check and format check passed for all changed files.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

AI assistance was used for drafting and implementation; the change and tests were reviewed and verified manually.
