### PR TITLE
fix(web): report urls OxylabsWebReader silently drops, mark reader remote

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/README.md
@@ -2,7 +2,7 @@
 
 Use Oxylabs Webpage Loader to load a webpage from any URL.
 
-For more information checkout out the [Oxylabs documentation](https://developers.oxylabs.io/scraper-apis/web-scraper-api).
+For more information check out the [Oxylabs documentation](https://developers.oxylabs.io/products/web-scraper-api).
 
 ## Instructions for OxylabsReader
 

--- a/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/llama_index/readers/web/oxylabs_web/base.py
@@ -1,6 +1,7 @@
 """Oxylabs Web Reader."""
 
 import asyncio
+import warnings
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from platform import architecture, python_version
 from importlib.metadata import version
@@ -26,7 +27,7 @@ class OxylabsWebReader(BasePydanticReader):
     """
     Scrape any website with Oxylabs Web Scraper API and get results in Markdown format.
 
-    [See the API documentation](https://developers.oxylabs.io/scraper-apis/web-scraper-api/other-websites)
+    [See the API documentation](https://developers.oxylabs.io/api-targets/any-domain)
 
     Args:
         username: Oxylabs API username.
@@ -54,8 +55,8 @@ class OxylabsWebReader(BasePydanticReader):
 
     """
 
-    timeout_s: int = 100
-    oxylabs_scraper_url: str = "https://realtime.oxylabs.io/v1/queries"
+    is_remote: bool = True
+
     api: "RealtimeAPI"
     async_api: "AsyncAPI"
     default_config: dict[str, Any] = Field(default_factory=get_default_config)
@@ -95,6 +96,29 @@ class OxylabsWebReader(BasePydanticReader):
             text=text,
         )
 
+    def _documents_from_responses(
+        self, urls: list[str], responses: list[Any]
+    ) -> List[Document]:
+        """
+        Build documents, reporting any url the API returned no result for.
+
+        Without the warning a failed url is indistinguishable from one that
+        was never requested, so a partially successful load looks complete.
+        """
+        documents = []
+
+        for url, response in zip(urls, responses):
+            if not response:
+                warnings.warn(
+                    f"Oxylabs returned no result for {url!r}. Skipping it.",
+                    stacklevel=3,
+                )
+                continue
+
+            documents.append(self._get_document_from_response(response))
+
+        return documents
+
     async def aload_data(
         self,
         urls: list[str],
@@ -106,7 +130,7 @@ class OxylabsWebReader(BasePydanticReader):
         Args:
             urls: List of URLs to load.
             additional_params: Dictionary of scraper parameters as described
-                [here](https://developers.oxylabs.io/scraper-apis/web-scraper-api/targets/generic-target#additional)
+                [here](https://developers.oxylabs.io/products/web-scraper-api/features)
 
         """
         if additional_params is None:
@@ -122,11 +146,7 @@ class OxylabsWebReader(BasePydanticReader):
             ]
         )
 
-        return [
-            self._get_document_from_response(response)
-            for response in responses
-            if response
-        ]
+        return self._documents_from_responses(urls, responses)
 
     def load_data(
         self,
@@ -139,7 +159,7 @@ class OxylabsWebReader(BasePydanticReader):
         Args:
             urls: List of URLs to load.
             additional_params: Dictionary of scraper parameters as described
-                [here](https://developers.oxylabs.io/scraper-apis/web-scraper-api/targets/generic-target#additional)
+                [here](https://developers.oxylabs.io/products/web-scraper-api/features)
 
         """
         if additional_params is None:
@@ -153,8 +173,4 @@ class OxylabsWebReader(BasePydanticReader):
             for url in urls
         ]
 
-        return [
-            self._get_document_from_response(response)
-            for response in responses
-            if response
-        ]
+        return self._documents_from_responses(urls, responses)

--- a/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-web/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-web"
-version = "0.6.0"
+version = "0.6.1"
 description = "llama-index readers web integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-web/tests/test_readers_oxylabs.py
+++ b/llama-index-integrations/readers/llama-index-readers-web/tests/test_readers_oxylabs.py
@@ -76,3 +76,52 @@ async def test_async_oxylabs_reader(
 
     for doc in docs:
         assert doc.text == expected_output
+
+
+@pytest.mark.skipif(skip_if_py39_or_lower, reason="Pytest does not support Python 3.9")
+def test_sync_oxylabs_reader_warns_on_dropped_url():
+    """A url the API returns no result for should be reported, not dropped."""
+    reader = OxylabsWebReader(
+        username="OXYLABS_USERNAME",
+        password="OXYLABS_PASSWORD",
+    )
+
+    ok = {
+        "results": [{"content": {"key1": "value1"}}],
+        "job": {"job_id": 42424242},
+    }
+    reader.api.get_response = MagicMock(side_effect=[ok, None])
+
+    with pytest.warns(UserWarning, match="https://bad.example"):
+        docs = reader.load_data(["https://good.example", "https://bad.example"])
+
+    assert len(docs) == 1
+
+
+@pytest.mark.skipif(skip_if_py39_or_lower, reason="Pytest does not support Python 3.9")
+@pytest.mark.asyncio
+async def test_async_oxylabs_reader_warns_on_dropped_url():
+    reader = OxylabsWebReader(
+        username="OXYLABS_USERNAME",
+        password="OXYLABS_PASSWORD",
+    )
+
+    ok = {
+        "results": [{"content": {"key1": "value1"}}],
+        "job": {"job_id": 42424242},
+    }
+    reader.async_api.get_response = AsyncMock(side_effect=[ok, None])
+
+    with pytest.warns(UserWarning, match="https://bad.example"):
+        docs = await reader.aload_data(["https://good.example", "https://bad.example"])
+
+    assert len(docs) == 1
+
+
+@pytest.mark.skipif(skip_if_py39_or_lower, reason="Pytest does not support Python 3.9")
+def test_reader_is_marked_remote():
+    reader = OxylabsWebReader(
+        username="OXYLABS_USERNAME",
+        password="OXYLABS_PASSWORD",
+    )
+    assert reader.is_remote is True


### PR DESCRIPTION
# Description

`OxylabsWebReader` filtered failed responses out with `if response`, so a url the API rejected disappeared with no exception and no warning. Load five urls with one bad and you get four documents back, with nothing indicating which failed.

That is a bad failure mode for an ingestion step, because a partial result is indistinguishable from a complete one. Reproduced before the fix:

```python
reader.load_data(["not-a-valid-url"])
# SDK logs: {"message":"Parameter `url` is invalid."}
# returned docs: 0        <- no exception raised
```

Each response is now paired with its url, and a dropped url produces a warning naming it. Both the sync and async paths share one helper. After the fix:

```
mixed batch -> 1 doc(s)
   WARNING: Oxylabs returned no result for 'not-a-valid-url'. Skipping it.
```

I chose a warning over raising so that one bad url in a large batch does not discard the successful documents, which would be a harsher behaviour change.

**Also in this PR:**

- Set `is_remote = True`. Every other networked reader in this package (`simple_web`, `rss`, `zenrows_web`, `trafilatura_web`, `beautiful_soup_web`) already does, and it feeds caching decisions in ingestion pipelines.
- Dropped the unused `timeout_s` and `oxylabs_scraper_url` fields; neither was ever read.
- Updated the documentation links, which all 404 against the current developers.oxylabs.io url scheme. Verified the replacements return 200.

For context: I have taken over maintenance of the Oxylabs integrations from @oxy-rostyslav, who has left Oxylabs. This PR is independent of the changes to the standalone `llama-index-readers-oxylabs` package and can be reviewed on its own.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `0.6.0` -> `0.6.1`
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Added three tests: the sync and async warning paths (using `pytest.warns`, asserting the failing url is named and that successful documents survive) and one asserting `is_remote`. All 5 Oxylabs tests in this package pass, `ruff` clean, and I verified the behaviour against the live Oxylabs API with a mixed good/bad batch.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
