### PR TITLE
fix(ingestion): defer docstore writes/deletes until after transformation succeeds (#22638, #22639)

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -460,7 +460,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -483,11 +482,6 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
@@ -528,9 +522,17 @@ class IngestionPipeline(BaseModel):
             DocstoreStrategy.UPSERTS,
             DocstoreStrategy.UPSERTS_AND_DELETE,
         ):
+            for node in nodes:
+                ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
+                existing_hash = self.docstore.get_document_hash(ref_doc_id)
+                if existing_hash and existing_hash != node.hash:
+                    self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
+                    if self.vector_store is not None:
+                        self.vector_store.delete(ref_doc_id)
             self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
             self.docstore.add_documents(nodes, store_text=store_doc_text)
         elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
+            self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
             self.docstore.add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
@@ -675,9 +677,17 @@ class IngestionPipeline(BaseModel):
             DocstoreStrategy.UPSERTS,
             DocstoreStrategy.UPSERTS_AND_DELETE,
         ):
+            for node in nodes:
+                ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
+                existing_hash = await self.docstore.aget_document_hash(ref_doc_id)
+                if existing_hash and existing_hash != node.hash:
+                    await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
+                    if self.vector_store is not None:
+                        await self.vector_store.adelete(ref_doc_id)
             await self.docstore.aset_document_hashes({n.id_: n.hash for n in nodes})
             await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
         elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
+            await self.docstore.aset_document_hashes({n.id_: n.hash for n in nodes})
             await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
@@ -695,7 +705,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -719,11 +728,6 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -400,6 +400,87 @@ def test_pipeline_with_transform_error() -> None:
     assert pipeline.docstore.get_node("1", raise_error=False) is None
 
 
+def test_pipeline_failed_transform_does_not_poison_hash() -> None:
+    """
+    Failed run must not persist the document hash (fixes #22638).
+
+    If the hash is written eagerly before transformation, a retry will skip
+    the document forever because _handle_duplicates sees it as already seen.
+    """
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError("transient failure")
+
+    doc = Document(text="hello world", doc_id="doc1")
+    docstore = SimpleDocumentStore()
+
+    failing = IngestionPipeline(
+        transformations=[RaisingTransform()],
+        docstore=docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+
+    with pytest.raises(RuntimeError):
+        failing.run(documents=[doc])
+
+    # Hash must NOT be in the docstore after a failed run
+    assert docstore.get_document_hash("doc1") is None
+
+    # A retry with a healthy pipeline must process the document, not skip it
+    retry = IngestionPipeline(
+        transformations=[],
+        docstore=docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = retry.run(documents=[doc])
+    assert len(nodes) == 1
+
+
+def test_pipeline_failed_upsert_does_not_delete_existing_doc() -> None:
+    """
+    Failed UPSERTS run must not delete the already-indexed document (fixes #22639).
+
+    If delete_ref_doc is called eagerly before transformation runs, a failure
+    leaves the index empty with no way to recover the original document.
+    """
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError("transient failure")
+
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    v1_doc = Document(text="v1 content", doc_id="doc1")
+    ok_pipeline = IngestionPipeline(
+        transformations=[MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    ok_pipeline.run(documents=[v1_doc])
+    assert len(vector_store.data.embedding_dict) > 0
+
+    v2_doc = Document(text="v2 content changed", doc_id="doc1")
+    failing = IngestionPipeline(
+        transformations=[RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+
+    with pytest.raises(RuntimeError):
+        failing.run(documents=[v2_doc])
+
+    # Original v1 embeddings must still be in the vector store
+    assert len(vector_store.data.embedding_dict) > 0
+
+
 @pytest.mark.asyncio
 async def test_arun_pipeline() -> None:
     pipeline = IngestionPipeline(
@@ -638,6 +719,76 @@ async def test_async_pipeline_with_transform_error() -> None:
         await pipeline.arun(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_failed_transform_does_not_poison_hash() -> None:
+    """Async: failed run must not persist the document hash (fixes #22638)."""
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError("transient failure")
+
+    doc = Document(text="hello world", doc_id="doc1")
+    docstore = SimpleDocumentStore()
+
+    failing = IngestionPipeline(
+        transformations=[RaisingTransform()],
+        docstore=docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+
+    with pytest.raises(RuntimeError):
+        await failing.arun(documents=[doc])
+
+    assert docstore.get_document_hash("doc1") is None
+
+    retry = IngestionPipeline(
+        transformations=[],
+        docstore=docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = await retry.arun(documents=[doc])
+    assert len(nodes) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_failed_upsert_does_not_delete_existing_doc() -> None:
+    """Async: failed UPSERTS run must not delete the already-indexed document (fixes #22639)."""
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError("transient failure")
+
+    docstore = SimpleDocumentStore()
+    vector_store = SimpleVectorStore()
+
+    v1_doc = Document(text="v1 content", doc_id="doc1")
+    ok_pipeline = IngestionPipeline(
+        transformations=[MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    await ok_pipeline.arun(documents=[v1_doc])
+    assert len(vector_store.data.embedding_dict) > 0
+
+    v2_doc = Document(text="v2 content changed", doc_id="doc1")
+    failing = IngestionPipeline(
+        transformations=[RaisingTransform()],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+
+    with pytest.raises(RuntimeError):
+        await failing.arun(documents=[v2_doc])
+
+    assert len(vector_store.data.embedding_dict) > 0
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:


### PR DESCRIPTION
Fixes #22638
Fixes #22639

## Root cause

Two related bugs in `IngestionPipeline` where docstore side effects were applied **before** transformations ran, making failures unrecoverable:

**#22638 — `DUPLICATES_ONLY`: poisoned hash**
`_handle_duplicates` called `set_document_hash` during the dedup decision phase, before `run_transformations`. A transient error left the hash persisted; every subsequent retry saw the hash as already present and silently skipped the document forever.

**#22639 — `UPSERTS`: eager delete**
`_handle_upserts` called `delete_ref_doc` and `vector_store.delete` during the decision phase, before `run_transformations`. A transient error left the index permanently empty with no path to restore the original document.

## What changed

- `_handle_duplicates` / `_ahandle_duplicates`: removed `set_document_hash` calls; the in-memory `current_hashes` set still prevents intra-batch duplicates.
- `_handle_upserts` / `_ahandle_upserts`: removed the per-node `delete_ref_doc` and `vector_store.delete` calls. The `UPSERTS_AND_DELETE` missing-doc sweep (documents absent from the current batch) is unchanged — those documents are not being transformed, so eager deletion there is safe.
- `_update_docstore` / `_aupdate_docstore`: moved both the hash write (DUPLICATES_ONLY) and the stale-version deletion (UPSERTS) here, so they only execute after `run_transformations` returns successfully.

## Test evidence

Four new tests added to `tests/ingestion/test_pipeline.py`:
- `test_pipeline_failed_transform_does_not_poison_hash` — sync DUPLICATES_ONLY: failed run leaves no hash; retry processes document.
- `test_pipeline_failed_upsert_does_not_delete_existing_doc` — sync UPSERTS: failed run leaves original embeddings intact.
- `test_async_pipeline_failed_transform_does_not_poison_hash` — async equivalent.
- `test_async_pipeline_failed_upsert_does_not_delete_existing_doc` — async equivalent.

All 30 tests in `tests/ingestion/test_pipeline.py` pass (`uv run pytest tests/ingestion/test_pipeline.py`).

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.