### PR TITLE
fix(openai): preserve user-provided temperature for o1 models (#22751)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -303,8 +303,8 @@ class OpenAI(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # Only force temperature=1.0 for o1 if caller did not explicitly set it
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         if not is_chatcomp_api_supported(model):

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -314,8 +314,8 @@ class OpenAIResponses(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # Only force temperature=1.0 for o1 if caller did not explicitly set it
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         super().__init__(

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -921,3 +921,16 @@ def test_from_openai_message_without_reasoning_content() -> None:
     assert len(thinking_blocks) == 0
     assert len(result.blocks) == 1
     assert result.blocks[0].text == "Hello!"
+
+
+def test_o1_model_temperature_handling() -> None:
+    """Regression test for issue #22751: User-specified temperature should not be silently overwritten."""
+    with CachedOpenAIApiKeys(set_fake_key=True):
+        # When temperature is not provided, defaults to 1.0 for O1
+        llm_default = OpenAI(model="o1-mini")
+        assert llm_default.temperature == 1.0
+
+        # When caller explicitly sets temperature, it must be preserved
+        llm_custom = OpenAI(model="o1-mini", temperature=0.7)
+        assert llm_custom.temperature == 0.7
+

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1009,3 +1009,15 @@ def test__parse_response_output(response_output: List[ResponseOutputItem]):
     assert [
         block for block in result.message.blocks if isinstance(block, ThinkingBlock)
     ][3].content == "hello\nworld"
+
+
+def test_o1_model_responses_temperature_handling() -> None:
+    """Regression test for issue #22751: User-specified temperature should not be silently overwritten in OpenAIResponses."""
+    # When temperature is not provided, defaults to 1.0 for O1
+    llm_default = OpenAIResponses(model="o1-mini", api_key="sk-test")
+    assert llm_default.temperature == 1.0
+
+    # When caller explicitly sets temperature, it must be preserved
+    llm_custom = OpenAIResponses(model="o1-mini", temperature=0.7, api_key="sk-test")
+    assert llm_custom.temperature == 0.7
+


### PR DESCRIPTION
## Description
Fixes #22751

In `OpenAI` (`base.py`) and `OpenAIResponses` (`responses.py`), `__init__()` previously forced `temperature = 1.0` unconditionally whenever `model in O1_MODELS`. This silently discarded any custom temperature value explicitly passed by the caller (e.g. `OpenAI(model="o1-mini", temperature=0.7)`).

### Solution:
- Updated the O1 model temperature check in both `OpenAI.__init__()` and `OpenAIResponses.__init__()` to only set `temperature = 1.0` when `temperature == DEFAULT_TEMPERATURE`.
- If the caller passes an explicit temperature, their chosen value is preserved.
- Added regression unit tests in `test_openai.py` and `test_openai_responses.py`.
