### PR TITLE
fix(core): validate retrievers in QueryFusionRetriever

### DIFF
--- a/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/fusion_retriever.py
@@ -53,6 +53,8 @@ class QueryFusionRetriever(BaseRetriever):
         self.use_async = use_async
 
         self._retrievers = retrievers
+        if not retrievers:
+            raise ValueError("QueryFusionRetriever requires at least one retriever")
         if retriever_weights is None:
             self._retriever_weights = [1.0 / len(retrievers)] * len(retrievers)
         else:

--- a/llama-index-core/tests/retrievers/test_fusion_retriever.py
+++ b/llama-index-core/tests/retrievers/test_fusion_retriever.py
@@ -33,3 +33,8 @@ async def test_aretrieve_uses_async_query_generation():
     await retriever.aretrieve("test query")
 
     assert async_called
+
+
+def test_query_fusion_retriever_requires_retrievers():
+    with pytest.raises(ValueError, match="retriever"):
+        QueryFusionRetriever(retrievers=[])


### PR DESCRIPTION
## Description

This PR adds validation to `QueryFusionRetriever` to ensure that at least one retriever is provided during initialization.

Previously, passing an empty retriever list caused a `ZeroDivisionError` while calculating retriever weights. This change raises a clear `ValueError` instead, preventing invalid initialization.

## Fixes

Fixes the empty retriever initialization issue in `QueryFusionRetriever`.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this is already covered by existing unit tests

Tested with:

bash
uv run -- pytest tests/retrievers/test_fusion_retriever.py -q

Result :
2 passed

Checklist
- I have performed a self-review of my own code
- I have added tests that prove my fix is effective
- New and existing unit tests pass locally with my changes
- My changes generate no new warnings
- I ran formatting and lint checks through pre-commit
