### PR TITLE
fix(core): preserve extractor deserialization input

### DIFF
--- a/llama-index-core/llama_index/core/extractors/interface.py
+++ b/llama-index-core/llama_index/core/extractors/interface.py
@@ -78,6 +78,7 @@ class BaseExtractor(TransformComponent):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any], **kwargs: Any) -> Self:  # type: ignore
+        data = dict(data)
         if isinstance(kwargs, dict):
             data.update(kwargs)
 

--- a/llama-index-core/tests/extractors/test_extractor_resilience.py
+++ b/llama-index-core/tests/extractors/test_extractor_resilience.py
@@ -42,6 +42,21 @@ def _make_nodes(n: int = 2) -> List[TextNode]:
 # ---------------------------------------------------------------------------
 
 
+def test_from_dict_does_not_mutate_input():
+    data = {
+        "class_name": "MetadataExtractor",
+        "max_retries": 1,
+        "raise_on_error": False,
+    }
+    original_data = data.copy()
+
+    extractor = _AlwaysFailExtractor.from_dict(data, retry_backoff=0.25)
+
+    assert data == original_data
+    assert extractor.max_retries == 1
+    assert extractor.retry_backoff == 0.25
+
+
 @pytest.mark.asyncio
 async def test_default_raises_on_error():
     """With max_retries=0 and raise_on_error=True, errors propagate."""


### PR DESCRIPTION
# Description

`BaseExtractor.from_dict()` mutates its caller-owned dictionary before constructing an extractor: it removes `class_name`, merges keyword overrides, and can replace serialized LLM fields in place. This differs from the non-mutating contract already implemented by `BaseComponent.from_dict()`.

Copy the input mapping before applying those transformations, so deserialization produces the same extractor without changing data retained by the caller.

Issue: N/A. I searched open issues and pull requests for this `MetadataExtractor.from_dict()` mutation and found no existing report or implementation.

## Reproduction

The regression passes a dictionary containing `class_name` plus extractor settings and supplies `retry_backoff` as a keyword override. Before the production change, the test fails because `class_name` is removed from the original dictionary and `retry_backoff` is inserted into it. After the change, the original dictionary remains unchanged while the constructed extractor still receives all settings.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No — this updates `llama-index-core`, which the template exempts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Commands and results:

- `uv run --no-sync -- pytest tests/extractors/test_extractor_resilience.py -q` — 8 passed
- `uv run --no-sync -- pytest tests/extractors tests/schema/test_base_component.py -q` — 20 passed
- `uv run --no-sync -- pytest -q` in `llama-index-core` — 1484 passed, 22 skipped, 6 xfailed
- `uv run --no-sync make format` — passed
- `uv run --no-sync make lint` — passed

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint`

## AI Assistance

AI assistance was used to compare the deserialization overrides and draft the regression test. I reviewed and understood every changed line, reproduced the mutation before the fix, and ran the complete verification listed above.