### PR TITLE
fix: forward Cerebras request parameters

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/llama_index/llms/cerebras/base.py
@@ -1,7 +1,8 @@
 import os
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from llama_index.llms.openai_like import OpenAILike
+from pydantic import Field
 
 
 class Cerebras(OpenAILike):
@@ -25,6 +26,11 @@ class Cerebras(OpenAILike):
 
     """
 
+    max_completion_tokens: Optional[int] = Field(
+        default=None,
+        description="Exact completion-token limit sent to the Cerebras API.",
+    )
+
     def __init__(
         self,
         model: str,
@@ -32,6 +38,10 @@ class Cerebras(OpenAILike):
         api_base: str = os.environ.get("CEREBRAS_BASE_URL", None)
         or "https://api.cerebras.ai/v1/",
         is_chat_model: bool = True,
+        max_completion_tokens: Optional[int] = None,
+        reasoning_effort: Optional[
+            Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+        ] = None,
         **kwargs: Any,
     ) -> None:
         api_key = api_key or os.environ.get("CEREBRAS_API_KEY", None)
@@ -45,8 +55,19 @@ class Cerebras(OpenAILike):
             api_key=api_key,
             api_base=api_base,
             is_chat_model=is_chat_model,
+            max_completion_tokens=max_completion_tokens,
+            reasoning_effort=reasoning_effort,
             **kwargs,
         )
+
+    def _get_model_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+        model_kwargs = super()._get_model_kwargs(**kwargs)
+        if self.max_completion_tokens is not None:
+            model_kwargs.pop("max_tokens", None)
+            model_kwargs["max_completion_tokens"] = self.max_completion_tokens
+        if self.reasoning_effort is not None:
+            model_kwargs["reasoning_effort"] = self.reasoning_effort
+        return model_kwargs
 
     @classmethod
     def class_name(cls) -> str:

--- a/llama-index-integrations/llms/llama-index-llms-cerebras/tests/test_llms_cerebras.py
+++ b/llama-index-integrations/llms/llama-index-llms-cerebras/tests/test_llms_cerebras.py
@@ -5,3 +5,27 @@ from llama_index.llms.cerebras import Cerebras
 def test_text_inference_embedding_class():
     names_of_base_classes = [b.__name__ for b in Cerebras.__mro__]
     assert BaseLLM.__name__ in names_of_base_classes
+
+
+def test_max_completion_tokens_is_preserved_without_alias():
+    llm = Cerebras(
+        model="gpt-oss-120b",
+        api_key="test-key",
+        max_tokens=32,
+        max_completion_tokens=64,
+    )
+
+    params = llm._get_model_kwargs()
+
+    assert params["max_completion_tokens"] == 64
+    assert "max_tokens" not in params
+
+
+def test_reasoning_effort_is_forwarded_for_cerebras_models():
+    llm = Cerebras(
+        model="gemma-4-31b",
+        api_key="test-key",
+        reasoning_effort="none",
+    )
+
+    assert llm._get_model_kwargs()["reasoning_effort"] == "none"


### PR DESCRIPTION
## Summary

- expose max_completion_tokens on the native Cerebras model
- suppress the max_tokens alias when the canonical field is supplied
- forward reasoning_effort for Cerebras model IDs
- add focused parameter tests

## Validation

- 3 focused tests passed
- Ruff check and format check passed