### PR TITLE
fix(core): fall back when metadata replacement target value is None

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
+++ b/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
@@ -23,11 +23,9 @@ class MetadataReplacementPostProcessor(BaseNodePostprocessor):
         query_bundle: Optional[QueryBundle] = None,
     ) -> List[NodeWithScore]:
         for n in nodes:
-            n.node.set_content(
-                n.node.metadata.get(
-                    self.target_metadata_key,
-                    n.node.get_content(metadata_mode=MetadataMode.NONE),
-                )
-            )
+            replacement = n.node.metadata.get(self.target_metadata_key)
+            if replacement is None:
+                replacement = n.node.get_content(metadata_mode=MetadataMode.NONE)
+            n.node.set_content(replacement)
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_metadata_replacement.py
+++ b/llama-index-core/tests/postprocessor/test_metadata_replacement.py
@@ -15,3 +15,30 @@ def test_metadata_replacement() -> None:
 
     assert len(nodes) == 1
     assert nodes[0].node.get_content() == "This is a another test."
+
+
+def test_metadata_replacement_falls_back_when_target_value_is_none() -> None:
+    """A key present with an explicit None means no replacement, so the content stands."""
+    node = TextNode(text="This is a test 1.", metadata={"key": None})
+
+    nodes = [NodeWithScore(node=node, score=1.0)]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+
+    nodes = postprocessor.postprocess_nodes(nodes)
+
+    assert len(nodes) == 1
+    assert nodes[0].node.get_content() == "This is a test 1."
+
+
+def test_metadata_replacement_falls_back_when_target_key_is_absent() -> None:
+    node = TextNode(text="This is a test 1.", metadata={"other": "unrelated"})
+
+    nodes = [NodeWithScore(node=node, score=1.0)]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+
+    nodes = postprocessor.postprocess_nodes(nodes)
+
+    assert len(nodes) == 1
+    assert nodes[0].node.get_content() == "This is a test 1."


### PR DESCRIPTION
# Description

`MetadataReplacementPostProcessor._postprocess_nodes` passed the node's original content as the *default* argument to `dict.get`:

```python
n.node.set_content(
    n.node.metadata.get(
        self.target_metadata_key,
        n.node.get_content(metadata_mode=MetadataMode.NONE),
    )
)
```

`dict.get(key, default)` only returns `default` when the key is **absent**. When the target key is present with an explicit `None`, `get` returns `None`, `set_content(None)` is called, and the node raises a pydantic `ValidationError`:

```
1 validation error for TextNode
text
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

A metadata key legitimately holds `None` in ordinary situations, such as an optional field a reader populates as `None`, or a JSON `null` surviving a round-trip through a vector store or docstore. In those cases the documented behaviour is to fall back to the node's own content, not to fail.

This treats a `None` value the same as an absent key, so the fallback applies in both cases. Content that is present and non-null is unaffected, and the absent-key path is unchanged.

Fixes #22772

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

(`llama-index-core` is exempt per the template.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`tests/postprocessor/test_metadata_replacement.py` gains two cases: the target key present with `None`, and the target key absent. I checked that the first genuinely covers the bug by reverting the fix and confirming it fails with the `ValidationError` above while the rest of the file still passes.

```
tests/postprocessor/test_metadata_replacement.py  3 passed
tests/postprocessor/                             17 passed, 2 skipped
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `ruff check` and `ruff format` over the changed files

AI assistance: I used an AI assistant while investigating and preparing this change, and I have reviewed and verified the result myself.
