### PR TITLE
fix(postprocessor): raise ValueError on missing API key in rerank postprocessors

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/llama_index/postprocessor/aimon_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/llama_index/postprocessor/aimon_rerank/base.py
@@ -39,7 +39,7 @@ class AIMonRerank(BaseNodePostprocessor):
         )
         try:
             api_key = api_key or os.environ["AIMON_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in AIMon API key or specify via AIMON_API_KEY environment variable"
             )

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-aimon-rerank"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index postprocessor aimon rerank integration"
 authors = [{name = "AIMon", email = "info@aimon.ai"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/tests/test_aimon_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-aimon-rerank/tests/test_aimon_rerank.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+import pytest
+from llama_index.postprocessor.aimon_rerank import AIMonRerank
+
+
+def test_missing_api_key_raises_value_error():
+    """A missing AIMON_API_KEY must raise a clear ValueError, not a raw KeyError."""
+    with mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in AIMon API key"):
+            AIMonRerank()

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -72,7 +72,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-cohere-rerank"
-version = "0.9.0"
+version = "0.9.1"
 description = "llama-index postprocessor cohere rerank integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import cohere
+import pytest
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.postprocessor.cohere_rerank import CohereRerank
@@ -103,3 +104,15 @@ def test_max_retries_parameter():
 
         reranker_default = CohereRerank(api_key="test_key")
         assert reranker_default.max_retries == 10
+
+
+def test_missing_api_key_raises_value_error():
+    """A missing COHERE_API_KEY must raise a clear ValueError, not a raw KeyError.
+
+    ``os.environ[...]`` raises ``KeyError`` when the variable is unset, but the
+    constructor caught ``IndexError``, so the intended ``ValueError`` never fired
+    and callers saw a bare ``KeyError`` instead.
+    """
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in cohere api key"):
+            CohereRerank()

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/llama_index/postprocessor/contextual_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/llama_index/postprocessor/contextual_rerank/base.py
@@ -43,7 +43,7 @@ class ContextualRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model)
         try:
             api_key = api_key or os.environ["CONTEXTUAL_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in contextual api key or "
                 "specify via CONTEXTUAL_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-contextual-rerank"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index postprocessor contextual rerank integration"
 authors = [{name = "Sean Smith", email = "sean.smith@contextual.ai"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/tests/test_contextual_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-contextual-rerank/tests/test_contextual_rerank.py
@@ -4,6 +4,15 @@ from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from contextual.types import RerankCreateResponse
 from unittest import mock, TestCase
 
+import pytest
+
+
+def test_missing_api_key_raises_value_error():
+    """A missing CONTEXTUAL_API_KEY must raise a clear ValueError, not a raw KeyError."""
+    with mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in contextual api key"):
+            ContextualRerank()
+
 
 class TestContextualRerank(TestCase):
     def test_contextual_rerank(self):

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/llama_index/postprocessor/dashscope_rerank/base.py
@@ -33,7 +33,7 @@ class DashScopeRerank(BaseNodePostprocessor):
     ):
         try:
             api_key = api_key or os.environ["DASHSCOPE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in dashscope api key or "
                 "specify via DASHSCOPE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-dashscope-rerank"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index postprocessor dashscope-rerank integration"
 authors = [{name = "dingkun-ldk", email = "dingkun.ldk@alibaba-inc.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/tests/test_dashscope_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-dashscope-rerank/tests/test_dashscope_rerank.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+import pytest
+from llama_index.postprocessor.dashscope_rerank import DashScopeRerank
+
+
+def test_missing_api_key_raises_value_error():
+    """A missing DASHSCOPE_API_KEY must raise a clear ValueError, not a raw KeyError."""
+    with mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in dashscope api key"):
+            DashScopeRerank()

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/llama_index/postprocessor/pinecone_native_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/llama_index/postprocessor/pinecone_native_rerank/base.py
@@ -36,7 +36,7 @@ class PineconeNativeRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model)
         try:
             api_key = api_key or os.environ["PINECONE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in pinecone api key or "
                 "specify via PINECONE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/pyproject.toml
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-postprocessor-pinecone-native-rerank"
-version = "0.3.0"
+version = "0.3.1"
 description = "llama-index postprocessor reranker models from pinecone cloud service"
 authors = [{name = "Jingyi Zhao", email = "zhao.elton@gmail.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/tests/test_pinecone_native_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-pinecone-native-rerank/tests/test_pinecone_native_rerank.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+import pytest
+from llama_index.postprocessor.pinecone_native_rerank import PineconeNativeRerank
+
+
+def test_missing_api_key_raises_value_error():
+    """A missing PINECONE_API_KEY must raise a clear ValueError, not a raw KeyError."""
+    with mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in pinecone api key"):
+            PineconeNativeRerank()


### PR DESCRIPTION
# Description

Five rerank postprocessors read their API key with `os.environ["<X>_API_KEY"]` but guard it with `except IndexError`. `os.environ[...]` raises `KeyError` (not `IndexError`) when the variable is unset, so the guard never fires and the intended `ValueError("Must pass in <x> api key ...")` is never raised — callers instead see a bare, confusing `KeyError`.

This changes the caught exception to `KeyError` in all five packages so a missing key produces the clear `ValueError` the code already intends:

```python
         try:
             api_key = api_key or os.environ["<X>_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError("Must pass in <x> api key or ...")
```

Packages fixed (each with a patch version bump and a regression test):

- `llama-index-postprocessor-cohere-rerank` (`0.9.0` → `0.9.1`) — Fixes #22774
- `llama-index-postprocessor-contextual-rerank` (`0.3.0` → `0.3.1`)
- `llama-index-postprocessor-aimon-rerank` (`0.3.0` → `0.3.1`)
- `llama-index-postprocessor-dashscope-rerank` (`0.5.0` → `0.5.1`)
- `llama-index-postprocessor-pinecone-native-rerank` (`0.3.0` → `0.3.1`)

Fixes #22774

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — each modified integration package's `pyproject.toml` version is bumped a patch.
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Each package gets a `test_missing_api_key_raises_value_error` that constructs the reranker with its API-key env var unset and asserts a `ValueError` (not a raw `KeyError`). Before the change every test fails with a raw `KeyError`; after, all pass.

```
contextual-rerank: 1 passed
aimon-rerank:      1 passed
dashscope-rerank:  1 passed
pinecone-native-rerank: 1 passed
cohere-rerank:     2 passed
```

![cohere before/after: raw KeyError -> 2 passed](https://github.com/user-attachments/assets/463297c8-4273-407d-9d7e-e8fd134abd17)

- [x] I stand by this change; the AI-assisted portions were reviewed line-by-line.
