### PR TITLE
fix: fall back to original content when metadata replacement key is None

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
+++ b/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
@@ -24,10 +24,8 @@ class MetadataReplacementPostProcessor(BaseNodePostprocessor):
     ) -> List[NodeWithScore]:
         for n in nodes:
             n.node.set_content(
-                n.node.metadata.get(
-                    self.target_metadata_key,
-                    n.node.get_content(metadata_mode=MetadataMode.NONE),
-                )
+                n.node.metadata.get(self.target_metadata_key)
+                or n.node.get_content(metadata_mode=MetadataMode.NONE)
             )
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_metadata_replacement.py
+++ b/llama-index-core/tests/postprocessor/test_metadata_replacement.py
@@ -15,3 +15,18 @@ def test_metadata_replacement() -> None:
 
     assert len(nodes) == 1
     assert nodes[0].node.get_content() == "This is a another test."
+
+
+def test_metadata_replacement_missing_or_none_key_falls_back() -> None:
+    nodes = [
+        NodeWithScore(node=TextNode(text="original content", metadata={}), score=1.0),
+        NodeWithScore(
+            node=TextNode(text="original content", metadata={"key": None}), score=1.0
+        ),
+    ]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+
+    nodes = postprocessor.postprocess_nodes(nodes)
+
+    assert all(node.node.get_content() == "original content" for node in nodes)


### PR DESCRIPTION
## What changed

`MetadataReplacementPostProcessor._postprocess_nodes` used `dict.get(key, default)`, which only falls back when the key is **absent**. A node whose metadata contains the target key with an explicit `None` value (e.g. an optional field round-tripped through a docstore/vector store, or a reader that populates the field as `None`) flowed into `n.node.set_content(None)` and raised a pydantic `ValidationError`, taking down the whole query.

The fallback now treats `None` like a missing key:

```python
n.node.set_content(
    n.node.metadata.get(self.target_metadata_key)
    or n.node.get_content(metadata_mode=MetadataMode.NONE)
)
```

so the postprocessor keeps its documented "replace with the metadata value, otherwise keep original content" semantics in every case.

## Test

Added `test_metadata_replacement_missing_or_none_key_falls_back` covering both boundaries from the issue: key absent and key present-but-`None`, both falling back to the original content. The existing replacement test still passes unchanged.

## Validation (run on Windows against the repo source, editable install)

```bash
python -m pytest tests/postprocessor/test_metadata_replacement.py -v
# tests/postprocessor/test_metadata_replacement.py::test_metadata_replacement PASSED
# tests/postprocessor/test_metadata_replacement.py::test_metadata_replacement_missing_or_none_key_falls_back PASSED
# 2 passed in 0.09s

ruff check llama_index/core/postprocessor/metadata_replacement.py tests/postprocessor/test_metadata_replacement.py
# All checks passed!
ruff format --check <same two files>
# 2 files already formatted
```

I did not run the full `uv run make lint` pre-commit gate (no pre-commit on this machine); the ruff check + format stages it would run on these two files were run directly and pass.

Fixes #22772