### PR TITLE
fix: stop counting a missing completion as a token

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -84,6 +84,8 @@ def get_llm_token_counts(
     if EventPayload.PROMPT in payload:
         prompt = payload.get(EventPayload.PROMPT)
         completion = payload.get(EventPayload.COMPLETION)
+        prompt_str = "" if prompt is None else str(prompt)
+        completion_str = "" if completion is None else str(completion)
 
         if completion:
             # get from raw or additional_kwargs
@@ -92,16 +94,16 @@ def get_llm_token_counts(
             prompt_tokens, completion_tokens = 0, 0
 
         if prompt_tokens == 0:
-            prompt_tokens = token_counter.get_string_tokens(str(prompt))
+            prompt_tokens = token_counter.get_string_tokens(prompt_str)
 
         if completion_tokens == 0:
-            completion_tokens = token_counter.get_string_tokens(str(completion))
+            completion_tokens = token_counter.get_string_tokens(completion_str)
 
         return TokenCountingEvent(
             event_id=event_id,
-            prompt=str(prompt),
+            prompt=prompt_str,
             prompt_token_count=prompt_tokens,
-            completion=str(completion),
+            completion=completion_str,
             completion_token_count=completion_tokens,
         )
 
@@ -110,7 +112,7 @@ def get_llm_token_counts(
         messages_str = "\n".join([str(x) for x in messages])
 
         response = payload.get(EventPayload.RESPONSE)
-        response_str = str(response)
+        response_str = "" if response is None else str(response)
 
         if response:
             prompt_tokens, completion_tokens = get_tokens_from_response(response)

--- a/llama-index-core/tests/callbacks/test_token_counter.py
+++ b/llama-index-core/tests/callbacks/test_token_counter.py
@@ -1,7 +1,8 @@
 """Embeddings."""
 
-from llama_index.core.callbacks.schema import CBEventType
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.callbacks.token_counting import TokenCountingHandler
+from llama_index.core.llms import ChatMessage
 
 TEST_PAYLOAD = {"chunks": ["one"], "formatted_prompt": "two", "response": "three"}
 TEST_ID = "my id"
@@ -41,10 +42,45 @@ def test_on_event_end() -> None:
     assert len(handler.embedding_token_counts) == 1
 
     assert handler.embedding_token_counts[0].total_token_count == 1
-    assert handler.llm_token_counts[0].total_token_count == 2
+    assert handler.llm_token_counts[0].total_token_count == 1
 
     # test actual counts
-    # LLM should be two (prompt plus response)
+    # LLM should be one: the payload carries a prompt but no completion, and
+    # EventPayload.RESPONSE is only read for the messages-based branch
     # Embedding should be one (single token chunk)
-    assert handler.total_llm_token_count == 2
+    assert handler.total_llm_token_count == 1
     assert handler.total_embedding_token_count == 1
+
+
+def test_missing_completion_is_not_counted_as_a_token() -> None:
+    """A payload with no completion should not be charged for the string "None"."""
+    handler = TokenCountingHandler()
+
+    handler.on_event_end(
+        CBEventType.LLM,
+        payload={EventPayload.PROMPT: "two", EventPayload.COMPLETION: None},
+        event_id=TEST_ID,
+    )
+
+    event = handler.llm_token_counts[0]
+    assert event.completion == ""
+    assert event.completion_token_count == 0
+    assert event.total_token_count == event.prompt_token_count
+
+
+def test_missing_response_is_not_counted_as_a_token() -> None:
+    """The messages branch should not be charged for the string "None" either."""
+    handler = TokenCountingHandler()
+
+    handler.on_event_end(
+        CBEventType.LLM,
+        payload={
+            EventPayload.MESSAGES: [ChatMessage(role="user", content="hi")],
+            EventPayload.RESPONSE: None,
+        },
+        event_id=TEST_ID,
+    )
+
+    event = handler.llm_token_counts[0]
+    assert event.completion == ""
+    assert event.completion_token_count == 0


### PR DESCRIPTION
get_llm_token_counts falls back to counting the completion as a string when the response carries no usage data. When there is no completion at all, that fallback ran on str(None), so the event was charged one token for the literal string "None" and stored "None" as its completion text. The messages branch did the same through str(response)

Both branches now coerce a missing value to an empty string before counting, which is already handled correctly and yields zero tokens

The existing test asserted a total of 2 for a payload holding a prompt and no completion, described in a comment as "prompt plus response". The PROMPT branch never reads EventPayload.RESPONSE, so the second token was the phantom "None" rather than the response. The assertion is now 1, with a comment saying why, and two tests cover the missing completion and missing response cases

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
