### PR TITLE
docs: fix typos and broken links

### DIFF
--- a/docs/src/content/docs/framework/changes/deprecated_terms.md
+++ b/docs/src/content/docs/framework/changes/deprecated_terms.md
@@ -12,7 +12,7 @@ This has been renamed to `VectorStoreIndex`, as well as unifying all vector inde
 
 Please see the following links for more details on usage.
 
-- [Index Usage Pattern](/python/framework/module_guides/evaluating/usage_pattern)
+- [Index Usage Pattern](/python/framework/module_guides/indexing/vector_store_index)
 - [Vector Store Guide](/python/framework/module_guides/indexing/vector_store_guide)
 - [Vector Store Integrations](/python/framework/community/integrations/vector_stores)
 
@@ -20,7 +20,7 @@ Please see the following links for more details on usage.
 
 This has been renamed to `VectorStoreIndex`, but it is only a cosmetic change. Please see the following links for more details on usage.
 
-- [Index Usage Pattern](/python/framework/module_guides/evaluating/usage_pattern)
+- [Index Usage Pattern](/python/framework/module_guides/indexing/vector_store_index)
 - [Vector Store Guide](/python/framework/module_guides/indexing/vector_store_guide)
 - [Vector Store Integrations](/python/framework/community/integrations/vector_stores)
 

--- a/docs/src/content/docs/framework/community/integrations/managed_indices.md
+++ b/docs/src/content/docs/framework/community/integrations/managed_indices.md
@@ -53,7 +53,7 @@ os.environ["VECTARA_CORPUS_KEY"] = "<YOUR_VECTARA_CORPUS_KEY>"
 Then construct the Vectara Index and query it as follows:
 
 ```python
-from llama_index.core import ManagedIndex, SimpleDirectoryReade
+from llama_index.core import ManagedIndex, SimpleDirectoryReader
 from llama_index.indices.managed.vectara import VectaraIndex
 
 # Load documents and build index

--- a/docs/src/content/docs/framework/module_guides/loading/node_parsers/index.md
+++ b/docs/src/content/docs/framework/module_guides/loading/node_parsers/index.md
@@ -2,7 +2,7 @@
 title: Node Parser Usage Pattern
 ---
 
-Node parsers are a simple abstraction that take a list of documents, and chunk them into `Node` objects, such that each node is a specific chunk of the parent document. When a document is broken into nodes, all of it's attributes are inherited to the children nodes (i.e. `metadata`, text and metadata templates, etc.). You can read more about `Node` and `Document` properties [here](/python/framework/module_guides/loading/documents_and_nodes).
+Node parsers are a simple abstraction that take a list of documents, and chunk them into `Node` objects, such that each node is a specific chunk of the parent document. When a document is broken into nodes, all of its attributes are inherited to the children nodes (i.e. `metadata`, text and metadata templates, etc.). You can read more about `Node` and `Document` properties [here](/python/framework/module_guides/loading/documents_and_nodes).
 
 ## Getting Started
 

--- a/docs/src/content/docs/framework/module_guides/observability/index.md
+++ b/docs/src/content/docs/framework/module_guides/observability/index.md
@@ -620,7 +620,7 @@ instrument_llama_index(instrument.get_dispatcher())
 
 #### Guides
 
-- [Evaluate Llama Index Agents](https://deepeval.com/integrations/frameworks/langchain)
+- [Evaluate Llama Index Agents](https://deepeval.com/integrations/frameworks/llamaindex)
 - [Tracing Llama Index Agents](https://documentation.confident-ai.com/docs/llm-tracing/integrations/llamaindex)
 
 ### Maxim AI


### PR DESCRIPTION
# Description

This is a small docs-only cleanup that fixes two typos and two incorrect links in the framework documentation.

Fixes # (issue)
N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Docs-only change. Ran `uv run make lint`.

- [ ] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods
