### PR TITLE
[Fix] Initialize splits with [text] to prevent UnboundLocalError in SentenceSplitter._get_splits_by_fns

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/sentence.py
+++ b/llama-index-core/llama_index/core/node_parser/text/sentence.py
@@ -337,6 +337,7 @@ class SentenceSplitter(MetadataAwareTextSplitter):
             if len(splits) > 1:
                 return splits, True
 
+        splits = [text]
         for split_fn in self._sub_sentence_split_fns:
             splits = split_fn(text)
             if len(splits) > 1:

--- a/llama-index-core/tests/text_splitter/test_sentence_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_sentence_splitter.py
@@ -197,3 +197,12 @@ def test_no_overflow_with_chinese_text_and_metadata() -> None:
             f"Node {i} has {content_length} tokens, exceeds chunk_size of 512. "
             f"This indicates the overflow bug is not fixed."
         )
+
+
+def test_empty_sub_sentence_split_fns_safety() -> None:
+    splitter = SentenceSplitter(chunk_size=50, chunk_overlap=0)
+    splitter._sub_sentence_split_fns = []
+    splits, is_sentence = splitter._get_splits_by_fns("SingleUnsplitSentenceWithoutSubSplits")
+    assert splits == ["SingleUnsplitSentenceWithoutSubSplits"]
+    assert is_sentence is False
+


### PR DESCRIPTION
## Description
In `SentenceSplitter._get_splits_by_fns`:
```python
for split_fn in self._split_fns:
    splits = split_fn(text)
    if len(splits) > 1:
        return splits, True

for split_fn in self._sub_sentence_split_fns:
    splits = split_fn(text)
    if len(splits) > 1:
        break

return splits, False
```
If `_sub_sentence_split_fns` is empty (or if custom split functions are configured without sub-sentence fallbacks), `splits` was not defined prior to the second loop, causing an `UnboundLocalError`.

This PR initializes `splits = [text]` before the loop to guarantee variable binding, and adds a test in `test_sentence_splitter.py`.