### PR TITLE
fix(ollama): handle object-shaped GenerateResponse in multimodal completion

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/llama_index/llms/ollama/base.py
@@ -54,10 +54,14 @@ DEFAULT_REQUEST_TIMEOUT = 30.0
 dispatcher = get_dispatcher(__name__)
 
 
-def get_additional_kwargs(
-    response: Dict[str, Any], exclude: Tuple[str, ...]
-) -> Dict[str, Any]:
-    return {k: v for k, v in response.items() if k not in exclude}
+def get_additional_kwargs(response: Any, exclude: Tuple[str, ...]) -> Dict[str, Any]:
+    """
+    Get additional kwargs from an ollama response, excluding the given keys.
+
+    Works with both plain dicts and object-shaped responses, since
+    ollama >= 0.4 returns pydantic models (e.g. ``GenerateResponse``).
+    """
+    return {k: v for k, v in dict(response).items() if k not in exclude}
 
 
 def force_single_tool_call(response: ChatResponse) -> None:

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_llms_ollama.py
@@ -1,13 +1,19 @@
 import os
+from typing import Annotated, Any
 
 import pytest
-from ollama import Client
-from typing import Annotated
+from ollama import ChatResponse, Client, Message
 
-from llama_index.core.base.llms.types import ThinkingBlock, TextBlock, ToolCallBlock
+from llama_index.core.base.llms.types import (
+    ImageBlock,
+    ThinkingBlock,
+    TextBlock,
+    ToolCallBlock,
+)
 from llama_index.core.base.llms.base import BaseLLM
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import ChatMessage
+from llama_index.core.program import MultiModalLLMCompletionProgram
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.ollama import Ollama
 
@@ -493,3 +499,99 @@ async def test_chat_methods_with_tool_input() -> None:
         ablocks.extend(r.message.blocks)
     assert len([block for block in ablocks if isinstance(block, TextBlock)]) > 0
     assert len([block for block in ablocks if isinstance(block, ToolCallBlock)]) == 0
+
+
+class StubOllamaClient:
+    """Stands in for ollama.Client, returning object-shaped (pydantic) responses."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.chat_kwargs: dict = {}
+
+    def chat(self, **kwargs: Any) -> Any:
+        self.chat_kwargs = kwargs
+        return self._response
+
+
+class StubOllamaAsyncClient(StubOllamaClient):
+    async def achat(self, **kwargs: Any) -> Any:  # pragma: no cover - unused
+        return self._response
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.chat_kwargs = kwargs
+        return self._response
+
+
+def _get_stub_chat_response(content: str) -> ChatResponse:
+    return ChatResponse(
+        model=test_model,
+        created_at="2024-11-29T00:00:00Z",
+        done=True,
+        message=Message(role="assistant", content=content),
+    )
+
+
+def test_multi_modal_llm_completion_program_with_object_shaped_response() -> None:
+    """Regression test for https://github.com/run-llama/llama_index/issues/17105."""
+    stub_client = StubOllamaClient(
+        _get_stub_chat_response(
+            '{"artist_name": "The Beatles", "song_name": "Let It Be"}'
+        )
+    )
+    llm = Ollama(
+        model=test_model,
+        context_window=8000,
+        client=stub_client,
+    )
+    image_documents = [ImageBlock(image=b"\x89PNG fake image bytes")]
+
+    program = MultiModalLLMCompletionProgram.from_defaults(
+        output_cls=Song,
+        prompt_template_str="{query_str}",
+        multi_modal_llm=llm,
+        image_documents=image_documents,
+    )
+
+    result = program(query_str="What is in the image?")
+
+    assert isinstance(result, Song)
+    assert result.artist_name == "The Beatles"
+    assert result.song_name == "Let It Be"
+
+    sent_messages = stub_client.chat_kwargs["messages"]
+    assert sent_messages[0]["images"] != []
+    assert "What is in the image?" in sent_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_async_multi_modal_llm_completion_program_with_object_shaped_response() -> (
+    None
+):
+    """Regression test for https://github.com/run-llama/llama_index/issues/17105."""
+    stub_client = StubOllamaAsyncClient(
+        _get_stub_chat_response(
+            '{"artist_name": "The Beatles", "song_name": "Let It Be"}'
+        )
+    )
+    llm = Ollama(
+        model=test_model,
+        context_window=8000,
+        async_client=stub_client,
+    )
+    image_documents = [ImageBlock(image=b"\x89PNG fake image bytes")]
+
+    program = MultiModalLLMCompletionProgram.from_defaults(
+        output_cls=Song,
+        prompt_template_str="{query_str}",
+        multi_modal_llm=llm,
+        image_documents=image_documents,
+    )
+
+    result = await program.acall(query_str="What is in the image?")
+
+    assert isinstance(result, Song)
+    assert result.artist_name == "The Beatles"
+    assert result.song_name == "Let It Be"
+
+    sent_messages = stub_client.chat_kwargs["messages"]
+    assert sent_messages[0]["images"] != []

--- a/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-ollama/tests/test_utils.py
@@ -1,3 +1,5 @@
+from ollama import GenerateResponse
+
 from llama_index.llms.ollama.base import get_additional_kwargs
 
 
@@ -10,3 +12,21 @@ def test_get_additional_kwargs():
     actual = get_additional_kwargs(response, exclude)
 
     assert actual == expected
+
+
+def test_get_additional_kwargs_with_ollama_response_object():
+    # ollama >= 0.4 returns pydantic models instead of plain dicts;
+    # see https://github.com/run-llama/llama_index/issues/17105
+    response = GenerateResponse(
+        model="llava",
+        created_at="2024-11-29T00:00:00Z",
+        response="a plate of fried chicken",
+        done=True,
+        eval_count=42,
+    )
+
+    actual = get_additional_kwargs(response, ("response",))
+
+    assert actual["model"] == "llava"
+    assert actual["eval_count"] == 42
+    assert "response" not in actual


### PR DESCRIPTION
The Ollama Python client (≥0.4) returns pydantic response objects rather than plain dicts. `get_additional_kwargs()` assumed dict input and crashed with `'GenerateResponse' object has no attribute 'items'` when given the raw client response — the long-standing failure behind #17105.

Normalize explicitly with `dict(response)` — the same pattern already used in `chat`/`achat`/`stream_chat`/`astream_chat`. Adds unit coverage with a real `GenerateResponse` plus stubbed end-to-end tests of `MultiModalLLMCompletionProgram` with images (sync + async), runnable without a live Ollama server.

Fixes #17105
