### PR TITLE
fix(instrumentation): use None sentinel for Dispatcher.__init__ defaults

### DIFF
--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers if event_handlers is not None else [],
+            span_handlers=span_handlers if span_handlers is not None else [],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,

--- a/llama-index-instrumentation/tests/test_dispatcher.py
+++ b/llama-index-instrumentation/tests/test_dispatcher.py
@@ -1220,3 +1220,48 @@ async def test_aevent_no_propagation():
     assert len(parent_handler.events) == 0
     assert child_handler.async_calls == 1
     assert parent_handler.async_calls == 0
+
+
+# --- Regression tests for https://github.com/run-llama/llama_index/issues/22705 ---
+# Dispatcher.__init__ previously used mutable default arguments (event_handlers=[],
+# span_handlers=[]) which are evaluated once at function-definition time and shared
+# across all calls. Replace with a None sentinel.
+
+
+def test_dispatcher_init_has_no_mutable_defaults() -> None:
+    """Regression test for #22705: __init__ signature must not carry mutable defaults."""
+    import inspect
+
+    sig = inspect.signature(Dispatcher.__init__)
+    assert sig.parameters["event_handlers"].default is None, (
+        "event_handlers must default to None (sentinel), not a mutable list"
+    )
+    assert sig.parameters["span_handlers"].default is None, (
+        "span_handlers must default to None (sentinel), not a mutable list"
+    )
+
+
+def test_dispatcher_constructs_distinct_default_lists() -> None:
+    """Regression test for #22705: two no-arg Dispatcher() instances must not share list state."""
+    d1 = Dispatcher()
+    d2 = Dispatcher()
+
+    # Fresh lists, not shared singletons
+    assert d1.event_handlers is not d2.event_handlers
+    assert d1.span_handlers is not d2.span_handlers
+
+    # Defaults still resolve to empty lists (observable behavior preserved)
+    assert d1.event_handlers == []
+    assert d1.span_handlers == []
+
+
+def test_dispatcher_mutating_one_instance_does_not_affect_another() -> None:
+    """Regression test for #22705: appending to one Dispatcher's handlers must not bleed into another."""
+    d1 = Dispatcher()
+    d2 = Dispatcher()
+
+    sentinel_handler = _TestEventHandler()
+    d1.event_handlers.append(sentinel_handler)
+
+    assert sentinel_handler in d1.event_handlers
+    assert sentinel_handler not in d2.event_handlers


### PR DESCRIPTION
fix(instrumentation): use None sentinel for Dispatcher.__init__ defaults

## Summary

Closes #22705

`Dispatcher.__init__` declared mutable default arguments (`event_handlers=[]`, `span_handlers=[]`). Python evaluates these once at function-definition time, so every no-arg `Dispatcher()` call would share the same list objects. While Pydantic currently copies on validation, the bad signature still:

- trips static analyzers (`ruff B006`),
- exposes a shared singleton via `inspect.signature(Dispatcher.__init__).parameters['event_handlers'].default`, and
- makes any future code path that bypasses Pydantic's copy semantics unsafe.

This PR switches to the **None-sentinel pattern**: signature defaults become `None`, and `__init__` resolves `None` to a fresh empty list when forwarding to `super().__init__()`. Observable behavior for callers is preserved.

## Test plan

Added 3 regression tests to `llama-index-instrumentation/tests/test_dispatcher.py`:

- `test_dispatcher_init_has_no_mutable_defaults`: asserts `inspect.signature` defaults are `None`, not `[]`.
- `test_dispatcher_constructs_distinct_default_lists`: two no-arg `Dispatcher()` instances must have independent list objects.
- `test_dispatcher_mutating_one_instance_does_not_affect_another`: appending to one Dispatcher's `event_handlers` must not bleed into another's.

Local run:

```
$ python3 -m pytest llama-index-instrumentation/tests/test_dispatcher.py -v
======================== 36 passed, 2 warnings in 0.58s ========================
```

(The 2 warnings are pre-existing `get_dispatch_event` deprecation warnings unrelated to this change.)

## Diff scope

- `llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py`: swap `[]` defaults for `None` in `__init__` signature, resolve inside the body.
- `llama-index-instrumentation/tests/test_dispatcher.py`: add 3 regression tests.

No public API change. No CHANGELOG entry needed (internal-only bugfix to argument defaults).
