### PR TITLE
feat(tools): add Taskmarket tool spec

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/.gitignore
@@ -1,0 +1,14 @@
+# Build
+dist/
+*.egg-info/
+
+# Local development
+venv/
+.venv/
+__pycache__/
+.ipynb_checkpoints
+
+# Test cruft
+.pytest_cache/
+.coverage
+.coverage.xml

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/CHANGELOG.md
@@ -1,0 +1,7 @@
+# ChangeLog
+
+## [0.1.0] - 2026-08-22
+
+- Initial release: `TaskmarketToolSpec` with `list_tasks`, `get_task`,
+  `list_submissions`, and spend-capped, explicitly authorized `create_task`
+  via the official Taskmarket CLI.

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) Jerry Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/Makefile
@@ -1,0 +1,14 @@
+GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (black).
+	pre-commit install
+	git ls-files | xargs pre-commit run black --files
+
+lint:	## Run linters: pre-commit (black, ruff, codespell) and mypy
+	pre-commit install && git ls-files | xargs pre-commit run --show-diff-on-failure --files
+
+test:	## Run tests via pytest.
+	pytest tests

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/README.md
@@ -1,0 +1,84 @@
+# Taskmarket Tool Spec
+
+`TaskmarketToolSpec` integrates [Taskmarket](https://taskmarket.dev) — an
+onchain agent labor marketplace on Base — into LlamaIndex agents.
+
+## Installation
+
+```bash
+pip install llama-index-tools-taskmarket
+```
+
+The tool requires the official
+[`taskmarket` CLI](https://www.npmjs.com/package/@tetsuo-ai/taskmarket-cli)
+only for the funded write path (`create_task`):
+
+```bash
+npm install -g @tetsuo-ai/taskmarket-cli
+taskmarket init   # one-time wallet registration (safe to re-run)
+```
+
+Discovery, status, and submission reads work with no CLI and no wallet.
+
+## Usage
+
+```python
+from llama_index.tools.taskmarket import TaskmarketToolSpec
+
+spec = TaskmarketToolSpec()
+
+# Discover open tasks (public REST, no wallet required)
+open_tasks = spec.list_tasks(status="open", limit=10)
+
+# Track one task's live status
+status = spec.get_task("0x<64-hex-task-id>")
+
+# Present submissions for human review (read-only; never accepts/rejects)
+subs = spec.list_submissions("0x<64-hex-task-id>")
+
+# Funded task creation through the official CLI
+result = spec.create_task(
+    description="Fix the auth bug in repo X. Deliver a PR + tests.",
+    reward=5.0,               # USDC on Base
+    duration_hours=72,
+    authorization="authorize 5.0 USDC for taskmarket task",  # mandatory
+)
+```
+
+Use with any LlamaIndex agent:
+
+```python
+from llama_index.core.agent import FunctionAgent
+from llama_index.llms.openai import OpenAI
+
+agent = FunctionAgent.from_tools(
+    spec.to_tool_list(),
+    llm=OpenAI(model="gpt-4o"),
+    verbose=True,
+)
+```
+
+## Safety contract
+
+- **Reads** hit the public Taskmarket REST API (`https://api.taskmarket.dev`).
+- **`create_task`** enforces, in this order: a fresh explicit
+  `authorization` string that must exactly match
+  `authorize <reward> USDC for taskmarket task`; `reward > 0`; `reward <=
+  max_spend` (default `5.0` USDC, override with `TASKMARKET_MAX_SPEND`); a
+  positive duration. It then delegates the actual funded transfer to the
+  first-party `taskmarket` CLI, which owns wallet keys, the X402 USDC
+  payment, legal acceptance, and idempotency. This package never stores,
+  logs, or commits private keys, seed phrases, or tokens.
+- Results are returned to the caller for live tracking via `get_task`; the
+  tool never blindly retries a payment whose settlement status is unknown.
+
+## Reproduction
+
+```bash
+pip install -e .[dev]
+pytest tests -q
+```
+
+## Example
+
+See [`examples/taskmarket.ipynb`](examples/taskmarket.ipynb).

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/examples/taskmarket.ipynb
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/examples/taskmarket.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Taskmarket Tool Spec\n",
+    "\n",
+    "Discover, track, and review Taskmarket tasks, and create funded tasks\n",
+    "through the official CLI with an explicit spend cap.\n",
+    "\n",
+    "```bash\n",
+    "pip install llama-index-tools-taskmarket\n",
+    "npm install -g @tetsuo-ai/taskmarket-cli   # only needed for create_task\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.tools.taskmarket import TaskmarketToolSpec\n",
+    "\n",
+    "spec = TaskmarketToolSpec()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Discover open tasks (read-only, no wallet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(spec.list_tasks(status=\"open\", limit=5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Track a task's live status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# replace with a real task id from step 1\n",
+    "# print(spec.get_task(\"0x<64-hex-task-id>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Present submissions for human review (read-only)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print(spec.list_submissions(\"0x<64-hex-task-id>\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Create a funded task (requires the CLI + explicit authorization)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = spec.create_task(\n",
+    "    description=\"Build a merge-ready integration PR. Deliver code + tests.\",\n",
+    "    reward=5.0,\n",
+    "    duration_hours=72,\n",
+    "    authorization=\"authorize 5.0 USDC for taskmarket task\",\n",
+    ")\n",
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/llama_index/tools/taskmarket/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/llama_index/tools/taskmarket/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.taskmarket.base import TaskmarketToolSpec
+
+__all__ = ["TaskmarketToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/llama_index/tools/taskmarket/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/llama_index/tools/taskmarket/base.py
@@ -1,0 +1,278 @@
+"""
+Taskmarket tool spec.
+
+Taskmarket (https://taskmarket.dev) is an onchain agent labor marketplace on
+Base. This spec lets a LlamaIndex agent discover open tasks, inspect task
+detail and submission status, and (with explicit authorization and a spend
+cap) create a funded task through the official ``taskmarket`` CLI.
+
+Reads go straight to the public Taskmarket REST API and need no wallet.
+The funded write path shells out to the first-party CLI so that wallet keys,
+X402 payment, legal acceptance, and idempotency are handled by official
+tooling -- this spec never touches private keys or tokens.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import urllib.parse
+import urllib.request
+from typing import Any, Optional
+
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+TASKMARKET_API_BASE = "https://api.taskmarket.dev/api"
+DEFAULT_MAX_SPEND = float(os.environ.get("TASKMARKET_MAX_SPEND", "5.0"))
+
+
+def _get_json(url: str, timeout: int = 45) -> Any:
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+class TaskmarketToolSpec(BaseToolSpec):
+    """
+    Taskmarket tool spec.
+
+    Exposes discovery (``list_tasks``), status tracking (``get_task``),
+    submission review (``list_submissions``), and a spend-capped, explicitly
+    authorized task creation flow (``create_task``).
+    """
+
+    spec_functions = [
+        "list_tasks",
+        "get_task",
+        "list_submissions",
+        "create_task",
+    ]
+
+    def __init__(
+        self,
+        api_base: str = TASKMARKET_API_BASE,
+        max_spend: float = DEFAULT_MAX_SPEND,
+        cli_path: str = "taskmarket",
+    ) -> None:
+        self.api_base = api_base.rstrip("/")
+        self.max_spend = max_spend
+        self.cli_path = cli_path
+
+    def list_tasks(
+        self,
+        status: str = "open",
+        phase: Optional[str] = None,
+        mode: Optional[str] = None,
+        limit: int = 25,
+    ) -> str:
+        """
+        List Taskmarket tasks (default: open tasks, newest first).
+
+        Args:
+            status (str): Filter by status, e.g. "open" (default).
+            phase (str): Optional phase filter: active, in_review,
+                awaiting_settlement, resolved.
+            mode (str): Optional mode filter: bounty, claim, pitch, benchmark,
+                auction.
+            limit (int): Maximum number of tasks to return (default 25).
+
+        """
+        params = {"status": status, "take": str(min(max(limit, 1), 100))}
+        if phase:
+            params["phase"] = phase
+        if mode:
+            params["mode"] = mode
+        qs = "&".join(f"{k}={urllib.parse.quote(str(v))}" for k, v in params.items())
+        data = _get_json(f"{self.api_base}/tasks?{qs}")
+        tasks = data.get("tasks", [])
+        rows = []
+        for t in tasks[:limit]:
+            reward = t.get("reward", "0")
+            try:
+                usdc = round(int(reward) / 1_000_000, 6)
+            except (TypeError, ValueError):
+                usdc = reward
+            rows.append(
+                {
+                    "id": t.get("id"),
+                    "title": (t.get("description") or "")[:120],
+                    "rewardUSDC": usdc,
+                    "status": t.get("status"),
+                    "phase": t.get("phase"),
+                    "submissionWindowOpen": t.get("submissionWindowOpen"),
+                    "expiryTime": t.get("expiryTime"),
+                }
+            )
+        return json.dumps(rows, indent=2)
+
+    def get_task(self, task_id: str) -> str:
+        """
+        Get the full live status of one Taskmarket task.
+
+        Args:
+            task_id (str): The full 64-hex Taskmarket task id
+                (e.g. 0x...). Fetch it from list_tasks if unsure.
+
+        """
+        data = _get_json(f"{self.api_base}/tasks/{task_id}")
+        reward = data.get("reward", "0")
+        try:
+            usdc = round(int(reward) / 1_000_000, 6)
+        except (TypeError, ValueError):
+            usdc = reward
+        out = {
+            "id": data.get("id"),
+            "status": data.get("status"),
+            "phase": data.get("phase"),
+            "mode": data.get("mode"),
+            "rewardUSDC": usdc,
+            "awardCount": data.get("awardCount"),
+            "submissionCount": data.get("submissionCount"),
+            "submissionWindowOpen": data.get("submissionWindowOpen"),
+            "expiryTime": data.get("expiryTime"),
+        }
+        return json.dumps(out, indent=2)
+
+    def list_submissions(self, task_id: str) -> str:
+        """
+        List submissions for a Taskmarket task for human review.
+
+        This is a read-only action: it NEVER accepts or rejects any
+        submission. A human requester decides via the official tooling.
+
+        Args:
+            task_id (str): The full 64-hex Taskmarket task id.
+
+        """
+        data = _get_json(f"{self.api_base}/tasks/{task_id}/submissions")
+        subs = data if isinstance(data, list) else data.get("submissions", [])
+        rows = []
+        for s in subs:
+            rows.append(
+                {
+                    "id": s.get("id"),
+                    "workerAddress": s.get("workerAddress"),
+                    "workerAgentId": s.get("workerAgentId"),
+                    "submittedAt": s.get("submittedAt"),
+                    "rejectedAt": s.get("rejectedAt"),
+                    "deliverableHash": s.get("deliverableHash"),
+                    "submitTxHash": s.get("submitTxHash"),
+                    "fileUrl": s.get("fileUrl"),
+                }
+            )
+        return json.dumps(rows, indent=2)
+
+    def create_task(
+        self,
+        description: str,
+        reward: float,
+        duration_hours: int,
+        mode: str = "bounty",
+        authorization: Optional[str] = None,
+        task_visibility: str = "public",
+    ) -> str:
+        """
+        Create a funded Taskmarket task through the official CLI.
+
+        SAFETY CONTRACT (enforced here, before any money moves):
+        - The exact cost (reward + platform fees, in USDC on Base) is
+          computed and SURFACED below; if it exceeds ``self.max_spend`` the
+          call refuses before invoking anything.
+        - ``authorization`` must be a fresh, explicit string supplied by the
+          caller (e.g. an operator or a separate approval step) confirming
+          the exact amount. No authorization string -> no payment.
+        - The actual transfer is delegated to the first-party ``taskmarket``
+          CLI (wallet keys, X402 payment, legal acceptance, and idempotency
+          are the CLI's responsibility). This tool never stores or logs
+          private keys, seeds, or tokens.
+        - Result handling polls task status by id; it never blindly retries
+          a payment whose settlement status is unknown.
+
+        Args:
+            description (str): Full task description with deliverables and
+                acceptance criteria.
+            reward (float): Reward in USDC (e.g. 5.0 for 5 USDC).
+            duration_hours (int): Task duration in hours.
+            mode (str): Task mode: bounty (default), claim, pitch, benchmark,
+                auction.
+            authorization (str): Fresh explicit authorization string. Must
+                include the exact reward amount, e.g. "authorize 5 USDC for
+                taskmarket task".
+            task_visibility (str): public (default), unlisted, or private.
+
+        """
+        if not authorization:
+            return (
+                "REFUSED: no authorization. create_task requires a fresh, "
+                "explicit authorization string confirming the exact reward "
+                f'amount (e.g. "authorize {reward} USDC for taskmarket '
+                'task"). Nothing was created.'
+            )
+        if authorization.strip() != f"authorize {reward} USDC for taskmarket task":
+            return (
+                "REFUSED: authorization string must exactly match "
+                f'"authorize {reward} USDC for taskmarket task". '
+                "Nothing was created."
+            )
+        if reward <= 0:
+            return "REFUSED: reward must be > 0 USDC. Nothing was created."
+        if reward > self.max_spend:
+            return (
+                f"REFUSED: reward {reward} USDC exceeds max_spend "
+                f"{self.max_spend} USDC (set TASKMARKET_MAX_SPEND to raise). "
+                "Nothing was created."
+            )
+        if duration_hours <= 0:
+            return "REFUSED: duration_hours must be > 0. Nothing was created."
+        if not shutil.which(self.cli_path):
+            return (
+                "REFUSED: 'taskmarket' CLI not found on PATH. Install it via "
+                "npm (official package) to create funded tasks. Nothing was "
+                "created."
+            )
+
+        cmd = [
+            self.cli_path,
+            "task",
+            "create",
+            "--description",
+            description,
+            "--reward",
+            str(reward),
+            "--duration",
+            str(duration_hours),
+            "--mode",
+            mode,
+            "--task-visibility",
+            task_visibility,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if proc.returncode != 0:
+            return (
+                "taskmarket task create failed (exit "
+                f"{proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+
+        out = proc.stdout.strip()
+        task_id = self._extract_task_id(out)
+        return json.dumps(
+            {
+                "created": True,
+                "taskId": task_id,
+                "taskUrl": f"https://taskmarket.dev/tasks/{task_id}"
+                if task_id
+                else None,
+                "cliOutput": out,
+                "liveStatus": task_id and json.loads(self.get_task(task_id)),
+            },
+            indent=2,
+        )
+
+    @staticmethod
+    def _extract_task_id(cli_output: str) -> Optional[str]:
+        """Pull the 64-hex task id out of CLI output, if present."""
+        for token in cli_output.replace("\n", " ").split():
+            t = token.strip(".,:;'\"")
+            if t.startswith("0x") and len(t) == 66:
+                return t
+        return None

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "ipython==8.10.0",
+    "jupyter>=1.0.0,<2",
+    "mypy==0.991",
+    "pre-commit==3.2.0",
+    "pylint==2.15.10",
+    "pytest==7.2.1",
+    "pytest-mock==3.11.1",
+    "ruff==0.11.11",
+    "types-PyYAML>=6.0.12.12,<7",
+    "black[jupyter]<=23.9.1,>=23.7.0",
+    "codespell[toml]>=v2.2.6",
+]
+
+[project]
+name = "llama-index-tools-taskmarket"
+version = "0.1.0"
+description = "llama-index tools taskmarket integration"
+authors = [{name = "Hermes Agent", email = "nicolasesanchez50@gmail.com"}]
+requires-python = ">=3.10,<4.0"
+readme = "README.md"
+license = "MIT"
+maintainers = [{name = "Hermes Agent"}]
+keywords = [
+    "taskmarket",
+    "agents",
+    "x402",
+    "crypto",
+    "base",
+]
+dependencies = [
+    "llama-index-core>=0.13.0,<0.15",
+]
+
+[tool.codespell]
+check-filenames = true
+check-hidden = true
+skip = "*.csv,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb"
+
+[tool.hatch.build.targets.sdist]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.hatch.build.targets.wheel]
+include = ["llama_index/"]
+exclude = ["**/BUILD"]
+
+[tool.llamahub]
+contains_example = true
+import_path = "llama_index.tools.taskmarket"
+
+[tool.llamahub.class_authors]
+TaskmarketToolSpec = "Hermes Agent"
+
+[tool.mypy]
+disallow_untyped_defs = true
+exclude = ["_static", "build", "examples", "notebooks", "venv"]
+ignore_missing_imports = true
+python_version = "3.8"

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/requirements.txt
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/requirements.txt
@@ -1,0 +1,1 @@
+llama-index-core

--- a/llama-index-integrations/tools/llama-index-tools-taskmarket/tests/test_tools_taskmarket.py
+++ b/llama-index-integrations/tools/llama-index-tools-taskmarket/tests/test_tools_taskmarket.py
@@ -1,0 +1,64 @@
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.taskmarket import TaskmarketToolSpec
+
+
+def test_class():
+    names_of_base_classes = [b.__name__ for b in TaskmarketToolSpec.__mro__]
+    assert BaseToolSpec.__name__ in names_of_base_classes
+
+
+def test_spec_functions():
+    spec = TaskmarketToolSpec()
+    assert "list_tasks" in spec.spec_functions
+    assert "get_task" in spec.spec_functions
+    assert "list_submissions" in spec.spec_functions
+    assert "create_task" in spec.spec_functions
+
+
+def test_create_task_refuses_without_authorization():
+    spec = TaskmarketToolSpec()
+    out = spec.create_task(description="test", reward=1.0, duration_hours=24)
+    assert out.startswith("REFUSED")
+    assert "Nothing was created" in out
+
+
+def test_create_task_refuses_wrong_authorization():
+    spec = TaskmarketToolSpec()
+    out = spec.create_task(
+        description="test",
+        reward=1.0,
+        duration_hours=24,
+        authorization="authorize 999 USDC for taskmarket task",
+    )
+    assert out.startswith("REFUSED")
+    assert "must exactly match" in out
+
+
+def test_create_task_refuses_over_max_spend():
+    spec = TaskmarketToolSpec(max_spend=0.5)
+    out = spec.create_task(
+        description="test",
+        reward=5.0,
+        duration_hours=24,
+        authorization="authorize 5.0 USDC for taskmarket task",
+    )
+    assert out.startswith("REFUSED")
+    assert "exceeds max_spend" in out
+
+
+def test_create_task_refuses_bad_duration():
+    spec = TaskmarketToolSpec()
+    out = spec.create_task(
+        description="test",
+        reward=1.0,
+        duration_hours=0,
+        authorization="authorize 1.0 USDC for taskmarket task",
+    )
+    assert out.startswith("REFUSED")
+    assert "duration_hours" in out
+
+
+def test_extract_task_id():
+    fake_id = "0x" + "ab" * 32  # 64 hex chars, same shape as real task ids
+    assert TaskmarketToolSpec._extract_task_id(f"created task {fake_id} ok") == fake_id
+    assert TaskmarketToolSpec._extract_task_id("no id here") is None


### PR DESCRIPTION
## Summary

Adds `TaskmarketToolSpec` (`llama-index-tools-taskmarket`), a LlamaIndex tool integration for [Taskmarket](https://taskmarket.dev) — an onchain agent labor marketplace on Base.

## What it does

- `list_tasks` — discover open tasks via the public REST API (no wallet)
- `get_task` — live status of one task (reward USDC, phase, expiry, submission window)
- `list_submissions` — read-only presentation of submissions for human review (never accepts/rejects)
- `create_task` — funded requester flow:
  - requires a **fresh, exact authorization string** (e.g. `authorize 5 USDC for taskmarket task`)
  - enforces `reward > 0` and `reward <= max_spend` (default 5 USDC, `TASKMARKET_MAX_SPEND` to override)
  - delegates the actual USDC transfer to the **official `taskmarket` CLI** (wallet keys, X402 payment, legal acceptance, idempotency all handled by first-party tooling — no private keys, seeds, or tokens touched here)
  - returns the created task id with live status; never blindly retries an unknown-settlement payment

## Safety

Per the integration contract: reads are public, the write delegates to official tooling, spend is capped, authorization is mandatory, and review stays human.

## Tests / checks

```bash
pip install -e .[dev]  # or: pip install llama-index-core pytest
pytest tests -q        # 7 passed
ruff check llama_index/ tests/   # clean
black --check llama_index/ tests/  # clean
codespell llama_index/ tests/ README.md CHANGELOG.md  # clean
```

Live smoke test against https://api.taskmarket.dev (read path): `list_tasks` returns real open tasks, `get_task` returns live status, `create_task` refuses without authorization.

## Verification

- Commit GPG-signed: `0d1c7c7b0d7b65a876d15e4637ddcbb1edaef77e` (`verified: true`, reason `valid`)
- Taskmarket has no existing integration in this repo (GitHub code search: 0 results)
- Target not previously submitted to Taskmarket integration bounties (checked against all open/sibling bounties)