### PR TITLE
Fix stale llm_predictor arg name in query transform docstrings

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/query_transform/base.py
+++ b/llama-index-core/llama_index/core/indices/query/query_transform/base.py
@@ -114,7 +114,7 @@ class HyDEQueryTransform(BaseQueryTransform):
         Initialize HyDEQueryTransform.
 
         Args:
-            llm_predictor (Optional[LLM]): LLM for generating
+            llm (Optional[LLM]): LLM for generating
                 hypothetical documents
             hyde_prompt (Optional[BasePromptTemplate]): Custom prompt for HyDE
             include_original (bool): Whether to include original query
@@ -158,7 +158,7 @@ class DecomposeQueryTransform(BaseQueryTransform):
     Performs a single step transformation.
 
     Args:
-        llm_predictor (Optional[LLM]): LLM for generating
+        llm (Optional[LLM]): LLM for generating
             hypothetical documents
 
     """
@@ -266,7 +266,7 @@ class StepDecomposeQueryTransform(BaseQueryTransform):
     NOTE: doesn't work yet.
 
     Args:
-        llm_predictor (Optional[LLM]): LLM for generating
+        llm (Optional[LLM]): LLM for generating
             hypothetical documents
 
     """


### PR DESCRIPTION
# Description

The three query transforms in `query_transform/base.py` still document the arg as `llm_predictor`, but it has been called `llm` in the signature for a while now. The type annotation next to it is already right, only the name lagged behind. Worth noting the deprecated `llm_predictor` kwarg in `extractors/metadata_extractors.py` is a real arg and I left it alone.

AI disclosure, per your contributing guide: a script of mine flagged the mismatch, I opened the file and checked each of the three against the signature by hand, and I wrote this description myself. No code paths changed.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
