### PR TITLE
fix: preserve custom temperature for o1 models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -314,8 +314,9 @@ class OpenAIResponses(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # OpenAI requires temperature=1 for o1 models, but preserve an explicit
+        # custom value so callers are not silently surprised by this adjustment.
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         super().__init__(

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -92,6 +92,13 @@ def test_get_model_kwargs(default_responses_llm):
     assert custom_kwargs["max_output_tokens"] == 100
 
 
+def test_o1_preserves_custom_temperature():
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(model=next(iter(O1_MODELS)), temperature=0.5)
+
+    assert llm.temperature == 0.5
+
 def test_get_model_kwargs_excludes_params_with_reasoning(default_responses_llm):
     """Test that certain parameters are excluded when reasoning_options is set."""
     llm = default_responses_llm


### PR DESCRIPTION
Closes #22751

OpenAI Responses initialization should apply the required default temperature for o1 models without silently overwriting a caller-provided custom value. Add a regression test covering an explicit `temperature=0.5`.

Validation:
- `python3 -m compileall -q llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py`
- `git diff --check`