### PR TITLE
Raise a clear error when Cohere API key is missing

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -72,7 +72,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import cohere
+import pytest
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.postprocessor.cohere_rerank import CohereRerank
@@ -103,3 +104,9 @@ def test_max_retries_parameter():
 
         reranker_default = CohereRerank(api_key="test_key")
         assert reranker_default.max_retries == 10
+
+
+def test_missing_api_key_raises_value_error():
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in cohere api key"):
+            CohereRerank()


### PR DESCRIPTION
Fixes #22774\n\nSummary:\n- Catch the missing environment variable correctly when constructing CohereRerank.\n- Add regression coverage for the missing-key path.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because pytest-asyncio is unavailable.