### PR TITLE
Fix metadata replacement for null values

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
+++ b/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
@@ -24,10 +24,8 @@ class MetadataReplacementPostProcessor(BaseNodePostprocessor):
     ) -> List[NodeWithScore]:
         for n in nodes:
             n.node.set_content(
-                n.node.metadata.get(
-                    self.target_metadata_key,
-                    n.node.get_content(metadata_mode=MetadataMode.NONE),
-                )
+                n.node.metadata.get(self.target_metadata_key)
+                or n.node.get_content(metadata_mode=MetadataMode.NONE)
             )
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_metadata_replacement.py
+++ b/llama-index-core/tests/postprocessor/test_metadata_replacement.py
@@ -15,3 +15,13 @@ def test_metadata_replacement() -> None:
 
     assert len(nodes) == 1
     assert nodes[0].node.get_content() == "This is a another test."
+
+
+def test_metadata_replacement_falls_back_for_none_value() -> None:
+    node = TextNode(text="original content", metadata={"key": None})
+    nodes = [NodeWithScore(node=node)]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+    postprocessor.postprocess_nodes(nodes)
+
+    assert nodes[0].node.get_content() == "original content"


### PR DESCRIPTION
Fixes #22772\n\nSummary:\n- Treat an explicit null replacement value like a missing value.\n- Preserve the node's original content and add regression coverage.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because pytest-asyncio is unavailable.