### PR TITLE
Raise ValueError when Cohere API key is missing

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -72,7 +72,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import cohere
+import pytest
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.schema import NodeWithScore, QueryBundle, TextNode
 from llama_index.postprocessor.cohere_rerank import CohereRerank
@@ -10,6 +11,12 @@ from llama_index.postprocessor.cohere_rerank.base import _create_retry_decorator
 def test_class():
     names_of_base_classes = [b.__name__ for b in CohereRerank.__mro__]
     assert BaseNodePostprocessor.__name__ in names_of_base_classes
+
+
+def test_missing_api_key_raises_value_error():
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in cohere api key"):
+            CohereRerank()
 
 
 def test_create_retry_decorator():


### PR DESCRIPTION
Fixes #22774.\n\nCohereRerank reads a missing environment variable with os.environ, which raises KeyError while the constructor incorrectly catches IndexError. Catch KeyError so callers receive the documented actionable ValueError.\n\nAdded a regression test with the environment variable cleared.\n\nValidation: git diff --check and python3 -m py_compile passed. The targeted pytest could not be collected locally because the cohere dependency is not installed.