### PR TITLE
fix(github-reader): generate browser source URLs

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/llama_index/readers/github/repository/base.py
@@ -860,6 +860,9 @@ class GithubRepositoryReader(BaseReader):
         return blobs_and_full_paths
 
     def _get_base_url(self, blob_url):
+        if blob_url.startswith("https://api.github.com/"):
+            return "https://github.com/"
+
         match = re.match(r"(https://[^/]+\.com/)", blob_url)
         if match:
             return match.group(1)

--- a/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-github/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-github"
-version = "0.11.2"
+version = "0.11.3"
 description = "llama-index readers github integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-github/tests/test_gh_base_url.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/tests/test_gh_base_url.py
@@ -18,6 +18,10 @@ def github_reader():
     [
         ("https://github.com/owner/repo/blob/main/file.py", "https://github.com/"),
         (
+            "https://api.github.com/repos/owner/repo/git/blobs/abc123",
+            "https://github.com/",
+        ),
+        (
             "https://github-enterprise.com/owner/repo/blob/main/file.py",
             "https://github-enterprise.com/",
         ),

--- a/llama-index-integrations/readers/llama-index-readers-github/tests/test_github_repository_reader.py
+++ b/llama-index-integrations/readers/llama-index-readers-github/tests/test_github_repository_reader.py
@@ -114,8 +114,18 @@ def test_timeout_and_retries_passed_to_request():
 
         # Load data via both branch and sha to exercise those functions in the
         # GithubClient
-        reader.load_data(branch="main")
-        reader.load_data(commit_sha="a11a953e738cbda93335ede83f012914d53dc4f7")
+        branch_documents = reader.load_data(branch="main")
+        commit_documents = reader.load_data(
+            commit_sha="a11a953e738cbda93335ede83f012914d53dc4f7"
+        )
+
+        assert branch_documents[0].metadata["url"] == (
+            "https://github.com/run-llama/llama_index/blob/main/README.md"
+        )
+        assert commit_documents[0].metadata["url"] == (
+            "https://github.com/run-llama/llama_index/blob/"
+            "a11a953e738cbda93335ede83f012914d53dc4f7/README.md"
+        )
 
         mock_request.assert_called()
         for call in mock_request.call_args_list:

--- a/llama-index-integrations/readers/llama-index-readers-github/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-github/uv.lock
@@ -1958,7 +1958,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-github"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Description

`GithubRepositoryReader` receives blob URLs from the public GitHub REST API. Those URLs use `api.github.com`, but the `Document.metadata["url"]` value should link users to the corresponding browser source page on `github.com`. This patch maps public API blob URLs to the browser host while preserving the existing custom and Enterprise host behavior.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-readers-github` 0.11.3
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Validation run locally:

- `uv run -- pytest` — 56 passed, 6 skipped
- Changed-file `ruff` check and format check
- Repository `pre-commit` hooks on all changed files

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI assistance and human oversight

AI assistance was used to develop and validate this focused patch. A human reviewer personally reviewed the complete diff before submission and authorized this disclosure.
