### PR TITLE
fix(core): preserve upsert data when transformations fail

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -475,6 +475,7 @@ class IngestionPipeline(BaseModel):
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        doc_ids_to_delete = set()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
@@ -483,11 +484,7 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
+                doc_ids_to_delete.add(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
@@ -497,14 +494,9 @@ class IngestionPipeline(BaseModel):
             existing_doc_ids_before = set(
                 self.docstore.get_all_document_hashes().values()
             )
-            doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                self.docstore.delete_document(ref_doc_id)
+            doc_ids_to_delete.update(existing_doc_ids_before - doc_ids_from_nodes)
 
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
-        return deduped_nodes_to_run
+        return deduped_nodes_to_run, doc_ids_to_delete
 
     @staticmethod
     def _node_batcher(
@@ -588,12 +580,13 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        doc_ids_to_delete: set[str] = set()
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = self._handle_upserts(input_nodes)
+                nodes_to_run, doc_ids_to_delete = self._handle_upserts(input_nodes)
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
                 nodes_to_run = self._handle_duplicates(input_nodes)
             else:
@@ -646,6 +639,13 @@ class IngestionPipeline(BaseModel):
             )
 
         nodes = nodes or []
+
+        for ref_doc_id in doc_ids_to_delete:
+            self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
+            if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
+                self.docstore.delete_document(ref_doc_id)
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]
@@ -705,12 +705,13 @@ class IngestionPipeline(BaseModel):
         self,
         nodes: Sequence[BaseNode],
         store_doc_text: bool = True,
-    ) -> Sequence[BaseNode]:
+    ) -> tuple[Sequence[BaseNode], set[str]]:
         """Handle docstore upserts by checking hashes and ids."""
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        doc_ids_to_delete = set()
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
@@ -719,11 +720,7 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
+                doc_ids_to_delete.add(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
@@ -733,14 +730,9 @@ class IngestionPipeline(BaseModel):
             existing_doc_ids_before = set(
                 (await self.docstore.aget_all_document_hashes()).values()
             )
-            doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
-            for ref_doc_id in doc_ids_to_delete:
-                await self.docstore.adelete_document(ref_doc_id)
+            doc_ids_to_delete.update(existing_doc_ids_before - doc_ids_from_nodes)
 
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
-        return deduped_nodes_to_run
+        return deduped_nodes_to_run, doc_ids_to_delete
 
     @dispatcher.span
     async def arun(
@@ -795,12 +787,13 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        doc_ids_to_delete: set[str] = set()
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = await self._ahandle_upserts(
+                nodes_to_run, doc_ids_to_delete = await self._ahandle_upserts(
                     input_nodes, store_doc_text=store_doc_text
                 )
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
@@ -866,6 +859,13 @@ class IngestionPipeline(BaseModel):
             nodes = nodes
 
         nodes = nodes or []
+
+        for ref_doc_id in doc_ids_to_delete:
+            await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
+            if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
+                await self.docstore.adelete_document(ref_doc_id)
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -400,6 +400,40 @@ def test_pipeline_with_transform_error() -> None:
     assert pipeline.docstore.get_node("1", raise_error=False) is None
 
 
+def test_pipeline_upserts_keep_previous_data_when_transform_fails() -> None:
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError
+
+    class TrackingVectorStore(SimpleVectorStore):
+        def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            self.data.embedding_dict.pop(ref_doc_id, None)
+
+        async def adelete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            self.data.embedding_dict.pop(ref_doc_id, None)
+
+    docstore = SimpleDocumentStore()
+    vector_store = TrackingVectorStore()
+    pipeline = IngestionPipeline(
+        transformations=[MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    original = Document(text="original", doc_id="1")
+    pipeline.run(documents=[original])
+
+    pipeline.transformations = [RaisingTransform()]
+    with pytest.raises(RuntimeError):
+        pipeline.run(documents=[Document(text="updated", doc_id="1")])
+
+    assert docstore.get_node("1", raise_error=False).text == "original"  # type: ignore
+    assert len(vector_store.data.embedding_dict) == 1
+
+
+
 @pytest.mark.asyncio
 async def test_arun_pipeline() -> None:
     pipeline = IngestionPipeline(
@@ -638,6 +672,40 @@ async def test_async_pipeline_with_transform_error() -> None:
         await pipeline.arun(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_upserts_keep_previous_data_when_transform_fails() -> None:
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError
+
+    class TrackingVectorStore(SimpleVectorStore):
+        def delete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            self.data.embedding_dict.pop(ref_doc_id, None)
+
+        async def adelete(self, ref_doc_id: str, **kwargs: Any) -> None:
+            self.data.embedding_dict.pop(ref_doc_id, None)
+
+    docstore = SimpleDocumentStore()
+    vector_store = TrackingVectorStore()
+    pipeline = IngestionPipeline(
+        transformations=[MockEmbedding(embed_dim=8)],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    original = Document(text="original", doc_id="1")
+    await pipeline.arun(documents=[original])
+
+    pipeline.transformations = [RaisingTransform()]
+    with pytest.raises(RuntimeError):
+        await pipeline.arun(documents=[Document(text="updated", doc_id="1")])
+
+    assert docstore.get_node("1", raise_error=False).text == "original"  # type: ignore
+    assert len(vector_store.data.embedding_dict) == 1
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -400,7 +400,12 @@ def test_pipeline_with_transform_error() -> None:
     assert pipeline.docstore.get_node("1", raise_error=False) is None
 
 
-def test_pipeline_upserts_keep_previous_data_when_transform_fails() -> None:
+@pytest.mark.parametrize(
+    "strategy", [DocstoreStrategy.UPSERTS, DocstoreStrategy.UPSERTS_AND_DELETE]
+)
+def test_pipeline_upserts_keep_previous_data_when_transform_fails(
+    strategy: DocstoreStrategy,
+) -> None:
     class RaisingTransform(TransformComponent):
         def __call__(
             self, nodes: Sequence[BaseNode], **kwargs: Any
@@ -420,7 +425,7 @@ def test_pipeline_upserts_keep_previous_data_when_transform_fails() -> None:
         transformations=[MockEmbedding(embed_dim=8)],
         docstore=docstore,
         vector_store=vector_store,
-        docstore_strategy=DocstoreStrategy.UPSERTS,
+        docstore_strategy=strategy,
     )
     original = Document(text="original", doc_id="1")
     pipeline.run(documents=[original])
@@ -675,7 +680,12 @@ async def test_async_pipeline_with_transform_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_pipeline_upserts_keep_previous_data_when_transform_fails() -> None:
+@pytest.mark.parametrize(
+    "strategy", [DocstoreStrategy.UPSERTS, DocstoreStrategy.UPSERTS_AND_DELETE]
+)
+async def test_async_pipeline_upserts_keep_previous_data_when_transform_fails(
+    strategy: DocstoreStrategy,
+) -> None:
     class RaisingTransform(TransformComponent):
         def __call__(
             self, nodes: Sequence[BaseNode], **kwargs: Any
@@ -695,7 +705,7 @@ async def test_async_pipeline_upserts_keep_previous_data_when_transform_fails() 
         transformations=[MockEmbedding(embed_dim=8)],
         docstore=docstore,
         vector_store=vector_store,
-        docstore_strategy=DocstoreStrategy.UPSERTS,
+        docstore_strategy=strategy,
     )
     original = Document(text="original", doc_id="1")
     await pipeline.arun(documents=[original])


### PR DESCRIPTION
## Summary

Fixes #22639.

`IngestionPipeline` previously deleted existing docstore/vector-store data while deciding which nodes to upsert, before transformations ran. If a transformation failed, the previous indexed version could be removed while the replacement was never written.

This change defers pending deletions until transformations complete successfully in both synchronous and asynchronous execution.

## Consistency scope

This PR guarantees that transformation failures do not delete the previously indexed data, covering both `UPSERTS` and `UPSERTS_AND_DELETE`. It does not claim strict cross-store transactional atomicity: the existing docstore and vector-store interfaces do not expose transactions, snapshots, or rollback hooks. Failures during later storage operations can still require store-specific recovery.

Providing strict transaction-level consistency would require an explicit transaction/rollback capability in the storage interfaces and is outside the scope of this focused issue fix.

## Compatibility

Successful upsert behavior is unchanged. Failed transformations now preserve the previously indexed data.

## Tests

- `python -m pytest tests/ingestion/test_pipeline.py -k 'upserts_keep_previous_data_when_transform_fails' -q --basetemp D:\\project\\tscodex\\github_pr\\pytest-target-22639-v2` — 4 passed (sync/async × both upsert strategies).
- `git diff --check` — passed.
- Full test-file execution was attempted; unrelated failures were caused by unavailable NLTK `stopwords`/`punkt_tab` resources in the local environment.

## Limitations

The repository-wide Ruff configuration could not be loaded because the local sparse checkout does not contain the root `pyproject.toml`; isolated Ruff reported existing baseline findings in unchanged code.

The AI-assisted portions of this change were reviewed line-by-line.