### PR TITLE
fix: llama-dev pkg info --json only kept the last package; README kwarg/pip-name fixes

### DIFF
--- a/llama-dev/llama_dev/pkg/info.py
+++ b/llama-dev/llama_dev/pkg/info.py
@@ -38,12 +38,16 @@ def info(obj: dict, all: bool, use_json: bool, package_names: tuple):
             packages.add(package_path)
 
     if use_json:
-        data = {}
+        data = []
         for package in packages:
             package_data = load_pyproject(package)
-            data["name"] = package_data["project"]["name"]
-            data["version"] = package_data["project"]["version"]
-            data["path"] = str(package)
+            data.append(
+                {
+                    "name": package_data["project"]["name"],
+                    "version": package_data["project"]["version"],
+                    "path": str(package),
+                }
+            )
         obj["console"].print(json.dumps(data))
     else:
         table = Table(box=None)

--- a/llama-index-integrations/agent/llama-index-agent-azure/README.md
+++ b/llama-index-integrations/agent/llama-index-agent-azure/README.md
@@ -11,7 +11,7 @@ This package provides an Azure Foundry Agent integration for LlamaIndex. It allo
 You can install the package via pip:
 
 ```bash
-pip install llama-index-agent-azure
+pip install llama-index-agent-azure-foundry
 ```
 
 or if working from source:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-netmind/README.md
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-netmind/README.md
@@ -5,7 +5,7 @@
 To install the required package, run:
 
 ```shell
-pip install llama-index-llms-netmind
+pip install llama-index-embeddings-netmind
 ```
 
 ## Setup
@@ -15,7 +15,7 @@ pip install llama-index-llms-netmind
 ```shell
 import os
 
-os.environ["NETMIND_API_KEY"] = "you_api_key"
+os.environ["NETMIND_API_KEY"] = "your_api_key"
 ```
 
 ## Basic Usage

--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/README.md
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/README.md
@@ -157,7 +157,7 @@ print(response.response)
 ```python
 images_index = LanceDBMultiModalIndex(
     uri="lancedb/images",
-    multi_modal_embedding_model="open-clip",
+    multimodal_embedding_model="open-clip",
     table_name="images",
 )
 
@@ -180,7 +180,7 @@ images_index = await LanceDBMultiModalIndex.from_documents(
         ),
     ],
     uri="lancedb/images",
-    multi_modal_embedding_model="open-clip",
+    multimodal_embedding_model="open-clip",
     table_name="images",
 )
 
@@ -218,7 +218,7 @@ data = pd.DataFrame(
 images_index = await LanceDBMultiModalIndex.from_data(
     data=data,
     uri="lancedb/images",
-    multi_modal_embedding_model="open-clip",
+    multimodal_embedding_model="open-clip",
     table_name="images",
 )
 ```

--- a/llama-index-integrations/ingestion/llama-index-ingestion-ray/README.md
+++ b/llama-index-integrations/ingestion/llama-index-ingestion-ray/README.md
@@ -7,7 +7,7 @@ This integration uses Ray’s distributed compute framework to parallelize docum
 ## Installation
 
 ```bash
-pip install llama-index-integrations-ray
+pip install llama-index-ingestion-ray
 ```
 
 ## Usage

--- a/llama-index-integrations/readers/llama-index-readers-guru/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-guru/README.md
@@ -15,7 +15,7 @@ Here's an example usage of the GuruReader.
 ```python
 from llama_index.readers.guru import GuruReader
 
-reader = GuruReader(username="<GURU_USERNAME>", api_key="<GURU_API_KEY>")
+reader = GuruReader(guru_username="<GURU_USERNAME>", api_token="<GURU_API_KEY>")
 
 # Load all documents in a collection
 documents = reader.load_data(

--- a/llama-index-integrations/readers/llama-index-readers-kaltura/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-kaltura/README.md
@@ -71,9 +71,9 @@ First, instantiate the KalturaReader (aka Kaltura Loader) with your Kaltura conf
 from llama_index.readers.kaltura_esearch import KalturaESearchReader
 
 loader = KalturaESearchReader(
-    partnerId="INSERT_YOUR_PARTNER_ID",
-    apiSecret="INSERT_YOUR_ADMIN_SECRET",
-    userId="INSERT_YOUR_USER_ID",
+    partner_id="INSERT_YOUR_PARTNER_ID",
+    api_secret="INSERT_YOUR_ADMIN_SECRET",
+    user_id="INSERT_YOUR_USER_ID",
 )
 ```
 

--- a/llama-index-integrations/tools/llama-index-tools-jira-issue/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-jira-issue/README.md
@@ -13,7 +13,7 @@ from llama_index.llms.openai import OpenAI
 llm = OpenAI(model="gpt-4o-mini", api_key=OPENAI_API_KEY, temperature=0.0)
 
 tool_spec = JiraIssueToolSpec(
-    server_url=SERVER, email=EMAIL, api_token=API_KEY
+    server_url=SERVER, email=EMAIL, api_key=API_KEY
 )
 
 agent_name = "Jira Issue Agent"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-firestore/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-firestore/README.md
@@ -9,7 +9,7 @@ A LlamaIndex vector store using Cloud Firestore as the backend.
 Pre-requisite:
 
 ```bash
-pip install llama-index-vector-stores-firestore
+pip install llama-index-vector-store-firestore
 ```
 
 Minimal example:


### PR DESCRIPTION
## Summary

### Code
**`llama-dev/llama_dev/pkg/info.py`**: the `--json` path looped overwriting the same three dict keys, so `llama-dev pkg info --json --all` emitted only ONE package no matter how many were selected (the table path correctly prints a row per package; tests only cover the table path). Now collects a list of per-package objects.

### README snippets that raise TypeError
- managed-lancedb (x3): `multi_modal_embedding_model` is not a kwarg — the parameter is `multimodal_embedding_model` (the underscored spelling is the `EmbeddingConfig` field, a different object).
- guru: `GuruReader(username=..., api_key=...)` → signature is `guru_username`/`api_token`.
- kaltura: `partnerId/apiSecret/userId` camelCase → `partner_id/api_secret/user_id`.
- jira-issue: `api_token` → `api_key`.

### Wrong pip package names
- embeddings-netmind README installed `llama-index-llms-netmind` (the LLM integration) instead of `llama-index-embeddings-netmind`; also 'you_api_key' typo.
- ingestion-ray README: `llama-index-integrations-ray` (PyPI 404) → `llama-index-ingestion-ray`.
- agent-azure README: `llama-index-agent-azure` (PyPI 404) → `llama-index-agent-azure-foundry`.
- vector-stores-firestore README: `llama-index-vector-stores-firestore` on PyPI is an unrelated third-party placeholder; the real package is `llama-index-vector-store-firestore` (singular).