### PR TITLE
docs: fix `asyntheszie` typo in response synthesizers guide

### DIFF
--- a/docs/src/content/docs/framework/module_guides/querying/response_synthesizers/response_synthesizers.md
+++ b/docs/src/content/docs/framework/module_guides/querying/response_synthesizers/response_synthesizers.md
@@ -15,7 +15,7 @@ The following shows the setup for utilizing all kwargs.
 - `streaming` configures whether to return a streaming response object or not
 - `structured_answer_filtering` enables the active filtering of text chunks that are not relevant to a given question
 
-In the `synthesize`/`asyntheszie` functions, you can optionally provide additional source nodes, which will be added to the `response.source_nodes` list.
+In the `synthesize`/`asynthesize` functions, you can optionally provide additional source nodes, which will be added to the `response.source_nodes` list.
 
 ```python
 from llama_index.core.data_structs import Node


### PR DESCRIPTION
The response synthesizers guide refers to the async method as `asyntheszie`, but the actual API method in `llama-index-core` (`ResponseSynthesizer.asynthesize`) is spelled `asynthesize`.

This fixes the misspelled method name so readers do not try to call a non-existent method.

- File: `docs/src/content/docs/framework/module_guides/querying/response_synthesizers/response_synthesizers.md` (line 18)