### PR TITLE
docs: remove duplicated word in transformations guide

### DIFF
--- a/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
+++ b/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
@@ -13,7 +13,7 @@ Currently, the following components are `Transformation` objects:
 
 ## Usage Pattern
 
-While transformations are best used with with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
+While transformations are best used with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
 
 ```python
 from llama_index.core.node_parser import SentenceSplitter


### PR DESCRIPTION
Removes a duplicated `with` in the opening sentence of the transformations guide.

- File: `docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md` (line 16)