### PR TITLE
fix(remote-depth): respect configured link depth

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-remote-depth/llama_index/readers/remote_depth/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-remote-depth/llama_index/readers/remote_depth/base.py
@@ -36,7 +36,7 @@ class RemoteDepthReader(BaseReader):
         links = self.get_links(url)
         urls = {-1: [url]}  # -1 is the starting point
         links_visited = []
-        for i in range(self.depth + 1):
+        for i in range(self.depth):
             urls[i] = []
             new_links = []
             print(f"Reading links at depth {i}...")

--- a/llama-index-integrations/readers/llama-index-readers-remote-depth/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-remote-depth/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-remote-depth"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers remote_depth integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<3.12"

--- a/llama-index-integrations/readers/llama-index-readers-remote-depth/tests/test_readers_remote_depth.py
+++ b/llama-index-integrations/readers/llama-index-readers-remote-depth/tests/test_readers_remote_depth.py
@@ -1,3 +1,5 @@
+import pytest
+
 from llama_index.core.readers.base import BaseReader
 from llama_index.readers.remote_depth import RemoteDepthReader
 
@@ -5,3 +7,40 @@ from llama_index.readers.remote_depth import RemoteDepthReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in RemoteDepthReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected_urls"),
+    [
+        (0, ["https://example.com/root"]),
+        (1, ["https://example.com/root", "https://example.com/child"]),
+    ],
+)
+def test_load_data_respects_link_depth(monkeypatch, depth, expected_urls):
+    root_url = "https://example.com/root"
+    child_url = "https://example.com/child"
+    grandchild_url = "https://example.com/grandchild"
+    links = {
+        root_url: [child_url],
+        child_url: [grandchild_url],
+        grandchild_url: [],
+    }
+    loaded_urls = []
+
+    class RecordingRemoteReader:
+        def __init__(self, **kwargs):
+            pass
+
+        def load_data(self, url):
+            loaded_urls.append(url)
+            return []
+
+    reader = RemoteDepthReader(depth=depth)
+    monkeypatch.setattr(reader, "get_links", links.__getitem__)
+    monkeypatch.setattr(
+        "llama_index.readers.remote_depth.base.RemoteReader", RecordingRemoteReader
+    )
+
+    reader.load_data(root_url)
+
+    assert loaded_urls == expected_urls

--- a/llama-index-integrations/readers/llama-index-readers-remote-depth/uv.lock
+++ b/llama-index-integrations/readers/llama-index-readers-remote-depth/uv.lock
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-readers-remote-depth"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },


### PR DESCRIPTION
# Description

`RemoteDepthReader` treated `depth` as one greater than the documented number of link levels: `depth=0` also loaded direct links, and `depth=1` also loaded grandchildren. This changes the traversal loop to use the configured link depth exactly.

No existing issue tracks this defect; the regression test captures the documented behavior.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

The `llama-index-readers-remote-depth` package version is bumped from `0.5.0` to `0.5.1`, with its package lock entry updated.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

The new mocked regression verifies that `depth=0` loads only the starting URL and `depth=1` loads the starting URL plus direct links, without making network calls.

Validation run locally:

- `uv run -- pytest tests/test_readers_remote_depth.py` — RED: 2 expected failures before the fix; GREEN: 3 passed after the fix.
- `uv run -- pytest` — 3 passed.
- Changed-file `ruff check` and `ruff format --check` — passed.
- Scoped repository `pre-commit run --show-diff-on-failure --files ...` — passed, including mypy.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI assistance and human oversight

AI assisted with drafting the focused code and test changes. The human author personally reviewed commit `c6fcd1b9313647d6a1f8d09db63f79e30be31382` and authorized this accurate disclosure and self-review statement.
