### PR TITLE
fix(instrumentation): replace mutable default arguments in Dispatcher

### DIFF
--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers or [],
-            span_handlers=span_handlers or [NullSpanHandler()],
+            event_handlers=event_handlers if event_handlers is not None else [],
+            span_handlers=span_handlers if span_handlers is not None else [NullSpanHandler()],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,

--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers or [],
+            span_handlers=span_handlers or [NullSpanHandler()],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,


### PR DESCRIPTION
# fix(instrumentation): replace mutable default arguments in Dispatcher

## Purpose
This PR fixes issue #22705 where the `Dispatcher` constructor used mutable default arguments (`[]`) for `event_handlers` and `span_handlers`. This is a classic Python anti-pattern that can lead to shared state across different instances of the `Dispatcher` class.

## Technical Details
- Replaced `List[BaseEventHandler] = []` with `Optional[List[BaseEventHandler]] = None`.
- Replaced `List[BaseSpanHandler] = []` with `Optional[List[BaseSpanHandler]] = None`.
- Initialized the handlers to new lists (or the default `NullSpanHandler`) within the `__init__` method using the `handlers or []` pattern.
- This ensures that each `Dispatcher` instance has its own independent list of handlers, even if none are provided at initialization.

## Verification Results
I verified the fix with a targeted regression test:
- Confirmed `Dispatcher.__init__.__defaults__` now contains `None` instead of empty lists.
- Confirmed that multiple instances of `Dispatcher` created without arguments now have unique `event_handlers` list objects (different `id()`).

All instrumentation tests are expected to remain unaffected by this change while improving the robustness of the class.