### PR TITLE
fix(core): treat explicit None usage sub-fields as missing in TokenCountingHandler

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -63,13 +63,13 @@ def get_tokens_from_response(
 
     prompt_tokens = 0
     for input_key in possible_input_keys:
-        if input_key in usage:
+        if usage.get(input_key) is not None:
             prompt_tokens = usage[input_key]
             break
 
     completion_tokens = 0
     for output_key in possible_output_keys:
-        if output_key in usage:
+        if usage.get(output_key) is not None:
             completion_tokens = usage[output_key]
             break
 

--- a/llama-index-core/tests/callbacks/test_token_counter.py
+++ b/llama-index-core/tests/callbacks/test_token_counter.py
@@ -1,7 +1,11 @@
 """Embeddings."""
 
-from llama_index.core.callbacks.schema import CBEventType
-from llama_index.core.callbacks.token_counting import TokenCountingHandler
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.callbacks.token_counting import (
+    TokenCountingHandler,
+    get_llm_token_counts,
+)
+from llama_index.core.utilities.token_counting import TokenCounter
 
 TEST_PAYLOAD = {"chunks": ["one"], "formatted_prompt": "two", "response": "three"}
 TEST_ID = "my id"
@@ -48,3 +52,23 @@ def test_on_event_end() -> None:
     # Embedding should be one (single token chunk)
     assert handler.total_llm_token_count == 2
     assert handler.total_embedding_token_count == 1
+
+
+def test_get_tokens_from_response_with_explicit_none_usage_subfield() -> None:
+    """A provider reporting a usage sub-field as explicit None should not crash."""
+
+    class FakeCompletion:
+        text = "hello"
+        raw = {
+            "usage": {"prompt_tokens": None, "completion_tokens": 5, "total_tokens": 5}
+        }
+        additional_kwargs = {}
+
+    payload = {EventPayload.PROMPT: "hi", EventPayload.COMPLETION: FakeCompletion()}
+
+    event = get_llm_token_counts(TokenCounter(), payload, event_id="x")
+
+    # prompt_tokens falls back to being estimated from the prompt string
+    # instead of staying None, and completion_tokens is read as reported.
+    assert event.prompt_token_count != 0
+    assert event.completion_token_count == 5


### PR DESCRIPTION
Fixes #22806

## Problem

`get_tokens_from_response` (in `llama-index-core/llama_index/core/callbacks/token_counting.py`) reads a usage sub-field straight into `TokenCountingEvent`'s arithmetic without checking it for `None`:

```python
prompt_tokens = 0
for input_key in possible_input_keys:
    if input_key in usage:
        prompt_tokens = usage[input_key]
        break
```

If a provider reports a usage sub-key with an explicit `None` value (rather than omitting it), `prompt_tokens` becomes `None`. The `if prompt_tokens == 0:` fallback later doesn't catch it (`None == 0` is `False`), so `None` flows into `TokenCountingEvent`, whose `__post_init__` does `self.prompt_token_count + self.completion_token_count`. Since `CallbackManager.on_event_end` calls handlers with no try/except, the resulting `TypeError` propagates out of the callback dispatch and crashes the caller's `chat()`/`complete()` invocation — after the LLM call has already succeeded (and, for a paid API, already been billed).

## Fix

Switch the lookup from an `in` check to a `None`-aware `.get(...) is not None` check, so an explicit `null` is treated the same as a missing key and falls back to the token-counter estimate, matching the surrounding loop's stated purpose (#15501) of tolerating heterogeneous provider usage shapes.

## Test plan

Added `test_get_tokens_from_response_with_explicit_none_usage_subfield` to `llama-index-core/tests/callbacks/test_token_counter.py`, using the exact reproduction from the issue (a fake completion with `raw["usage"]["prompt_tokens"] = None`).

Confirmed the test fails without the fix (reverted only the source file with `git checkout HEAD~1 -- llama-index-core/llama_index/core/callbacks/token_counting.py`, i.e. before this commit):

```
tests/callbacks/test_token_counter.py::test_get_tokens_from_response_with_explicit_none_usage_subfield FAILED
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

And passes with the fix applied:

```
$ uv run -- pytest tests/callbacks/ -v
tests/callbacks/test_llama_debug.py::test_on_event_start PASSED
tests/callbacks/test_llama_debug.py::test_on_event_end PASSED
tests/callbacks/test_llama_debug.py::test_get_event_stats PASSED
tests/callbacks/test_llama_debug.py::test_flush_events PASSED
tests/callbacks/test_llama_debug.py::test_ignore_events PASSED
tests/callbacks/test_token_budget.py::test_token_budget_enforcement PASSED
tests/callbacks/test_token_budget.py::test_token_budget_via_callback_manager PASSED
tests/callbacks/test_token_counter.py::test_on_event_start PASSED
tests/callbacks/test_token_counter.py::test_on_event_end PASSED
tests/callbacks/test_token_counter.py::test_get_tokens_from_response_with_explicit_none_usage_subfield PASSED

10 passed in 0.19s
```

Also ran `uv run make lint` at the repo root — all checks (ruff, ruff-format, mypy, etc.) passed.

## AI-assistance disclosure

This change was drafted with AI assistance (Claude). The diff is a minimal, targeted fix scoped to the exact root cause described in the issue (and independently confirmed by @dosu's analysis on the issue thread); I reviewed the change, reproduced the crash before the fix, and verified the added test and full callback test suite pass after it.
