### PR TITLE
feat(finance): add optional Adanos market sentiment tools

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-finance/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-finance/README.md
@@ -63,3 +63,44 @@ response = await agent.run(
     "What happened to AAPL stock on February 19th, 2024?"
 )
 ```
+
+## Adanos Market Sentiment
+
+The package also provides an independent tool spec for the
+[Adanos Market Sentiment API](https://adanos.org/). It gives agents structured
+stock sentiment from Reddit, X / FinTwit, financial news, and Polymarket, plus
+Reddit crypto sentiment.
+
+Create an API key at [adanos.org/register](https://adanos.org/register), then add
+the tools to an agent:
+
+```python
+import os
+
+from llama_index.core.agent.workflow import FunctionAgent
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.finance import AdanosMarketSentimentToolSpec
+
+adanos = AdanosMarketSentimentToolSpec(api_key=os.environ["ADANOS_API_KEY"])
+agent = FunctionAgent(
+    tools=adanos.to_tool_list(),
+    llm=OpenAI(model="gpt-4o"),
+)
+
+response = await agent.run(
+    "Compare AAPL and NVDA Reddit sentiment from 2026-08-01 to 2026-08-07."
+)
+```
+
+Available functions:
+
+- `get_adanos_stock_sentiment`: sentiment for one stock from a selected source.
+- `get_adanos_crypto_sentiment`: Reddit sentiment for one crypto asset.
+- `get_adanos_trending_assets`: ranked stock or crypto attention.
+- `compare_adanos_asset_sentiment`: side-by-side sentiment for multiple assets.
+- `get_adanos_market_sentiment`: an aggregate market snapshot.
+
+Date windows use inclusive UTC `start_date` and `end_date` values. The Free,
+Hobby, and Professional plans support up to 30, 90, and 365 days of historical
+lookback respectively. See the [API documentation](https://api.adanos.org/docs)
+for response fields and current plan limits.

--- a/llama-index-integrations/tools/llama-index-tools-finance/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-finance/README.md
@@ -104,3 +104,7 @@ Date windows use inclusive UTC `start_date` and `end_date` values. The Free,
 Hobby, and Professional plans support up to 30, 90, and 365 days of historical
 lookback respectively. See the [API documentation](https://api.adanos.org/docs)
 for response fields and current plan limits.
+
+Rate-limit responses raise `requests.HTTPError` with the API message and any
+`Retry-After` guidance. The tool does not retry automatically, so callers retain
+control over retry timing and quota usage.

--- a/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/__init__.py
@@ -1,6 +1,6 @@
-## init
+from llama_index.tools.finance.adanos import AdanosMarketSentimentToolSpec
 from llama_index.tools.finance.base import (
     FinanceAgentToolSpec,
 )
 
-__all__ = ["FinanceAgentToolSpec"]
+__all__ = ["AdanosMarketSentimentToolSpec", "FinanceAgentToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/adanos.py
+++ b/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/adanos.py
@@ -1,0 +1,243 @@
+"""Adanos market sentiment tool spec."""
+
+import re
+from typing import Any, Dict, List, Optional, Union, cast
+
+import requests
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+
+class AdanosMarketSentimentToolSpec(BaseToolSpec):
+    """Expose Adanos stock and crypto market sentiment data to agents."""
+
+    spec_functions = [
+        "get_adanos_stock_sentiment",
+        "get_adanos_crypto_sentiment",
+        "get_adanos_trending_assets",
+        "compare_adanos_asset_sentiment",
+        "get_adanos_market_sentiment",
+    ]
+
+    _STOCK_SOURCE_PREFIXES = {
+        "reddit": "/reddit/stocks/v1",
+        "x": "/x/stocks/v1",
+        "news": "/news/stocks/v1",
+        "polymarket": "/polymarket/stocks/v1",
+    }
+    _CRYPTO_PREFIX = "/reddit/crypto/v1"
+    _STOCK_TICKER_PATTERN = re.compile(
+        r"^\$?(?:[A-Za-z0-9]{1,8}[.-][A-Za-z]|"
+        r"(?=[A-Za-z0-9]{1,10}$)(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]+|"
+        r"[0-9]{3,10})$"
+    )
+    _CRYPTO_SYMBOL_PATTERN = re.compile(r"^\$?[A-Za-z0-9]{1,20}$")
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.adanos.org",
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the tool with an Adanos API key."""
+        if not api_key.strip():
+            raise ValueError("An Adanos API key is required.")
+        if timeout <= 0:
+            raise ValueError("timeout must be greater than zero.")
+
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Accept": "application/json",
+                "X-API-Key": api_key,
+            }
+        )
+
+    @staticmethod
+    def _date_params(
+        start_date: Optional[str], end_date: Optional[str]
+    ) -> Dict[str, str]:
+        params = {}
+        if start_date:
+            params["from"] = start_date
+        if end_date:
+            params["to"] = end_date
+        return params
+
+    def _stock_prefix(self, source: str) -> str:
+        normalized_source = source.strip().lower()
+        try:
+            return self._STOCK_SOURCE_PREFIXES[normalized_source]
+        except KeyError as exc:
+            supported = ", ".join(self._STOCK_SOURCE_PREFIXES)
+            raise ValueError(f"source must be one of: {supported}.") from exc
+
+    def _asset_prefix(self, asset_type: str, source: str) -> str:
+        normalized_asset_type = asset_type.strip().lower()
+        if normalized_asset_type == "stock":
+            return self._stock_prefix(source)
+        if normalized_asset_type == "crypto":
+            if source.strip().lower() != "reddit":
+                raise ValueError("Crypto sentiment is available from reddit only.")
+            return self._CRYPTO_PREFIX
+        raise ValueError("asset_type must be either 'stock' or 'crypto'.")
+
+    @classmethod
+    def _stock_ticker(cls, ticker: str) -> str:
+        normalized_ticker = ticker.strip().upper()
+        if not cls._STOCK_TICKER_PATTERN.fullmatch(normalized_ticker):
+            raise ValueError("ticker is not a valid stock ticker symbol.")
+        return normalized_ticker
+
+    @classmethod
+    def _crypto_symbol(cls, symbol: str) -> str:
+        normalized_symbol = symbol.strip().upper()
+        if not cls._CRYPTO_SYMBOL_PATTERN.fullmatch(normalized_symbol):
+            raise ValueError("symbol is not a valid crypto symbol.")
+        return normalized_symbol
+
+    def _get(
+        self, path: str, params: Optional[Dict[str, Any]] = None
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        response = self._session.get(
+            f"{self._base_url}{path}", params=params, timeout=self._timeout
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_adanos_stock_sentiment(
+        self,
+        ticker: str,
+        source: str = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get sentiment and attention metrics for one stock.
+
+        Args:
+            ticker: Stock ticker, for example ``AAPL`` or ``BRK.A``.
+            source: One of ``reddit``, ``x``, ``news``, or ``polymarket``.
+            start_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            end_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+
+        """
+        prefix = self._stock_prefix(source)
+        return cast(
+            Dict[str, Any],
+            self._get(
+                f"{prefix}/stock/{self._stock_ticker(ticker)}",
+                self._date_params(start_date, end_date),
+            ),
+        )
+
+    def get_adanos_crypto_sentiment(
+        self,
+        symbol: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get Reddit sentiment and attention metrics for one crypto asset.
+
+        Args:
+            symbol: Crypto symbol, for example ``BTC`` or ``ETH``.
+            start_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            end_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+
+        """
+        return cast(
+            Dict[str, Any],
+            self._get(
+                f"{self._CRYPTO_PREFIX}/token/{self._crypto_symbol(symbol)}",
+                self._date_params(start_date, end_date),
+            ),
+        )
+
+    def get_adanos_trending_assets(
+        self,
+        asset_type: str = "stock",
+        source: str = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """
+        Rank trending stocks or crypto assets by attention.
+
+        Args:
+            asset_type: Either ``stock`` or ``crypto``.
+            source: Stock source, or ``reddit`` for crypto.
+            start_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            end_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            limit: Number of assets to return, from 1 to 100.
+
+        """
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100.")
+        prefix = self._asset_prefix(asset_type, source)
+        params: Dict[str, Any] = self._date_params(start_date, end_date)
+        params["limit"] = limit
+        return cast(List[Dict[str, Any]], self._get(f"{prefix}/trending", params))
+
+    def compare_adanos_asset_sentiment(
+        self,
+        symbols: List[str],
+        asset_type: str = "stock",
+        source: str = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Compare sentiment metrics for several stocks or crypto assets.
+
+        Args:
+            symbols: One to ten stock tickers or crypto symbols to compare.
+            asset_type: Either ``stock`` or ``crypto``.
+            source: Stock source, or ``reddit`` for crypto.
+            start_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            end_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+
+        """
+        if not symbols:
+            raise ValueError("symbols must contain at least one asset.")
+
+        prefix = self._asset_prefix(asset_type, source)
+        is_crypto = asset_type.strip().lower() == "crypto"
+        normalize = self._crypto_symbol if is_crypto else self._stock_ticker
+        normalized_symbols = list(
+            dict.fromkeys(normalize(symbol) for symbol in symbols)
+        )
+        if len(normalized_symbols) > 10:
+            raise ValueError("symbols must contain at most 10 unique assets.")
+
+        params = self._date_params(start_date, end_date)
+        params["symbols" if is_crypto else "tickers"] = ",".join(normalized_symbols)
+        return cast(Dict[str, Any], self._get(f"{prefix}/compare", params))
+
+    def get_adanos_market_sentiment(
+        self,
+        asset_type: str = "stock",
+        source: str = "reddit",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get an aggregate market sentiment snapshot.
+
+        Args:
+            asset_type: Either ``stock`` or ``crypto``.
+            source: Stock source, or ``reddit`` for crypto.
+            start_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+            end_date: Optional inclusive UTC date in ``YYYY-MM-DD`` format.
+
+        """
+        prefix = self._asset_prefix(asset_type, source)
+        return cast(
+            Dict[str, Any],
+            self._get(
+                f"{prefix}/market-sentiment",
+                self._date_params(start_date, end_date),
+            ),
+        )

--- a/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/adanos.py
+++ b/llama-index-integrations/tools/llama-index-tools-finance/llama_index/tools/finance/adanos.py
@@ -103,6 +103,19 @@ class AdanosMarketSentimentToolSpec(BaseToolSpec):
         response = self._session.get(
             f"{self._base_url}{path}", params=params, timeout=self._timeout
         )
+        if response.status_code == 429:
+            message = "Adanos rate limit exceeded."
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {}
+            detail = payload.get("detail", {}) if isinstance(payload, dict) else {}
+            if isinstance(detail, dict) and detail.get("message"):
+                message = str(detail["message"])
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                message = f"{message} Retry after {retry_after} seconds."
+            raise requests.HTTPError(message, response=response)
         response.raise_for_status()
         return response.json()
 

--- a/llama-index-integrations/tools/llama-index-tools-finance/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-finance/pyproject.toml
@@ -26,13 +26,14 @@ dev = [
 
 [project]
 name = "llama-index-tools-finance"
-version = "0.5.0"
+version = "0.6.0"
 description = "llama-index finance-tools integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<3.12"
 readme = "README.md"
 license = "MIT"
 dependencies = [
+    "requests>=2.32.0,<3.0.0",
     "yfinance>=0.2.36,<0.3",
     "newsapi-python>=0.2.7,<0.3",
     "pytrends>=4.9.2,<5",
@@ -57,6 +58,7 @@ import_path = "llama_index.tools.finance"
 
 [tool.llamahub.class_authors]
 FinanceAgentToolSpec = "345ishaan"
+AdanosMarketSentimentToolSpec = "alexander-schneider"
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/llama-index-integrations/tools/llama-index-tools-finance/tests/test_finance_tools.py
+++ b/llama-index-integrations/tools/llama-index-tools-finance/tests/test_finance_tools.py
@@ -1,7 +1,134 @@
+from typing import Any
+
+import pytest
+import requests
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
-from llama_index.tools.finance import FinanceAgentToolSpec
+from llama_index.tools.finance import (
+    AdanosMarketSentimentToolSpec,
+    FinanceAgentToolSpec,
+)
+
+TEST_VALUE = "test-value"
 
 
 def test_class():
     name_of_base_classes = [b.__name__ for b in FinanceAgentToolSpec.__mro__]
     assert BaseToolSpec.__name__ in name_of_base_classes
+
+
+@pytest.fixture()
+def adanos_tool() -> AdanosMarketSentimentToolSpec:
+    return AdanosMarketSentimentToolSpec(TEST_VALUE)
+
+
+def mock_response(mocker, payload: Any):
+    response = mocker.Mock()
+    response.json.return_value = payload
+    return response
+
+
+def test_adanos_tool_spec_exposes_agent_functions(adanos_tool):
+    names = [tool.metadata.name for tool in adanos_tool.to_tool_list()]
+
+    assert names == AdanosMarketSentimentToolSpec.spec_functions
+
+
+def test_adanos_tool_requires_credentials_and_valid_timeout():
+    with pytest.raises(ValueError, match="API key"):
+        AdanosMarketSentimentToolSpec(" ")
+    with pytest.raises(ValueError, match="timeout"):
+        AdanosMarketSentimentToolSpec(TEST_VALUE, timeout=0)
+
+
+def test_get_stock_sentiment_uses_source_and_date_window(adanos_tool, mocker):
+    response = mock_response(mocker, {"ticker": "AAPL", "buzz_score": 72.0})
+    get = mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    result = adanos_tool.get_adanos_stock_sentiment(
+        "aapl", source="news", start_date="2026-08-01", end_date="2026-08-07"
+    )
+
+    assert result == {"ticker": "AAPL", "buzz_score": 72.0}
+    get.assert_called_once_with(
+        "https://api.adanos.org/news/stocks/v1/stock/AAPL",
+        params={"from": "2026-08-01", "to": "2026-08-07"},
+        timeout=30.0,
+    )
+    response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.parametrize("ticker", ["AAPL/%6d%65%6e%74%69%6f%6e%73", "AAPL/mentions"])
+def test_get_stock_sentiment_rejects_path_injection(adanos_tool, ticker):
+    with pytest.raises(ValueError, match="valid stock ticker"):
+        adanos_tool.get_adanos_stock_sentiment(ticker)
+
+
+def test_get_crypto_sentiment_uses_reddit_crypto_endpoint(adanos_tool, mocker):
+    response = mock_response(mocker, {"symbol": "BTC"})
+    get = mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    assert adanos_tool.get_adanos_crypto_sentiment("btc") == {"symbol": "BTC"}
+    get.assert_called_once_with(
+        "https://api.adanos.org/reddit/crypto/v1/token/BTC",
+        params={},
+        timeout=30.0,
+    )
+
+    with pytest.raises(ValueError, match="valid crypto symbol"):
+        adanos_tool.get_adanos_crypto_sentiment("BTC/%2fmentions")
+
+
+def test_trending_assets_validates_limit_and_crypto_source(adanos_tool, mocker):
+    response = mock_response(mocker, [{"symbol": "BTC", "buzz_score": 80.0}])
+    get = mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    assert adanos_tool.get_adanos_trending_assets(asset_type="crypto", limit=5) == [
+        {"symbol": "BTC", "buzz_score": 80.0}
+    ]
+    get.assert_called_once_with(
+        "https://api.adanos.org/reddit/crypto/v1/trending",
+        params={"limit": 5},
+        timeout=30.0,
+    )
+
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        adanos_tool.get_adanos_trending_assets(limit=0)
+    with pytest.raises(ValueError, match="reddit only"):
+        adanos_tool.get_adanos_trending_assets(asset_type="crypto", source="news")
+
+
+def test_compare_assets_normalizes_symbols(adanos_tool, mocker):
+    response = mock_response(mocker, {"comparison": []})
+    get = mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    assert adanos_tool.compare_adanos_asset_sentiment(
+        [" aapl ", "nvda", "AAPL"], source="x"
+    ) == {"comparison": []}
+    get.assert_called_once_with(
+        "https://api.adanos.org/x/stocks/v1/compare",
+        params={"tickers": "AAPL,NVDA"},
+        timeout=30.0,
+    )
+
+    with pytest.raises(ValueError, match="at least one"):
+        adanos_tool.compare_adanos_asset_sentiment([])
+    with pytest.raises(ValueError, match="valid stock ticker"):
+        adanos_tool.compare_adanos_asset_sentiment(["AAPL,NVDA"])
+    with pytest.raises(ValueError, match="at most 10"):
+        adanos_tool.compare_adanos_asset_sentiment([f"A{index}" for index in range(11)])
+
+
+def test_market_sentiment_rejects_unknown_values(adanos_tool):
+    with pytest.raises(ValueError, match="source must be one of"):
+        adanos_tool.get_adanos_market_sentiment(source="stocktwits")
+    with pytest.raises(ValueError, match="asset_type"):
+        adanos_tool.get_adanos_market_sentiment(asset_type="forex")
+
+
+def test_adanos_http_errors_are_not_swallowed(adanos_tool, mocker):
+    response = mock_response(mocker, {})
+    response.raise_for_status.side_effect = requests.HTTPError("rate limited")
+    mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    with pytest.raises(requests.HTTPError, match="rate limited"):
+        adanos_tool.get_adanos_market_sentiment()

--- a/llama-index-integrations/tools/llama-index-tools-finance/tests/test_finance_tools.py
+++ b/llama-index-integrations/tools/llama-index-tools-finance/tests/test_finance_tools.py
@@ -132,3 +132,22 @@ def test_adanos_http_errors_are_not_swallowed(adanos_tool, mocker):
 
     with pytest.raises(requests.HTTPError, match="rate limited"):
         adanos_tool.get_adanos_market_sentiment()
+
+
+def test_adanos_rate_limit_error_includes_retry_guidance(adanos_tool, mocker):
+    response = mock_response(
+        mocker,
+        {"detail": {"message": "Too many requests for this account."}},
+    )
+    response.status_code = 429
+    response.headers = {"Retry-After": "42"}
+    mocker.patch.object(adanos_tool._session, "get", return_value=response)
+
+    with pytest.raises(
+        requests.HTTPError,
+        match=r"Too many requests for this account\. Retry after 42 seconds\.",
+    ) as exc_info:
+        adanos_tool.get_adanos_market_sentiment()
+
+    assert exc_info.value.response is response
+    response.raise_for_status.assert_not_called()

--- a/llama-index-integrations/tools/llama-index-tools-finance/uv.lock
+++ b/llama-index-integrations/tools/llama-index-tools-finance/uv.lock
@@ -1421,7 +1421,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-tools-finance"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "llama-index-core" },
@@ -1429,6 +1429,7 @@ dependencies = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytrends" },
+    { name = "requests" },
     { name = "yfinance" },
 ]
 
@@ -1460,6 +1461,7 @@ requires-dist = [
     { name = "newsapi-python", specifier = ">=0.2.7,<0.3" },
     { name = "pandas" },
     { name = "pytrends", specifier = ">=4.9.2,<5" },
+    { name = "requests", specifier = ">=2.32.0,<3.0.0" },
     { name = "yfinance", specifier = ">=0.2.36,<0.3" },
 ]
 


### PR DESCRIPTION
# Description

Adds an independent `AdanosMarketSentimentToolSpec` to the existing `llama-index-tools-finance` package. The existing `FinanceAgentToolSpec` and its constructor remain unchanged.

The tool exposes five read-only, agent-friendly functions for:

- stock sentiment from Reddit, X / FinTwit, financial news, or Polymarket
- Reddit crypto sentiment
- trending stock or crypto assets
- multi-asset sentiment comparison
- aggregate market sentiment

Requests use an explicit Adanos API key and reproducible inclusive UTC `start_date` / `end_date` windows; the deprecated `days` parameter is not exposed. The implementation validates source, asset type, ticker/symbol grammar, compare size, and trending limits before issuing requests. It uses only aggregate endpoints available across Free, Hobby, and Professional plans and does not expose Professional-only raw mentions or direct text analysis.

## New Package?

- [ ] Yes
- [x] No. This extends the existing `llama-index-tools-finance` package.

## Version Bump?

- [x] Yes. `llama-index-tools-finance` is bumped from `0.5.0` to `0.6.0`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Added mocked unit tests covering tool metadata, endpoint routing, date parameters, source and asset validation, path-injection rejection, compare normalization and limits, list response shape, and HTTP error propagation.
- [x] `uv run --locked -- pytest -q` (`11 passed`)
- [x] `uv run --locked -- ruff check llama_index/tools/finance tests`
- [x] `uv run --locked -- ruff format --check llama_index/tools/finance tests`
- [x] `uv run --locked -- mypy -p llama_index.tools.finance.adanos`
- [x] Targeted repository `pre-commit` hooks on all changed files
- [x] Built sdist/wheel with `uv build` and installed the wheel in a fresh Python 3.11 environment
- [x] Compared the stock ticker validator with the current Adanos OpenAPI regex over 100,000 deterministic generated inputs

No tests call the live Adanos API or require credentials.

## Suggested Checklist

- [x] I have performed a self-review of the change
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing package tests pass locally
- [x] The lockfile contains only the package version and direct `requests` dependency changes

## AI Assistance

Codex was used to assist with repository analysis, implementation, tests, and structured review. The resulting patch was validated against the repository's contribution rules, the current Adanos OpenAPI contract, package tests, static checks, pre-commit hooks, and a clean wheel installation.
