### PR TITLE
fix: treat a None usage sub-field as a missing key in token counting

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -63,14 +63,16 @@ def get_tokens_from_response(
 
     prompt_tokens = 0
     for input_key in possible_input_keys:
-        if input_key in usage:
-            prompt_tokens = usage[input_key]
+        token_count = usage.get(input_key)
+        if token_count is not None:
+            prompt_tokens = token_count
             break
 
     completion_tokens = 0
     for output_key in possible_output_keys:
-        if output_key in usage:
-            completion_tokens = usage[output_key]
+        token_count = usage.get(output_key)
+        if token_count is not None:
+            completion_tokens = token_count
             break
 
     return prompt_tokens, completion_tokens

--- a/llama-index-core/tests/callbacks/test_token_budget.py
+++ b/llama-index-core/tests/callbacks/test_token_budget.py
@@ -72,3 +72,44 @@ def test_token_budget_via_callback_manager():
             CBEventType.LLM,
             payload={EventPayload.PROMPT: "p", EventPayload.COMPLETION: resp},
         )
+
+
+def test_null_usage_subfield_is_treated_as_missing():
+    """A provider reporting an explicit null usage sub-field must not crash. (#22806)"""
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = [1, 2, 3, 4, 5]  # always 5 tokens
+
+    handler = TokenCountingHandler(tokenizer=mock_tokenizer)
+    response_object = CompletionResponse(
+        text="hello",
+        raw={"usage": {"prompt_tokens": None, "completion_tokens": 5, "total_tokens": 5}},
+    )
+    handler.on_event_end(
+        event_type=CBEventType.LLM,
+        payload={EventPayload.PROMPT: "hi", EventPayload.COMPLETION: response_object},
+    )
+
+    event = handler.llm_token_counts[-1]
+    assert event.prompt_token_count == 5  # null prompt_tokens fell back to the tokenizer
+    assert event.completion_token_count == 5  # non-null sub-field used as reported
+    assert event.total_token_count == 10
+
+
+def test_null_completion_subfield_is_treated_as_missing():
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = [1, 2, 3, 4, 5]
+
+    handler = TokenCountingHandler(tokenizer=mock_tokenizer)
+    response_object = CompletionResponse(
+        text="hello",
+        raw={"usage": {"prompt_tokens": 7, "completion_tokens": None, "total_tokens": None}},
+    )
+    handler.on_event_end(
+        event_type=CBEventType.LLM,
+        payload={EventPayload.PROMPT: "hi", EventPayload.COMPLETION: response_object},
+    )
+
+    event = handler.llm_token_counts[-1]
+    assert event.prompt_token_count == 7  # non-null sub-field used as reported
+    assert event.completion_token_count == 5  # null completion_tokens fell back to the tokenizer
+    assert event.total_token_count == 12

--- a/llama-index-core/tests/callbacks/test_token_budget.py
+++ b/llama-index-core/tests/callbacks/test_token_budget.py
@@ -82,7 +82,9 @@ def test_null_usage_subfield_is_treated_as_missing():
     handler = TokenCountingHandler(tokenizer=mock_tokenizer)
     response_object = CompletionResponse(
         text="hello",
-        raw={"usage": {"prompt_tokens": None, "completion_tokens": 5, "total_tokens": 5}},
+        raw={
+            "usage": {"prompt_tokens": None, "completion_tokens": 5, "total_tokens": 5}
+        },
     )
     handler.on_event_end(
         event_type=CBEventType.LLM,
@@ -90,7 +92,9 @@ def test_null_usage_subfield_is_treated_as_missing():
     )
 
     event = handler.llm_token_counts[-1]
-    assert event.prompt_token_count == 5  # null prompt_tokens fell back to the tokenizer
+    assert (
+        event.prompt_token_count == 5
+    )  # null prompt_tokens fell back to the tokenizer
     assert event.completion_token_count == 5  # non-null sub-field used as reported
     assert event.total_token_count == 10
 
@@ -102,7 +106,13 @@ def test_null_completion_subfield_is_treated_as_missing():
     handler = TokenCountingHandler(tokenizer=mock_tokenizer)
     response_object = CompletionResponse(
         text="hello",
-        raw={"usage": {"prompt_tokens": 7, "completion_tokens": None, "total_tokens": None}},
+        raw={
+            "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": None,
+                "total_tokens": None,
+            }
+        },
     )
     handler.on_event_end(
         event_type=CBEventType.LLM,
@@ -111,5 +121,7 @@ def test_null_completion_subfield_is_treated_as_missing():
 
     event = handler.llm_token_counts[-1]
     assert event.prompt_token_count == 7  # non-null sub-field used as reported
-    assert event.completion_token_count == 5  # null completion_tokens fell back to the tokenizer
+    assert (
+        event.completion_token_count == 5
+    )  # null completion_tokens fell back to the tokenizer
     assert event.total_token_count == 12


### PR DESCRIPTION
## What

`get_tokens_from_response` read `prompt_tokens`/`completion_tokens` usage sub-fields straight into `TokenCountingEvent`'s arithmetic without checking for `None`. A provider that reports "unknown" as an **explicit null** sub-field (e.g. `{"usage": {"prompt_tokens": None, ...}}`) crashed the whole `chat()`/`complete()` call in the callback dispatch after the LLM call had already succeeded (and been billed) — `None == 0` is `False`, so the existing tokenizer fallback never ran, and `None + int` raised `TypeError` in `__post_init__`.

A `None` sub-field is now treated the same as a missing key: the loop keeps the `0` default and the existing fallback (`prompt_tokens == 0` → tokenizer count) covers it. This is the generic-core recurrence the issue describes — the `usage is None` guard from #9298 and Ollama's `additional_kwargs` patch from #17150 were both untouched.

## Validation

```bash
pytest llama-index-core/tests/callbacks/test_token_budget.py -q   # 4 passed (2 existing + 2 new)
ruff check llama-index-core/llama_index/core/callbacks/token_counting.py llama-index-core/tests/callbacks/test_token_budget.py  # clean
```

Note on the environment: this checkout's workspace layout references sibling integration packages that are not present locally, so the repo-level `uv sync` cannot complete here; I verified in an isolated venv with `llama-index-core` installed from PyPI and the local edited source shadowing it via `PYTHONPATH` (confirmed `token_counting.py` resolves to the local file). The regression tests encode the issue's exact repro (explicit-null `prompt_tokens` and `completion_tokens`).

## Tests added

- `test_null_usage_subfield_is_treated_as_missing` — null `prompt_tokens` + real `completion_tokens`: event counts as reported/fallback, no crash.
- `test_null_completion_subfield_is_treated_as_missing` — mirror case on the completion side.

Fixes #22806