### PR TITLE
fix: don't record document hash before ingestion transformations succeed

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -460,7 +460,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -531,6 +530,7 @@ class IngestionPipeline(BaseModel):
             self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
             self.docstore.add_documents(nodes, store_text=store_doc_text)
         elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
+            self.docstore.set_document_hashes({n.id_: n.hash for n in nodes})
             self.docstore.add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
@@ -678,6 +678,7 @@ class IngestionPipeline(BaseModel):
             await self.docstore.aset_document_hashes({n.id_: n.hash for n in nodes})
             await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
         elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
+            await self.docstore.aset_document_hashes({n.id_: n.hash for n in nodes})
             await self.docstore.async_add_documents(nodes, store_text=store_doc_text)
         else:
             raise ValueError(f"Invalid docstore strategy: {effective_strategy}")
@@ -695,7 +696,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -398,6 +398,16 @@ def test_pipeline_with_transform_error() -> None:
         pipeline.run(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore.get_document_hash("1") is None, "failed run must not record the hash"
+
+    # retrying after the failure must not be treated as a duplicate
+    retry_pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(chunk_size=25, chunk_overlap=0)],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = retry_pipeline.run(documents=[document1])
+    assert len(nodes) > 0
 
 
 @pytest.mark.asyncio
@@ -638,6 +648,16 @@ async def test_async_pipeline_with_transform_error() -> None:
         await pipeline.arun(documents=[document1])
 
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore.get_document_hash("1") is None, "failed run must not record the hash"
+
+    # retrying after the failure must not be treated as a duplicate
+    retry_pipeline = IngestionPipeline(
+        transformations=[SentenceSplitter(chunk_size=25, chunk_overlap=0)],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    nodes = await retry_pipeline.arun(documents=[document1])
+    assert len(nodes) > 0
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:


### PR DESCRIPTION
## Summary

`IngestionPipeline._handle_duplicates` (and its async twin `_ahandle_duplicates`) wrote each document's hash to the docstore during the *decision* phase, before any transformation ran. If a transformation raised an exception, the hash was already persisted, so every subsequent retry on the same document was silently skipped as a false duplicate — even though the document was never actually ingested.

This moves the hash write into `_update_docstore`/`_aupdate_docstore`, right alongside `add_documents`/`async_add_documents`, so it only happens after transformations complete successfully. This mirrors exactly how the `UPSERTS` strategy already handles it a few lines above in the same function.

## Repro (from the issue)

```python
from llama_index.core.ingestion import IngestionPipeline
from llama_index.core.schema import Document, TransformComponent
from llama_index.core.storage.docstore import SimpleDocumentStore


class Boom(TransformComponent):
    def __call__(self, nodes, **kwargs):
        raise RuntimeError("transient failure")


docstore = SimpleDocumentStore()
doc = Document(text="hello world", doc_id="doc1")

failing = IngestionPipeline(transformations=[Boom()], docstore=docstore)
try:
    failing.run(documents=[doc])
except RuntimeError:
    pass

print(docstore.get_document_hash("doc1"))  # was the poisoned hash, now None

retry = IngestionPipeline(transformations=[], docstore=docstore)
nodes = retry.run(documents=[doc])
print(len(nodes))  # was 0, now 1
```

## Test plan

- Extended the existing `test_pipeline_with_transform_error` and `test_async_pipeline_with_transform_error` tests, which already exercised this failure path but only asserted the *node* wasn't stored — they missed checking the *hash*, which is exactly this bug. Added assertions that the hash isn't recorded, plus a retry that confirms the document is picked up on the next run.
- Ran the full `tests/ingestion/test_pipeline.py` suite (26 tests) — all pass.

Fixes #22638