### PR TITLE
fix: don't delete previous document version before upsert re-ingest succeeds

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -10,7 +10,7 @@ from functools import partial
 from hashlib import sha256
 from itertools import repeat
 from pathlib import Path
-from typing import Any, Generator, List, Optional, Sequence, Union
+from typing import Any, Generator, List, Optional, Sequence, Tuple, Union
 
 from fsspec import AbstractFileSystem
 
@@ -469,12 +469,13 @@ class IngestionPipeline(BaseModel):
     def _handle_upserts(
         self,
         nodes: Sequence[BaseNode],
-    ) -> Sequence[BaseNode]:
+    ) -> Tuple[Sequence[BaseNode], List[str]]:
         """Handle docstore upserts by checking hashes and ids."""
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        ref_doc_ids_to_delete: List[str] = []
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
@@ -483,11 +484,8 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    self.vector_store.delete(ref_doc_id)
-
+                # defer the delete until the re-ingest actually succeeds
+                ref_doc_ids_to_delete.append(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
@@ -504,7 +502,7 @@ class IngestionPipeline(BaseModel):
                 if self.vector_store is not None:
                     self.vector_store.delete(ref_doc_id)
 
-        return deduped_nodes_to_run
+        return deduped_nodes_to_run, ref_doc_ids_to_delete
 
     @staticmethod
     def _node_batcher(
@@ -588,12 +586,15 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        ref_doc_ids_to_delete: List[str] = []
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = self._handle_upserts(input_nodes)
+                nodes_to_run, ref_doc_ids_to_delete = self._handle_upserts(
+                    input_nodes
+                )
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
                 nodes_to_run = self._handle_duplicates(input_nodes)
             else:
@@ -646,6 +647,11 @@ class IngestionPipeline(BaseModel):
             )
 
         nodes = nodes or []
+
+        for ref_doc_id in ref_doc_ids_to_delete:
+            self.docstore.delete_ref_doc(ref_doc_id, raise_error=False)  # type: ignore
+            if self.vector_store is not None:
+                self.vector_store.delete(ref_doc_id)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]
@@ -705,12 +711,13 @@ class IngestionPipeline(BaseModel):
         self,
         nodes: Sequence[BaseNode],
         store_doc_text: bool = True,
-    ) -> Sequence[BaseNode]:
+    ) -> Tuple[Sequence[BaseNode], List[str]]:
         """Handle docstore upserts by checking hashes and ids."""
         assert self.docstore is not None
 
         doc_ids_from_nodes = set()
         deduped_nodes_to_run = []
+        ref_doc_ids_to_delete: List[str] = []
         for node in nodes:
             ref_doc_id = node.ref_doc_id if node.ref_doc_id else node.id_
             doc_ids_from_nodes.add(ref_doc_id)
@@ -719,11 +726,8 @@ class IngestionPipeline(BaseModel):
                 # document doesn't exist, so add it
                 deduped_nodes_to_run.append(node)
             elif existing_hash and existing_hash != node.hash:
-                await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)
-
-                if self.vector_store is not None:
-                    await self.vector_store.adelete(ref_doc_id)
-
+                # defer the delete until the re-ingest actually succeeds
+                ref_doc_ids_to_delete.append(ref_doc_id)
                 deduped_nodes_to_run.append(node)
             else:
                 continue  # document exists and is unchanged, so skip it
@@ -740,7 +744,7 @@ class IngestionPipeline(BaseModel):
                 if self.vector_store is not None:
                     await self.vector_store.adelete(ref_doc_id)
 
-        return deduped_nodes_to_run
+        return deduped_nodes_to_run, ref_doc_ids_to_delete
 
     @dispatcher.span
     async def arun(
@@ -795,12 +799,13 @@ class IngestionPipeline(BaseModel):
             effective_strategy = DocstoreStrategy.DUPLICATES_ONLY
 
         # check if we need to dedup
+        ref_doc_ids_to_delete: List[str] = []
         if self.docstore is not None and self.vector_store is not None:
             if effective_strategy in (
                 DocstoreStrategy.UPSERTS,
                 DocstoreStrategy.UPSERTS_AND_DELETE,
             ):
-                nodes_to_run = await self._ahandle_upserts(
+                nodes_to_run, ref_doc_ids_to_delete = await self._ahandle_upserts(
                     input_nodes, store_doc_text=store_doc_text
                 )
             elif effective_strategy == DocstoreStrategy.DUPLICATES_ONLY:
@@ -866,6 +871,11 @@ class IngestionPipeline(BaseModel):
             nodes = nodes
 
         nodes = nodes or []
+
+        for ref_doc_id in ref_doc_ids_to_delete:
+            await self.docstore.adelete_ref_doc(ref_doc_id, raise_error=False)  # type: ignore
+            if self.vector_store is not None:
+                await self.vector_store.adelete(ref_doc_id)
 
         if self.vector_store is not None:
             nodes_with_embeddings = [n for n in nodes if n.embedding is not None]

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -317,6 +317,44 @@ def test_pipeline_upserts_keep_all_nodes_per_doc() -> None:
     )
 
 
+def test_pipeline_upserts_failed_run_preserves_previous_version() -> None:
+    """Regression test: a failed UPSERTS re-ingest must not delete the previously indexed version."""
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError
+
+    docstore, vector_store = SimpleDocumentStore(), SimpleVectorStore()
+    ok = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+            MockEmbedding(embed_dim=8),
+        ],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    ok.run(documents=[Document(text="version one.", doc_id="doc1")])
+    indexed_before = set(vector_store.data.embedding_dict.keys())
+    assert len(indexed_before) > 0
+
+    failing = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+            RaisingTransform(),
+        ],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    with pytest.raises(RuntimeError):
+        failing.run(documents=[Document(text="version two.", doc_id="doc1")])
+
+    assert set(vector_store.data.embedding_dict.keys()) == indexed_before, "failed re-ingest deleted the previous version"
+
+
 @pytest.mark.skipif(cpu_count() < 2, reason="requires at least 2 CPUs")
 def test_pipeline_parallel_cache_populated() -> None:
     num_workers = 2
@@ -549,6 +587,45 @@ async def test_async_pipeline_upserts_keep_all_nodes_per_doc() -> None:
     assert {n.id_ for n in result} == {n.id_ for n in nodes}, (
         "all nodes sharing a ref_doc_id must be kept, not collapsed to one"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_upserts_failed_run_preserves_previous_version() -> None:
+    """Async counterpart of ``test_pipeline_upserts_failed_run_preserves_previous_version``."""
+
+    class RaisingTransform(TransformComponent):
+        def __call__(
+            self, nodes: Sequence[BaseNode], **kwargs: Any
+        ) -> Sequence[BaseNode]:
+            raise RuntimeError
+
+    docstore, vector_store = SimpleDocumentStore(), SimpleVectorStore()
+    ok = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+            MockEmbedding(embed_dim=8),
+        ],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    await ok.arun(documents=[Document(text="version one.", doc_id="doc1")])
+    indexed_before = set(vector_store.data.embedding_dict.keys())
+    assert len(indexed_before) > 0
+
+    failing = IngestionPipeline(
+        transformations=[
+            SentenceSplitter(chunk_size=25, chunk_overlap=0),
+            RaisingTransform(),
+        ],
+        docstore=docstore,
+        vector_store=vector_store,
+        docstore_strategy=DocstoreStrategy.UPSERTS,
+    )
+    with pytest.raises(RuntimeError):
+        await failing.arun(documents=[Document(text="version two.", doc_id="doc1")])
+
+    assert set(vector_store.data.embedding_dict.keys()) == indexed_before, "failed re-ingest deleted the previous version"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`IngestionPipeline._handle_upserts` (and its async twin `_ahandle_upserts`) deleted the old docstore entry and vector store entries for a changed document during the *decision* phase, before any transformation ran. If a transformation then raised an exception, the old version was already deleted and the new one was never written, so the document disappeared from the index entirely instead of the failed run being a no-op.

This defers the delete: `_handle_upserts` now collects the `ref_doc_id`s that need cleanup during the decision phase but returns them separately instead of deleting immediately. The actual delete only happens in `run`/`arun`, right after transformations complete successfully and right before the new nodes are written.

Note: this PR only addresses the "changed document" delete path described in the issue. The separate `UPSERTS_AND_DELETE` "prune missing docs" branch in the same function has a similar premature-delete property, but that's a distinct behavior not covered by the linked issue, so I left it out of scope here to keep this PR focused.

## Repro (from the issue)

```python
from llama_index.core.embeddings.mock_embed_model import MockEmbedding
from llama_index.core.ingestion import DocstoreStrategy, IngestionPipeline
from llama_index.core.node_parser import SentenceSplitter
from llama_index.core.schema import Document, TransformComponent
from llama_index.core.storage.docstore import SimpleDocumentStore
from llama_index.core.vector_stores import SimpleVectorStore


class Boom(TransformComponent):
    def __call__(self, nodes, **kwargs):
        raise RuntimeError("transient failure")


docstore, vector_store = SimpleDocumentStore(), SimpleVectorStore()

ok = IngestionPipeline(
    transformations=[SentenceSplitter(), MockEmbedding(embed_dim=8)],
    docstore=docstore,
    vector_store=vector_store,
    docstore_strategy=DocstoreStrategy.UPSERTS,
)
ok.run(documents=[Document(text="v1 content of the document.", doc_id="doc1")])
print(len(vector_store.data.embedding_dict))  # was > 0, still > 0

failing = IngestionPipeline(
    transformations=[SentenceSplitter(), Boom()],
    docstore=docstore,
    vector_store=vector_store,
    docstore_strategy=DocstoreStrategy.UPSERTS,
)
try:
    failing.run(documents=[Document(text="v2 content of the document.", doc_id="doc1")])
except RuntimeError:
    pass

print(len(vector_store.data.embedding_dict))  # was 0 (v1 deleted), now unchanged
```

## Test plan

- Added `test_pipeline_upserts_failed_run_preserves_previous_version` and its async counterpart, verifying a failed re-ingest leaves the previously indexed vectors untouched.
- Verified the normal (successful) upsert path still replaces old chunks with new ones when a re-ingest actually succeeds.
- Ran the full `tests/ingestion/test_pipeline.py` suite (28 tests) — all pass.

Fixes #22639