### PR TITLE
docs: fix duplicated words in framework guides

### DIFF
--- a/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
+++ b/docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md
@@ -13,7 +13,7 @@ Currently, the following components are `Transformation` objects:
 
 ## Usage Pattern
 
-While transformations are best used with with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
+While transformations are best used with an [`IngestionPipeline`](/python/framework/module_guides/loading/ingestion_pipeline), they can also be used directly.
 
 ```python
 from llama_index.core.node_parser import SentenceSplitter

--- a/docs/src/content/docs/framework/module_guides/observability/instrumentation.md
+++ b/docs/src/content/docs/framework/module_guides/observability/instrumentation.md
@@ -281,7 +281,7 @@ event handlers as well as “local” ones.
 Consider the project structure defined below. There are 3 `dispatcher`'s: one at
 the top-level of the `project` and then two others at the individual sub-modules
 `llama1` and `llama2`. With this setup, any `EventHandler`’s attached to the
-project root’s `dispatcher` will be be subscribed to all `Event`'s that occur in
+project root’s `dispatcher` will be subscribed to all `Event`'s that occur in
 the execution of code in `llama1` and `llama2`. On the other hand, `EventHandler`'s
 defined in the respective `llama<x>` sub modules will only be subscribed to the
 `Event`'s that occur within their respective sub-module execution.


### PR DESCRIPTION
## What
Fix two duplicated-word typos in the framework documentation:
- `docs/src/content/docs/framework/module_guides/loading/ingestion_pipeline/transformations.md`: "used with with an" → "used with an"
- `docs/src/content/docs/framework/module_guides/observability/instrumentation.md`: "will be be subscribed" → "will be subscribed"

## Why
Both are accidental repeated words in prose; the preposition/verb should appear only once.

## How verified
- Read both lines in context; the duplication is in prose, not inside a code block.
- Each change deletes only the single repeated token; no other wording is altered.
- Docs-only change: no package code touched, no new `pyproject.toml`.

## AI assistance disclosure
Per the contributing guide's transparency principle: these were found with AI assistance (an automated scan for duplicated words across the docs) and each was manually verified by reading the surrounding prose to confirm it is an unintended repetition, not intentional phrasing.