### PR TITLE
docs: add event-loop safety guidance for sync/async integration methods

### DIFF
--- a/docs/src/content/docs/framework/CONTRIBUTING.md
+++ b/docs/src/content/docs/framework/CONTRIBUTING.md
@@ -215,6 +215,49 @@ If you’re integrating with a remote system, **mock** it to prevent test failur
 
 By default, CICD will fail if test coverage is less than 50% -- so please do add tests for your code!
 
+### Event-Loop Safety for Sync/Async Method Pairs
+
+Many integrations expose both a sync method (e.g. `query`) and its async counterpart (e.g. `aquery`). When
+implementing the sync version, **never call `asyncio.run()` directly**. Users may invoke your sync method from
+inside a notebook, an ASGI service (FastAPI, etc.), or any other context where an event loop is already running,
+and `asyncio.run()` raises `RuntimeError: asyncio.run() cannot be called from a running event loop` in that case.
+
+Instead, use `asyncio_run` from `llama_index.core.async_utils`, which falls back to running the coroutine in a
+separate thread when a loop is already active:
+
+```python
+from llama_index.core.async_utils import asyncio_run
+
+
+class MyIntegration:
+    async def aquery(self, prompt: str) -> str:
+        ...
+
+    def query(self, prompt: str) -> str:
+        # Safe whether or not an event loop is already running.
+        return asyncio_run(self.aquery(prompt))
+```
+
+If your method is inherently async-only (no meaningful sync equivalent), it's fine to only expose the `a`-prefixed
+version rather than forcing a blocking wrapper.
+
+To verify your sync wrapper is event-loop safe, add a test that calls it from inside a running loop, e.g.:
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_sync_method_is_event_loop_safe() -> None:
+    integration = MyIntegration()
+    # This runs inside pytest-asyncio's event loop; a naive `asyncio.run()`
+    # implementation would raise RuntimeError here.
+    result = integration.query("hello")
+    assert result
+```
+
+See `llama-index-core/tests/test_async_utils.py` for an example of this pattern applied to `asyncio_run` itself.
+
 ---
 
 ## 👥 Join the Community

--- a/llama-index-core/tests/test_async_utils.py
+++ b/llama-index-core/tests/test_async_utils.py
@@ -19,6 +19,27 @@ def test_batch_gather_indivisible_task_list() -> None:
 
 
 @pytest.mark.asyncio
+async def test_asyncio_run_is_safe_inside_running_loop() -> None:
+    """
+    A naive sync wrapper using `asyncio.run()` fails when called from
+    inside a running event loop (e.g. a notebook or ASGI service). `asyncio_run`
+    must not raise in that same situation.
+    """
+
+    async def coro() -> str:
+        return "ok"
+
+    unawaited = coro()
+    try:
+        with pytest.raises(RuntimeError):
+            asyncio.run(unawaited)
+    finally:
+        unawaited.close()
+
+    assert asyncio_run(coro()) == "ok"
+
+
+@pytest.mark.asyncio
 async def test_asyncio_run_copies_contextvars_when_loop_running() -> None:
     """
     Validate that context vars are copied when loop.is_running() is True.


### PR DESCRIPTION
Fixes #22820

## Problem

Integration authors that expose both a sync and async entry point (e.g.
`query`/`aquery`) sometimes implement the sync wrapper with a direct call to
`asyncio.run()`. That breaks the moment a user calls the sync method from a
context where an event loop is already running — a notebook, an ASGI service
like FastAPI, etc. — raising:

```
RuntimeError: asyncio.run() cannot be called from a running event loop
```

The issue asks for contributor guidance so this stops being rediscovered
independently by each integration.

## Change

This is a documentation-only change to `docs/src/content/docs/framework/CONTRIBUTING.md`
(the framework's contribution guide, which already covers integration
contributions):

- A new "Event-Loop Safety for Sync/Async Method Pairs" section that:
  - Distinguishes sync wrappers, native async methods, and event-loop-safe
    adapters.
  - Points to the existing `asyncio_run` helper in
    `llama_index.core.async_utils` as the safe adapter pattern (it already
    detects a running loop and offloads to a thread instead of calling
    `asyncio.run()` directly).
  - Shows a minimal `pytest.mark.asyncio` test pattern that calls the sync
    wrapper from inside a running loop, which is exactly what would catch a
    naive `asyncio.run()` implementation.

Also added `test_asyncio_run_is_safe_inside_running_loop` to
`llama-index-core/tests/test_async_utils.py`, a concrete example of the test
pattern described in the doc: it asserts that a bare `asyncio.run()` call
raises `RuntimeError` inside pytest-asyncio's running loop, while
`asyncio_run` succeeds in the same situation.

No source behavior changes — `asyncio_run` already implements the safe
pattern; this PR documents it and adds a regression test that pins the
behavior the doc recommends.

## Test plan

Ran the updated test file directly:

```
$ cd llama-index-core && uv run -- pytest tests/test_async_utils.py -v
...
tests/test_async_utils.py::test_batch_gather_indivisible_task_list PASSED [ 33%]
tests/test_async_utils.py::test_asyncio_run_is_safe_inside_running_loop PASSED [ 66%]
tests/test_async_utils.py::test_asyncio_run_copies_contextvars_when_loop_running PASSED [100%]
3 passed in 0.01s
```

Verified the new test actually catches the failure mode it documents: with
`asyncio_run` temporarily replaced by a naive `return asyncio.run(coro)`
implementation, both the new test and the pre-existing
`test_asyncio_run_copies_contextvars_when_loop_running` fail with
`RuntimeError: asyncio.run() cannot be called from a running event loop`;
restoring the real implementation makes them pass again.

Ran `pre-commit` on the changed files (ruff, ruff-format, mypy, black-docs-py,
black-docs-text, prettier, codespell, etc.) — all hooks passed.

## AI assistance disclosure

This PR was prepared with the help of an AI coding agent (Claude), which
proposed the documentation content and test, and verified the test against
the failure mode described above. All changes were reviewed before submitting.
