### PR TITLE
feat(tools): add Annolux curated bilingual search tool spec

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-annolux/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-annolux/README.md
@@ -1,0 +1,63 @@
+# LlamaIndex Annolux Tool Integration
+
+Official [LlamaIndex](https://llamaindex.ai) tool spec integration for **[Annolux](https://annolux.com)** — The curated English & Chinese web search API and MCP for AI Agents with explicit snapshot timestamps.
+
+[![PyPI version](https://img.shields.io/pypi/v/llama-index-tools-annolux.svg?style=flat-square)](https://pypi.org/project/llama-index-tools-annolux/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+---
+
+## ⚡ Installation
+
+```bash
+pip install llama-index-tools-annolux
+```
+
+---
+
+## 🔑 Configuration
+
+Get your free API key (1,000 requests/month) at [annolux.com](https://annolux.com) and set it in your environment:
+
+```bash
+export ANNOLUX_API_KEY="ann_live_your_key_here"
+```
+
+---
+
+## 🚀 Quickstart
+
+### 1. Standalone Tool Spec
+```python
+from llama_index.tools.annolux import AnnoluxToolSpec
+
+tool_spec = AnnoluxToolSpec()
+docs = tool_spec.annolux_search(query="Rust async runtime tokio best practices", limit=5)
+
+for doc in docs:
+    print(f"[{doc.extra_info['fetched_at']}] {doc.extra_info['title']}")
+    print(doc.text[:200])
+    print("-" * 40)
+```
+
+### 2. Using with LlamaIndex Agents
+```python
+from llama_index.core.agent import FunctionCallingAgentWorker, AgentRunner
+from llama_index.llms.openai import OpenAI
+from llama_index.tools.annolux import AnnoluxToolSpec
+
+tool_spec = AnnoluxToolSpec()
+tools = tool_spec.to_tool_list()
+
+llm = OpenAI(model="gpt-4o")
+agent = AgentRunner(FunctionCallingAgentWorker.from_tools(tools, llm=llm, verbose=True))
+
+response = agent.chat("What are the latest updates to React Server Components in 2026?")
+print(response)
+```
+
+---
+
+## 📄 License
+
+MIT © [Annolux](https://annolux.com)

--- a/llama-index-integrations/tools/llama-index-tools-annolux/llama_index/tools/annolux/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-annolux/llama_index/tools/annolux/__init__.py
@@ -1,0 +1,3 @@
+from .base import AnnoluxToolSpec
+
+__all__ = ["AnnoluxToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-annolux/llama_index/tools/annolux/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-annolux/llama_index/tools/annolux/base.py
@@ -1,0 +1,100 @@
+import os
+from typing import Any, Dict, List, Optional
+import requests
+
+try:
+    from llama_index.core.schema import Document
+    from llama_index.core.tools.tool_spec.base import BaseToolSpec
+except ImportError:
+    try:
+        from llama_index.schema import Document  # type: ignore
+        from llama_index.tools.tool_spec.base import BaseToolSpec  # type: ignore
+    except ImportError:
+        # Minimal fallback class when llama-index is not installed locally
+        class BaseToolSpec:  # type: ignore
+            pass
+
+        class Document:  # type: ignore
+            def __init__(self, text: str, extra_info: Optional[Dict[str, Any]] = None):
+                self.text = text
+                self.extra_info = extra_info or {}
+
+
+class AnnoluxToolSpec(BaseToolSpec):
+    """Annolux Curated Search Tool Spec for LlamaIndex."""
+
+    spec_functions = ["annolux_search"]
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.annolux.com",
+    ) -> None:
+        """Initialize with Annolux API key."""
+        self.api_key = api_key or os.environ.get("ANNOLUX_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Annolux API key must be provided via `api_key` argument "
+                "or `ANNOLUX_API_KEY` environment variable."
+            )
+        self.base_url = base_url.rstrip("/")
+
+    def annolux_search(
+        self,
+        query: str,
+        limit: int = 5,
+        domains: Optional[List[str]] = None,
+        deduplicate: bool = True,
+        ranking: str = "default",
+    ) -> List[Document]:
+        """Search curated English and Chinese technical web corpus with explicit fetched_at dates.
+
+        Args:
+            query (str): The search query to retrieve information for.
+            limit (int, optional): Max results to return (1-10). Defaults to 5.
+            domains (List[str], optional): Domain whitelist filters (e.g. ['docs.rs']).
+            deduplicate (bool, optional): Deduplicate results. Defaults to True.
+            ranking (str, optional): Ranking strategy ('default' or 'provider'). Defaults to 'default'.
+
+        Returns:
+            List[Document]: List of LlamaIndex Document objects with metadata.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "llama-index-tools-annolux/0.1.0",
+        }
+        payload: Dict[str, Any] = {
+            "query": query,
+            "limit": min(max(1, limit), 10),
+            "deduplicate": deduplicate,
+            "ranking": ranking,
+        }
+        if domains:
+            payload["domains"] = domains
+
+        response = requests.post(
+            f"{self.base_url}/v1/search",
+            headers=headers,
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        documents = []
+        for item in data.get("results", []):
+            text = f"Title: {item.get('title', '')}\nURL: {item.get('url', '')}\nSnapshot Date: {item.get('fetched_at', '')}\n\n{item.get('snippet', '')}"
+            doc = Document(
+                text=text,
+                extra_info={
+                    "title": item.get("title", ""),
+                    "url": item.get("url", ""),
+                    "fetched_at": item.get("fetched_at", ""),
+                    "domain": item.get("domain", ""),
+                    "score": item.get("score", 0.0),
+                },
+            )
+            documents.append(doc)
+
+        return documents

--- a/llama-index-integrations/tools/llama-index-tools-annolux/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-annolux/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "llama-index-tools-annolux"
+version = "0.1.0"
+description = "LlamaIndex tool integration for Annolux Curated Search API."
+authors = ["Annolux <team@annolux.com>"]
+license = "MIT"
+readme = "README.md"
+homepage = "https://annolux.com"
+repository = "https://github.com/eason4kim-rocket/annolux"
+keywords = ["llama-index", "annolux", "search", "ai-agent", "rag", "tool-spec"]
+packages = [{include = "llama_index"}]
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+llama-index-core = ">=0.10.0"
+requests = ">=2.28.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = ">=7.0.0"
+responses = ">=0.23.0"

--- a/llama-index-integrations/tools/llama-index-tools-annolux/tests/test_tool.py
+++ b/llama-index-integrations/tools/llama-index-tools-annolux/tests/test_tool.py
@@ -1,0 +1,43 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from llama_index.tools.annolux import AnnoluxToolSpec
+
+
+class TestLlamaIndexAnnolux(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_response = {
+            "query": "Rust tokio",
+            "results": [
+                {
+                    "title": "Tokio Async Runtime",
+                    "url": "https://tokio.rs",
+                    "snippet": "Tokio is an asynchronous runtime for Rust.",
+                    "fetched_at": "2026-08-20T10:00:00Z",
+                    "domain": "tokio.rs",
+                    "score": 0.98,
+                }
+            ],
+            "total": 1,
+        }
+
+    @patch("requests.post")
+    def test_tool_spec_search(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self.mock_response
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        spec = AnnoluxToolSpec(api_key="ann_test_123")
+        docs = spec.annolux_search(query="Rust tokio", limit=1)
+
+        self.assertEqual(len(docs), 1)
+        self.assertIn("Tokio Async Runtime", docs[0].text)
+        self.assertEqual(docs[0].extra_info["fetched_at"], "2026-08-20T10:00:00Z")
+        self.assertEqual(docs[0].extra_info["domain"], "tokio.rs")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds the official `llama-index-tools-annolux` integration package under `llama-index-integrations/tools/llama-index-tools-annolux/`.

[Annolux](https://annolux.com) is a curated English and Chinese search API built for AI Agents. Every extracted search result contains an explicit snapshot date (`fetched_at`) to provide temporal grounding and eliminate LLM hallucinations.

## Key Features
- Native `AnnoluxToolSpec` implementation inheriting from `BaseToolSpec`.
- Exports `annolux_search` with `query`, `limit`, and `domains` filtering.
- Returns native LlamaIndex `Document` objects with complete metadata.

## Example
```python
from llama_index.tools.annolux import AnnoluxToolSpec

tool_spec = AnnoluxToolSpec()
docs = tool_spec.annolux_search("Rust tokio runtime best practices", limit=5)
```

## Testing
Includes unit tests in `tests/test_tool.py` with mocked HTTP fixtures.