### PR TITLE
test(core): cover empty arguments in streamed tool calls

### DIFF
--- a/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
+++ b/llama-index-core/tests/agent/workflow/test_single_agent_workflow.py
@@ -179,6 +179,53 @@ async def test_single_function_agent(function_agent):
 
 
 @pytest.mark.asyncio
+async def test_function_agent_streams_empty_tool_arguments() -> None:
+    async def run_agent(streaming: bool) -> str:
+        call_count = 0
+
+        def empty_tool() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "empty tool result"
+
+        responses = [
+            ChatMessage(
+                role=MessageRole.ASSISTANT,
+                content="calling empty tool",
+                additional_kwargs={
+                    "tool_calls": [
+                        ToolSelection(
+                            tool_id="empty-call", tool_name="empty_tool", tool_kwargs={}
+                        )
+                    ]
+                },
+            ),
+            ChatMessage(role=MessageRole.ASSISTANT, content="finished"),
+        ]
+        agent = FunctionAgent(
+            name="agent",
+            description="test",
+            tools=[empty_tool],
+            llm=MockFunctionCallingLLM(
+                response_generator=_response_generator_from_list(responses)
+            ),
+            streaming=streaming,
+        )
+
+        handler = agent.run(user_msg="Run the empty tool")
+        async for _ in handler.stream_events():
+            pass
+        response = await handler
+
+        assert call_count == 1
+        return response.response.content or ""
+
+    streamed_response = await run_agent(streaming=True)
+    assert streamed_response == "finished"
+    assert streamed_response == await run_agent(streaming=False)
+
+
+@pytest.mark.asyncio
 async def test_single_react_agent(calculator_agent):
     """Verify execution of basic ReAct single agent."""
     memory = ChatMemoryBuffer.from_defaults()


### PR DESCRIPTION
# Description

Adds deterministic regression coverage for a zero-parameter tool call whose streamed argument object is empty. The test exercises both streamed and non-streamed `FunctionAgent` execution, verifies the tool runs exactly once in each mode, and confirms both paths return the same final response.

No new dependencies are required.

Fixes run-llama/llama_index#22821

AI assistance disclosure: I used Codex to help draft this focused test. I reviewed the agent and mock-LLM execution paths, kept the change to one test file, and verified it with the commands listed below.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No — not applicable; this updates an existing core test.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No — not applicable to `llama-index-core`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test-only regression coverage

## How Has This Been Tested?

Your pull-request will likely not be merged unless it is covered by some form of impactful unit testing.

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Commands run:

- `uv run pytest tests/agent/workflow/test_single_agent_workflow.py -q` — 13 passed
- `uv run ruff check tests/agent/workflow/test_single_agent_workflow.py`
- `uv run ruff format --check tests/agent/workflow/test_single_agent_workflow.py`
- `uv run codespell tests/agent/workflow/test_single_agent_workflow.py`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; the test follows existing mock-agent patterns and has no non-obvious production logic.
- [ ] I have made corresponding changes to the documentation — N/A; test-only change.
- [ ] I have added Google Colab support for the newly added notebooks — N/A; no notebook added.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods — I ran the focused Ruff format/check and codespell commands listed above.
