### PR TITLE
fix(core): drop out-of-range document numbers in StructuredLLMRerank parse

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/structured_llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/structured_llm_rerank.py
@@ -66,7 +66,7 @@ def default_parse_structured_choice_select_answer(
     documents = [
         doc
         for doc in document_relevance_list.documents
-        if doc.document_number <= num_choices
+        if 1 <= doc.document_number <= num_choices
     ]
     doc_numbers = [doc.document_number for doc in documents]
     doc_relevance_scores = [doc.relevance for doc in documents]

--- a/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
@@ -10,6 +10,7 @@ from llama_index.core.postprocessor.structured_llm_rerank import (
     StructuredLLMRerank,
     DocumentWithRelevance,
     DocumentRelevanceList,
+    default_parse_structured_choice_select_answer,
 )
 from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle, TextNode
@@ -136,3 +137,27 @@ def test_llm_rerank_errored_structured_predict(raise_on_failure: bool) -> None:
         )
         assert len(result_nodes) == top_n
         assert all(n.score == 0 for n in result_nodes)
+
+
+def test_parse_filters_out_of_range_document_numbers() -> None:
+    """document_number must be within 1..num_choices; 0 and > num_choices are dropped.
+
+    Regression: document_number=0 previously passed the upper-bound-only filter and
+    later mapped to nodes_batch[int(0) - 1] == nodes_batch[-1], silently reranking
+    the last node in the batch.
+    """
+    relevance_list = DocumentRelevanceList(
+        documents=[
+            DocumentWithRelevance(document_number=0, relevance=9),
+            DocumentWithRelevance(document_number=1, relevance=8),
+            DocumentWithRelevance(document_number=2, relevance=7),
+            DocumentWithRelevance(document_number=3, relevance=6),
+        ]
+    )
+
+    doc_numbers, doc_scores = default_parse_structured_choice_select_answer(
+        relevance_list, num_choices=2
+    )
+
+    assert doc_numbers == [1, 2]
+    assert doc_scores == [8, 7]

--- a/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
@@ -149,7 +149,8 @@ def test_llm_rerank_errored_structured_predict(raise_on_failure: bool) -> None:
 
 
 def test_parse_filters_out_of_range_document_numbers() -> None:
-    """document_number must be within 1..num_choices; 0 and > num_choices are dropped.
+    """
+    document_number must be within 1..num_choices; 0 and > num_choices are dropped.
 
     Regression: document_number=0 previously passed the upper-bound-only filter and
     later mapped to nodes_batch[int(0) - 1] == nodes_batch[-1], silently reranking


### PR DESCRIPTION
# Description

`default_parse_structured_choice_select_answer` in `StructuredLLMRerank` filters the
model's returned document numbers with an upper bound only:

```python
if doc.document_number <= num_choices
```

Document numbers are 1-indexed (the prompt lists documents as `Document 1`,
`Document 2`, ...), and downstream the choice is mapped back to a node with
`nodes_batch[int(choice) - 1]`. A `document_number` of `0` (or any non-positive
value) passes the upper-bound check, then maps to `nodes_batch[-1]` — silently
reranking the **last** node in the batch instead of being discarded. Function-calling
models do occasionally emit out-of-range indices, so this produces a wrong rerank
result with no error.

The fix bounds the document number on both sides so only valid 1..`num_choices`
selections survive:

```python
if 1 <= doc.document_number <= num_choices
```

Fixes # (out-of-range document number handling in StructuredLLMRerank)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `test_parse_filters_out_of_range_document_numbers` in
`tests/postprocessor/test_structured_llm_rerank.py`, which feeds document numbers
`0, 1, 2, 3` with `num_choices=2` and asserts that only `1` and `2` survive. The test
fails before the change (the out-of-range `0` leaks through and maps to the last node)
and passes after.

Before / after:

<img width="3024" height="1790" alt="ev-rerank0" src="https://github.com/user-attachments/assets/1c519a22-1c97-43bb-b32b-b943684f0feb" />

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
