### PR TITLE
fix(core): don't mutate input blocks in merge_neighboring_same_role_messages

### DIFF
--- a/llama-index-core/llama_index/core/utilities/gemini_utils.py
+++ b/llama-index-core/llama_index/core/utilities/gemini_utils.py
@@ -39,8 +39,11 @@ def merge_neighboring_same_role_messages(
 
     while i < len(messages):
         current_message = messages[i]
-        # Initialize merged content with current message content
-        merged_content = current_message.blocks
+        # Initialize merged content with a copy of the current message content.
+        # Aliasing current_message.blocks here would let the extend() below mutate
+        # the caller's input message in place (and corrupt it if the same sequence
+        # is passed in again).
+        merged_content = list(current_message.blocks)
 
         # Check if the next message exists and has the same role
         while (

--- a/llama-index-core/tests/utilities/test_gemini_utils.py
+++ b/llama-index-core/tests/utilities/test_gemini_utils.py
@@ -7,7 +7,8 @@ from llama_index.core.utilities.gemini_utils import (
 
 
 def test_merge_neighboring_same_role_messages_does_not_mutate_input() -> None:
-    """Merging must not mutate the caller's input messages.
+    """
+    Merging must not mutate the caller's input messages.
 
     Regression: merged_content aliased current_message.blocks, so extend() mutated
     the caller's first message in place. Re-running the merge on the same list then

--- a/llama-index-core/tests/utilities/test_gemini_utils.py
+++ b/llama-index-core/tests/utilities/test_gemini_utils.py
@@ -1,0 +1,34 @@
+"""Tests for Gemini message utilities."""
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.utilities.gemini_utils import (
+    merge_neighboring_same_role_messages,
+)
+
+
+def test_merge_neighboring_same_role_messages_does_not_mutate_input() -> None:
+    """Merging must not mutate the caller's input messages.
+
+    Regression: merged_content aliased current_message.blocks, so extend() mutated
+    the caller's first message in place. Re-running the merge on the same list then
+    produced duplicated blocks.
+    """
+    messages = [
+        ChatMessage(role=MessageRole.USER, content="U1"),
+        ChatMessage(role=MessageRole.USER, content="U2"),
+        ChatMessage(role=MessageRole.ASSISTANT, content="A1"),
+    ]
+
+    merged = merge_neighboring_same_role_messages(messages)
+
+    # The two neighboring USER messages merge into one.
+    assert [m.role for m in merged] == [MessageRole.USER, MessageRole.MODEL]
+    assert [b.text for b in merged[0].blocks] == ["U1", "U2"]
+
+    # The caller's input is untouched.
+    assert [b.text for b in messages[0].blocks] == ["U1"]
+    assert [b.text for b in messages[1].blocks] == ["U2"]
+
+    # Merging the same input again is idempotent (not corrupted by the first call).
+    merged_again = merge_neighboring_same_role_messages(messages)
+    assert [b.text for b in merged_again[0].blocks] == ["U1", "U2"]


### PR DESCRIPTION
# Description

`merge_neighboring_same_role_messages` in `gemini_utils.py` mutates the caller's input messages. It aliases the first message's block list instead of copying it:

```python
merged_content = current_message.blocks     # aliases the caller's list
...
    merged_content.extend(next_message.blocks)   # mutates messages[i].blocks in place
```

So after merging `[USER "U1", USER "U2", ASSISTANT "A1"]`, the caller's `messages[0].blocks` is silently changed from `["U1"]` to `["U1", "U2"]`. Passing the same message list in again (a common pattern when building a Gemini/Vertex request from a retained history) then produces duplicated content: `["U1", "U2", "U2"]`.

The fix copies the list so the merge is pure:

```python
merged_content = list(current_message.blocks)
```

Fixes # (in-place mutation of input messages in merge_neighboring_same_role_messages)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `llama-index-core/tests/utilities/test_gemini_utils.py`, which asserts the input list is unmutated and that a repeated merge is idempotent. The test fails before the change and passes after.

Before (source reverted):

```
>  assert [b.text for b in messages[0].blocks] == ["U1"]
E  AssertionError: assert ['U1', 'U2'] == ['U1']
FAILED
```

After (fix in place):

```
tests/utilities/test_gemini_utils.py . [100%]
1 passed
```

- [x] I added new unit tests to cover this change

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

**Rendered before/after test run:**

![before/after test run](https://github.com/user-attachments/assets/0f6efd1a-8922-4ac2-88c1-12e423a4d887)
