### PR TITLE
fix(weaviate): use Filter.by_id() for node_ids query filter

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/llama_index/vector_stores/weaviate/base.py
@@ -619,7 +619,7 @@ class WeaviateVectorStore(BasePydanticVectorStore):
             filters = wvc.query.Filter.by_property("doc_id").contains_any(query.doc_ids)
 
         if query.node_ids:
-            filters = wvc.query.Filter.by_property("id").contains_any(query.node_ids)
+            filters = wvc.query.Filter.by_id().contains_any(query.node_ids)
 
         return_metatada = wvc.query.MetadataQuery(distance=True, score=True)
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-weaviate"
-version = "1.6.2"
+version = "1.6.3"
 description = "llama-index vector_stores weaviate integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-weaviate/tests/test_vector_stores_weaviate.py
@@ -302,6 +302,28 @@ class TestWeaviateSync:
 
         assert results.similarities[0] > results.similarities[1]
 
+    def test_query_with_node_ids(self, vector_store_with_sample_nodes):
+        all_nodes = vector_store_with_sample_nodes.query(
+            VectorStoreQuery(
+                query_embedding=[0.3, 0.0, 0.0],
+                similarity_top_k=10,
+                mode=VectorStoreQueryMode.DEFAULT,
+            )
+        )
+        target_node_id = all_nodes.ids[0]
+
+        query = VectorStoreQuery(
+            query_embedding=[0.3, 0.0, 0.0],
+            similarity_top_k=10,
+            node_ids=[target_node_id],
+            mode=VectorStoreQueryMode.DEFAULT,
+        )
+
+        results = vector_store_with_sample_nodes.query(query)
+
+        assert len(results.nodes) == 1
+        assert results.ids[0] == target_node_id
+
     def test_hybrid_search(self, vector_store_with_sample_nodes):
         query = VectorStoreQuery(
             query_embedding=[0.0, 0.3, 0.0],


### PR DESCRIPTION
# Description

`WeaviateVectorStore.get_query_parameters()` filters `node_ids` using
`Filter.by_property("id")`. But `"id"` is not a real property in Weaviate's
default schema — it's the internal object UUID, which Weaviate only exposes
through `Filter.by_id()`. Any query passing `node_ids` fails on the server
with:

```
no such prop with name 'id' found in class '...'
```

`delete_nodes` / `adelete_nodes` in the same file already filter by node id
correctly with `Filter.by_id()` — this PR brings the query path in line with
that existing, working pattern. No new dependencies required.

Fixes #15743

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

Bumped `llama-index-vector-stores-weaviate` 1.6.2 → 1.6.3 (patch, matching
the convention used by the last bug-fix PR on this package, #22540).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Added `test_query_with_node_ids` to `test_vector_stores_weaviate.py`,
covering the exact path described in the issue: add nodes, query by
`node_ids`, assert the correct single node comes back. Confirmed the new
test fails against the unfixed line (reproduces the reported
`no such prop with name 'id'` error) and passes after the fix.

Ran the full `test_vector_stores_weaviate.py` suite locally against an
embedded Weaviate instance. Two unrelated tests
(`TestWeaviateAsync::test_async_basic_flow`,
`TestWeaviateSync::test_async_methods_called_without_async_client`) fail in
my sandbox both before and after this change — confirmed pre-existing /
environment-related, not caused by this fix.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

---

*Used Claude Code for investigation and fix, and reviewed/verified everything myself.*
