### PR TITLE
fix(core): treat explicit null token usage sub-fields as missing (#22806)

### DIFF
--- a/llama-index-core/llama_index/core/callbacks/token_counting.py
+++ b/llama-index-core/llama_index/core/callbacks/token_counting.py
@@ -63,13 +63,13 @@ def get_tokens_from_response(
 
     prompt_tokens = 0
     for input_key in possible_input_keys:
-        if input_key in usage:
+        if input_key in usage and usage[input_key] is not None:
             prompt_tokens = usage[input_key]
             break
 
     completion_tokens = 0
     for output_key in possible_output_keys:
-        if output_key in usage:
+        if output_key in usage and usage[output_key] is not None:
             completion_tokens = usage[output_key]
             break
 

--- a/llama-index-core/tests/callbacks/test_token_counter.py
+++ b/llama-index-core/tests/callbacks/test_token_counter.py
@@ -48,3 +48,21 @@ def test_on_event_end() -> None:
     # Embedding should be one (single token chunk)
     assert handler.total_llm_token_count == 2
     assert handler.total_embedding_token_count == 1
+
+
+def test_token_counting_with_explicit_none_usage():
+    from llama_index.core.callbacks.schema import EventPayload
+    from llama_index.core.callbacks.token_counting import get_llm_token_counts
+    from llama_index.core.utilities.token_counting import TokenCounter
+
+    class FakeCompletion:
+        text = "hello"
+        raw = {"usage": {"prompt_tokens": None, "completion_tokens": 5, "total_tokens": 5}}
+        additional_kwargs = {}
+
+    payload = {EventPayload.PROMPT: "hi", EventPayload.COMPLETION: FakeCompletion()}
+    event = get_llm_token_counts(TokenCounter(), payload, event_id="x")
+    assert event.completion_token_count == 5
+    assert event.prompt_token_count > 0
+    assert event.total_token_count == event.prompt_token_count + event.completion_token_count
+


### PR DESCRIPTION
## Description
Fixes #22806

`get_tokens_from_response` in `llama_index.core.callbacks.token_counting` previously checked `if input_key in usage:` / `if output_key in usage:` and assigned the value directly. If a provider explicitly returned `None` for a sub-field (e.g. `{"prompt_tokens": None}`), `prompt_tokens` remained `None`, bypassing the fallback check (`if prompt_tokens == 0:`) and leading to a `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` in `TokenCountingEvent.__post_init__`.

### Changes
- Check that `usage[input_key] is not None` and `usage[output_key] is not None` before assigning token counts in `get_tokens_from_response`.
- Added unit test in `llama-index-core/tests/callbacks/test_token_counter.py` verifying behavior when raw response contains explicit `None` in usage fields.