### PR TITLE
Preserve node content for null replacement metadata

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
+++ b/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
@@ -23,11 +23,11 @@ class MetadataReplacementPostProcessor(BaseNodePostprocessor):
         query_bundle: Optional[QueryBundle] = None,
     ) -> List[NodeWithScore]:
         for n in nodes:
+            replacement = n.node.metadata.get(self.target_metadata_key)
             n.node.set_content(
-                n.node.metadata.get(
-                    self.target_metadata_key,
-                    n.node.get_content(metadata_mode=MetadataMode.NONE),
-                )
+                replacement
+                if replacement is not None
+                else n.node.get_content(metadata_mode=MetadataMode.NONE)
             )
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_metadata_replacement.py
+++ b/llama-index-core/tests/postprocessor/test_metadata_replacement.py
@@ -15,3 +15,13 @@ def test_metadata_replacement() -> None:
 
     assert len(nodes) == 1
     assert nodes[0].node.get_content() == "This is a another test."
+
+
+def test_metadata_replacement_none_value() -> None:
+    node = TextNode(text="Original content.", metadata={"key": None})
+    nodes = [NodeWithScore(node=node, score=1.0)]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+    nodes = postprocessor.postprocess_nodes(nodes)
+
+    assert nodes[0].node.get_content() == "Original content."


### PR DESCRIPTION
# Description

Preserve a node's original text when the configured replacement metadata key is present with an explicit `None` value. Previously, that value was passed to `TextNode.set_content()` and raised a Pydantic `ValidationError`.

The regression test reproduces the reported behavior on the current upstream base and verifies the fallback. Empty strings remain valid replacement values because the implementation checks specifically for `None`.

Fixes #22772

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Focused validation:

- `uv run --project llama-index-core pytest -q llama-index-core/tests/postprocessor/test_metadata_replacement.py` — 2 passed
- `uv run --project llama-index-core ruff check ...` — passed
- `uv run mypy llama_index/core/postprocessor/metadata_replacement.py tests/postprocessor/test_metadata_replacement.py` from `llama-index-core/` — passed

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing focused unit tests pass locally with my changes

## AI Assistance

AI assistance was used to inspect the issue, implement the small fix, and draft the regression test. The reported reproduction was independently run against upstream `main` before the fix; the focused test, Ruff, and mypy checks above were then run after the fix.
