### PR TITLE
respect an explicitly-passed temperature for o1-class models

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/base.py
@@ -303,8 +303,10 @@ class OpenAI(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # o1-class models reject temperature != 1.0 at the API, so only the
+        # default is forced to 1.0; an explicitly-passed value is forwarded
+        # as-is instead of being silently discarded (#22751).
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         if not is_chatcomp_api_supported(model):

--- a/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/llama_index/llms/openai/responses.py
@@ -314,8 +314,10 @@ class OpenAIResponses(FunctionCallingLLM):
             api_version=api_version,
         )
 
-        # TODO: Temp forced to 1.0 for o1
-        if model in O1_MODELS:
+        # o1-class models reject temperature != 1.0 at the API, so only the
+        # default is forced to 1.0; an explicitly-passed value is forwarded
+        # as-is instead of being silently discarded (#22751).
+        if model in O1_MODELS and temperature == DEFAULT_TEMPERATURE:
             temperature = 1.0
 
         super().__init__(

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai.py
@@ -294,6 +294,22 @@ def mock_chat_completion_stream_v1(
 
 
 @patch("llama_index.llms.openai.base.SyncOpenAI")
+def test_o1_default_temperature_is_forced_to_one(MockSyncOpenAI: MagicMock) -> None:
+    """o1-class models reject temperature != 1.0; the default is forced."""
+    with CachedOpenAIApiKeys(set_fake_key=True):
+        llm = OpenAI(model="o1-mini")
+    assert llm.temperature == 1.0
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
+def test_o1_explicit_temperature_is_not_overwritten(MockSyncOpenAI: MagicMock) -> None:
+    """#22751: an explicitly-passed temperature must never be silently discarded."""
+    with CachedOpenAIApiKeys(set_fake_key=True):
+        llm = OpenAI(model="o1-mini", temperature=0.5)
+    assert llm.temperature == 0.5
+
+
+@patch("llama_index.llms.openai.base.SyncOpenAI")
 def test_completion_model_basic(MockSyncOpenAI: MagicMock) -> None:
     with CachedOpenAIApiKeys(set_fake_key=True):
         mock_instance = MockSyncOpenAI.return_value

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -64,6 +64,24 @@ def test_init_and_properties(default_responses_llm):
     assert metadata.is_chat_model is True
 
 
+def test_o1_default_temperature_is_forced_to_one():
+    """o1-class models reject temperature != 1.0; the default is forced."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(model="o1-mini", api_key="fake-api-key")
+    assert llm.temperature == 1.0
+
+
+def test_o1_explicit_temperature_is_not_overwritten():
+    """#22751: an explicitly-passed temperature must never be silently discarded."""
+    with patch("llama_index.llms.openai.responses.SyncOpenAI"):
+        with patch("llama_index.llms.openai.responses.AsyncOpenAI"):
+            llm = OpenAIResponses(
+                model="o1-mini", temperature=0.5, api_key="fake-api-key"
+            )
+    assert llm.temperature == 0.5
+
+
 def test_get_model_name():
     """Test different model name formats are properly handled."""
     with patch("llama_index.llms.openai.responses.SyncOpenAI"):


### PR DESCRIPTION
Fixes #22751

## What changed

`OpenAIResponses.__init__` and `OpenAI.__init__` unconditionally forced `temperature = 1.0` for o1-class models, silently discarding whatever the caller passed. The force now applies only when the caller did not set temperature (`temperature == DEFAULT_TEMPERATURE`); an explicitly-passed value is forwarded as-is, so nothing a caller wrote is dropped without a trace. The same defect existed in both classes, so both are fixed here.

## Tests

- `test_o1_default_temperature_is_forced_to_one` (both `test_openai.py` and `test_openai_responses.py`): o1 model with default temperature still gets 1.0.
- `test_o1_explicit_temperature_is_not_overwritten` (both files): `temperature=0.5` on an o1 model is preserved.

## Validation

```
pytest test_openai.py -k o1 + test_openai_responses.py -k o1        # 11 passed
pytest test_openai.py test_openai_responses.py                      # 55 passed, 12 skipped, 1 failed
ruff check (repo-pinned v0.11.8)                                     # clean on all 4 changed files
ruff format --check (v0.11.8)                                        # clean
```

Note on validation environment: tests ran in an isolated venv (llama-index-core 0.14.24, openai 3.3.1) with this package's source shadowed via PYTHONPATH, since the monorepo's sibling integration packages are not fully checked out on this machine. The 1 failing test (`test_process_response_event_with_text_annotation`) is pre-existing: it fails identically on a clean tree (verified via `git stash`) because its mock annotation payload (`{'type': 'test_annotation'}`) is rejected by the openai 3.x SDK models under pydantic v2.13 — unrelated to this change.