### PR TITLE
fix(core): avoid retrying failed function tools

### DIFF
--- a/llama-index-core/llama_index/core/tools/calling.py
+++ b/llama-index-core/llama_index/core/tools/calling.py
@@ -1,10 +1,27 @@
-from llama_index.core.tools.types import BaseTool, ToolOutput, adapt_to_async_tool
-from typing import TYPE_CHECKING, Sequence
-from llama_index.core.llms.llm import ToolSelection
+import inspect
 import json
+from typing import TYPE_CHECKING, Sequence
+
+from llama_index.core.llms.llm import ToolSelection
+from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.types import BaseTool, ToolOutput, adapt_to_async_tool
 
 if TYPE_CHECKING:
     from llama_index.core.tools.types import BaseTool
+
+
+def _function_tool_accepts_kwargs(tool: FunctionTool, arguments: dict) -> bool:
+    """Check whether a function tool can receive its generated arguments as kwargs."""
+    try:
+        signature = inspect.signature(tool._real_fn)
+    except (TypeError, ValueError):
+        return True
+
+    try:
+        signature.bind_partial(**arguments)
+    except TypeError:
+        return False
+    return True
 
 
 def call_tool(tool: BaseTool, arguments: dict) -> ToolOutput:
@@ -14,8 +31,12 @@ def call_tool(tool: BaseTool, arguments: dict) -> ToolOutput:
             len(tool.metadata.get_parameters_dict()["properties"]) == 1
             and len(arguments) == 1
         ):
+            single_arg = arguments[next(iter(arguments))]
+            if isinstance(tool, FunctionTool):
+                if _function_tool_accepts_kwargs(tool, arguments):
+                    return tool(**arguments)
+                return tool(single_arg)
             try:
-                single_arg = arguments[next(iter(arguments))]
                 return tool(single_arg)
             except Exception:
                 # some tools will REQUIRE kwargs, so try it
@@ -41,8 +62,12 @@ async def acall_tool(tool: BaseTool, arguments: dict) -> ToolOutput:
             len(tool.metadata.get_parameters_dict()["properties"]) == 1
             and len(arguments) == 1
         ):
+            single_arg = arguments[next(iter(arguments))]
+            if isinstance(tool, FunctionTool):
+                if _function_tool_accepts_kwargs(tool, arguments):
+                    return await async_tool.acall(**arguments)
+                return await async_tool.acall(single_arg)
             try:
-                single_arg = arguments[next(iter(arguments))]
                 return await async_tool.acall(single_arg)
             except Exception:
                 # some tools will REQUIRE kwargs, so try it

--- a/llama-index-core/llama_index/core/tools/calling.py
+++ b/llama-index-core/llama_index/core/tools/calling.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 def _function_tool_accepts_kwargs(tool: FunctionTool, arguments: dict) -> bool:
     """Check whether a function tool can receive its generated arguments as kwargs."""
     try:
-        signature = inspect.signature(tool._real_fn)
+        signature = inspect.signature(tool.real_fn)
     except (TypeError, ValueError):
         return True
 

--- a/llama-index-core/tests/tools/test_calling.py
+++ b/llama-index-core/tests/tools/test_calling.py
@@ -1,0 +1,59 @@
+"""Tests for tool invocation helpers."""
+
+import pytest
+
+from llama_index.core.tools.calling import acall_tool, call_tool
+from llama_index.core.tools.function_tool import FunctionTool
+
+
+def test_call_tool_does_not_retry_failed_function_tool() -> None:
+    calls = []
+
+    def remote_write(input: str) -> str:
+        calls.append(input)
+        raise RuntimeError("response lost after request was accepted")
+
+    tool = FunctionTool.from_defaults(remote_write)
+
+    output = call_tool(tool, {"input": "charge"})
+
+    assert output.is_error
+    assert calls == ["charge"]
+
+
+@pytest.mark.asyncio
+async def test_acall_tool_does_not_retry_failed_function_tool() -> None:
+    calls = []
+
+    async def remote_write(input: str) -> str:
+        calls.append(input)
+        raise RuntimeError("response lost after request was accepted")
+
+    tool = FunctionTool.from_defaults(async_fn=remote_write)
+
+    output = await acall_tool(tool, {"input": "charge"})
+
+    assert output.is_error
+    assert calls == ["charge"]
+
+
+def test_call_tool_supports_keyword_only_function_tool() -> None:
+    def lookup(*, query: str) -> str:
+        return query
+
+    tool = FunctionTool.from_defaults(lookup)
+
+    output = call_tool(tool, {"query": "LlamaIndex"})
+
+    assert output.raw_output == "LlamaIndex"
+
+
+def test_call_tool_supports_positional_only_function_tool() -> None:
+    def lookup(query: str, /) -> str:
+        return query
+
+    tool = FunctionTool.from_defaults(lookup)
+
+    output = call_tool(tool, {"query": "LlamaIndex"})
+
+    assert output.raw_output == "LlamaIndex"


### PR DESCRIPTION
# Description

`call_tool` and `acall_tool` currently interpret any exception from the one-argument positional call as a signal to retry the same `FunctionTool` with keyword arguments. A tool can perform an irreversible side effect and then raise a business or transport exception, so this behavior can execute it twice.

For `FunctionTool`, this change determines the supported calling convention from the wrapped callable's signature *before* invocation. Keyword-only tools still receive keyword arguments, positional-only tools still receive the single positional value, and the existing fallback behavior for other tool implementations is unchanged.

No dependencies or documentation changes are required. There is no related issue; the regression tests below reproduce the defect directly.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (this change is in `llama-index-core`, which is exempted by the template)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Executed locally:

```text
uv run --no-sync python -m pytest tests/tools/test_calling.py -vv -ra
# 4 passed

uv run --no-sync python -m pytest tests/program/test_function_program.py -k 'single_field' -vv -ra
# 3 passed

uv run --no-sync python -m pytest tests/tools -q -ra
# 67 passed, 4 skipped

uv run --no-sync ruff check llama_index/core/tools/calling.py tests/tools/test_calling.py
uv run --no-sync ruff format --check llama_index/core/tools/calling.py tests/tools/test_calling.py
git diff --check
```

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI assistance

AI assistance was used to investigate, draft, and test this change. The human submitter reviewed every changed line, understands the behavior, and witnessed the tests listed above.
