### PR TITLE
feat(core): add native async support to StructuredLLMRerank

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/structured_llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/structured_llm_rerank.py
@@ -1,6 +1,6 @@
 """LLM reranker."""
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import logging
 
 from llama_index.core.bridge.pydantic import (
@@ -9,6 +9,7 @@ from llama_index.core.bridge.pydantic import (
     PrivateAttr,
     SerializeAsAny,
 )
+from llama_index.core.async_utils import run_jobs
 from llama_index.core.indices.utils import (
     default_format_node_batch_fn,
 )
@@ -23,7 +24,7 @@ from llama_index.core.instrumentation.events.rerank import (
 from llama_index.core.prompts import BasePromptTemplate
 from llama_index.core.prompts.default_prompts import STRUCTURED_CHOICE_SELECT_PROMPT
 from llama_index.core.prompts.mixin import PromptDictType
-from llama_index.core.schema import NodeWithScore, QueryBundle
+from llama_index.core.schema import BaseNode, NodeWithScore, QueryBundle
 from llama_index.core.settings import Settings
 
 
@@ -140,11 +141,56 @@ class StructuredLLMRerank(BaseNodePostprocessor):
     def class_name(cls) -> str:
         return "StructuredLLMRerank"
 
-    def _postprocess_nodes(
+    def _get_node_batches(self, nodes: List[NodeWithScore]) -> List[List[BaseNode]]:
+        return [
+            [node.node for node in nodes[idx : idx + self.choice_batch_size]]
+            for idx in range(0, len(nodes), self.choice_batch_size)
+        ]
+
+    def _get_predict_kwargs(
+        self, nodes_batch: List[BaseNode], query_str: str
+    ) -> Dict[str, Any]:
+        return {
+            "output_cls": self._document_relevance_list_cls,
+            "prompt": self.choice_select_prompt,
+            "context_str": self._format_node_batch_fn(nodes_batch),
+            "query_str": query_str,
+        }
+
+    def _parse_batch_result(
         self,
-        nodes: List[NodeWithScore],
-        query_bundle: Optional[QueryBundle] = None,
+        result: Union[BaseModel, str],
+        nodes_batch: List[BaseNode],
+        batch_idx: int,
     ) -> List[NodeWithScore]:
+        """Score a single batch of nodes from its structured prediction."""
+        # in case structured prediction fails, a str of the raised exception is returned
+        if isinstance(result, str):
+            start_idx = batch_idx * self.choice_batch_size
+            msg = (
+                f"Structured prediction failed for nodes "
+                f"{start_idx} - {start_idx + self.choice_batch_size}: {result}"
+            )
+            if self._raise_on_structured_prediction_failure:
+                raise ValueError(msg)
+            logger.warning(msg)
+            # add all nodes with score 0
+            return [NodeWithScore(node=node, score=0.0) for node in nodes_batch]
+
+        raw_choices, relevances = self._parse_choice_select_answer_fn(
+            result, len(nodes_batch)
+        )
+        choice_idxs = [int(choice) - 1 for choice in raw_choices]
+        choice_nodes = [nodes_batch[idx] for idx in choice_idxs]
+        relevances = relevances or [1.0 for _ in choice_nodes]
+        return [
+            NodeWithScore(node=node, score=relevance)
+            for node, relevance in zip(choice_nodes, relevances)
+        ]
+
+    def _rerank_start_event(
+        self, nodes: List[NodeWithScore], query_bundle: Optional[QueryBundle]
+    ) -> None:
         dispatcher.event(
             ReRankStartEvent(
                 query=query_bundle,
@@ -154,66 +200,92 @@ class StructuredLLMRerank(BaseNodePostprocessor):
             )
         )
 
+    def _reranking_event_payload(
+        self, nodes: List[NodeWithScore], query_bundle: QueryBundle
+    ) -> Dict[str, Any]:
+        return {
+            EventPayload.NODES: nodes,
+            EventPayload.MODEL_NAME: self.llm.metadata.model_name,
+            EventPayload.QUERY_STR: query_bundle.query_str,
+            EventPayload.TOP_K: self.top_n,
+        }
+
+    def _sort_and_truncate(
+        self, initial_results: List[NodeWithScore]
+    ) -> List[NodeWithScore]:
+        return sorted(initial_results, key=lambda x: x.score or 0.0, reverse=True)[
+            : self.top_n
+        ]
+
+    def _postprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        self._rerank_start_event(nodes, query_bundle)
+
         if query_bundle is None:
             raise ValueError("Query bundle must be provided.")
         if len(nodes) == 0:
             return []
 
+        node_batches = self._get_node_batches(nodes)
         initial_results: List[NodeWithScore] = []
         with self.callback_manager.event(
             CBEventType.RERANKING,
-            payload={
-                EventPayload.NODES: nodes,
-                EventPayload.MODEL_NAME: self.llm.metadata.model_name,
-                EventPayload.QUERY_STR: query_bundle.query_str,
-                EventPayload.TOP_K: self.top_n,
-            },
+            payload=self._reranking_event_payload(nodes, query_bundle),
         ) as event:
-            for idx in range(0, len(nodes), self.choice_batch_size):
-                nodes_batch = [
-                    node.node for node in nodes[idx : idx + self.choice_batch_size]
-                ]
-
-                query_str = query_bundle.query_str
-                fmt_batch_str = self._format_node_batch_fn(nodes_batch)
+            for batch_idx, nodes_batch in enumerate(node_batches):
                 # call each batch independently
                 result: Union[BaseModel, str] = self.llm.structured_predict(
-                    output_cls=self._document_relevance_list_cls,
-                    prompt=self.choice_select_prompt,
-                    context_str=fmt_batch_str,
-                    query_str=query_str,
+                    **self._get_predict_kwargs(nodes_batch, query_bundle.query_str)
                 )
-                # in case structured prediction fails, a str of the raised exception is returned
-                if isinstance(result, str):
-                    if self._raise_on_structured_prediction_failure:
-                        raise ValueError(
-                            f"Structured prediction failed for nodes {idx} - {idx + self.choice_batch_size}: {result}"
-                        )
-                    logger.warning(
-                        f"Structured prediction failed for nodes {idx} - {idx + self.choice_batch_size}: {result}"
-                    )
-                    # add all nodes with score 0
-                    initial_results.extend(
-                        [NodeWithScore(node=node, score=0.0) for node in nodes_batch]
-                    )
-                    continue
-
-                raw_choices, relevances = self._parse_choice_select_answer_fn(
-                    result, len(nodes_batch)
-                )
-                choice_idxs = [int(choice) - 1 for choice in raw_choices]
-                choice_nodes = [nodes_batch[idx] for idx in choice_idxs]
-                relevances = relevances or [1.0 for _ in choice_nodes]
                 initial_results.extend(
-                    [
-                        NodeWithScore(node=node, score=relevance)
-                        for node, relevance in zip(choice_nodes, relevances)
-                    ]
+                    self._parse_batch_result(result, nodes_batch, batch_idx)
                 )
 
-            reranked_nodes = sorted(
-                initial_results, key=lambda x: x.score or 0.0, reverse=True
-            )[: self.top_n]
+            reranked_nodes = self._sort_and_truncate(initial_results)
+            event.on_end(payload={EventPayload.NODES: reranked_nodes})
+
+        dispatcher.event(ReRankEndEvent(nodes=reranked_nodes))
+        return reranked_nodes
+
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        self._rerank_start_event(nodes, query_bundle)
+
+        if query_bundle is None:
+            raise ValueError("Query bundle must be provided.")
+        if len(nodes) == 0:
+            return []
+
+        node_batches = self._get_node_batches(nodes)
+        initial_results: List[NodeWithScore] = []
+        with self.callback_manager.event(
+            CBEventType.RERANKING,
+            payload=self._reranking_event_payload(nodes, query_bundle),
+        ) as event:
+            # call each batch independently, in parallel
+            results: List[Union[BaseModel, str]] = await run_jobs(
+                [
+                    self.llm.astructured_predict(
+                        **self._get_predict_kwargs(nodes_batch, query_bundle.query_str)
+                    )
+                    for nodes_batch in node_batches
+                ]
+            )
+
+            for batch_idx, (result, nodes_batch) in enumerate(
+                zip(results, node_batches)
+            ):
+                initial_results.extend(
+                    self._parse_batch_result(result, nodes_batch, batch_idx)
+                )
+
+            reranked_nodes = self._sort_and_truncate(initial_results)
             event.on_end(payload={EventPayload.NODES: reranked_nodes})
 
         dispatcher.event(ReRankEndEvent(nodes=reranked_nodes))

--- a/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_structured_llm_rerank.py
@@ -1,9 +1,11 @@
 """Test LLM reranker."""
 
+import asyncio
 from typing import Any, List
 from unittest.mock import patch
 import pytest
 
+from llama_index.core.async_utils import DEFAULT_NUM_WORKERS
 from llama_index.core.base.llms.types import LLMMetadata
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.postprocessor.structured_llm_rerank import (
@@ -42,6 +44,13 @@ def mock_llmpredictor_structured_predict(
         for c, s in choices_and_scores
     ]
     return DocumentRelevanceList(documents=doc_with_relvance)
+
+
+async def amock_llmpredictor_structured_predict(
+    self: Any, prompt: BasePromptTemplate, **prompt_args: Any
+) -> DocumentRelevanceList:
+    """Patch llm predictor astructured_predict."""
+    return mock_llmpredictor_structured_predict(self, prompt, **prompt_args)
 
 
 def mock_format_node_batch_fn(nodes: List[BaseNode]) -> str:
@@ -136,3 +145,144 @@ def test_llm_rerank_errored_structured_predict(raise_on_failure: bool) -> None:
         )
         assert len(result_nodes) == top_n
         assert all(n.score == 0 for n in result_nodes)
+
+
+async def amock_errored_structured_predict(
+    self: Any, prompt: BasePromptTemplate, **prompt_args: Any
+) -> str:
+    return "fake error"
+
+
+@patch.object(
+    MockFunctionCallingLLM,
+    "astructured_predict",
+    amock_llmpredictor_structured_predict,
+)
+@pytest.mark.asyncio
+async def test_allm_rerank() -> None:
+    """Test async LLM rerank matches the sync ranking."""
+    nodes = [
+        TextNode(text="Test"),
+        TextNode(text="Test2"),
+        TextNode(text="Test3"),
+        TextNode(text="Test4"),
+        TextNode(text="Test5"),
+        TextNode(text="Test6"),
+        TextNode(text="Test7"),
+        TextNode(text="Test8"),
+    ]
+    nodes_with_score = [NodeWithScore(node=n) for n in nodes]
+
+    # choice batch size 4 (so two batches)
+    # take top-3 across all data
+    llm = MockFunctionCallingLLM()
+    llm.metadata.is_function_calling_model = True
+    llm_rerank = StructuredLLMRerank(
+        llm=llm,
+        format_node_batch_fn=mock_format_node_batch_fn,
+        choice_batch_size=4,
+        top_n=3,
+    )
+    query_str = "What is?"
+    result_nodes = await llm_rerank.apostprocess_nodes(
+        nodes_with_score, QueryBundle(query_str)
+    )
+    assert len(result_nodes) == 3
+    assert result_nodes[0].node.get_content() == "Test7"
+    assert result_nodes[1].node.get_content() == "Test5"
+    assert result_nodes[2].node.get_content() == "Test3"
+
+
+@patch.object(
+    MockFunctionCallingLLM,
+    "astructured_predict",
+    amock_errored_structured_predict,
+)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raise_on_failure", [True, False])
+async def test_allm_rerank_errored_structured_predict(raise_on_failure: bool) -> None:
+    """Test async LLM rerank with errored structured predict."""
+    nodes = [
+        TextNode(text="Test"),
+        TextNode(text="Test2"),
+        TextNode(text="Test3"),
+        TextNode(text="Test4"),
+    ]
+    nodes_with_score = [NodeWithScore(node=n) for n in nodes]
+
+    llm = MockFunctionCallingLLM()
+    llm.metadata.is_function_calling_model = True
+    top_n = 3
+    llm_rerank = StructuredLLMRerank(
+        llm=llm,
+        format_node_batch_fn=mock_format_node_batch_fn,
+        choice_batch_size=4,
+        top_n=top_n,
+        raise_on_structured_prediction_failure=raise_on_failure,
+    )
+    query_str = "What is?"
+    if raise_on_failure:
+        with pytest.raises(ValueError, match="Structured prediction failed for nodes"):
+            await llm_rerank.apostprocess_nodes(
+                nodes_with_score, QueryBundle(query_str)
+            )
+    else:
+        result_nodes = await llm_rerank.apostprocess_nodes(
+            nodes_with_score, QueryBundle(query_str)
+        )
+        assert len(result_nodes) == top_n
+        assert all(n.score == 0 for n in result_nodes)
+
+
+@patch.object(
+    MockFunctionCallingLLM,
+    "astructured_predict",
+    amock_llmpredictor_structured_predict,
+)
+@pytest.mark.asyncio
+async def test_allm_rerank_runs_batches_concurrently() -> None:
+    """Async rerank should have all batches in flight at once, not one at a time."""
+    # 6 nodes / batch size 2 -> 3 batches. Deliberately kept BELOW
+    # async_utils.DEFAULT_NUM_WORKERS (4) so that the assertion measures this
+    # method's dispatch, not run_jobs' semaphore ceiling.
+    n_batches = 3
+    nodes_with_score = [
+        NodeWithScore(node=TextNode(text=f"Test{i}" if i > 1 else "Test"))
+        for i in range(1, 7)
+    ]
+    assert n_batches < DEFAULT_NUM_WORKERS
+
+    llm = MockFunctionCallingLLM()
+    llm.metadata.is_function_calling_model = True
+    llm_rerank = StructuredLLMRerank(
+        llm=llm,
+        format_node_batch_fn=mock_format_node_batch_fn,
+        choice_batch_size=2,
+        top_n=3,
+    )
+
+    in_flight = 0
+    max_in_flight = 0
+
+    original = amock_llmpredictor_structured_predict
+
+    async def tracking_predict(
+        self: Any, prompt: BasePromptTemplate, **prompt_args: Any
+    ) -> DocumentRelevanceList:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            # yield control so a sequential implementation cannot overlap
+            await asyncio.sleep(0)
+            return await original(self, prompt, **prompt_args)
+        finally:
+            in_flight -= 1
+
+    with patch.object(MockFunctionCallingLLM, "astructured_predict", tracking_predict):
+        await llm_rerank.apostprocess_nodes(nodes_with_score, QueryBundle("What is?"))
+
+    assert max_in_flight == n_batches, (
+        f"expected all {n_batches} batches in flight concurrently, "
+        f"saw at most {max_in_flight}"
+    )


### PR DESCRIPTION
# Description

`StructuredLLMRerank` did not override `_apostprocess_nodes`, so `await reranker.apostprocess_nodes(...)` fell through to the default in `BaseNodePostprocessor`:

```python
async def _apostprocess_nodes(self, nodes, query_bundle=None):
    return await asyncio.to_thread(self._postprocess_nodes, nodes, query_bundle)
```

That moves the synchronous method onto a worker thread but does not make it concurrent. The batches inside still run one at a time — the loop makes a blocking `llm.structured_predict` call per batch, sequentially — while a thread from the default executor is held for the entire chain of network calls. The async API looked async without delivering any of the benefit.

Reranking 100 nodes at the default `choice_batch_size=10` means 10 sequential LLM round-trips, even though the batches are fully independent (the existing code comments say as much: `# call each batch independently`).

This PR adds a real `_apostprocess_nodes` that dispatches all batches concurrently via `run_jobs` over `llm.astructured_predict`, following the approach used for `LLMRerank` in #22597.

To avoid duplicating ~40 lines between the sync and async paths, the shared logic is first extracted into helpers (`_get_node_batches`, `_get_predict_kwargs`, `_parse_batch_result`, `_sort_and_truncate`, and two small event helpers). Both paths now call the same code and cannot drift apart. This is why the diff is larger than the fix itself.

Note that `run_jobs` caps concurrency at `DEFAULT_NUM_WORKERS` (4) via an internal semaphore, so this is not an unbounded fan-out. `LLMRerank` uses the same bare `run_jobs([...])` call with no `workers` argument, so the behaviour is consistent with the existing precedent.

**Behavioural note:** in the async path all batches are dispatched before any result is parsed, so when a batch fails with `raise_on_structured_prediction_failure=True`, every batch has already been sent. The sync path still short-circuits on the first failure. This is inherent to fan-out and matches `LLMRerank`, but it means the async path can consume more tokens than the sync path in that specific failure case.

Sync behaviour, error message text, and emitted events are unchanged.


## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Four tests added to `tests/postprocessor/test_structured_llm_rerank.py`:

- `test_allm_rerank` — async produces the same ranking as sync
- `test_allm_rerank_errored_structured_predict[True|False]` — failure handling in async, both raise and log modes
- `test_allm_rerank_runs_batches_concurrently` — counts in-flight calls and asserts all batches overlap. It uses 3 batches, deliberately below `DEFAULT_NUM_WORKERS` (4), so the assertion measures this method's dispatch rather than `run_jobs`' semaphore ceiling.

Verification performed:

- Full `llama-index-core` suite: **1487 passed**, 22 skipped, 6 xfailed (baseline on `main` is 1483 — the 4 new tests are the difference; no regressions, no new warnings).
- The unmodified test file from `main` passes against the new implementation, confirming the existing contract holds without adapting the tests.
- Differential check, old vs new **sync** implementation over 840 configurations (node counts × batch sizes × `top_n` × failure positions × raise/log), comparing returned nodes and scores in order, exception types and exact messages, and dispatched events: **0 mismatches**.
- Differential check, old **sync** vs new **async** over the same 840 configurations, with batches rigged to complete in reverse order to stress the result-ordering assumption: **0 mismatches**.
- Confirmed `run_jobs` returns results in submission order on both of its branches — `asyncio.gather` directly, and `tqdm_asyncio.gather` (which uses `as_completed` internally but re-sorts by index before returning). The `zip(results, node_batches)` in the new code depends on this.
- Confirmed the new tests fail when the `_apostprocess_nodes` override is removed, so they measure the fix rather than passing incidentally.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI Assistance

Per the contributing guidelines: I used an AI assistant while writing this change. It was used for the mechanical helper extraction and to draft the tests. I reviewed every line, and validated the result with the differential runs described above — specifically comparing the old and new implementations over 840 configurations, and confirming the new tests fail without the fix. I understand this code and am able to maintain it.
