### PR TITLE
fix(tools/mcp): correct streamable-http tuple unpack for mcp 2.0 (#22655)

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -251,7 +251,7 @@ class BasicMCPClient(ClientSession):
                 async with streamable_http_client(
                     url=self.command_or_url,
                     http_client=self.http_client,
-                ) as (read, write, _):
+                ) as (read, write):
                     async with ClientSession(
                         read,
                         write,

--- a/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-tools-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index tools mcp integration"
 authors = [{name = "Chojan Shang", email = "psiace@outlook.com"}, {name = "Sebastian Kalisz"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -259,3 +259,49 @@ def test_enable_sse():
     # Test command-style inputs (non-URL)
     assert enable_sse("python") is False
     assert enable_sse("/usr/bin/python") is False
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_tuple_unpack():
+    """Regression test for #22655: streamable_http_client yields 2-tuple in mcp 2.0.
+
+    Previously _run_session unpacked ``(read, write, _)``, which fails when
+    streamable_http_client yields exactly two items under mcp >= 2.0.0.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    client = BasicMCPClient("https://example.com/mcp")
+
+    fake_read = MagicMock()
+    fake_write = MagicMock()
+
+    class FakeACM:
+        async def __aenter__(self):
+            return (fake_read, fake_write)
+        async def __aexit__(self, *args):
+            pass
+
+    # Mock ClientSession as an async context manager that yields a mock session
+    mock_session_instance = MagicMock()
+    mock_session_instance.initialize = AsyncMock()
+
+    class MockClientSession:
+        def __init__(self, read, write, read_timeout_seconds, sampling_callback):
+            self.read = read
+            self.write = write
+        async def __aenter__(self):
+            return mock_session_instance
+        async def __aexit__(self, *args):
+            pass
+
+    with patch(
+        "llama_index.tools.mcp.client.streamable_http_client",
+        return_value=FakeACM(),
+    ) as mock_shc, patch(
+        "llama_index.tools.mcp.client.ClientSession", MockClientSession
+    ):
+        async with client._run_session() as session:
+            pass
+
+    # streamable_http_client was called for the https endpoint
+    assert mock_shc.called

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -263,7 +263,8 @@ def test_enable_sse():
 
 @pytest.mark.asyncio
 async def test_streamable_http_tuple_unpack():
-    """Regression test for #22655: streamable_http_client yields 2-tuple in mcp 2.0.
+    """
+    Regression test for #22655: streamable_http_client yields 2-tuple in mcp 2.0.
 
     Previously _run_session unpacked ``(read, write, _)``, which fails when
     streamable_http_client yields exactly two items under mcp >= 2.0.0.
@@ -278,6 +279,7 @@ async def test_streamable_http_tuple_unpack():
     class FakeACM:
         async def __aenter__(self):
             return (fake_read, fake_write)
+
         async def __aexit__(self, *args):
             pass
 
@@ -289,16 +291,19 @@ async def test_streamable_http_tuple_unpack():
         def __init__(self, read, write, read_timeout_seconds, sampling_callback):
             self.read = read
             self.write = write
+
         async def __aenter__(self):
             return mock_session_instance
+
         async def __aexit__(self, *args):
             pass
 
-    with patch(
-        "llama_index.tools.mcp.client.streamable_http_client",
-        return_value=FakeACM(),
-    ) as mock_shc, patch(
-        "llama_index.tools.mcp.client.ClientSession", MockClientSession
+    with (
+        patch(
+            "llama_index.tools.mcp.client.streamable_http_client",
+            return_value=FakeACM(),
+        ) as mock_shc,
+        patch("llama_index.tools.mcp.client.ClientSession", MockClientSession),
     ):
         async with client._run_session() as session:
             pass


### PR DESCRIPTION
## Description

Fixes #22655

`mcp` 2.0.0 changed `streamable_http_client()` to yield a **2-tuple** `(read, write)` instead of the previous 3-tuple. `BasicMCPClient._run_session()` was still unpacking `(read, write, _)`, causing every streamable-HTTP connection to raise `ValueError: not enough values to unpack`.

## Changes

- **client.py**: Remove the trailing `_` placeholder from the tuple unpack.
- **test_client.py**: Add `test_streamable_http_tuple_unpack` regression test that mocks `streamable_http_client` as a 2-tuple ACM and verifies `_run_session()` completes without error.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added/updated unit tests for the change
- [x] `pytest tests/test_client.py::test_streamable_http_tuple_unpack` passes

---

cc @logan-markewich