### PR TITLE
fix(instrumentation): avoid shared dispatcher handler defaults

### DIFF
--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,8 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers or [],
+            span_handlers=span_handlers or [],
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,

--- a/llama-index-instrumentation/tests/test_dispatcher.py
+++ b/llama-index-instrumentation/tests/test_dispatcher.py
@@ -35,6 +35,17 @@ value_error = ValueError("value error")
 cancelled_error = CancelledError("cancelled error")
 
 
+def test_dispatcher_default_handlers_are_not_shared():
+    first = Dispatcher()
+    second = Dispatcher()
+
+    first.add_event_handler(_TestEventHandler())
+    first.span_handlers.append(None)  # type: ignore[arg-type]
+
+    assert second.event_handlers == []
+    assert second.span_handlers == []
+
+
 class _TestStartEvent(BaseEvent):
     @classmethod
     def class_name(cls):


### PR DESCRIPTION
## Summary

`Dispatcher.__init__` used mutable list defaults for event and span handlers. Although Pydantic currently copies these values, the public constructor still exposes shared mutable defaults and triggers static checks such as Ruff B006.

This changes both defaults to `None` and creates fresh lists inside the constructor, preserving the existing behavior for explicitly supplied handlers.

## Testing

- `uv run --frozen pytest tests/test_dispatcher.py` (34 passed)
- `uv run --frozen ruff check src/llama_index_instrumentation/dispatcher.py tests/test_dispatcher.py`
- `git diff --check`

Related issue: #22888
