### PR TITLE
fix(bedrock): forward Cohere embedding options

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -527,12 +527,12 @@ class BedrockEmbedding(BaseEmbedding):
             }
             payload = [payload] if isinstance(payload, str) else payload
             payload = [p[:2048] if len(p) > 2048 else p for p in payload]
-            request_body = json.dumps(
-                {
-                    "texts": payload,
-                    "input_type": input_types[input_type],
-                }
-            )
+            cohere_body_request = {
+                "texts": payload,
+                "input_type": input_types[input_type],
+                **self.additional_kwargs,
+            }
+            request_body = json.dumps(cohere_body_request)
         else:
             raise ValueError("Provider not supported")
         return request_body

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
@@ -1,3 +1,5 @@
+import json
+
 import boto3
 import pytest
 from llama_index.core.base.embeddings.base import BaseEmbedding
@@ -87,6 +89,24 @@ def test_non_empty_payload_still_builds_request_body():
 
     body = embedding._get_request_body("cohere", ["hello", "world"], "text")
     assert '"hello"' in body and '"world"' in body
+
+
+def test_cohere_additional_kwargs_are_included_in_request_body():
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    embedding = BedrockEmbedding(
+        model_name="cohere.embed-v4",
+        client=bedrock_client,
+        additional_kwargs={"output_dimension": 512, "truncate": "END"},
+    )
+
+    body = json.loads(embedding._get_request_body("cohere", ["hello"], "text"))
+
+    assert body == {
+        "texts": ["hello"],
+        "input_type": "search_document",
+        "output_dimension": 512,
+        "truncate": "END",
+    }
 
     embedding = BedrockEmbedding(
         model_name="too.many.parts.in.name", client=bedrock_client


### PR DESCRIPTION
## Summary

- Forward `additional_kwargs` when building Cohere Bedrock embedding request bodies.
- This enables Cohere-specific options such as `output_dimension` to reach the Bedrock API.
- Add a regression test covering multiple additional request fields.

## Validation

- `python -m compileall -q llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py`
- `git diff --check`
- The focused pytest command could not collect in this partial checkout because the local environment lacks the `llama_index.core` dependency.

Related issue: #22648
