### PR TITLE
feat(core): add native async support to PIINodePostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/pii.py
+++ b/llama-index-core/llama_index/core/postprocessor/pii.py
@@ -4,6 +4,7 @@ import json
 from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Tuple
 
+from llama_index.core.async_utils import run_jobs
 from llama_index.core.llms.llm import LLM
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts.base import PromptTemplate
@@ -56,21 +57,52 @@ class PIINodePostprocessor(BaseNodePostprocessor):
     def class_name(cls) -> str:
         return "PIINodePostprocessor"
 
-    def mask_pii(self, text: str) -> Tuple[str, Dict]:
-        """Mask PII in text."""
+    def _get_pii_prompt(self) -> Tuple[PromptTemplate, str]:
+        """Build the prompt and task string shared by the sync and async paths."""
         pii_prompt = PromptTemplate(self.pii_str_tmpl)
         # TODO: allow customization
         task_str = (
             "Mask out the PII, replace each PII with a tag, and return the text. "
             "Return the mapping in JSON."
         )
+        return pii_prompt, task_str
 
-        response = self.llm.predict(pii_prompt, context_str=text, query_str=task_str)
+    def _parse_pii_response(self, response: str) -> Tuple[str, Dict]:
+        """Split an LLM response into the masked text and its PII mapping."""
         splits = response.split("Output Mapping:")
         text_output = splits[0].strip()
         json_str_output = splits[1].strip()
         json_dict = json.loads(json_str_output)
         return text_output, json_dict
+
+    def _build_masked_node(
+        self,
+        node_with_score: NodeWithScore,
+        new_text: str,
+        mapping_info: Dict,
+    ) -> NodeWithScore:
+        """Copy a node, swapping in the masked text and recording the mapping."""
+        node = node_with_score.node
+        new_node = deepcopy(node)
+        new_node.excluded_embed_metadata_keys.append(self.pii_node_info_key)
+        new_node.excluded_llm_metadata_keys.append(self.pii_node_info_key)
+        new_node.metadata[self.pii_node_info_key] = mapping_info
+        new_node.set_content(new_text)
+        return NodeWithScore(node=new_node, score=node_with_score.score)
+
+    def mask_pii(self, text: str) -> Tuple[str, Dict]:
+        """Mask PII in text."""
+        pii_prompt, task_str = self._get_pii_prompt()
+        response = self.llm.predict(pii_prompt, context_str=text, query_str=task_str)
+        return self._parse_pii_response(response)
+
+    async def amask_pii(self, text: str) -> Tuple[str, Dict]:
+        """Mask PII in text (async)."""
+        pii_prompt, task_str = self._get_pii_prompt()
+        response = await self.llm.apredict(
+            pii_prompt, context_str=text, query_str=task_str
+        )
+        return self._parse_pii_response(response)
 
     def _postprocess_nodes(
         self,
@@ -81,18 +113,36 @@ class PIINodePostprocessor(BaseNodePostprocessor):
         # swap out text from nodes, with the original node mappings
         new_nodes = []
         for node_with_score in nodes:
-            node = node_with_score.node
+            # mask each node independently
             new_text, mapping_info = self.mask_pii(
-                node.get_content(metadata_mode=MetadataMode.LLM)
+                node_with_score.node.get_content(metadata_mode=MetadataMode.LLM)
             )
-            new_node = deepcopy(node)
-            new_node.excluded_embed_metadata_keys.append(self.pii_node_info_key)
-            new_node.excluded_llm_metadata_keys.append(self.pii_node_info_key)
-            new_node.metadata[self.pii_node_info_key] = mapping_info
-            new_node.set_content(new_text)
-            new_nodes.append(NodeWithScore(node=new_node, score=node_with_score.score))
+            new_nodes.append(
+                self._build_masked_node(node_with_score, new_text, mapping_info)
+            )
 
         return new_nodes
+
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """Postprocess nodes (async)."""
+        # mask each node independently, in parallel
+        results = await run_jobs(
+            [
+                self.amask_pii(
+                    node_with_score.node.get_content(metadata_mode=MetadataMode.LLM)
+                )
+                for node_with_score in nodes
+            ]
+        )
+
+        return [
+            self._build_masked_node(node_with_score, new_text, mapping_info)
+            for node_with_score, (new_text, mapping_info) in zip(nodes, results)
+        ]
 
 
 class NERPIINodePostprocessor(BaseNodePostprocessor):

--- a/llama-index-core/tests/postprocessor/test_pii.py
+++ b/llama-index-core/tests/postprocessor/test_pii.py
@@ -1,0 +1,149 @@
+"""Test PII postprocessor."""
+
+import asyncio
+import json
+from typing import Any, Dict
+
+import pytest
+from unittest.mock import patch
+
+from llama_index.core.async_utils import DEFAULT_NUM_WORKERS
+from llama_index.core.llms.mock import MockLLM
+from llama_index.core.postprocessor.pii import PIINodePostprocessor
+from llama_index.core.prompts import BasePromptTemplate
+from llama_index.core.schema import MetadataMode, NodeWithScore, TextNode
+
+PII_KEY = "__pii_node_info__"
+NAMES = {"Zhang Wei": "[NAME1]", "John": "[NAME2]"}
+
+
+def _fake_masked_response(text: str) -> str:
+    """Build a response in the shape the postprocessor parses."""
+    masked = text
+    mapping: Dict[str, str] = {}
+    for name, tag in NAMES.items():
+        if name in masked:
+            masked = masked.replace(name, tag)
+            mapping[tag] = name
+    return f"{masked}\nOutput Mapping:\n{json.dumps(mapping)}"
+
+
+def mock_predict(self: Any, prompt: BasePromptTemplate, **prompt_args: Any) -> str:
+    """Patch llm.predict."""
+    return _fake_masked_response(prompt_args["context_str"])
+
+
+async def amock_predict(
+    self: Any, prompt: BasePromptTemplate, **prompt_args: Any
+) -> str:
+    """Patch llm.apredict."""
+    return mock_predict(self, prompt, **prompt_args)
+
+
+def _nodes() -> list:
+    return [
+        NodeWithScore(node=TextNode(text="Hello Zhang Wei"), score=0.9),
+        NodeWithScore(node=TextNode(text="I am John"), score=0.5),
+        NodeWithScore(node=TextNode(text="nothing to mask here"), score=0.1),
+    ]
+
+
+def _content(node_with_score: NodeWithScore) -> str:
+    return node_with_score.node.get_content(metadata_mode=MetadataMode.NONE)
+
+
+@patch.object(MockLLM, "predict", mock_predict)
+def test_pii_postprocessor() -> None:
+    """Test PII masking, mapping metadata, and score preservation."""
+    nodes = _nodes()
+    pp = PIINodePostprocessor(llm=MockLLM())
+    results = pp.postprocess_nodes(nodes)
+
+    assert [_content(n) for n in results] == [
+        "Hello [NAME1]",
+        "I am [NAME2]",
+        "nothing to mask here",
+    ]
+    assert results[0].node.metadata[PII_KEY] == {"[NAME1]": "Zhang Wei"}
+    assert results[1].node.metadata[PII_KEY] == {"[NAME2]": "John"}
+    assert results[2].node.metadata[PII_KEY] == {}
+    # scores are carried through untouched
+    assert [n.score for n in results] == [0.9, 0.5, 0.1]
+    # the mapping must not leak back into the LLM or the embedding model
+    for n in results:
+        assert PII_KEY in n.node.excluded_llm_metadata_keys
+        assert PII_KEY in n.node.excluded_embed_metadata_keys
+
+
+@patch.object(MockLLM, "predict", mock_predict)
+def test_pii_postprocessor_does_not_mutate_input() -> None:
+    """The original nodes must be left untouched (the class deep-copies)."""
+    nodes = _nodes()
+    PIINodePostprocessor(llm=MockLLM()).postprocess_nodes(nodes)
+
+    assert [_content(n) for n in nodes] == [
+        "Hello Zhang Wei",
+        "I am John",
+        "nothing to mask here",
+    ]
+    assert all(PII_KEY not in n.node.metadata for n in nodes)
+
+
+@patch.object(MockLLM, "apredict", amock_predict)
+@pytest.mark.asyncio
+async def test_apii_postprocessor() -> None:
+    """Async masking must match the sync result exactly."""
+    nodes = _nodes()
+    pp = PIINodePostprocessor(llm=MockLLM())
+    results = await pp.apostprocess_nodes(nodes)
+
+    assert [_content(n) for n in results] == [
+        "Hello [NAME1]",
+        "I am [NAME2]",
+        "nothing to mask here",
+    ]
+    assert results[0].node.metadata[PII_KEY] == {"[NAME1]": "Zhang Wei"}
+    assert results[1].node.metadata[PII_KEY] == {"[NAME2]": "John"}
+    assert [n.score for n in results] == [0.9, 0.5, 0.1]
+
+
+@patch.object(MockLLM, "apredict", amock_predict)
+@pytest.mark.asyncio
+async def test_apii_postprocessor_empty_nodes() -> None:
+    """No nodes means no LLM calls and an empty result."""
+    pp = PIINodePostprocessor(llm=MockLLM())
+    assert await pp.apostprocess_nodes([]) == []
+
+
+@pytest.mark.asyncio
+async def test_apii_postprocessor_runs_nodes_concurrently() -> None:
+    """Every node should be masked in parallel, not one at a time."""
+    # 3 nodes, deliberately BELOW async_utils.DEFAULT_NUM_WORKERS (4) so the
+    # assertion measures this method's dispatch, not run_jobs' semaphore ceiling.
+    nodes = _nodes()
+    assert len(nodes) < DEFAULT_NUM_WORKERS
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def tracking_predict(
+        self: Any, prompt: BasePromptTemplate, **prompt_args: Any
+    ) -> str:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            # yield control so a sequential implementation cannot overlap
+            await asyncio.sleep(0)
+            return mock_predict(self, prompt, **prompt_args)
+        finally:
+            in_flight -= 1
+
+    pp = PIINodePostprocessor(llm=MockLLM())
+    with patch.object(MockLLM, "apredict", tracking_predict):
+        await pp.apostprocess_nodes(nodes)
+
+    assert max_in_flight == len(nodes), (
+        f"expected all {len(nodes)} nodes in flight concurrently, "
+        f"saw at most {max_in_flight}"
+    )


### PR DESCRIPTION
# Description

`PIINodePostprocessor` does not override `_apostprocess_nodes`, so `await postprocessor.apostprocess_nodes(...)` falls through to the default in `BaseNodePostprocessor`:

```python
async def _apostprocess_nodes(self, nodes, query_bundle=None):
    return await asyncio.to_thread(self._postprocess_nodes, nodes, query_bundle)
```

That moves the synchronous method onto a worker thread but does not make it concurrent, and here the sequential cost is unusually high because this postprocessor makes **one LLM call per node** with no batching at all:

```python
for node_with_score in nodes:
    new_text, mapping_info = self.mask_pii(...)   # -> self.llm.predict(...)
```

Retrieving 20 nodes means 20 sequential LLM round-trips, while a thread from the default executor is held for the whole chain. Unlike the rerankers there is no `choice_batch_size` to tune — the only place this can be fixed is inside the class.

This PR adds `amask_pii()` (using `llm.apredict`) and an `_apostprocess_nodes` that masks every node concurrently via `run_jobs`, following the pattern already established for `LLMRerank` (#22597) and `StructuredLLMRerank` (#22842).

Shared logic is first extracted into `_get_pii_prompt()`, `_parse_pii_response()` and `_build_masked_node()` so the sync and async paths call the same code and cannot drift apart.

### Scope

- **`NERPIINodePostprocessor` is deliberately left unchanged.** It runs a local HF `transformers` pipeline, so it is CPU-bound rather than I/O-bound and the inherited `to_thread` behaviour is the correct thing for it.
- **Response parsing is byte-identical**, including its current behaviour on malformed LLM output. Making that more robust is a separate concern already covered by other open PRs, and this change deliberately stays off it.
- `run_jobs` caps concurrency at `DEFAULT_NUM_WORKERS` (4) via an internal semaphore, so this is not an unbounded fan-out. This matches how `LLMRerank` and `StructuredLLMRerank` call it.

**Behavioural note:** in the async path every node is dispatched before any response is parsed, so a failure part-way through means all LLM calls have already been sent. The sync path still short-circuits on the first failure. This is inherent to fan-out and matches the existing rerankers.

Related to #22596, which reports the same underlying problem for `LLMRerank` ("does not actually implement async function requiring a sync function to run it async in a separate thread"). That issue is worded specifically about `LLMRerank`, so this PR does not claim to close it.

Sync behaviour is unchanged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`tests/postprocessor/test_pii.py` is a **new file** — `PIINodePostprocessor` had no test coverage at all before this PR. Five tests:

- `test_pii_postprocessor` — masking, PII mapping metadata, score preservation, and that the mapping is excluded from both LLM and embedding metadata
- `test_pii_postprocessor_does_not_mutate_input` — the original nodes are left untouched
- `test_apii_postprocessor` — async produces exactly the sync result
- `test_apii_postprocessor_empty_nodes` — empty input is a no-op
- `test_apii_postprocessor_runs_nodes_concurrently` — counts in-flight calls and asserts all nodes overlap. It uses 3 nodes, deliberately below `DEFAULT_NUM_WORKERS` (4), so the assertion measures this method's dispatch rather than `run_jobs`' semaphore ceiling.

Verification performed:

- Full `llama-index-core` suite: **1492 passed**, 22 skipped, 6 xfailed (baseline is 1487 — the 5 new tests are the difference; no regressions).
- Differential check, old vs new **sync** implementation across 0–25 nodes over a range of inputs (no PII, repeated PII, multiple entities, empty strings, unicode), comparing masked content, score, PII mapping, both `excluded_*_metadata_keys` lists, and that input nodes are never mutated: **0 mismatches**.
- Differential check, old **sync** vs new **async** over the same configurations: **0 mismatches**.
- Ordering stress test: 12 nodes with completion order fully reversed (earliest node finishes last) — every node still paired with its own mapping and score, confirming the `zip(nodes, results)` assumption holds against `run_jobs`' documented ordering.
- Confirmed the async tests fail when the `_apostprocess_nodes` override is removed, so they measure the fix rather than passing incidentally.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI Assistance

Per the contributing guidelines: I used an AI assistant while writing this change. It was used for the mechanical helper extraction and to draft the tests. I reviewed every line, and validated the result with the differential and ordering runs described above. I understand this code and am able to maintain it.
