### PR TITLE
fix(core): fall back to plain-text read when nltk 3.10.3+ rejects hardlinked stopwords

### DIFF
--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -101,17 +101,37 @@ class GlobalsHelper:
         except Exception as e:
             print(f"NLTK download error: {e}")
 
+    def _load_stopwords(self) -> List[str]:
+        """
+        Return English stopwords, falling back to a direct file read if nltk's
+        corpus reader rejects the bundled data due to the CWE-59 hardlink check
+        introduced in nltk 3.10.3 (pathsec.open raises PermissionError when
+        st_nlink > 1).
+        """
+        from nltk.corpus import stopwords
+
+        try:
+            return stopwords.words("english")
+        except PermissionError:
+            # The installed package stores the stopwords file with st_nlink > 1
+            # (e.g. hardlinked by pip or the build toolchain).  Read the
+            # plain-text file directly to avoid the security gate.
+            if self._nltk_data_dir is None:
+                raise
+            stopwords_path = (
+                Path(self._nltk_data_dir) / "corpora" / "stopwords" / "english"
+            )
+            return stopwords_path.read_text(encoding="utf-8").splitlines()
+
     @property
     def stopwords(self) -> List[str]:
         """Get stopwords, ensuring data is downloaded."""
         if self._stopwords is None:
-            # Wait for stopwords to be available
             self.wait_for_nltk_check()
 
-            from nltk.corpus import stopwords
             from nltk.tokenize import PunktSentenceTokenizer
 
-            self._stopwords = stopwords.words("english")
+            self._stopwords = self._load_stopwords()
             self._punkt_tokenizer = PunktSentenceTokenizer()
 
         return self._stopwords
@@ -120,14 +140,12 @@ class GlobalsHelper:
     def punkt_tokenizer(self) -> "PunktSentenceTokenizer":
         """Get punkt tokenizer, ensuring data is downloaded."""
         if self._punkt_tokenizer is None:
-            # Wait for punkt to be available
             self.wait_for_nltk_check()
 
-            from nltk.corpus import stopwords
             from nltk.tokenize import PunktSentenceTokenizer
 
             self._punkt_tokenizer = PunktSentenceTokenizer()
-            self._stopwords = stopwords.words("english")
+            self._stopwords = self._load_stopwords()
 
         return self._punkt_tokenizer
 

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -353,3 +353,34 @@ def test_get_cache_dir_env_var_precedence(tmp_path, monkeypatch) -> None:
         mock_user_cache_dir.return_value = "/should/not/be/used"
         get_cache_dir()
         mock_user_cache_dir.assert_not_called()
+
+
+def test_globals_helper_stopwords_fallback_on_permission_error(tmp_path: Path) -> None:
+    """
+    GlobalsHelper.stopwords reads bundled plain-text file when nltk raises
+    PermissionError (st_nlink > 1 hardlink check introduced in nltk 3.10.3).
+    """
+    from llama_index.core.utils import GlobalsHelper
+
+    # Minimal English stopwords bundled file
+    sw_dir = tmp_path / "corpora" / "stopwords"
+    sw_dir.mkdir(parents=True)
+    (sw_dir / "english").write_text("the\na\nan\n", encoding="utf-8")
+
+    helper = GlobalsHelper()
+    # Reset class-level cache so the property body actually runs
+    helper._stopwords = None
+    helper._punkt_tokenizer = None
+    helper._nltk_data_dir = str(tmp_path)
+
+    with mock.patch.object(helper, "wait_for_nltk_check"):
+        with mock.patch(
+            "nltk.corpus.stopwords.words",
+            side_effect=PermissionError(
+                "Security Violation [pathsec]: multiply-linked file"
+            ),
+        ):
+            with mock.patch("nltk.tokenize.PunktSentenceTokenizer"):
+                result = helper.stopwords
+
+    assert result == ["the", "a", "an"]


### PR DESCRIPTION
## Summary

Fixes #22839

nltk 3.10.3 introduced a CWE-59 hardlink security check (`pathsec.open`) that raises `PermissionError` when a file has `st_nlink > 1`. Some pip / build-toolchain configurations install the bundled `nltk_cache/corpora/stopwords/english` file with `st_nlink=2`, causing the corpus reader to fail on every invocation.

**Changes:**
- Extract `GlobalsHelper._load_stopwords()` helper (previously inlined at two call-sites).
- Catch `PermissionError` in `_load_stopwords()` and fall back to reading the bundled plain-text stopwords file directly, bypassing the hardlink security gate.
- Guard the fallback with `if self._nltk_data_dir is None: raise` so it only activates when the data directory is actually initialised.
- Add `test_globals_helper_stopwords_fallback_on_permission_error` regression test.

## Root cause

```
PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
  '.../_static/nltk_cache/corpora/stopwords/english' (st_nlink=2)
```

The English stopwords corpus is a plain newline-delimited text file. Reading it directly avoids the corpus-reader's hardlink check while still returning the same data.

## Test plan

- [x] `test_globals_helper_stopwords_fallback_on_permission_error` — mocks `nltk.corpus.stopwords.words` to raise `PermissionError` and asserts the fallback returns the correct word list.
- [x] All pre-commit hooks pass (ruff, mypy, codespell).
- [x] Existing `test_utils.py` suite unaffected.