### PR TITLE
fix(cohere-rerank): catch KeyError when COHERE_API_KEY is missing to raise intended ValueError (#22774)

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -72,7 +72,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except (KeyError, IndexError):
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "

--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/tests/test_postprocessor_cohere_rerank.py
@@ -103,3 +103,12 @@ def test_max_retries_parameter():
 
         reranker_default = CohereRerank(api_key="test_key")
         assert reranker_default.max_retries == 10
+
+
+def test_missing_api_key_raises_value_error():
+    """Test that missing api_key raises ValueError when environment variable is not set (#22774)."""
+    import pytest
+
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="Must pass in cohere api key"):
+            CohereRerank(api_key=None)


### PR DESCRIPTION
## Summary

Fixes #22774.

In `CohereRerank.__init__`, looking up `os.environ["COHERE_API_KEY"]` raises a `KeyError` when unset, but the `try` block only caught `IndexError`, causing a raw `KeyError` instead of the intended helpful `ValueError`.

### Changes
- Updated `except IndexError:` to `except (KeyError, IndexError):` in `llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py`.
- Added unit test `test_missing_api_key_raises_value_error` in `tests/test_postprocessor_cohere_rerank.py`.