### PR TITLE
fix(core): fallback to original node content when target metadata key is None (#22772)

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
+++ b/llama-index-core/llama_index/core/postprocessor/metadata_replacement.py
@@ -23,11 +23,9 @@ class MetadataReplacementPostProcessor(BaseNodePostprocessor):
         query_bundle: Optional[QueryBundle] = None,
     ) -> List[NodeWithScore]:
         for n in nodes:
-            n.node.set_content(
-                n.node.metadata.get(
-                    self.target_metadata_key,
-                    n.node.get_content(metadata_mode=MetadataMode.NONE),
-                )
-            )
+            replacement = n.node.metadata.get(self.target_metadata_key)
+            if replacement is None:
+                replacement = n.node.get_content(metadata_mode=MetadataMode.NONE)
+            n.node.set_content(replacement)
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_metadata_replacement.py
+++ b/llama-index-core/tests/postprocessor/test_metadata_replacement.py
@@ -15,3 +15,19 @@ def test_metadata_replacement() -> None:
 
     assert len(nodes) == 1
     assert nodes[0].node.get_content() == "This is a another test."
+
+
+def test_metadata_replacement_none_fallback() -> None:
+    """Test that explicit None in target metadata key falls back to original content (#22772)."""
+    node = TextNode(
+        text="Original text", metadata={"key": None}
+    )
+
+    nodes = [NodeWithScore(node=node, score=1.0)]
+
+    postprocessor = MetadataReplacementPostProcessor(target_metadata_key="key")
+
+    nodes = postprocessor.postprocess_nodes(nodes)
+
+    assert len(nodes) == 1
+    assert nodes[0].node.get_content() == "Original text"


### PR DESCRIPTION
## Summary

Fixes #22772.

`MetadataReplacementPostProcessor._postprocess_nodes` crashed with a Pydantic `ValidationError` when `target_metadata_key` was explicitly `None` in node metadata, because `dict.get(key, default)` returns `None` instead of falling back to the default.

### Changes
- Explicitly check if the retrieved metadata replacement is `None` before calling `set_content`, falling back to `n.node.get_content(metadata_mode=MetadataMode.NONE)`.
- Added unit test `test_metadata_replacement_none_fallback` in `llama-index-core/tests/postprocessor/test_metadata_replacement.py`.