### PR TITLE
docs: add Rostam to the vector store integrations list

### DIFF
--- a/docs/src/content/docs/framework/community/integrations/vector_stores.md
+++ b/docs/src/content/docs/framework/community/integrations/vector_stores.md
@@ -47,6 +47,7 @@ as the storage backend for `VectorStoreIndex`.
 - LanceDB (`LanceDBVectorStore`) [Installation/Quickstart](https://lancedb.github.io/lancedb/basic/)
 - Redis (`RedisVectorStore`). [Installation](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/).
 - Relyt (`RelytVectorStore`). [Quickstart](https://docs.relyt.cn/docs/vector-engine/).
+- Rostam (`RostamVectorStore`). [Quickstart](https://docs.rostamlabs.com/). [Python Client](https://pypi.org/project/llama-index-vector-stores-rostam/).
 - Supabase (`SupabaseVectorStore`). [Quickstart](https://supabase.github.io/vecs/api/).
 - Tablestore (`Tablestore`). [Tablestore Overview](https://www.aliyun.com/product/ots). [Quickstart](/python/examples/vector_stores/tablestoredemo). [Python Client](https://github.com/aliyun/aliyun-tablestore-python-sdk).
 - TiDB (`TiDBVectorStore`). [Quickstart](/python/examples/vector_stores/tidbvector). [Installation](https://tidb.cloud/ai). [Python Client](https://github.com/pingcap/tidb-vector-python).

--- a/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/vector_stores.md
@@ -52,6 +52,7 @@ We are actively adding more integrations and improving feature coverage for each
 | pgvecto.rs                 | self-hosted / cloud     | ✓                  | ✓             | ✓      | ✓               |                               |
 | Qdrant                     | self-hosted / cloud     | ✓                  | ✓             | ✓      | ✓               | ✓                             |
 | Redis                      | self-hosted / cloud     | ✓                  |               | ✓      | ✓               |                               |
+| Rostam                     | self-hosted             | ✓                  | ✓             | ✓      | ✓               | ✓                             |
 | S3                         | cloud                   | ✓                  |               | ✓      | ✓               | ✓\* (using asyncio.to_thread) |
 | Simple                     | in-memory               | ✓                  |               | ✓      |                 |                               |
 | SingleStore                | self-hosted / cloud     | ✓                  |               | ✓      | ✓               |                               |


### PR DESCRIPTION
# Description

Adds **Rostam** (`RostamVectorStore`) to the vector store integration docs, so it shows up alongside the other supported vector stores.

[Rostam](https://rostamlabs.com) is a self-hosted vector database and sub-microsecond key-value store in a single Go engine. The LlamaIndex integration is published on PyPI as [`llama-index-vector-stores-rostam`](https://pypi.org/project/llama-index-vector-stores-rostam/) and imports as `llama_index.vector_stores.rostam`. `RostamVectorStore` implements `BasePydanticVectorStore` with add/query/delete, async variants, metadata filtering, and hybrid (dense + full-text) search.

This is a **docs-only** change (no new `pyproject.toml`), consistent with the current policy of not accepting new integration packages in the monorepo. It follows the existing precedent for externally-maintained integrations that are listed in these pages (e.g. Google AlloyDB and Cloud SQL for PostgreSQL).

Changes:

- `framework/community/integrations/vector_stores.md` — add Rostam to the "Using a Vector Store as an Index" list.
- `framework/module_guides/storing/vector_stores.md` — add a Rostam row to the "Vector Store Options & Feature Support" table.

Fixes # (n/a)

## New Package?

No — this is documentation only; no package is added to the monorepo.

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

Documentation-only change. Verified the added table row is byte-aligned with the surrounding rows and that the new list entry matches the existing formatting.

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
