### PR TITLE
fix(core): dehardlink bundled nltk cache to survive nltk 3.10.3+ pathsec check

### DIFF
--- a/llama-index-core/llama_index/core/indices/keyword_table/utils.py
+++ b/llama-index-core/llama_index/core/indices/keyword_table/utils.py
@@ -36,6 +36,10 @@ def rake_extract_keywords(
     except ImportError:
         raise ImportError("Please install rake_nltk: `pip install rake_nltk`")
 
+    # ensures nltk.data.path points at our (hardlink-safe) bundled cache and
+    # that punkt_tab is present before sent_tokenize/wordpunct_tokenize need it
+    globals_helper.wait_for_nltk_check()
+
     r = Rake(
         sentence_tokenizer=nltk.tokenize.sent_tokenize,
         word_tokenizer=nltk.tokenize.wordpunct_tokenize,

--- a/llama-index-core/llama_index/core/utils.py
+++ b/llama-index-core/llama_index/core/utils.py
@@ -5,6 +5,7 @@ import base64
 import inspect
 import os
 import random
+import shutil
 import sys
 import time
 import traceback
@@ -52,26 +53,28 @@ class GlobalsHelper:
         """Initialize NLTK data download."""
         from nltk.data import path as nltk_path
 
-        # Set up NLTK data directory
-        if "NLTK_DATA" in os.environ:
-            self._nltk_data_dir = str(Path(os.environ["NLTK_DATA"]))
-        else:
-            # 1. Check for bundled static cache first
-            bundled_path = (
-                Path(os.path.dirname(os.path.abspath(__file__))) / "_static/nltk_cache"
-            )
-
-            # Use bundled cache ONLY if it exists and is not empty
-            if bundled_path.exists() and any(bundled_path.iterdir()):
-                self._nltk_data_dir = str(bundled_path)
+        if self._nltk_data_dir is None:
+            # Set up NLTK data directory
+            if "NLTK_DATA" in os.environ:
+                self._nltk_data_dir = str(Path(os.environ["NLTK_DATA"]))
             else:
-                # 2. Fallback to user cache (prevents crash if bundled cache is missing)
-                path = Path(platformdirs.user_cache_dir("llama_index"))
-                self._nltk_data_dir = str(path / "_static/nltk_cache")
+                # 1. Check for bundled static cache first
+                bundled_path = (
+                    Path(os.path.dirname(os.path.abspath(__file__)))
+                    / "_static/nltk_cache"
+                )
 
-        # Ensure the directory exists
-        if not os.path.exists(self._nltk_data_dir):
-            os.makedirs(self._nltk_data_dir, exist_ok=True)
+                # Use bundled cache ONLY if it exists and is not empty
+                if bundled_path.exists() and any(bundled_path.iterdir()):
+                    self._nltk_data_dir = str(self._reject_hardlinks(bundled_path))
+                else:
+                    # 2. Fallback to user cache (prevents crash if bundled cache is missing)
+                    path = Path(platformdirs.user_cache_dir("llama_index"))
+                    self._nltk_data_dir = str(path / "_static/nltk_cache")
+
+            # Ensure the directory exists
+            if not os.path.exists(self._nltk_data_dir):
+                os.makedirs(self._nltk_data_dir, exist_ok=True)
 
         # Add to NLTK path if not already present
         if self._nltk_data_dir not in nltk_path:
@@ -79,6 +82,33 @@ class GlobalsHelper:
 
         # Start downloading NLTK data / confirming it's available
         self._download_nltk_data()
+
+    @staticmethod
+    def _reject_hardlinks(bundled_path: Path) -> Path:
+        """
+        Nltk >= 3.10.3 refuses to read a resource file with st_nlink > 1
+        (pathsec's CWE-59 hardlink guard). Some pip/build toolchains install
+        the packages under _static/nltk_cache (stopwords, punkt_tab, ...) as
+        hardlinks, which trips that guard on every resource in the bundle,
+        not just the one a caller happens to touch first. If that's the
+        case here, copy the whole tree once into a private cache directory
+        so every file we hand to nltk has a single link.
+        """
+        try:
+            if not any(
+                f.is_file() and os.stat(f).st_nlink > 1 for f in bundled_path.rglob("*")
+            ):
+                return bundled_path
+
+            private_dir = (
+                Path(platformdirs.user_cache_dir("llama_index"))
+                / "_static"
+                / "nltk_cache_no_hardlinks"
+            )
+            shutil.copytree(bundled_path, private_dir, dirs_exist_ok=True)
+            return private_dir
+        except OSError:
+            return bundled_path
 
     def _download_nltk_data(self) -> None:
         """Download NLTK data packages in the background."""

--- a/llama-index-core/tests/indices/keyword_table/test_utils.py
+++ b/llama-index-core/tests/indices/keyword_table/test_utils.py
@@ -1,7 +1,10 @@
 """Test utils."""
 
+from unittest import mock
+
 from llama_index.core.indices.keyword_table.utils import (
     extract_keywords_given_response,
+    rake_extract_keywords,
 )
 
 
@@ -38,3 +41,20 @@ def test_extract_keywords_with_start_delimiter() -> None:
         "bar",
         "foobar",
     }
+
+
+def test_rake_extract_keywords_ensures_nltk_data_dir_is_ready() -> None:
+    """
+    rake_extract_keywords reads punkt_tab via nltk.tokenize.sent_tokenize,
+    which is bundled in _static/nltk_cache the same way stopwords is and is
+    subject to the same nltk >= 3.10.3 hardlink rejection. It must go
+    through wait_for_nltk_check() (like the stopwords/punkt_tokenizer
+    properties already do) instead of relying on nltk's own default,
+    unprotected resource lookup.
+    """
+    with mock.patch(
+        "llama_index.core.indices.keyword_table.utils.globals_helper"
+    ) as mock_globals_helper:
+        rake_extract_keywords("Hello world, this is a test.", max_keywords=5)
+
+    mock_globals_helper.wait_for_nltk_check.assert_called_once()

--- a/llama-index-core/tests/test_utils.py
+++ b/llama-index-core/tests/test_utils.py
@@ -12,6 +12,7 @@ from llama_index.core.utils import (
     _ANSI_COLORS,
     _LLAMA_INDEX_COLORS,
     ErrorToRetry,
+    GlobalsHelper,
     aretry_on_exceptions_with_backoff,
     _get_colored_text,
     get_cache_dir,
@@ -353,3 +354,71 @@ def test_get_cache_dir_env_var_precedence(tmp_path, monkeypatch) -> None:
         mock_user_cache_dir.return_value = "/should/not/be/used"
         get_cache_dir()
         mock_user_cache_dir.assert_not_called()
+
+
+def test_reject_hardlinks_dehardlinks_when_needed(tmp_path, monkeypatch) -> None:
+    bundled = tmp_path / "bundled" / "corpora" / "stopwords"
+    bundled.mkdir(parents=True)
+    source = bundled / "source"
+    source.write_text("the\na\nan\n", encoding="utf-8")
+    target = bundled / "english"
+    os.link(source, target)  # st_nlink=2, same shape as the reported pip install
+
+    monkeypatch.setattr(
+        "platformdirs.user_cache_dir", lambda name: str(tmp_path / "private_cache")
+    )
+
+    result = GlobalsHelper._reject_hardlinks(tmp_path / "bundled")
+
+    assert result != tmp_path / "bundled"
+    copied = result / "corpora" / "stopwords" / "english"
+    assert copied.read_text(encoding="utf-8") == "the\na\nan\n"
+    assert os.stat(copied).st_nlink == 1
+
+
+def test_reject_hardlinks_noop_when_no_hardlinks(tmp_path, monkeypatch) -> None:
+    bundled = tmp_path / "bundled" / "corpora" / "stopwords"
+    bundled.mkdir(parents=True)
+    (bundled / "english").write_text("the\na\nan\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "platformdirs.user_cache_dir", lambda name: str(tmp_path / "private_cache")
+    )
+
+    result = GlobalsHelper._reject_hardlinks(tmp_path / "bundled")
+
+    assert result == tmp_path / "bundled"
+    assert not (tmp_path / "private_cache").exists()
+
+
+def test_wait_for_nltk_check_dehardlinks_bundled_cache(tmp_path, monkeypatch) -> None:
+    """
+    Regression test for nltk >= 3.10.3's pathsec hardlink guard: a bundled
+    _static/nltk_cache directory where files were installed as hardlinks
+    (st_nlink > 1, as some pip/build toolchains do) must be transparently
+    swapped for a private, single-linked copy so nltk can read from it.
+    """
+    fake_core_dir = tmp_path / "core"
+    bundled = fake_core_dir / "_static" / "nltk_cache" / "corpora" / "stopwords"
+    bundled.mkdir(parents=True)
+    source = bundled / "source"
+    source.write_text("the\na\n", encoding="utf-8")
+    os.link(source, bundled / "english")
+
+    monkeypatch.delenv("NLTK_DATA", raising=False)
+    monkeypatch.setattr(
+        "llama_index.core.utils.__file__", str(fake_core_dir / "utils.py")
+    )
+    monkeypatch.setattr(
+        "platformdirs.user_cache_dir", lambda name: str(tmp_path / "private_cache")
+    )
+
+    helper = GlobalsHelper()
+    with mock.patch.object(helper, "_download_nltk_data"):
+        helper.wait_for_nltk_check()
+
+    resolved = Path(helper._nltk_data_dir)
+    assert resolved != fake_core_dir / "_static" / "nltk_cache"
+    resolved_file = resolved / "corpora" / "stopwords" / "english"
+    assert resolved_file.read_text(encoding="utf-8") == "the\na\n"
+    assert os.stat(resolved_file).st_nlink == 1


### PR DESCRIPTION
Fixes #22839

nltk 3.10.3 added a hardlink guard (pathsec) that refuses to open any resource file with `st_nlink > 1`. Some pip/build toolchains install `_static/nltk_cache` as hardlinks, which breaks not just stopwords but also `punkt_tab` — used directly by `rake_extract_keywords`/`RAKEKeywordTableIndex` via `nltk.tokenize.sent_tokenize`, a path #22850 doesn't touch.

Instead of catching `PermissionError` at each call site, this detects hardlinked files in the bundled cache once in `wait_for_nltk_check()` and copies the tree to a private, single-linked cache directory before nltk touches it — covering both current bundled resources and any added later. Also routes `rake_extract_keywords` through `wait_for_nltk_check()` so it reliably uses that directory.

`llama-index-core` is exempt from the package version bump requirement, so no `pyproject.toml` change here.

AI disclosure: used Claude Code to help trace the punkt_tab code path and draft this fix and its tests; reviewed the diff and reasoning and ran the test/lint suite before opening this.