### PR TITLE
fix: keep TokenTextSplitter chunks within chunk_size after stripping

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -193,6 +193,26 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                 new_splits.extend(self._split(split, chunk_size=chunk_size))
         return new_splits
 
+    def _leading_strip_delta(self, split: str) -> int:
+        """
+        Tokens gained when a chunk's first split loses its leading whitespace.
+
+        Splits carry their leading separator, so a chunk is budgeted from splits
+        like `" jumps"` but emitted as `"jumps"` once `.strip()` runs. Those do not
+        always cost the same: with the default tokenizer `" jumps"` is one token
+        and `"jumps"` is two, so a chunk budgeted at exactly `chunk_size` can be
+        emitted one token over it. Counting that difference up front keeps the
+        budget measuring the text this actually emits.
+        """
+        if self.keep_whitespaces:
+            return 0
+
+        stripped = split.lstrip()
+        if stripped == split:
+            return 0
+
+        return len(self._tokenizer(stripped)) - len(self._tokenizer(split))
+
     def _merge(self, splits: List[str], chunk_size: int) -> List[str]:
         """
         Merge splits into chunks.
@@ -207,6 +227,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
 
         cur_chunk: List[str] = []
         cur_len = 0
+        head_delta = 0
         for split in splits:
             split_len = len(self._tokenizer(split))
             if split_len > chunk_size:
@@ -217,7 +238,7 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
 
             # if we exceed the chunk size after adding the new split, then
             # we need to end the current chunk and start a new one
-            if cur_len + split_len > chunk_size:
+            if cur_len + head_delta + split_len > chunk_size:
                 # end the previous chunk
                 chunk = (
                     "".join(cur_chunk)
@@ -232,11 +253,18 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                 #   1. the current chunk length is less than chunk overlap
                 #   2. the total length is less than chunk size
                 while cur_chunk and (
-                    cur_len > self.chunk_overlap or cur_len + split_len > chunk_size
+                    cur_len + head_delta > self.chunk_overlap
+                    or cur_len + head_delta + split_len > chunk_size
                 ):
                     # pop off the first element
                     first_chunk = cur_chunk.pop(0)
                     cur_len -= len(self._tokenizer(first_chunk))
+                    head_delta = (
+                        self._leading_strip_delta(cur_chunk[0]) if cur_chunk else 0
+                    )
+
+            if not cur_chunk:
+                head_delta = self._leading_strip_delta(split)
 
             cur_chunk.append(split)
             cur_len += split_len

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -89,3 +89,23 @@ def test_split_with_metadata(english_text: str) -> None:
     for chunk in chunks:
         node_content = chunk + metadata_str
         assert len(tokenizer.encode(node_content)) <= 100
+
+
+def test_chunks_do_not_exceed_chunk_size_after_stripping() -> None:
+    """
+    Chunks are budgeted from splits that carry their leading separator, but
+    emitted stripped. With the default tokenizer `" jumps"` is one token while
+    `"jumps"` is two, so a chunk budgeted at exactly chunk_size used to be emitted
+    one token over it.
+    """
+    tokenizer = tiktoken.get_encoding("gpt2")
+    text = "The quick brown fox jumps over the lazy dog. " * 4
+    splitter = TokenTextSplitter(
+        chunk_size=12, chunk_overlap=4, tokenizer=tokenizer.encode
+    )
+
+    chunks = splitter.split_text(text)
+
+    assert chunks
+    for chunk in chunks:
+        assert len(tokenizer.encode(chunk)) <= 12


### PR DESCRIPTION
# Description

`TokenTextSplitter._merge()` budgets from splits that carry their leading separator, but emits the chunk stripped:

```python
chunk = "".join(cur_chunk) if self.keep_whitespaces else "".join(cur_chunk).strip()
```

Those two do not always cost the same. With the default tokenizer `" jumps"` is one token and `"jumps"` is two, so a chunk budgeted at exactly `chunk_size` gains a token when `.strip()` removes the leading space of its first split, and is emitted one token over the limit.

It happens on ordinary prose at realistic sizes, not only tiny ones. 4000 words with `chunk_overlap=20`:

| chunk_size | chunks | over the limit |
| --- | --- | --- |
| 128 | 37 | 2 (129 tokens) |
| 256 | 17 | 2 (257 tokens) |
| 512 | 9 | 1 (513 tokens) |

Setting `chunk_size` to an embedding model's real input limit is the usual reason to set it at all, so a chunk that goes over comes back as a 400 or gets silently truncated, for a chunk the splitter reported as within budget.

The fix counts that difference once when a chunk's first split is chosen and carries it in the running total, so the budget measures the text actually emitted. Only chunks that would have overflowed change, and the extra tokenizer call happens once per chunk boundary rather than once per split.

Fixes #22858

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

`test_chunks_do_not_exceed_chunk_size_after_stripping` reproduces the reported case and asserts every chunk stays within `chunk_size`. It fails on `main` and passes with this change.

Before, on `main`:

```
$ python -c "
from llama_index.core.node_parser import TokenTextSplitter
from llama_index.core.utils import get_tokenizer
tok = get_tokenizer()
text = 'The quick brown fox jumps over the lazy dog. ' * 4
for c in TokenTextSplitter(chunk_size=12, chunk_overlap=4).split_text(text):
    n = len(tok(c)); print(f\"{n:3d} {'OVER' if n > 12 else '    '} {c!r}\")
"
 12      'The quick brown fox jumps over the lazy dog. The quick'
 12      'dog. The quick brown fox jumps over the lazy dog.'
 12      'the lazy dog. The quick brown fox jumps over the lazy'
 13 OVER 'jumps over the lazy dog. The quick brown fox jumps over'
  8      'brown fox jumps over the lazy dog.'
```

After, same command on this branch:

```
 12      'The quick brown fox jumps over the lazy dog. The quick'
 12      'dog. The quick brown fox jumps over the lazy dog.'
 12      'the lazy dog. The quick brown fox jumps over the lazy'
 12      'jumps over the lazy dog. The quick brown fox jumps'
  9      'over brown fox jumps over the lazy dog.'
```

Full `llama-index-core` suite, same 4 pre-existing failures before and after this change (2 in `tests/ingestion/test_pipeline.py`, 2 in `tests/postprocessor/test_base.py`, all failing on a clean tree for unrelated import reasons):

```
$ pytest tests/ -q --ignore=tests/node_parser/test_markdown_element.py
main:        5 failed, 1464 passed   (the 5th is the new regression test)
this branch: 4 failed, 1465 passed
```

`ruff check` and `ruff format --check` are clean on both changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
