### PR TITLE
fix(core): defer ingestion hash persistence until transforms succeed

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -460,7 +460,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                self.docstore.set_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 
@@ -695,7 +694,6 @@ class IngestionPipeline(BaseModel):
         nodes_to_run = []
         for node in nodes:
             if node.hash not in existing_hashes and node.hash not in current_hashes:
-                await self.docstore.aset_document_hash(node.id_, node.hash)
                 nodes_to_run.append(node)
                 current_hashes.add(node.hash)
 

--- a/llama-index-core/tests/ingestion/test_pipeline.py
+++ b/llama-index-core/tests/ingestion/test_pipeline.py
@@ -397,7 +397,16 @@ def test_pipeline_with_transform_error() -> None:
     with pytest.raises(RuntimeError):
         pipeline.run(documents=[document1])
 
+    assert pipeline.docstore is not None
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert pipeline.docstore.get_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    assert len(retry_pipeline.run(documents=[document1])) == 1
 
 
 @pytest.mark.asyncio
@@ -637,7 +646,16 @@ async def test_async_pipeline_with_transform_error() -> None:
     with pytest.raises(RuntimeError):
         await pipeline.arun(documents=[document1])
 
+    assert pipeline.docstore is not None
     assert pipeline.docstore.get_node("1", raise_error=False) is None
+    assert await pipeline.docstore.aget_document_hash("1") is None
+
+    retry_pipeline = IngestionPipeline(
+        transformations=[],
+        docstore=pipeline.docstore,
+        docstore_strategy=DocstoreStrategy.DUPLICATES_ONLY,
+    )
+    assert len(await retry_pipeline.arun(documents=[document1])) == 1
 
 
 def test_docstore_strategy_not_mutated_on_run_without_vector_store() -> None:


### PR DESCRIPTION
## Summary

- Defer document-hash persistence in the synchronous and asynchronous duplicate-handling paths until the transformed nodes are successfully written to the docstore.
- Add regression coverage showing that a failed transformation does not poison the hash and a later retry ingests the document.

Fixes #22638

## Test plan

- `python -m pytest tests/ingestion/test_pipeline.py -k "transform_error" -q`
- `python -m pytest tests/ingestion/test_pipeline.py -q`
- `ruff check llama_index/core/ingestion/pipeline.py tests/ingestion/test_pipeline.py`

## AI assistance

This PR was prepared with AI assistance. The change was reviewed against the current ingestion and docstore implementations, and the targeted regression tests plus the full ingestion pipeline test file were run locally.