### PR TITLE
fix(core): reject out-of-range reranker choices

### DIFF
--- a/llama-index-core/llama_index/core/indices/utils.py
+++ b/llama-index-core/llama_index/core/indices/utils.py
@@ -146,7 +146,7 @@ def default_parse_choice_select_answer_fn(
                     "Answer line must be of the form: "
                     "answer_num: <int>, answer_relevance: <float>"
                 )
-        if answer_num > num_choices:
+        if answer_num < 1 or answer_num > num_choices:
             continue
         answer_nums.append(answer_num)
         # extract just the first digits after the colon.

--- a/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
+++ b/llama-index-core/llama_index/core/postprocessor/llm_rerank.py
@@ -101,9 +101,16 @@ class LLMRerank(BaseNodePostprocessor):
         raw_choices, relevances = self._parse_choice_select_answer_fn(
             raw_response, len(nodes_batch)
         )
-        choice_idxs = [int(choice) - 1 for choice in raw_choices]
-        choice_nodes = [nodes_batch[idx] for idx in choice_idxs]
-        relevances = relevances or [1.0 for _ in choice_nodes]
+        valid_choices = []
+        for choice, relevance in zip(
+            raw_choices, relevances or [1.0 for _ in raw_choices]
+        ):
+            choice_idx = int(choice) - 1
+            if 0 <= choice_idx < len(nodes_batch):
+                valid_choices.append((choice_idx, relevance))
+
+        choice_nodes = [nodes_batch[idx] for idx, _ in valid_choices]
+        relevances = [relevance for _, relevance in valid_choices]
         return [
             NodeWithScore(node=node, score=relevance)
             for node, relevance in zip(choice_nodes, relevances)

--- a/llama-index-core/tests/indices/test_utils.py
+++ b/llama-index-core/tests/indices/test_utils.py
@@ -34,3 +34,19 @@ def test_default_parse_choice_select_answer_fn(answer):
     answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
     assert answer_nums == [2, 4]
     assert answer_relevances == [8, 6]
+
+
+def test_default_parse_choice_select_answer_fn_skips_out_of_range_choices():
+    from llama_index.core.indices.utils import default_parse_choice_select_answer_fn
+
+    answer = (
+        "Doc: 0, Relevance: 9\n"
+        "Doc: -2, Relevance: 8\n"
+        "Doc: 2, Relevance: 7\n"
+        "Doc: 6, Relevance: 6"
+    )
+
+    answer_nums, answer_relevances = default_parse_choice_select_answer_fn(answer, 5)
+
+    assert answer_nums == [2]
+    assert answer_relevances == [7]

--- a/llama-index-core/tests/postprocessor/test_llm_rerank.py
+++ b/llama-index-core/tests/postprocessor/test_llm_rerank.py
@@ -204,6 +204,25 @@ def test_llm_rerank_multimodal(png_1px_b64, mp3_bytes, mp4_bytes) -> None:
     assert result_nodes[3].node.get_content_blocks() == [TextBlock(text="Test3")]
 
 
+def test_llm_rerank_filters_invalid_custom_choices() -> None:
+    """Test that custom parsers cannot select nodes outside the current batch."""
+
+    def parse_choices(_raw_response: str, _num_choices: int):
+        return [0, 2, 4], [0.9, 0.8, 0.7]
+
+    nodes = [TextNode(text=f"Document {idx}") for idx in range(3)]
+    llm_rerank = LLMRerank(
+        llm=MockLLM(),
+        parse_choice_select_answer_fn=parse_choices,
+    )
+
+    result_nodes = llm_rerank._parse_raw_response("ignored", nodes)
+
+    assert len(result_nodes) == 1
+    assert result_nodes[0].node.get_content() == "Document 1"
+    assert result_nodes[0].score == 0.8
+
+
 @patch.object(
     MockLLM,
     "chat",


### PR DESCRIPTION
## Summary

- Reject choice numbers below 1 in the default choice-select parser.
- Filter invalid indexes from custom parsers before indexing the current node batch.
- Keep relevance scores paired with the valid choices that survive filtering.
- Add regression coverage for zero, negative, and high choice numbers.

Fixes #22743

## Test plan

- `python -m pytest llama-index-core/tests/indices/test_utils.py llama-index-core/tests/postprocessor/test_llm_rerank.py -q`
- `ruff check llama-index-core/llama_index/core/indices/utils.py llama-index-core/llama_index/core/postprocessor/llm_rerank.py llama-index-core/tests/indices/test_utils.py llama-index-core/tests/postprocessor/test_llm_rerank.py`

Both test files passed (10 tests).

## AI assistance

This PR was prepared with AI assistance. The change was reviewed against the parser and reranker call path, and the regression tests plus lint checks were run locally.