### PR TITLE
fix(core): keep TokenTextSplitter chunks within budget

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -207,23 +207,34 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
 
         cur_chunk: List[str] = []
         cur_len = 0
+
+        def join_splits(splits: List[str]) -> str:
+            chunk = "".join(splits)
+            return chunk if self.keep_whitespaces else chunk.strip()
+
+        def split_len(split: str, index: int) -> int:
+            if self.keep_whitespaces or index > 0:
+                return len(self._tokenizer(split))
+
+            stripped_split = split.strip()
+            return len(self._tokenizer(stripped_split)) if stripped_split else 0
+
+        def chunk_len(splits: List[str]) -> int:
+            return sum(split_len(split, index) for index, split in enumerate(splits))
+
         for split in splits:
-            split_len = len(self._tokenizer(split))
-            if split_len > chunk_size:
+            split_size = chunk_len([split])
+            if split_size > chunk_size:
                 _logger.warning(
-                    f"Got a split of size {split_len}, ",
+                    f"Got a split of size {split_size}, ",
                     f"larger than chunk size {chunk_size}.",
                 )
 
             # if we exceed the chunk size after adding the new split, then
             # we need to end the current chunk and start a new one
-            if cur_len + split_len > chunk_size:
+            if cur_chunk and cur_len + split_len(split, len(cur_chunk)) > chunk_size:
                 # end the previous chunk
-                chunk = (
-                    "".join(cur_chunk)
-                    if self.keep_whitespaces
-                    else "".join(cur_chunk).strip()
-                )
+                chunk = join_splits(cur_chunk)
                 if chunk:
                     chunks.append(chunk)
 
@@ -232,19 +243,18 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                 #   1. the current chunk length is less than chunk overlap
                 #   2. the total length is less than chunk size
                 while cur_chunk and (
-                    cur_len > self.chunk_overlap or cur_len + split_len > chunk_size
+                    cur_len > self.chunk_overlap
+                    or cur_len + split_len(split, len(cur_chunk)) > chunk_size
                 ):
                     # pop off the first element
-                    first_chunk = cur_chunk.pop(0)
-                    cur_len -= len(self._tokenizer(first_chunk))
+                    cur_chunk.pop(0)
+                    cur_len = chunk_len(cur_chunk)
 
             cur_chunk.append(split)
-            cur_len += split_len
+            cur_len += split_len(split, len(cur_chunk) - 1)
 
         # handle the last chunk
-        chunk = (
-            "".join(cur_chunk) if self.keep_whitespaces else "".join(cur_chunk).strip()
-        )
+        chunk = join_splits(cur_chunk)
         if chunk:
             chunks.append(chunk)
 

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -21,6 +21,21 @@ def test_split_token() -> None:
     assert chunks == ["foo bar", "bar hello", "hello world"]
 
 
+def test_split_token_respects_chunk_size_after_stripping() -> None:
+    tokenizer = tiktoken.get_encoding("cl100k_base")
+    text = "The quick brown fox jumps over the lazy dog. " * 4
+    text_splitter = TokenTextSplitter(
+        chunk_size=12,
+        chunk_overlap=4,
+        tokenizer=tokenizer.encode,
+    )
+
+    chunks = text_splitter.split_text(text)
+
+    assert chunks
+    assert all(len(tokenizer.encode(chunk)) <= 12 for chunk in chunks)
+
+
 def test_start_end_char_idx() -> None:
     document = Document(text="foo bar hello world baz bbq")
     text_splitter = TokenTextSplitter(chunk_size=3, chunk_overlap=1)


### PR DESCRIPTION
# Description

Fixes #22858

`TokenTextSplitter._merge()` budgeted chunks using the raw split token sizes, but emitted stripped chunks when `keep_whitespaces=False`. For BPE tokenizers, removing the leading separator from the first split can increase the emitted chunk token count, so ordinary prose could exceed `chunk_size` by one token.

This change counts the first split in a pending chunk the same way it will be emitted after stripping, while preserving the existing split-size summing behavior for the rest of the chunk. It also reuses the same join/strip helper for emitted chunks and adds regression coverage for the reported prose case.

No new dependencies.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Validation run locally:

- `llama-index-core/.venv/bin/pytest llama-index-core/tests/text_splitter/test_token_splitter.py -q`
- `llama-index-core/.venv/bin/ruff format --check llama-index-core/llama_index/core/node_parser/text/token.py llama-index-core/tests/text_splitter/test_token_splitter.py`
- `llama-index-core/.venv/bin/ruff check llama-index-core/llama_index/core/node_parser/text/token.py llama-index-core/tests/text_splitter/test_token_splitter.py`
- `git diff --check`