### PR TITLE
fix(node_parser): prevent TokenTextSplitter chunk token overflow when stripped (fix #22858)

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -193,6 +193,28 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                 new_splits.extend(self._split(split, chunk_size=chunk_size))
         return new_splits
 
+    def _merge_trimmed_splits(self, splits: List[str], chunk_size: int) -> List[str]:
+        """Merge splits without dropping content when trimming changes token counts."""
+        chunks: List[str] = []
+        current: List[str] = []
+
+        for split in splits:
+            candidate = "".join(current + [split]).strip()
+            if current and len(self._tokenizer(candidate)) > chunk_size:
+                chunks.append("".join(current).strip())
+                current = []
+                candidate = split.strip()
+
+            current.append(split)
+            if len(self._tokenizer(candidate)) > chunk_size and len(current) == 1:
+                chunks.append(candidate)
+                current = []
+
+        if current:
+            chunks.append("".join(current).strip())
+
+        return [chunk for chunk in chunks if chunk]
+
     def _merge(self, splits: List[str], chunk_size: int) -> List[str]:
         """
         Merge splits into chunks.
@@ -225,13 +247,10 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                     else "".join(cur_chunk).strip()
                 )
                 if chunk:
-                    # Stripping leading whitespace can increase token count with some BPE tokenizers
                     if not self.keep_whitespaces:
-                        while len(cur_chunk) > 1 and len(self._tokenizer(chunk)) > chunk_size:
-                            first_chunk = cur_chunk.pop(0)
-                            cur_len -= len(self._tokenizer(first_chunk))
-                            chunk = "".join(cur_chunk).strip()
-                    chunks.append(chunk)
+                        chunks.extend(self._merge_trimmed_splits(cur_chunk, chunk_size))
+                    else:
+                        chunks.append(chunk)
 
                 # start a new chunk with overlap
                 # keep popping off the first element of the previous chunk until:
@@ -253,10 +272,8 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
         )
         if chunk:
             if not self.keep_whitespaces:
-                while len(cur_chunk) > 1 and len(self._tokenizer(chunk)) > chunk_size:
-                    first_chunk = cur_chunk.pop(0)
-                    cur_len -= len(self._tokenizer(first_chunk))
-                    chunk = "".join(cur_chunk).strip()
-            chunks.append(chunk)
+                chunks.extend(self._merge_trimmed_splits(cur_chunk, chunk_size))
+            else:
+                chunks.append(chunk)
 
         return chunks

--- a/llama-index-core/llama_index/core/node_parser/text/token.py
+++ b/llama-index-core/llama_index/core/node_parser/text/token.py
@@ -225,6 +225,12 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
                     else "".join(cur_chunk).strip()
                 )
                 if chunk:
+                    # Stripping leading whitespace can increase token count with some BPE tokenizers
+                    if not self.keep_whitespaces:
+                        while len(cur_chunk) > 1 and len(self._tokenizer(chunk)) > chunk_size:
+                            first_chunk = cur_chunk.pop(0)
+                            cur_len -= len(self._tokenizer(first_chunk))
+                            chunk = "".join(cur_chunk).strip()
                     chunks.append(chunk)
 
                 # start a new chunk with overlap
@@ -246,6 +252,11 @@ class TokenTextSplitter(MetadataAwareTextSplitter):
             "".join(cur_chunk) if self.keep_whitespaces else "".join(cur_chunk).strip()
         )
         if chunk:
+            if not self.keep_whitespaces:
+                while len(cur_chunk) > 1 and len(self._tokenizer(chunk)) > chunk_size:
+                    first_chunk = cur_chunk.pop(0)
+                    cur_len -= len(self._tokenizer(first_chunk))
+                    chunk = "".join(cur_chunk).strip()
             chunks.append(chunk)
 
         return chunks

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -101,3 +101,17 @@ def test_split_token_does_not_overflow_when_stripped() -> None:
     chunks = splitter.split_text(text)
     for chunk in chunks:
         assert len(tokenizer.encode(chunk)) <= 12
+
+
+def test_split_token_preserves_content_when_stripping_would_overflow() -> None:
+    """Trimming a leading separator must not drop the first split."""
+
+    def tokenizer(value: str) -> list[int]:
+        # The leading separator shares a token with the following text before
+        # trimming, so stripping it makes the combined chunk one token longer.
+        return [0] * (len(value) - int(value.startswith(" ")))
+
+    splitter = TokenTextSplitter(chunk_size=2, chunk_overlap=0, tokenizer=tokenizer)
+    chunks = splitter.split_text("a b")
+
+    assert "".join(chunks).replace(" ", "") == "ab"

--- a/llama-index-core/tests/text_splitter/test_token_splitter.py
+++ b/llama-index-core/tests/text_splitter/test_token_splitter.py
@@ -89,3 +89,15 @@ def test_split_with_metadata(english_text: str) -> None:
     for chunk in chunks:
         node_content = chunk + metadata_str
         assert len(tokenizer.encode(node_content)) <= 100
+
+
+def test_split_token_does_not_overflow_when_stripped() -> None:
+    """Test that stripped chunks do not exceed chunk_size when leading space removal changes token count."""
+    text = "The quick brown fox jumps over the lazy dog. " * 4
+    tokenizer = tiktoken.get_encoding("gpt2")
+    splitter = TokenTextSplitter(
+        chunk_size=12, chunk_overlap=4, tokenizer=tokenizer.encode
+    )
+    chunks = splitter.split_text(text)
+    for chunk in chunks:
+        assert len(tokenizer.encode(chunk)) <= 12


### PR DESCRIPTION
Fixes #22858

### Problem
In TokenTextSplitter._merge, when keep_whitespaces is False, chunks are stripped via strip(). With certain BPE tokenizers, removing leading whitespace increases the token count by 1, resulting in emitted chunks that exceed chunk_size.

### Solution
- In _merge, if stripping causes the emitted chunk length to exceed chunk_size, pop leading elements until the token count is within chunk_size.
- Added test test_split_token_does_not_overflow_when_stripped in test_token_splitter.py.