### PR TITLE
feat(core): give ChatMessage an optional id and Memory a way to look one up

### DIFF
--- a/llama-index-core/llama_index/core/base/llms/types.py
+++ b/llama-index-core/llama_index/core/base/llms/types.py
@@ -1159,6 +1159,10 @@ ContentBlock = Annotated[
 class ChatMessage(BaseRecursiveContentBlock):
     """Chat message."""
 
+    id_: Optional[str] = Field(
+        default=None,
+        description="Optional unique ID of the message.",
+    )
     role: MessageRole = MessageRole.USER
     additional_kwargs: dict[str, Any] = Field(default_factory=dict)
     blocks: list[ContentBlock] = Field(default_factory=list)

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -840,6 +840,20 @@ class Memory(BaseMemory):
         """Get all messages."""
         return await self.sql_store.get_messages(self.session_id, status=status)
 
+    async def aget_by_id(
+        self, id_: str, status: Optional[MessageStatus] = None
+    ) -> Optional[ChatMessage]:
+        """
+        Get a single message from this session by its `ChatMessage.id_`.
+
+        Returns None if this session holds no message with that id. Messages
+        are given an id when they are written, so the id to pass here is the
+        one read off a message returned by `get_all()`.
+        """
+        return await self.sql_store.get_message_by_id(
+            self.session_id, id_, status=status
+        )
+
     async def areset(self, status: Optional[MessageStatus] = None) -> None:
         """Reset the memory."""
         await self.sql_store.delete_messages(self.session_id, status=status)
@@ -867,6 +881,12 @@ class Memory(BaseMemory):
     def set(self, messages: List[ChatMessage]) -> None:
         """Set the chat history."""
         return asyncio_run(self.aset(messages))
+
+    def get_by_id(
+        self, id_: str, status: Optional[MessageStatus] = None
+    ) -> Optional[ChatMessage]:
+        """Get a single message from this session by its `ChatMessage.id_`."""
+        return asyncio_run(self.aget_by_id(id_, status=status))
 
     def reset(self) -> None:
         """Reset the memory."""

--- a/llama-index-core/llama_index/core/storage/chat_store/base_db.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/base_db.py
@@ -73,6 +73,25 @@ class AsyncDBChatStore(BaseModel):
     ) -> None:
         """Set all messages for a key (replacing existing ones) with the specified status (async)."""
 
+    async def get_message_by_id(
+        self,
+        key: str,
+        id_: str,
+        status: Optional[MessageStatus] = MessageStatus.ACTIVE,
+    ) -> Optional[ChatMessage]:
+        """
+        Get a single message for a key by its `ChatMessage.id_` (async).
+
+        Returns None when no message under that key carries the id. Concrete
+        implementations are free to push the match down into the database; this
+        default reads the key's messages back and compares in Python, which is
+        correct whatever the backend stores them in.
+        """
+        for message in await self.get_messages(key, status=status):
+            if message.id_ == id_:
+                return message
+        return None
+
     @abstractmethod
     async def delete_message(self, key: str, idx: int) -> Optional[ChatMessage]:
         """Delete a specific message by ID and return it (async)."""

--- a/llama-index-core/llama_index/core/storage/chat_store/sql.py
+++ b/llama-index-core/llama_index/core/storage/chat_store/sql.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import (
@@ -221,6 +222,18 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
             rows = result.fetchall()
             return len(rows)
 
+    @staticmethod
+    def _assign_id(message: ChatMessage) -> None:
+        """
+        Give a message an id if it does not have one yet.
+
+        Stored messages need a handle that survives a round trip, so that a
+        caller can address one later without relying on its position in the
+        list. A message that already carries an id keeps it.
+        """
+        if message.id_ is None:
+            message.id_ = str(uuid.uuid4())
+
     async def add_message(
         self,
         key: str,
@@ -229,6 +242,7 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Add a message for a key with the specified status (async)."""
         session_factory, table = await self._initialize()
+        self._assign_id(message)
 
         async with session_factory() as session:
             await session.execute(
@@ -250,6 +264,8 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
     ) -> None:
         """Add a list of messages in batch for the specified key and status (async)."""
         session_factory, table = await self._initialize()
+        for message in messages:
+            self._assign_id(message)
 
         async with session_factory() as session:
             await session.execute(
@@ -282,6 +298,8 @@ class SQLAlchemyChatStore(AsyncDBChatStore):
 
         # Then add new messages
         current_time = time.time_ns()
+        for message in messages:
+            self._assign_id(message)
 
         async with session_factory() as session:
             for i, message in enumerate(messages):

--- a/llama-index-core/tests/base/llms/test_types.py
+++ b/llama-index-core/tests/base/llms/test_types.py
@@ -169,6 +169,7 @@ def test_chat_message_serializer():
         additional_kwargs={"some_list": ["a", "b", "c"], "some_object": SimpleModel()},
     )
     assert m.model_dump() == {
+        "id_": None,
         "role": MessageRole.USER,
         "additional_kwargs": {
             "some_list": ["a", "b", "c"],
@@ -186,6 +187,7 @@ def test_chat_message_legacy_roundtrip():
     }
     m = ChatMessage(**legacy_message)
     assert m.model_dump() == {
+        "id_": None,
         "additional_kwargs": {},
         "blocks": [{"block_type": "text", "text": "foo"}],
         "role": MessageRole.USER,
@@ -1956,3 +1958,33 @@ def test_tool_call_block_format():
     # Currently, ToolCallBlock does not support template vars
     assert formatted_block.tool_name == "{tool_name}"
     assert formatted_block.tool_kwargs == {"param": "{param_value}"}
+
+
+def test_chat_message_id_is_absent_by_default():
+    """
+    Identity is opt-in, and that is the point of the default being None.
+
+    A default id would give every message a fresh uuid, which would make two
+    otherwise identical messages compare unequal and change model_dump() for
+    every existing caller.
+    """
+    assert ChatMessage(content="hello").id_ is None
+    assert ChatMessage(content="hello") == ChatMessage(content="hello")
+
+
+def test_chat_message_id_round_trips():
+    """An id that was set survives serialization and validation."""
+    m = ChatMessage(content="hello", id_="an-id")
+    assert m.id_ == "an-id"
+
+    restored = ChatMessage.model_validate(m.model_dump(mode="json"))
+    assert restored.id_ == "an-id"
+
+
+def test_chat_message_ids_distinguish_identical_messages():
+    """Two messages with the same content are told apart by their ids."""
+    first = ChatMessage(content="say that again", id_="first")
+    second = ChatMessage(content="say that again", id_="second")
+
+    assert first != second
+    assert [m for m in (first, second) if m.id_ == "second"] == [second]

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -337,3 +337,46 @@ async def test_manage_queue_only_tool_message_remaining():
         assert cur_messages[0].role == "user", (
             f"First message must be 'user', got '{cur_messages[0].role}'"
         )
+
+
+@pytest.mark.asyncio
+async def test_aget_by_id_addresses_a_message_without_using_its_position(memory):
+    """
+    The use case from #14881: hold a handle on an earlier message.
+
+    Two messages with identical text are indistinguishable by content, which is
+    what a caller is otherwise reduced to comparing on.
+    """
+    first = ChatMessage(role="user", content="say that again")
+    second = ChatMessage(role="user", content="say that again")
+    await memory.aput_messages([first, second])
+
+    assert first.id_ is not None
+    assert second.id_ is not None
+    assert first.id_ != second.id_
+
+    found = await memory.aget_by_id(second.id_)
+    assert found is not None
+    assert found.id_ == second.id_
+
+
+@pytest.mark.asyncio
+async def test_aget_by_id_returns_none_for_an_unknown_id(memory):
+    """An id from another session, or no session at all, is not found here."""
+    await memory.aput(ChatMessage(role="user", content="hello"))
+
+    assert await memory.aget_by_id("no-such-id") is None
+
+
+@pytest.mark.asyncio
+async def test_ids_survive_being_read_back(memory):
+    """The id read off get_all() is the one aget_by_id() accepts."""
+    await memory.aput(ChatMessage(role="user", content="hello"))
+
+    stored = await memory.aget_all()
+    assert len(stored) == 1
+    assert stored[0].id_ is not None
+
+    found = await memory.aget_by_id(stored[0].id_)
+    assert found is not None
+    assert found.content == "hello"

--- a/llama-index-core/tests/storage/chat_store/test_sql.py
+++ b/llama-index-core/tests/storage/chat_store/test_sql.py
@@ -285,3 +285,92 @@ async def test_dump_load_store(chat_store: SQLAlchemyChatStore):
     messages = await loaded_store.get_messages("dump_user2")
     assert len(messages) == 1
     assert messages[0].content == "message2"
+
+
+@pytest.mark.asyncio
+async def test_stored_message_gets_an_id(chat_store: SQLAlchemyChatStore):
+    """A message written without an id is given one, and it survives the round trip."""
+    message = ChatMessage(role="user", content="hello")
+    assert message.id_ is None
+
+    await chat_store.add_message("id_user", message)
+    assert message.id_ is not None
+
+    stored = await chat_store.get_messages("id_user")
+    assert len(stored) == 1
+    assert stored[0].id_ == message.id_
+
+
+@pytest.mark.asyncio
+async def test_stored_message_keeps_a_caller_supplied_id(
+    chat_store: SQLAlchemyChatStore,
+):
+    """An id the caller chose is not overwritten."""
+    message = ChatMessage(role="user", content="hello", id_="from-the-caller")
+
+    await chat_store.add_message("id_user", message)
+
+    stored = await chat_store.get_messages("id_user")
+    assert [m.id_ for m in stored] == ["from-the-caller"]
+
+
+@pytest.mark.asyncio
+async def test_batched_and_set_messages_get_distinct_ids(
+    chat_store: SQLAlchemyChatStore,
+):
+    """add_messages and set_messages assign ids too, one per message."""
+    await chat_store.add_messages(
+        "id_user",
+        [
+            ChatMessage(role="user", content="hello"),
+            ChatMessage(role="assistant", content="world"),
+        ],
+    )
+    ids = [m.id_ for m in await chat_store.get_messages("id_user")]
+    assert len(ids) == 2
+    assert all(i is not None for i in ids)
+    assert len(set(ids)) == 2
+
+    await chat_store.set_messages(
+        "id_user",
+        [
+            ChatMessage(role="user", content="again"),
+            ChatMessage(role="assistant", content="and again"),
+        ],
+    )
+    replaced = [m.id_ for m in await chat_store.get_messages("id_user")]
+    assert len(replaced) == 2
+    assert all(i is not None for i in replaced)
+    assert len(set(replaced)) == 2
+    assert not set(replaced) & set(ids)
+
+
+@pytest.mark.asyncio
+async def test_get_message_by_id(chat_store: SQLAlchemyChatStore):
+    """A stored message can be fetched back by its id, and only under its own key."""
+    first = ChatMessage(role="user", content="hello")
+    second = ChatMessage(role="user", content="hello")
+    await chat_store.add_messages("id_user", [first, second])
+
+    # The two have identical content, which is exactly the case that comparing
+    # by content cannot tell apart.
+    found = await chat_store.get_message_by_id("id_user", second.id_)
+    assert found is not None
+    assert found.id_ == second.id_
+
+    assert await chat_store.get_message_by_id("id_user", "no-such-id") is None
+    assert await chat_store.get_message_by_id("other_user", first.id_) is None
+
+
+@pytest.mark.asyncio
+async def test_get_message_by_id_respects_status(chat_store: SQLAlchemyChatStore):
+    """An archived message is not returned by the default ACTIVE lookup."""
+    message = ChatMessage(role="user", content="hello")
+    await chat_store.add_message("id_user", message, status=MessageStatus.ARCHIVED)
+
+    assert await chat_store.get_message_by_id("id_user", message.id_) is None
+    assert (
+        await chat_store.get_message_by_id(
+            "id_user", message.id_, status=MessageStatus.ARCHIVED
+        )
+    ) is not None


### PR DESCRIPTION
# Description

`ChatMessage` carries `role`, `blocks` and `additional_kwargs`, and nothing
that identifies it. Two messages with the same text are indistinguishable, so
a caller who wants to address an earlier message — to edit it and drop what
came after, which is ordinary chat-app behaviour — is left comparing content,
which is wrong the moment a user says the same thing twice.

This adds the two things asked for in #14881:

**1. `ChatMessage.id_`, defaulting to `None`.**

The default is the design decision here, and it was measured rather than
assumed. The obvious form is the one `BaseNode` already uses,
`Field(default_factory=lambda: str(uuid.uuid4()))` — and it takes the
`llama-index-core` suite from 0 failures to **42**. A generated default makes
two otherwise identical messages compare unequal, and `ChatMessage` equality is
asserted throughout the library: the breakage was in `tests/prompts/test_base.py`,
`tests/response_synthesizers/*`, `tests/indices/test_prompt_helper.py` and
`tests/storage/chat_store/test_simple_chat_store.py`, none of it about identity.
With `None` the same suite gives 2 failures, both of them this package's own
exact-`model_dump()` assertions in `tests/base/llms/test_types.py`, which
necessarily change when a field is added; those two are updated here. So
identity is opt-in and no existing caller's equality or serialization behaviour
changes.

**2. `Memory.aget_by_id()` / `Memory.get_by_id()`**, on top of a new
`AsyncDBChatStore.get_message_by_id()`.

That method is on the base class because `Memory.sql_store` is typed
`AsyncDBChatStore`, and it is **concrete rather than `@abstractmethod`** so that
third-party chat stores subclassing it are not broken by this change. The
default implementation reads the key's messages back and matches in Python,
which is correct whatever the backend is; matching inside the `data` JSON column
in SQL would be faster but the operators for it differ between SQLite, Postgres
and the rest. A concrete store can override it later.

**3. `SQLAlchemyChatStore` mints an id on write** when a message does not
already have one — in `add_message`, `add_messages` and `set_messages`. This is
what makes the `None` default useful rather than decorative: callers do not have
to invent ids, but every *stored* message has one, which is where the use case
needs it. A message that already carries an id keeps it, and the message object
is mutated in place so the caller can read the id straight back off what they
passed in.

One thing found while doing this and deliberately left alone, in case it is
useful: `BaseChatStore.delete_message(key, idx)` means two different things in
its two implementations. `SimpleChatStore` does `self.store[key].pop(idx)`, a
positional index; `SQLAlchemyChatStore` does `where(table.c.id == idx)`, the
row's autoincrement primary key. Since `get_messages()` never carries the row id
out of the query, nothing in the public API hands a caller a valid `idx` for the
second one. Happy to open a separate issue for it rather than widen this change.

Fixes #14881

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No — everything here is in `llama-index-core`, which the template excepts.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

11 new tests: 3 in `tests/base/llms/test_types.py`, 5 in
`tests/storage/chat_store/test_sql.py`, 3 in `tests/memory/test_memory_base.py`.
They cover the default being absent, a caller-supplied id being kept, ids
surviving a store round trip, `set_messages`/`add_messages` assigning distinct
ids, the lookup respecting `MessageStatus`, and the case the issue is actually
about — telling two messages with identical content apart.

`llama-index-core`, before and after, on `main` at `39f481fc4`:

```
before   1494 passed, 22 skipped, 6 xfailed, 0 failed
after    1505 passed, 22 skipped, 6 xfailed, 0 failed
```

The +11 is exactly the tests added; the set of failing test ids is empty on
both sides. With the source change reverted and the tests kept, all 11 fail.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the linters — `ruff check` and `ruff format --check` clean on the
  touched files. `mypy llama_index` could not be run in the exact CI form: with
  `python_version = "3.10"` from `llama-index-core/pyproject.toml` and the numpy
  my environment resolves, it stops at
  `numpy/__init__.pyi:737: Type statement is only supported in Python 3.12 and
  greater` before checking anything — the same output on an unmodified checkout,
  so it is not from this change. At `--python-version 3.12` it reports 12
  pre-existing errors in 8 files, identical before and after this diff, none of
  them in a file this touches.

---

Per the *How to Use AI when Contributing* section of `CONTRIBUTING.md`: this was
written with AI assistance. It was used for the code and the tests in this diff
and for reading the surrounding chat-store and memory modules; the design
decisions — the `None` default, putting `get_message_by_id` on the base class as
a concrete method, and leaving `delete_message` alone — are mine. Validation is
the numbers above: the full `llama-index-core` suite before and after on a clean
checkout of `main`, the reverted-source run showing the new tests fail without
the change, and the linters as described. I have read every line of the diff and
am here for the review.
