### PR TITLE
Memory waterfall loses flushed messages when a memory block fails

### DIFF
--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -168,6 +168,10 @@ memory = Memory.from_defaults(
 
 As the memory is used, the short-term memory will fill up. Once the short-term memory exceeds the `chat_history_token_ratio`, the oldest messages that fit into the `token_flush_size` will be flushed and sent to each memory block for processing.
 
+Messages stay active until every block accepts the batch. If a block fails, the next put retries the same batch only for blocks that did not return successfully. New messages are processed in later batches. If archiving fails, completed block deliveries are retained while the archive is retried or recognized as already committed.
+
+This retry state belongs to the current `Memory` instance and is not persisted by serialization or shared across instances. Use one `Memory` instance to mutate a session's history; direct changes to its chat store or concurrent writers are not coordinated. A process restart, or a block that writes data before raising or being cancelled, can still cause duplicate delivery. Blocks that need stronger guarantees should make their own writes idempotent. If replacing or resetting active history fails, retry that operation successfully before adding or flushing more messages, since the store may have changed the history before reporting the error.
+
 When memory is retrieved, the short-term and long-term memories are merged together. The `Memory` object will ensure that the short-term memory + long-term memory content is less than or equal to the `token_limit`. If it is longer, the `.truncate()` method will be called on the memory blocks, using the `priority` to determine the truncation order.
 
 <Aside type="tip">

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -778,13 +778,12 @@ class Memory(BaseMemory):
                             reversed_queue = turn_messages[::-1] + reversed_queue
                         # else: No user message found - queue may remain empty (defensive)
 
-                # Archive the flushed messages
+                # Waterfall the flushed messages to memory blocks. This must
+                # happen BEFORE archiving: if a block raises (e.g. a transient
+                # LLM/embedding failure), the messages stay active so a later
+                # flush can retry the delivery instead of the messages being
+                # silently dropped from the conversation.
                 if messages_to_flush:
-                    await self.sql_store.archive_oldest_messages(
-                        self.session_id, n=len(messages_to_flush)
-                    )
-
-                    # Waterfall the flushed messages to memory blocks
                     await asyncio.gather(
                         *[
                             block.aput(
@@ -794,6 +793,14 @@ class Memory(BaseMemory):
                             )
                             for block in self.memory_blocks
                         ]
+                    )
+
+                    # Archive the flushed messages only once every block has
+                    # accepted them. If archiving itself fails, the messages
+                    # stay active and are delivered to the blocks again on the
+                    # next flush, which is the safer failure mode.
+                    await self.sql_store.archive_oldest_messages(
+                        self.session_id, n=len(messages_to_flush)
                     )
 
                 # Recalculate remaining tokens

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -1,6 +1,7 @@
 import asyncio
 import uuid
 from abc import abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
 from sqlalchemy.ext.asyncio import AsyncEngine
 from typing import (
@@ -9,6 +10,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
     TypeVar,
@@ -34,6 +36,7 @@ from llama_index.core.base.llms.types import (
 from llama_index.core.bridge.pydantic import (
     BaseModel,
     Field,
+    PrivateAttr,
     model_validator,
     ConfigDict,
 )
@@ -185,6 +188,16 @@ class BaseMemoryBlock(BaseModel, Generic[T]):
         return None
 
 
+@dataclass
+class _PendingFlush:
+    """One fixed batch and its in-process delivery acknowledgements."""
+
+    messages: List[ChatMessage]
+    blocks: List[BaseMemoryBlock]
+    delivered: Set[int] = field(default_factory=set)
+    archived_count: Optional[int] = None
+
+
 class Memory(BaseMemory):
     """
     A memory module that waterfalls into memory blocks.
@@ -195,7 +208,14 @@ class Memory(BaseMemory):
     - various parameters (pressure size, token limit, etc.)
 
     When the FIFO queue reaches the token limit, the oldest messages within the pressure size are ejected from the FIFO queue.
-    The messages are then processed by each memory block.
+    The messages are then processed by each memory block, and archived only after all
+    blocks return successfully. Failed flushes retain a fixed batch and retry only
+    unacknowledged blocks on this Memory instance, even if new messages arrive.
+
+    Delivery acknowledgements are in-process only: they are not serialized or shared
+    across Memory instances. Use one Memory instance to mutate a session's history.
+    A block that performs a side effect and then raises or is cancelled can still
+    receive that batch again; this is not an exactly-once delivery guarantee.
 
     When pulling messages from this memory, the memory blocks are processed in order, and the messages are injected into the system message or the latest user message.
     """
@@ -256,6 +276,10 @@ class Memory(BaseMemory):
         default_factory=generate_chat_store_key,
         description="The key to use for storing messages in the chat store.",
     )
+
+    _queue_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
+    _pending_flush: Optional[_PendingFlush] = PrivateAttr(default=None)
+    _history_replacement_failed: bool = PrivateAttr(default=False)
 
     @classmethod
     def class_name(cls) -> str:
@@ -669,16 +693,96 @@ class Memory(BaseMemory):
             chat_history, memory_content, chat_message_data
         )
 
+    async def _flush_pending(self) -> None:
+        """Deliver the pending batch, retaining successful acknowledgements on error."""
+        pending = self._pending_flush
+        if pending is None:
+            return
+
+        async def deliver(index: int, block: BaseMemoryBlock) -> None:
+            # BaseMemoryBlock adds session metadata and blocks may mutate messages.
+            # Keep the batch snapshot intact, including across retries.
+            await block.aput(
+                [message.model_copy(deep=True) for message in pending.messages],
+                from_short_term_memory=True,
+                session_id=self.session_id,
+            )
+            pending.delivered.add(index)
+
+        results = await asyncio.gather(
+            *[
+                deliver(index, block)
+                for index, block in enumerate(pending.blocks)
+                if index not in pending.delivered
+            ],
+            return_exceptions=True,
+        )
+        # Wait for every sibling to settle before releasing the queue lock. A
+        # successful sibling must not still be running when a retry starts.
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+
+        if await self._pending_was_archived():
+            self._pending_flush = None
+            return
+
+        archived = await self.sql_store.archive_oldest_messages(
+            self.session_id, n=len(pending.messages)
+        )
+        if len(archived) != len(pending.messages):
+            raise RuntimeError("The pending memory batch was not fully archived.")
+        self._pending_flush = None
+
+    async def _pending_was_archived(self) -> bool:
+        """Recognize an archive that committed before raising or being cancelled."""
+        pending = self._pending_flush
+        if pending is None:
+            return False
+
+        archived_count = await self.sql_store.count_messages(
+            self.session_id, status=MessageStatus.ARCHIVED
+        )
+        if pending.archived_count is None:
+            pending.archived_count = archived_count
+        elif archived_count == pending.archived_count + len(pending.messages):
+            return True
+        elif archived_count != pending.archived_count:
+            # The chat-store interface has no row IDs or transactional batch key.
+            # Fail closed if another writer or a partial archive changed history.
+            raise RuntimeError(
+                "Archived history changed while a memory flush was pending. "
+                "Use one Memory instance to mutate a session's history."
+            )
+        return False
+
+    def _check_history_replacement(self) -> None:
+        if self._history_replacement_failed:
+            raise RuntimeError(
+                "Chat history replacement did not complete. Retry aset() or "
+                "areset() for active history before adding or flushing messages."
+            )
+
     async def _manage_queue(self) -> None:
+        """Serialize flushes and resume any pending batch before selecting another."""
+        async with self._queue_lock:
+            await self._manage_queue_locked()
+
+    async def _manage_queue_locked(self) -> None:
         """
-        Manage the FIFO queue.
+        Manage the FIFO queue while holding the queue lock.
 
         This function manages the memory queue using a waterfall approach:
         1. If the queue exceeds the token limit, it removes oldest messages first
-        2. Removed messages are archived and passed to memory blocks
+        2. Removed messages are passed to memory blocks, then archived
         3. It ensures conversation integrity by keeping related messages together
         4. It maintains at least one complete conversation turn
         """
+        self._check_history_replacement()
+        # Finish exactly the original batch before recalculating boundaries or
+        # token pressure; newly appended messages belong to subsequent batches.
+        await self._flush_pending()
+
         # Calculate if we need to waterfall
         current_queue = await self.sql_store.get_messages(
             self.session_id, status=MessageStatus.ACTIVE
@@ -778,30 +882,15 @@ class Memory(BaseMemory):
                             reversed_queue = turn_messages[::-1] + reversed_queue
                         # else: No user message found - queue may remain empty (defensive)
 
-                # Waterfall the flushed messages to memory blocks. This must
-                # happen BEFORE archiving: if a block raises (e.g. a transient
-                # LLM/embedding failure), the messages stay active so a later
-                # flush can retry the delivery instead of the messages being
-                # silently dropped from the conversation.
                 if messages_to_flush:
-                    await asyncio.gather(
-                        *[
-                            block.aput(
-                                messages_to_flush,
-                                from_short_term_memory=True,
-                                session_id=self.session_id,
-                            )
-                            for block in self.memory_blocks
-                        ]
+                    self._pending_flush = _PendingFlush(
+                        messages=[
+                            message.model_copy(deep=True)
+                            for message in messages_to_flush
+                        ],
+                        blocks=list(self.memory_blocks),
                     )
-
-                    # Archive the flushed messages only once every block has
-                    # accepted them. If archiving itself fails, the messages
-                    # stay active and are delivered to the blocks again on the
-                    # next flush, which is the safer failure mode.
-                    await self.sql_store.archive_oldest_messages(
-                        self.session_id, n=len(messages_to_flush)
-                    )
+                    await self._flush_pending()
 
                 # Recalculate remaining tokens
                 chronological_view = reversed_queue[::-1]
@@ -817,29 +906,33 @@ class Memory(BaseMemory):
 
     async def aput(self, message: ChatMessage) -> None:
         """Add a message to the chat store and process waterfall logic if needed."""
-        # Add the message to the chat store
-        await self.sql_store.add_message(
-            self.session_id, message, status=MessageStatus.ACTIVE
-        )
-
-        # Ensure the active queue is managed
-        await self._manage_queue()
+        async with self._queue_lock:
+            self._check_history_replacement()
+            await self.sql_store.add_message(
+                self.session_id, message, status=MessageStatus.ACTIVE
+            )
+            await self._manage_queue_locked()
 
     async def aput_messages(self, messages: List[ChatMessage]) -> None:
         """Add a list of messages to the chat store and process waterfall logic if needed."""
-        # Add the messages to the chat store
-        await self.sql_store.add_messages(
-            self.session_id, messages, status=MessageStatus.ACTIVE
-        )
-
-        # Ensure the active queue is managed
-        await self._manage_queue()
+        async with self._queue_lock:
+            self._check_history_replacement()
+            await self.sql_store.add_messages(
+                self.session_id, messages, status=MessageStatus.ACTIVE
+            )
+            await self._manage_queue_locked()
 
     async def aset(self, messages: List[ChatMessage]) -> None:
-        """Set the chat history."""
-        await self.sql_store.set_messages(
-            self.session_id, messages, status=MessageStatus.ACTIVE
-        )
+        """Set the chat history, discarding any pending flush of replaced messages."""
+        async with self._queue_lock:
+            # A custom store can replace some/all history before reporting an
+            # error. Do not apply old acknowledgements to that uncertain history.
+            self._history_replacement_failed = True
+            await self.sql_store.set_messages(
+                self.session_id, messages, status=MessageStatus.ACTIVE
+            )
+            self._pending_flush = None
+            self._history_replacement_failed = False
 
     async def aget_all(
         self, status: Optional[MessageStatus] = None
@@ -849,7 +942,21 @@ class Memory(BaseMemory):
 
     async def areset(self, status: Optional[MessageStatus] = None) -> None:
         """Reset the memory."""
-        await self.sql_store.delete_messages(self.session_id, status=status)
+        async with self._queue_lock:
+            pending = self._pending_flush
+            if status != MessageStatus.ARCHIVED:
+                self._history_replacement_failed = True
+                await self.sql_store.delete_messages(self.session_id, status=status)
+                self._pending_flush = None
+                self._history_replacement_failed = False
+            else:
+                if pending is not None and pending.archived_count is not None:
+                    if await self._pending_was_archived():
+                        self._pending_flush = None
+                    # Re-read the baseline even if deleting archived history
+                    # commits before raising. Active deliveries are unaffected.
+                    pending.archived_count = None
+                await self.sql_store.delete_messages(self.session_id, status=status)
 
     # ---- Sync method wrappers ----
 

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,5 +1,7 @@
 import pytest
 
+from typing import Any, List, Optional
+
 from llama_index.core.base.llms.types import (
     ChatMessage,
     DocumentBlock,
@@ -7,7 +9,8 @@ from llama_index.core.base.llms.types import (
     AudioBlock,
     VideoBlock,
 )
-from llama_index.core.memory.memory import Memory
+from llama_index.core.bridge.pydantic import Field
+from llama_index.core.memory.memory import BaseMemoryBlock, Memory
 from llama_index.core.storage.chat_store.sql import MessageStatus
 
 
@@ -337,3 +340,135 @@ async def test_manage_queue_only_tool_message_remaining():
         assert cur_messages[0].role == "user", (
             f"First message must be 'user', got '{cur_messages[0].role}'"
         )
+
+
+class _RecordingBlock(BaseMemoryBlock[str]):
+    """Test block that records every batch pushed from short-term memory."""
+
+    received: List[List[str]] = Field(default_factory=list)
+    fail_next: bool = False
+
+    async def _aget(
+        self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any
+    ) -> str:
+        return ""
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("transient block failure")
+        self.received.append([m.content or "" for m in messages])
+
+
+class _OrderCheckingBlock(BaseMemoryBlock[str]):
+    """Test block that checks the flushed messages are still active when called."""
+
+    sql_store: Any = None
+    saw_active: List[bool] = Field(default_factory=list)
+
+    async def _aget(
+        self, messages: Optional[List[ChatMessage]] = None, **block_kwargs: Any
+    ) -> str:
+        return ""
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        session_id = messages[0].additional_kwargs["session_id"]
+        active = await self.sql_store.get_messages(
+            session_id, status=MessageStatus.ACTIVE
+        )
+        active_contents = {m.content for m in active}
+        self.saw_active.append(all(m.content in active_contents for m in messages))
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_block_failure_keeps_messages_active() -> None:
+    """A failing memory block must not cause flushed messages to be archived."""
+    block = _RecordingBlock(name="rec", fail_next=True)
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        session_id="test_block_failure",
+        memory_blocks=[block],
+    )
+    chat_messages = [
+        ChatMessage(role="user", content="x " * 500),
+        ChatMessage(role="assistant", content="y " * 500),
+        ChatMessage(role="user", content="z " * 500),
+    ]
+
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(chat_messages)
+
+    # Nothing may be archived: the block never accepted the messages, so they
+    # must stay active for a later flush to retry the delivery.
+    active = await memory.aget_all(status=MessageStatus.ACTIVE)
+    archived = await memory.aget_all(status=MessageStatus.ARCHIVED)
+    assert {m.content for m in active} == {m.content for m in chat_messages}
+    assert len(archived) == 0
+    assert block.received == []
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_blocks_run_before_archiving() -> None:
+    """Memory blocks receive flushed messages while they are still active."""
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        session_id="test_flush_ordering",
+    )
+    block = _OrderCheckingBlock(name="order", sql_store=memory.sql_store)
+    memory.memory_blocks.append(block)
+
+    await memory.aput_messages(
+        [
+            ChatMessage(role="user", content="x " * 500),
+            ChatMessage(role="assistant", content="y " * 500),
+            ChatMessage(role="user", content="z " * 500),
+        ]
+    )
+
+    # Every batch the block received was still active at delivery time.
+    assert block.saw_active
+    assert all(block.saw_active)
+
+    # After a successful flush the delivered messages are archived.
+    archived = await memory.aget_all(status=MessageStatus.ARCHIVED)
+    assert len(archived) > 0
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_retries_block_delivery_after_failure() -> None:
+    """After a block failure, the next flush redelivers the backlog (at-least-once)."""
+    block = _RecordingBlock(name="rec_retry", fail_next=True)
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        session_id="test_block_retry",
+        memory_blocks=[block],
+    )
+    chat_messages = [
+        ChatMessage(role="user", content="x " * 500),
+        ChatMessage(role="assistant", content="y " * 500),
+        ChatMessage(role="user", content="z " * 500),
+    ]
+
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(chat_messages)
+    assert block.received == []
+
+    # The block has recovered; adding another message triggers a new flush.
+    await memory.aput(ChatMessage(role="assistant", content="w " * 500))
+
+    # Everything that ends up archived must have been delivered to the block.
+    archived = await memory.aget_all(status=MessageStatus.ARCHIVED)
+    delivered = {content for batch in block.received for content in batch}
+    assert len(archived) > 0
+    assert all(m.content in delivered for m in archived)
+
+    # And nothing was lost: every message is still either active or archived.
+    active = await memory.aget_all(status=MessageStatus.ACTIVE)
+    remaining = {m.content for m in active} | {m.content for m in archived}
+    assert remaining == {m.content for m in chat_messages} | {"w " * 500}

--- a/llama-index-core/tests/memory/test_memory_base.py
+++ b/llama-index-core/tests/memory/test_memory_base.py
@@ -1,6 +1,8 @@
+import asyncio
+
 import pytest
 
-from typing import Any, List, Optional
+from typing import Any, Generator, List, Optional
 
 from llama_index.core.base.llms.types import (
     ChatMessage,
@@ -11,18 +13,22 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.bridge.pydantic import Field
 from llama_index.core.memory.memory import BaseMemoryBlock, Memory
-from llama_index.core.storage.chat_store.sql import MessageStatus
+from llama_index.core.storage.chat_store.sql import MessageStatus, SQLAlchemyChatStore
 
 
 @pytest.fixture()
-def memory():
-    """Create a basic memory instance for testing."""
-    return Memory(
+def memory(event_loop: asyncio.AbstractEventLoop) -> Generator[Memory, None, None]:
+    """Create a basic memory instance and close its database after each test."""
+    memory = Memory(
         token_limit=1000,
         token_flush_size=700,
         chat_history_token_ratio=0.9,
         session_id="test_user",
     )
+    yield memory
+    assert isinstance(memory.sql_store, SQLAlchemyChatStore)
+    if memory.sql_store._async_engine is not None:
+        event_loop.run_until_complete(memory.sql_store._async_engine.dispose())
 
 
 @pytest.mark.asyncio
@@ -472,3 +478,364 @@ async def test_manage_queue_retries_block_delivery_after_failure() -> None:
     active = await memory.aget_all(status=MessageStatus.ACTIVE)
     remaining = {m.content for m in active} | {m.content for m in archived}
     assert remaining == {m.content for m in chat_messages} | {"w " * 500}
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_retries_only_failed_blocks() -> None:
+    """A sibling failure must not redeliver an already acknowledged batch."""
+    recorder = _RecordingBlock(name="recorder")
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    memory = Memory(
+        token_limit=1000,
+        token_flush_size=700,
+        chat_history_token_ratio=0.9,
+        memory_blocks=[recorder, retrying],
+    )
+    messages = [
+        ChatMessage(role="user", content="x " * 500),
+        ChatMessage(role="assistant", content="y " * 500),
+        ChatMessage(role="user", content="z " * 500),
+    ]
+    batch = [message.content for message in messages[:2]]
+
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(messages)
+    assert recorder.received == [batch]
+    assert retrying.received == []
+    assert await memory.aget_all(status=MessageStatus.ARCHIVED) == []
+
+    await memory._manage_queue()
+
+    assert recorder.received == [batch]
+    assert retrying.received == [batch]
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ARCHIVED)
+    ] == batch
+
+
+@pytest.fixture()
+def waterfall_messages() -> List[ChatMessage]:
+    return [
+        ChatMessage(role="user", content="x " * 500),
+        ChatMessage(role="assistant", content="y " * 500),
+        ChatMessage(role="user", content="z " * 500),
+    ]
+
+
+class _WaitingBlock(_RecordingBlock):
+    started: asyncio.Event = Field(default_factory=asyncio.Event)
+    release: asyncio.Event = Field(default_factory=asyncio.Event)
+    cancelled: bool = False
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        self.started.set()
+        try:
+            await self.release.wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        await super()._aput(messages)
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_waits_for_siblings_after_failure(
+    memory: Memory, waterfall_messages: List[ChatMessage]
+) -> None:
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    waiting = _WaitingBlock(name="waiting")
+    memory.memory_blocks = [retrying, waiting]
+    flush = asyncio.create_task(memory.aput_messages(waterfall_messages))
+    await asyncio.wait_for(waiting.started.wait(), timeout=5)
+    assert not flush.done()
+    waiting.release.set()
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await asyncio.wait_for(flush, timeout=5)
+
+    await memory._manage_queue()
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert waiting.received == [batch]
+    assert retrying.received == [batch]
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_serializes_overlapping_puts(
+    memory: Memory, waterfall_messages: List[ChatMessage]
+) -> None:
+    waiting = _WaitingBlock(name="waiting")
+    memory.memory_blocks = [waiting]
+    first = asyncio.create_task(memory.aput_messages(waterfall_messages))
+    await asyncio.wait_for(waiting.started.wait(), timeout=5)
+    new_message = ChatMessage(role="assistant", content="w " * 500)
+    second = asyncio.create_task(memory.aput(new_message))
+    await asyncio.sleep(0)
+    waiting.release.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=5)
+
+    assert waiting.received == [[message.content for message in waterfall_messages[:2]]]
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ACTIVE)
+    ] == [waterfall_messages[-1].content, new_message.content]
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_cancellation_retains_acknowledgements(
+    memory: Memory, waterfall_messages: List[ChatMessage]
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    waiting = _WaitingBlock(name="waiting")
+    memory.memory_blocks = [recorder, waiting]
+    flush = asyncio.create_task(memory.aput_messages(waterfall_messages))
+    await asyncio.wait_for(waiting.started.wait(), timeout=5)
+    flush.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await flush
+    assert waiting.cancelled
+    assert await memory.aget_all(status=MessageStatus.ARCHIVED) == []
+
+    waiting.release.set()
+    await memory._manage_queue()
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch]
+    assert waiting.received == [batch]
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_retries_original_batch_before_new_messages(
+    memory: Memory, waterfall_messages: List[ChatMessage]
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    memory.memory_blocks = [recorder, retrying]
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(waterfall_messages)
+
+    # A pending batch must complete even if the new limit would not trigger a
+    # flush, or the new flush size would select a different conversation boundary.
+    memory.token_limit = 5000
+    memory.token_flush_size = 3000
+    new_message = ChatMessage(role="assistant", content="w " * 500)
+    await memory.aput(new_message)
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch]
+    assert retrying.received == [batch]
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ACTIVE)
+    ] == [waterfall_messages[-1].content, new_message.content]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("committed", [False, True])
+@pytest.mark.parametrize("cancelled", [False, True])
+async def test_manage_queue_recovers_archive_failure_without_redelivery(
+    memory: Memory,
+    waterfall_messages: List[ChatMessage],
+    monkeypatch: pytest.MonkeyPatch,
+    committed: bool,
+    cancelled: bool,
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    memory.memory_blocks = [recorder]
+    archive = type(memory.sql_store).archive_oldest_messages
+    calls = 0
+    started = asyncio.Event()
+
+    async def fail_once(store: Any, key: str, n: int) -> List[ChatMessage]:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            return await archive(store, key, n)
+        if committed:
+            await archive(store, key, n)
+        started.set()
+        if cancelled:
+            await asyncio.Event().wait()
+        raise RuntimeError("archive failure")
+
+    monkeypatch.setattr(type(memory.sql_store), "archive_oldest_messages", fail_once)
+    flush = asyncio.create_task(memory.aput_messages(waterfall_messages))
+    await asyncio.wait_for(started.wait(), timeout=5)
+    if cancelled:
+        flush.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await flush
+    else:
+        with pytest.raises(RuntimeError, match="archive failure"):
+            await flush
+
+    memory.token_limit = 5000
+    # The same content in later messages must not be mistaken for the batch
+    # whose archive committed before the store reported a failure.
+    await memory.aput_messages(waterfall_messages[:2])
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch]
+    assert calls == (1 if committed else 2)
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ARCHIVED)
+    ] == batch
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ACTIVE)
+    ] == [waterfall_messages[-1].content, *batch]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["set", "reset", "reset_active"])
+async def test_manage_queue_discards_pending_batch_when_history_is_replaced(
+    memory: Memory, waterfall_messages: List[ChatMessage], operation: str
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    memory.memory_blocks = [recorder, retrying]
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(waterfall_messages)
+
+    if operation == "set":
+        await memory.aset(waterfall_messages)
+    else:
+        await memory.areset(
+            status=MessageStatus.ACTIVE if operation == "reset_active" else None
+        )
+        await memory.aput_messages(waterfall_messages)
+    await memory._manage_queue()
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch, batch]
+    assert retrying.received == [batch]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["set", "reset"])
+@pytest.mark.parametrize("committed", [False, True])
+async def test_manage_queue_requires_failed_history_replacement_to_be_retried(
+    memory: Memory,
+    waterfall_messages: List[ChatMessage],
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    committed: bool,
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    memory.memory_blocks = [recorder, retrying]
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(waterfall_messages)
+
+    method = "set_messages" if operation == "set" else "delete_messages"
+    original = getattr(type(memory.sql_store), method)
+    calls = 0
+
+    async def fail_once(store: Any, *args: Any, **kwargs: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls != 1 or committed:
+            await original(store, *args, **kwargs)
+        if calls == 1:
+            raise RuntimeError("history replacement failure")
+
+    monkeypatch.setattr(type(memory.sql_store), method, fail_once)
+
+    async def replace_history() -> None:
+        if operation == "set":
+            await memory.aset(waterfall_messages)
+        else:
+            await memory.areset(status=MessageStatus.ACTIVE)
+
+    with pytest.raises(RuntimeError, match="history replacement failure"):
+        await replace_history()
+    with pytest.raises(RuntimeError, match="Chat history replacement did not complete"):
+        await memory._manage_queue()
+    active = await memory.aget_all(status=MessageStatus.ACTIVE)
+    with pytest.raises(RuntimeError, match="Chat history replacement did not complete"):
+        await memory.aput(ChatMessage(role="user", content="must not be added"))
+    assert await memory.aget_all(status=MessageStatus.ACTIVE) == active
+    assert len(recorder.received) == 1
+    assert retrying.received == []
+
+    await replace_history()
+    if operation == "reset":
+        await memory.aput_messages(waterfall_messages)
+    await memory._manage_queue()
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch, batch]
+    assert retrying.received == [batch]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("archive_committed", [False, True])
+@pytest.mark.parametrize("delete_committed", [False, True])
+async def test_manage_queue_preserves_pending_delivery_when_resetting_archives_fails(
+    memory: Memory,
+    waterfall_messages: List[ChatMessage],
+    monkeypatch: pytest.MonkeyPatch,
+    archive_committed: bool,
+    delete_committed: bool,
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    memory.memory_blocks = [recorder]
+    # An existing archive makes deleting archived history change the baseline.
+    await memory.sql_store.add_message(
+        memory.session_id,
+        ChatMessage(role="user", content="previous archive"),
+        status=MessageStatus.ARCHIVED,
+    )
+    archive = type(memory.sql_store).archive_oldest_messages
+    delete = type(memory.sql_store).delete_messages
+    archive_calls = 0
+
+    async def fail_archive_once(store: Any, key: str, n: int) -> List[ChatMessage]:
+        nonlocal archive_calls
+        archive_calls += 1
+        if archive_calls > 1:
+            return await archive(store, key, n)
+        if archive_committed:
+            await archive(store, key, n)
+        raise RuntimeError("archive failure")
+
+    async def fail_delete(
+        store: Any, key: str, status: Optional[MessageStatus] = None
+    ) -> None:
+        if delete_committed:
+            await delete(store, key, status=status)
+        raise RuntimeError("delete failure")
+
+    monkeypatch.setattr(
+        type(memory.sql_store), "archive_oldest_messages", fail_archive_once
+    )
+    with pytest.raises(RuntimeError, match="archive failure"):
+        await memory.aput_messages(waterfall_messages)
+    monkeypatch.setattr(type(memory.sql_store), "delete_messages", fail_delete)
+    with pytest.raises(RuntimeError, match="delete failure"):
+        await memory.areset(status=MessageStatus.ARCHIVED)
+
+    await memory._manage_queue()
+    batch = [message.content for message in waterfall_messages[:2]]
+    assert recorder.received == [batch]
+    assert archive_calls == (1 if archive_committed else 2)
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ACTIVE)
+    ] == [waterfall_messages[-1].content]
+
+
+@pytest.mark.asyncio
+async def test_manage_queue_delivers_later_identical_messages_as_a_new_batch(
+    memory: Memory, waterfall_messages: List[ChatMessage]
+) -> None:
+    recorder = _RecordingBlock(name="recorder")
+    retrying = _RecordingBlock(name="retrying", fail_next=True)
+    memory.memory_blocks = [recorder, retrying]
+    with pytest.raises(RuntimeError, match="transient block failure"):
+        await memory.aput_messages(waterfall_messages)
+
+    next_response = ChatMessage(role="assistant", content="w " * 500)
+    await memory.aput_messages([next_response, *waterfall_messages])
+    batch = [message.content for message in waterfall_messages[:2]]
+    expected = [batch, [waterfall_messages[-1].content, next_response.content], batch]
+    assert recorder.received == expected
+    assert retrying.received == expected
+    assert [
+        message.content
+        for message in await memory.aget_all(status=MessageStatus.ARCHIVED)
+    ] == [content for delivered in expected for content in delivered]


### PR DESCRIPTION
# Description

A failed memory waterfall can lose context if its messages are archived before the memory blocks accept them. Simply reversing that order creates a second problem: when one block succeeds and a sibling fails, retrying the entire batch duplicates the successful block's facts or vector entries.

This change keeps a fixed pending batch and records successful delivery to each block. A retry targets only unacknowledged blocks, completes that original batch before selecting newer messages, and archives it only after all blocks return successfully. Concurrent puts and history mutations are serialized, and a failed delivery waits for its siblings to settle before a retry can start.

Archive failures retain the delivery acknowledgements. The existing chat-store count API identifies an archive that committed before raising or being cancelled, so recovery does not accidentally archive the next batch. Resetting archived history preserves pending deliveries. If replacing or resetting active history fails, it must be retried successfully before another put or flush can use the uncertain history.

The acknowledgements are **in-process state on one `Memory` instance**, not a durable exactly-once protocol. They are not shared across instances or persisted by model serialization. A restart, or a block that performs a side effect before raising or being cancelled, can still cause duplicate delivery. The public memory-block and chat-store interfaces are unchanged; the user guide documents these limits and the single-writer requirement.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

No version bump is required for `llama-index-core`.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

The two-block partial-failure regression was first run against the previous PR head (`a31ebe45a`) and failed because the successful block received the same batch twice. It now passes. Additional coverage exercises slow siblings, overlapping puts, cancellation, new messages and changed flush limits, identical later batches, archive errors and cancellation before/after commit, and failed history replacement or archive deletion.

From `llama-index-core`, using Python 3.11 and the frozen development dependencies:

- `pytest tests/memory/ tests/storage/chat_store/ -q` — **134 passed**.
- `ruff check llama_index/core/memory/memory.py tests/memory/test_memory_base.py` — passed.
- `ruff format --check llama_index/core/memory/memory.py tests/memory/test_memory_base.py` — passed.
- `codespell llama_index/core/memory/memory.py tests/memory/test_memory_base.py` — passed.
- `mypy --follow-imports=silent llama_index/core/memory/memory.py` — passed.
- `git diff --check` — passed.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted unit tests pass locally with my changes
- [x] Formatting, lint, spelling, and targeted type checks pass
