### PR TITLE
docs: Update MongoDB Key-Value Stores section

### DIFF
--- a/docs/src/content/docs/framework/module_guides/storing/kv_stores.md
+++ b/docs/src/content/docs/framework/module_guides/storing/kv_stores.md
@@ -7,7 +7,7 @@ Key-Value stores are the underlying storage abstractions that power our [Documen
 We provide the following key-value stores:
 
 - **Simple Key-Value Store**: An in-memory KV store. The user can choose to call `persist` on this kv store to persist data to disk.
-- **MongoDB Key-Value Store**: A MongoDB KV store.
+- **MongoDB Key-Value Store**: A MongoDB KV store. Data is persisted as it is written, so the user doesn’t need to call `persist` and multiple processes can share the same store. Supports async operations.
 - **Tablestore Key-Value Store**: A Tablestore KV store.
 
 See the [API Reference](/python/framework-api-reference/storage/kvstore) for more details.


### PR DESCRIPTION
# Description

This PR updates the MongoDB section of the Key-Value Stores page. I updated the MongoDB bullet point on the page to include two benefits of using MongoDB as a KV store without (hopefully) lengthening the bullet point too much. 

## Type of Change

This is a documentation update, and only includes text edits.

## Suggested Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## AI assistance disclosure

I used AI to indentify these benefits and verified them in the source code: [no persist method in the MongoDBKVStore class](https://github.com/run-llama/llama_index/blob/d8021225eb7e7b276d5ceb476b0a4650240f27f8/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-mongodb/llama_index/storage/kvstore/mongodb/base.py#L15), [from_uri() creates an async client](https://github.com/run-llama/llama_index/blob/d8021225eb7e7b276d5ceb476b0a4650240f27f8/llama-index-integrations/storage/kvstore/llama-index-storage-kvstore-mongodb/llama_index/storage/kvstore/mongodb/base.py#L80).