### PR TITLE
Remove version checks below the supported Python floor (sec-filings reader, solr vector store)

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/fetch.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/fetch.py
@@ -3,15 +3,9 @@
 import json
 import os
 import re
-import sys
-from typing import List, Optional, Tuple, Union
+from typing import Final, List, Optional, Tuple, Union
 
 import requests
-
-if sys.version_info < (3, 8):  # noqa: UP036
-    from typing import Final
-else:
-    from typing import Final
 
 import webbrowser
 

--- a/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/sec_document.py
+++ b/llama-index-integrations/readers/llama-index-readers-sec-filings/llama_index/readers/sec_filings/prepline_sec_filings/sec_document.py
@@ -1,12 +1,6 @@
 import re
-import sys
 from functools import partial
-from typing import Any, Iterable, Iterator, List, Optional, Tuple
-
-if sys.version_info < (3, 8):  # noqa: UP036
-    from typing import Final
-else:
-    from typing import Final
+from typing import Any, Final, Iterable, Iterator, List, Optional, Tuple
 
 from collections import defaultdict
 

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-solr/llama_index/vector_stores/solr/client/async_.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-solr/llama_index/vector_stores/solr/client/async_.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import sys
 import time
 from asyncio import Task
 from collections.abc import Mapping, Sequence
@@ -52,11 +51,8 @@ class AsyncSolrClient(_BaseSolrClient):
                     **self._client_kwargs,
                 }
 
-            if sys.version_info < (3, 10):
-                args["timeout"] = self._request_timeout_sec
-            else:
-                args["read_timeout"] = self._request_timeout_sec
-                args["write_timeout"] = self._request_timeout_sec
+            args["read_timeout"] = self._request_timeout_sec
+            args["write_timeout"] = self._request_timeout_sec
 
             logger.debug("Initializing AIOSolr client with args: %s", self._base_url)
             client = aiosolr.Client(**args)

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-solr/tests/test_async_client.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-solr/tests/test_async_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 from typing import Any, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -492,12 +491,6 @@ async def test_async_solr_client_build_client(
     _ = await client._build_client()
 
     # THEN
-    # handle py3.9
-    if sys.version_info < (3, 10):
-        expected_args["timeout"] = expected_args["read_timeout"]
-        del expected_args["read_timeout"]
-        del expected_args["write_timeout"]
-
     mock_aiosolr_client_init.assert_called_once_with(**expected_args)
     assert mock_aiosolr_client_instance.session.headers == expected_headers
 


### PR DESCRIPTION
## Summary

Both packages declare `requires-python = ">=3.10"`, but still carry runtime version checks for interpreters they no longer support.

**llama-index-readers-sec-filings** — `sec_document.py` and `fetch.py`:

    if sys.version_info < (3, 8):  # noqa: UP036
        from typing import Final
    else:
        from typing import Final

The gate can never be true under the package's own floor — and both branches are identical, so it decided nothing either way. The `# noqa: UP036` was suppressing the pyupgrade rule that exists to catch exactly this. `Final` now comes from each module's main `typing` import.

**llama-index-vector-stores-solr** — `client/async_.py` picked `aiosolr` timeout kwargs under `if sys.version_info < (3, 10):`; the `timeout` branch is unreachable on every supported interpreter. The matching "handle py3.9" block in `tests/test_async_client.py` is removed with it.

## Changes

Remove the three dead gates and the now-unused `import sys` in each touched file (+4/−27). No behavior change: the surviving code is exactly what already ran on every supported Python. Happy to bump the package versions if preferred — left untouched since these are no-op cleanups.

Found while auditing long-lived workarounds in popular open-source projects.
