### PR TITLE
docs: 修复 Vespa 文档链接缺失 https 前缀

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vespa/README.md
@@ -14,7 +14,7 @@ Huggingface 🤗 embedders are supported, as well as SPLADE and ColBERT.
 
 ## Abstraction level of this integration
 
-To make it really simple to get started, we provide a template Vespa application that will be deployed upon initializing the vector store. This removes some of the complexity of setting up Vespa for the first time, but for serious use cases, we strongly recommend that you read the [Vespa documentation](docs.vespa.ai) and tailor the application to your needs.
+To make it really simple to get started, we provide a template Vespa application that will be deployed upon initializing the vector store. This removes some of the complexity of setting up Vespa for the first time, but for serious use cases, we strongly recommend that you read the [Vespa documentation](https://docs.vespa.ai) and tailor the application to your needs.
 
 ## The template
 


### PR DESCRIPTION
README 里 `[Vespa documentation](docs.vespa.ai)` 少了协议前缀，GitHub 上会被当成相对链接跳不到页面。补上 `https://`，指向 https://docs.vespa.ai 即可。

（由 Codex 提交，按 CONTRIBUTING 要求说明：改 1 行，已验证链接域名有效。）