### PR TITLE
docs: 修复 Qdrant 链接缺失 https 前缀

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-qdrant/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-qdrant/README.md
@@ -4,7 +4,7 @@
 
 The Qdrant Reader allows you to retrieve documents from existing Qdrant collections. Qdrant is a similarity search engine that helps you efficiently search and retrieve similar items from large datasets based on vector embeddings.
 
-For more detailed information about Qdrant, visit [Qdrant](qdrant.io)
+For more detailed information about Qdrant, visit [Qdrant](https://qdrant.io)
 
 ### Installation
 


### PR DESCRIPTION
README 里 `[Qdrant](qdrant.io)` 少了协议前缀，GitHub 上跳不到官网。补上 `https://`，指向 https://qdrant.io 即可。

（由 Codex 提交，按 CONTRIBUTING 要求说明：改 1 行，已验证链接域名有效。）