### PR TITLE
feat(core): allow LLM responses when context retrieval is empty

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -11,6 +11,7 @@ from llama_index.core.base.llms.types import (
 )
 from llama_index.core.base.response.schema import (
     AsyncStreamingResponse,
+    RESPONSE_TYPE,
     StreamingResponse,
 )
 from llama_index.core.callbacks import CallbackManager, trace_method
@@ -87,6 +88,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
     First condense a conversation and latest user message to a standalone question
     Then build a context for the standalone question from a retriever,
     Then pass the context along with prompt and user message to LLM to generate a response.
+    Empty retrieval results can optionally be passed to the LLM without context.
     """
 
     def __init__(
@@ -102,6 +104,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         callback_manager: Optional[CallbackManager] = None,
         verbose: bool = False,
+        respond_with_llm_on_empty_context: bool = False,
     ):
         self._retriever = retriever
         self._llm = llm
@@ -133,6 +136,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         self._token_counter = TokenCounter()
         self._verbose = verbose
+        self._respond_with_llm_on_empty_context = respond_with_llm_on_empty_context
 
     @classmethod
     def from_defaults(
@@ -148,6 +152,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         skip_condense: bool = False,
         node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
         verbose: bool = False,
+        respond_with_llm_on_empty_context: bool = False,
         **kwargs: Any,
     ) -> "CondensePlusContextChatEngine":
         """Initialize a CondensePlusContextChatEngine from default parameters."""
@@ -170,6 +175,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             node_postprocessors=node_postprocessors,
             system_prompt=system_prompt,
             verbose=verbose,
+            respond_with_llm_on_empty_context=respond_with_llm_on_empty_context,
         )
 
     def _condense_question(
@@ -319,13 +325,37 @@ class CondensePlusContextChatEngine(BaseChatEngine):
 
         return response_synthesizer, context_source, context_nodes
 
+    def _synthesize(
+        self,
+        synthesizer: CompactAndRefine,
+        message: str,
+        context_nodes: List[NodeWithScore],
+    ) -> RESPONSE_TYPE:
+        if context_nodes or not self._respond_with_llm_on_empty_context:
+            return synthesizer.synthesize(message, context_nodes)
+
+        response = synthesizer.get_response(query_str=message, text_chunks=[""])
+        return synthesizer._prepare_response_output(response, [])
+
+    async def _asynthesize(
+        self,
+        synthesizer: CompactAndRefine,
+        message: str,
+        context_nodes: List[NodeWithScore],
+    ) -> RESPONSE_TYPE:
+        if context_nodes or not self._respond_with_llm_on_empty_context:
+            return await synthesizer.asynthesize(message, context_nodes)
+
+        response = await synthesizer.aget_response(query_str=message, text_chunks=[""])
+        return synthesizer._prepare_response_output(response, [])
+
     @trace_method("chat")
     def chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
         synthesizer, context_source, context_nodes = self._run_c3(message, chat_history)
 
-        response = synthesizer.synthesize(message, context_nodes)
+        response = self._synthesize(synthesizer, message, context_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -348,7 +378,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = synthesizer.synthesize(message, context_nodes)
+        response = self._synthesize(synthesizer, message, context_nodes)
         assert isinstance(response, StreamingResponse)
 
         self._memory.put(ChatMessage(content=message, role=MessageRole.USER))
@@ -384,7 +414,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        response = await self._asynthesize(synthesizer, message, context_nodes)
 
         user_message = ChatMessage(content=message, role=MessageRole.USER)
         assistant_message = ChatMessage(
@@ -407,7 +437,7 @@ class CondensePlusContextChatEngine(BaseChatEngine):
             message, chat_history, streaming=True
         )
 
-        response = await synthesizer.asynthesize(message, context_nodes)
+        response = await self._asynthesize(synthesizer, message, context_nodes)
         assert isinstance(response, AsyncStreamingResponse)
 
         await self._memory.aput(ChatMessage(content=message, role=MessageRole.USER))

--- a/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py
@@ -29,7 +29,7 @@ from llama_index.core.memory import BaseMemory, Memory
 from llama_index.core.postprocessor.types import BaseNodePostprocessor
 from llama_index.core.prompts import PromptTemplate
 from llama_index.core.response_synthesizers import CompactAndRefine
-from llama_index.core.schema import NodeWithScore
+from llama_index.core.schema import NodeWithScore, TextNode
 from llama_index.core.settings import Settings
 from llama_index.core.types import Thread
 from llama_index.core.utilities.token_counting import TokenCounter
@@ -79,6 +79,16 @@ DEFAULT_CONDENSE_PROMPT_TEMPLATE = """
   {chat_history}
   Follow Up Input: {question}
   Standalone question:"""
+
+
+def _empty_context_node() -> NodeWithScore:
+    return NodeWithScore(node=TextNode(text=""))
+
+
+def _drop_source_nodes(response: RESPONSE_TYPE) -> RESPONSE_TYPE:
+    response.source_nodes = []
+    response.metadata = {}
+    return response
 
 
 class CondensePlusContextChatEngine(BaseChatEngine):
@@ -334,8 +344,11 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         if context_nodes or not self._respond_with_llm_on_empty_context:
             return synthesizer.synthesize(message, context_nodes)
 
-        response = synthesizer.get_response(query_str=message, text_chunks=[""])
-        return synthesizer._prepare_response_output(response, [])
+        # A placeholder chunk keeps the fallback on the regular synthesize path,
+        # which the synthesize events and the SYNTHESIZE callback hang off, and
+        # is then dropped because it is not a retrieved source.
+        response = synthesizer.synthesize(message, [_empty_context_node()])
+        return _drop_source_nodes(response)
 
     async def _asynthesize(
         self,
@@ -346,8 +359,8 @@ class CondensePlusContextChatEngine(BaseChatEngine):
         if context_nodes or not self._respond_with_llm_on_empty_context:
             return await synthesizer.asynthesize(message, context_nodes)
 
-        response = await synthesizer.aget_response(query_str=message, text_chunks=[""])
-        return synthesizer._prepare_response_output(response, [])
+        response = await synthesizer.asynthesize(message, [_empty_context_node()])
+        return _drop_source_nodes(response)
 
     @trace_method("chat")
     def chat(

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -1,9 +1,22 @@
 import time
+from typing import Any, List
 
 import pytest
+from pydantic import Field
 
+import llama_index.core.instrumentation as instrument
 from llama_index.core import MockEmbedding
 from llama_index.core.base.llms.types import MessageRole
+from llama_index.core.callbacks import (
+    CallbackManager,
+    CBEventType,
+    LlamaDebugHandler,
+)
+from llama_index.core.instrumentation.event_handlers import BaseEventHandler
+from llama_index.core.instrumentation.events.synthesis import (
+    SynthesizeEndEvent,
+    SynthesizeStartEvent,
+)
 from llama_index.core.chat_engine.condense_plus_context import (
     CondensePlusContextChatEngine,
 )
@@ -13,6 +26,18 @@ from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.core.schema import Document
 
 SYSTEM_PROMPT = "Talk like a pirate."
+
+
+class _SynthesizeEventCollector(BaseEventHandler):
+    collected: List[str] = Field(default_factory=list)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "_SynthesizeEventCollector"
+
+    def handle(self, event: Any, **kwargs: Any) -> None:
+        if isinstance(event, (SynthesizeStartEvent, SynthesizeEndEvent)):
+            self.collected.append(type(event).__name__)
 
 
 @pytest.fixture()
@@ -77,6 +102,34 @@ def test_chat_empty_context_can_respond_with_llm(
     assert "Hello World!" in str(response)
     assert response.source_nodes == []
     assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
+
+
+def test_chat_empty_context_fallback_keeps_synthesize_instrumentation():
+    debug_handler = LlamaDebugHandler()
+    index = VectorStoreIndex.from_documents([], embed_model=MockEmbedding(embed_dim=3))
+    llm = MockLLM()
+    engine = CondensePlusContextChatEngine(
+        retriever=index.as_retriever(),
+        llm=llm,
+        memory=ChatMemoryBuffer.from_defaults(llm=llm),
+        system_prompt=SYSTEM_PROMPT,
+        callback_manager=CallbackManager([debug_handler]),
+        respond_with_llm_on_empty_context=True,
+    )
+
+    collector = _SynthesizeEventCollector()
+    dispatcher = instrument.get_dispatcher()
+    dispatcher.add_event_handler(collector)
+    try:
+        response = engine.chat("Hello World!")
+    finally:
+        dispatcher.event_handlers.remove(collector)
+
+    assert SYSTEM_PROMPT in str(response)
+    assert response.source_nodes == []
+    assert collector.collected.count("SynthesizeStartEvent") == 1
+    assert collector.collected.count("SynthesizeEndEvent") == 1
+    assert len(debug_handler.get_event_pairs(CBEventType.SYNTHESIZE)) == 1
 
 
 def test_stream_chat_empty_context_can_respond_with_llm(

--- a/llama-index-core/tests/chat_engine/test_condense_plus_context.py
+++ b/llama-index-core/tests/chat_engine/test_condense_plus_context.py
@@ -26,6 +26,25 @@ def chat_engine() -> CondensePlusContextChatEngine:
     )
 
 
+@pytest.fixture()
+def empty_chat_engine() -> CondensePlusContextChatEngine:
+    index = VectorStoreIndex.from_documents([], embed_model=MockEmbedding(embed_dim=3))
+    return CondensePlusContextChatEngine.from_defaults(
+        index.as_retriever(), llm=MockLLM(), system_prompt=SYSTEM_PROMPT
+    )
+
+
+@pytest.fixture()
+def empty_chat_engine_with_llm_fallback() -> CondensePlusContextChatEngine:
+    index = VectorStoreIndex.from_documents([], embed_model=MockEmbedding(embed_dim=3))
+    return CondensePlusContextChatEngine.from_defaults(
+        index.as_retriever(),
+        llm=MockLLM(),
+        system_prompt=SYSTEM_PROMPT,
+        respond_with_llm_on_empty_context=True,
+    )
+
+
 def test_chat(chat_engine: CondensePlusContextChatEngine):
     response = chat_engine.chat("Hello World!")
     assert SYSTEM_PROMPT in str(response)
@@ -37,6 +56,39 @@ def test_chat(chat_engine: CondensePlusContextChatEngine):
     assert "Hello World!" in str(response)
     assert "What is the capital of the moon?" in str(response)
     assert len(chat_engine.chat_history) == 4
+
+
+def test_chat_empty_context_returns_empty_response_by_default(
+    empty_chat_engine: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine.chat("Hello World!")
+
+    assert str(response) == "Empty Response"
+    assert response.source_nodes == []
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+def test_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine_with_llm_fallback.chat("Hello World!")
+
+    assert SYSTEM_PROMPT in str(response)
+    assert "Hello World!" in str(response)
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
+
+
+def test_stream_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = empty_chat_engine_with_llm_fallback.stream_chat("Hello World!")
+    full_response = "".join(response.response_gen)
+
+    assert SYSTEM_PROMPT in full_response
+    assert "Hello World!" in full_response
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
 
 
 def test_chat_stream(chat_engine: CondensePlusContextChatEngine):
@@ -82,6 +134,47 @@ def test_stream_chat_memory_not_lost_on_incomplete_consumption(
     assert response.is_done
     assert len(chat_engine.chat_history) == 2
     assert chat_engine.chat_history[1].role == MessageRole.ASSISTANT
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_empty_context_returns_empty_response_by_default(
+    empty_chat_engine: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine.astream_chat("Hello World!")
+    full_response = ""
+    async for token in response.async_response_gen():
+        full_response += token
+
+    assert full_response == "Empty Response"
+    assert response.source_nodes == []
+    assert len(empty_chat_engine.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_achat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine_with_llm_fallback.achat("Hello World!")
+
+    assert SYSTEM_PROMPT in str(response)
+    assert "Hello World!" in str(response)
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_empty_context_can_respond_with_llm(
+    empty_chat_engine_with_llm_fallback: CondensePlusContextChatEngine,
+):
+    response = await empty_chat_engine_with_llm_fallback.astream_chat("Hello World!")
+    full_response = ""
+    async for token in response.async_response_gen():
+        full_response += token
+
+    assert SYSTEM_PROMPT in full_response
+    assert "Hello World!" in full_response
+    assert response.source_nodes == []
+    assert len(empty_chat_engine_with_llm_fallback.chat_history) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Adds an opt-in `respond_with_llm_on_empty_context` setting to `CondensePlusContextChatEngine` for conversational applications whose retriever can legitimately return no nodes. When enabled, the engine uses its existing context-aware response synthesizer with an empty context chunk, preserving the system prompt and chat history while returning no source nodes.

The default remains `False`, so existing strict-RAG behavior continues to return `"Empty Response"`.

Fixes #20894

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Coverage includes default and opt-in behavior across synchronous, streaming, asynchronous, and asynchronous-streaming chat paths. The full `llama-index-core` suite passes locally: 1,500 passed, 22 skipped, 6 xfailed.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods

Validation also includes the repository-wide `uv run make lint`, focused Ruff formatting/linting, mypy, and `git diff --check`.

[Written by Devin](https://app.devin.ai/sessions/eb8ef8a13a8a44298d282429f292fa0b)
