### PR TITLE
fix(core): skip blank documents in SemanticSplitterNodeParser

### DIFF
--- a/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
+++ b/llama-index-core/llama_index/core/node_parser/text/semantic_splitter.py
@@ -167,6 +167,8 @@ class SemanticSplitterNodeParser(NodeParser):
         for doc in documents:
             text = doc.text
             text_splits = self.sentence_splitter(text)
+            if not any(text_split.strip() for text_split in text_splits):
+                continue
 
             sentences = self._build_sentence_groups(text_splits)
 
@@ -202,6 +204,8 @@ class SemanticSplitterNodeParser(NodeParser):
         for doc in documents:
             text = doc.text
             text_splits = self.sentence_splitter(text)
+            if not any(text_split.strip() for text_split in text_splits):
+                continue
 
             sentences = self._build_sentence_groups(text_splits)
 

--- a/llama-index-core/tests/node_parser/test_semantic_splitter.py
+++ b/llama-index-core/tests/node_parser/test_semantic_splitter.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import pytest
+
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.node_parser.text.semantic_splitter import (
     SemanticSplitterNodeParser,
@@ -117,4 +119,66 @@ def test_split_and_permutated() -> None:
     assert (
         sentences[2]["combined_sentence"]
         == "I can't carry it for you. But I can carry you!"
+    )
+
+
+class RecordingEmbedding(MockEmbedding):
+    """Mock embedding that records the batches it is asked to embed."""
+
+    batches: List[List[str]] = []
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "RecordingEmbedding"
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        self.batches.append(texts)
+        return [self._get_text_embedding(text) for text in texts]
+
+    async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        self.batches.append(texts)
+        return [await self._aget_text_embedding(text) for text in texts]
+
+
+@pytest.mark.parametrize("text", ["", "   \n\t "])
+def test_blank_document_produces_no_nodes(text: str) -> None:
+    embeddings = RecordingEmbedding(batches=[])
+
+    node_parser = SemanticSplitterNodeParser.from_defaults(embeddings)
+
+    assert node_parser.get_nodes_from_documents([Document(text=text)]) == []
+    assert embeddings.batches == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["", "   \n\t "])
+async def test_blank_document_produces_no_nodes_async(text: str) -> None:
+    embeddings = RecordingEmbedding(batches=[])
+
+    node_parser = SemanticSplitterNodeParser.from_defaults(embeddings)
+
+    nodes = await node_parser.aget_nodes_from_documents([Document(text=text)])
+
+    assert nodes == []
+    assert embeddings.batches == []
+
+
+def test_blank_document_does_not_affect_other_documents() -> None:
+    embeddings = MockEmbedding()
+
+    node_parser = SemanticSplitterNodeParser.from_defaults(embeddings)
+
+    nodes = node_parser.get_nodes_from_documents(
+        [
+            Document(text="  "),
+            Document(
+                text="They're taking the Hobbits to Isengard! I can't carry it for you. But I can carry you!"
+            ),
+        ]
+    )
+
+    assert len(nodes) == 1
+    assert (
+        nodes[0].get_content()
+        == "They're taking the Hobbits to Isengard! I can't carry it for you. But I can carry you!"
     )


### PR DESCRIPTION
## Summary

`SemanticSplitterNodeParser` on a document whose text is empty or whitespace-only sends that blank text to the embedding model and then emits a node with no content:

```python
parser = SemanticSplitterNodeParser.from_defaults(embed_model)
parser.get_nodes_from_documents([Document(text="   \n  ")])
# -> [TextNode(text='')]   # plus one embedding request for the blank text
```

Two problems: the embedding call is wasted (and providers such as OpenAI reject empty inputs with a 400), and the empty node lands in the index where it can be retrieved. Every other text parser drops blank input -- `SentenceSplitter`, `TokenTextSplitter` and `SentenceWindowNodeParser` all return `[]` for a whitespace-only document.

The fix short-circuits the per-document loop in both `build_semantic_nodes_from_documents` and `abuild_semantic_nodes_from_documents` before the embedding call:

```python
text_splits = self.sentence_splitter(text)
+ if not any(text_split.strip() for text_split in text_splits):
+     continue
```

Documents with real content are unaffected, including blank documents mixed into the same batch. Tests cover the sync and async paths and assert no embedding batch is requested (via a `MockEmbedding` subclass that records the batches it receives).
