### PR TITLE
fix(instrumentation): avoid mutable default arguments in Dispatcher.__init__ (#22705)

### DIFF
--- a/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
+++ b/llama-index-instrumentation/src/llama_index_instrumentation/dispatcher.py
@@ -90,8 +90,8 @@ class Dispatcher(BaseModel):
     def __init__(
         self,
         name: str = "",
-        event_handlers: List[BaseEventHandler] = [],
-        span_handlers: List[BaseSpanHandler] = [],
+        event_handlers: Optional[List[BaseEventHandler]] = None,
+        span_handlers: Optional[List[BaseSpanHandler]] = None,
         parent_name: str = "",
         manager: Optional["Manager"] = None,
         root_name: str = "root",
@@ -99,8 +99,12 @@ class Dispatcher(BaseModel):
     ):
         super().__init__(
             name=name,
-            event_handlers=event_handlers,
-            span_handlers=span_handlers,
+            event_handlers=event_handlers if event_handlers is not None else [],
+            span_handlers=(
+                span_handlers
+                if span_handlers is not None
+                else [NullSpanHandler()]
+            ),
             parent_name=parent_name,
             manager=manager,
             root_name=root_name,

--- a/llama-index-instrumentation/tests/test_dispatcher.py
+++ b/llama-index-instrumentation/tests/test_dispatcher.py
@@ -1220,3 +1220,12 @@ async def test_aevent_no_propagation():
     assert len(parent_handler.events) == 0
     assert child_handler.async_calls == 1
     assert parent_handler.async_calls == 0
+
+
+def test_dispatcher_default_arguments_immutability():
+    """Ensure that default event_handlers and span_handlers lists are not shared between instances."""
+    d1 = Dispatcher(name="d1")
+    d2 = Dispatcher(name="d2")
+    assert d1.event_handlers is not d2.event_handlers
+    assert d1.span_handlers is not d2.span_handlers
+


### PR DESCRIPTION
## Summary

Fixes #22705

Changes default arguments for `event_handlers` and `span_handlers` in `Dispatcher.__init__` from mutable list literals (`[]`) to `None`, instantiating fresh list instances when `None` is provided.

- `event_handlers`: `Optional[List[BaseEventHandler]] = None` -> defaults to `[]`
- `span_handlers`: `Optional[List[BaseSpanHandler]] = None` -> defaults to `[NullSpanHandler()]`

## Verification

Added unit test `test_dispatcher_default_arguments_immutability` verifying list isolation between multiple `Dispatcher` instances.
All 51 test cases in `llama-index-instrumentation/tests` passed.