### PR TITLE
fix(box): pass the Box client when triggering text generation

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/llama_index/readers/box/BoxAPI/box_api.py
@@ -321,7 +321,9 @@ def get_text_representation(
 
         # Handle cases where the extracted text needs generation
         if extracted_text_entry.status.state == "none":
-            _do_request(extracted_text_entry.info.url)  # Trigger text generation
+            _do_request(
+                box_client, extracted_text_entry.info.url
+            )  # Trigger text generation
 
         # Construct the download URL and sanitize filename
         url = extracted_text_entry.content.url_template.replace("{+asset_path}", "")

--- a/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-box/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-box"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers box integration"
 authors = [{name = "Box Developer Relations", email = "dx@box.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_text_generation_trigger.py
+++ b/llama-index-integrations/readers/llama-index-readers-box/tests/test_readers_box_text_generation_trigger.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from llama_index.readers.box.BoxAPI import box_api
+
+
+def _pending_representation():
+    """An `extracted_text` representation Box has not generated yet."""
+    return SimpleNamespace(
+        representation="extracted_text",
+        status=SimpleNamespace(state="none"),
+        info=SimpleNamespace(url="https://api.box.com/2.0/files/1/content/text.txt"),
+        content=SimpleNamespace(url_template="https://dl.boxcloud.com/{+asset_path}"),
+    )
+
+
+def test_pending_text_representation_is_triggered_with_the_box_client(monkeypatch):
+    """
+    `_do_request` takes (box_client, url).
+
+    The call that triggers generation for a still-pending representation must pass
+    the client too, exactly like the download call right below it.
+    """
+    calls = []
+
+    def fake_do_request(box_client, url):
+        calls.append((box_client, url))
+        return b"CONTENT"
+
+    monkeypatch.setattr(box_api, "_do_request", fake_do_request)
+
+    entry = _pending_representation()
+    representation_file = SimpleNamespace(
+        id="1", representations=SimpleNamespace(entries=[entry])
+    )
+    box_client = SimpleNamespace(
+        files=SimpleNamespace(
+            get_file_by_id=lambda *args, **kwargs: representation_file
+        )
+    )
+    box_file = SimpleNamespace(id="1", text_representation=None)
+
+    result = box_api.get_text_representation(box_client, [box_file], token_limit=4)
+
+    # both the trigger and the download go through the client
+    assert [client for client, _ in calls] == [box_client, box_client]
+    assert calls[0][1] == entry.info.url
+    assert calls[1][1] == "https://dl.boxcloud.com/"
+
+    assert result == [box_file]
+    assert box_file.text_representation == b"CONT"


### PR DESCRIPTION
# Description

`get_text_representation()` in the Box reader triggers generation for a
not-yet-generated `extracted_text` representation like this:

```python
if extracted_text_entry.status.state == "none":
    _do_request(extracted_text_entry.info.url)  # Trigger text generation
```

But `_do_request` takes **two** required parameters:

```python
def _do_request(box_client: BoxClient, url: str):
```

So the URL is bound to `box_client`, `url` is never supplied, and the call raises:

```
TypeError: _do_request() missing 1 required positional argument: 'url'
```

This hits any Box file whose extracted-text representation has not been generated
yet (`status.state == "none"`) — exactly the case the branch exists to handle. The
download call six lines below already gets it right (`_do_request(box_client, url)`),
which is the intended shape.

Fixes the trigger call to pass the client, and adds a regression test.

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating?
(Except for the `llama-index-core` package)

- [x] Yes (`llama-index-readers-box` 0.5.0 → 0.5.1)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added new unit/integration tests

`tests/test_readers_box_text_generation_trigger.py` drives
`get_text_representation()` with a stubbed client whose representation is in the
`"none"` state, replacing `_do_request` with a stub carrying the **real** two-argument
signature, and asserts both the trigger call and the download call receive the client.

Running that test body against both revisions:

| revision | result |
|---|---|
| `main` | ❌ `TypeError: _do_request() missing 1 required positional argument: 'url'` |
| this PR | ✅ passes — trigger called with `(box_client, info.url)` |

`ruff check` and `ruff format` (v0.11.8, matching `.pre-commit-config.yaml`) are clean
on both changed files.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `ruff check` and `ruff format` on the changed files

> Note: #22341 also touches this package and bumps it to `0.5.1`. The code hunks do not
> overlap (that PR changes `download_file_by_id`, this one `get_text_representation`),
> so only the version line would need a trivial rebase if both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
