### PR TITLE
docs: fix incorrect example output in starter tutorial

### DIFF
--- a/docs/src/content/docs/framework/getting_started/starter_example.mdx
+++ b/docs/src/content/docs/framework/getting_started/starter_example.mdx
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-This will output something like: `The result of \( 1234 \times 4567 \) is \( 5,678,678 \).`
+This will output something like: `The result of \( 1234 \times 4567 \) is \( 5,635,678 \).`
 
 What happened is:
 


### PR DESCRIPTION
## Description
The Starter Tutorial's "Basic Agent Example" section shows an example output for the calculation 1234 × 4567 as `5,678,678`. This is incorrect — the correct result is `5,635,678` (verified with Python: `1234 * 4567 = 5635678`). This PR corrects the number in the example output so the tutorial is accurate.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?
This is a documentation-only text correction (a single incorrect number in an example output string). No code was changed, so no unit tests apply.
- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings