### PR TITLE
test(opengauss): fix hybrid parameter spelling

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-openGauss/tests/test_opengauss.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-openGauss/tests/test_opengauss.py
@@ -209,13 +209,13 @@ async def test_sparse_query(
     assert res.nodes[1].node_id == "ddd"
 
 
-@pytest.mark.parametrize("hybird", [True, False])
-def test_opengauss_init(hybird: bool) -> None:
+@pytest.mark.parametrize("hybrid", [True, False])
+def test_opengauss_init(hybrid: bool) -> None:
     store = OpenGaussStore.from_params(
         **PARAMS,
         database=TEST_DB,
         table_name=TEST_TABLE_NAME,
         schema_name=TEST_SCHEMA_NAME,
-        hybrid_search=hybird,
+        hybrid_search=hybrid,
         embed_dim=TEST_EMBED_DIM,
     )


### PR DESCRIPTION
## What changed

Rename the `hybird` parameter in `test_opengauss_init` to `hybrid` and update its use in the test.

## Why

The corrected name matches the `hybrid_search` option and makes the test easier to read. This change does not affect runtime behavior.

## Validation

- Compiled the modified test file with Python to verify its syntax.
- Ran `git diff --check`.
- The full integration test was not run locally because it requires a supported Python version and an openGauss instance.

AI assistance was used to identify the typo and prepare the patch. I reviewed the complete diff and verified the checks listed above.
