### PR TITLE
fix(core): preserve composition keywords and guarantee valid parameter schemas in ToolMetadata

### DIFF
--- a/llama-index-core/llama_index/core/bridge/pydantic.py
+++ b/llama-index-core/llama_index/core/bridge/pydantic.py
@@ -10,6 +10,7 @@ from pydantic import (
     GetJsonSchemaHandler,
     PlainSerializer,
     PrivateAttr,
+    RootModel,
     Secret,
     SecretStr,
     SerializationInfo,
@@ -35,6 +36,7 @@ from pydantic.json_schema import JsonSchemaValue
 __all__ = [
     "pydantic",
     "BaseModel",
+    "RootModel",
     "ConfigDict",
     "GetJsonSchemaHandler",
     "GetCoreSchemaHandler",

--- a/llama-index-core/llama_index/core/tools/types.py
+++ b/llama-index-core/llama_index/core/tools/types.py
@@ -41,8 +41,28 @@ class ToolMetadata:
             parameters = {
                 k: v
                 for k, v in parameters.items()
-                if k in ["type", "properties", "required", "definitions", "$defs"]
+                if k
+                in [
+                    "type",
+                    "properties",
+                    "required",
+                    "definitions",
+                    "$defs",
+                    "$ref",
+                    "anyOf",
+                    "oneOf",
+                    "allOf",
+                    "items",
+                    "prefixItems",
+                    "additionalProperties",
+                    "enum",
+                    "default",
+                ]
             }
+            if parameters.get("type") == "object" or "properties" in parameters:
+                parameters.setdefault("type", "object")
+                parameters.setdefault("properties", {})
+                parameters.setdefault("required", [])
         return parameters
 
     @property

--- a/llama-index-core/tests/tools/test_types.py
+++ b/llama-index-core/tests/tools/test_types.py
@@ -1,7 +1,10 @@
+from typing import List, Literal, Union
+
 import pytest
 
-from llama_index.core.bridge.pydantic import BaseModel
+from llama_index.core.bridge.pydantic import BaseModel, RootModel
 from llama_index.core.program.function_program import get_function_tool
+from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.types import ToolMetadata
 
 
@@ -38,3 +41,81 @@ def test_nested_tool_schema() -> None:
 
     assert schema["required"][0] == "inner"
     assert schema["properties"] == {"inner": {"$ref": "#/$defs/Inner"}}
+
+
+def test_parameterless_tool_schema() -> None:
+    def ping() -> str:
+        """Ping service."""
+        return "pong"
+
+    tool = FunctionTool.from_defaults(fn=ping)
+    schema = tool.metadata.get_parameters_dict()
+    assert schema == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+    openai_tool = tool.metadata.to_openai_tool()
+    assert openai_tool["function"]["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+
+def test_all_default_args_tool_schema() -> None:
+    def greet(name: str = "world") -> str:
+        """Greet someone."""
+        return f"hello {name}"
+
+    tool = FunctionTool.from_defaults(fn=greet)
+    schema = tool.metadata.get_parameters_dict()
+    assert schema["type"] == "object"
+    assert "name" in schema["properties"]
+    assert schema["required"] == []
+
+
+def test_root_model_tool_schema_keeps_defs_and_ref() -> None:
+    class ModelInner(BaseModel):
+        x: int
+
+    class Root(RootModel[ModelInner]):
+        pass
+
+    schema = ToolMetadata(
+        description="d", name="t", fn_schema=Root
+    ).get_parameters_dict()
+    assert "$defs" in schema
+    assert "$ref" in schema
+    assert schema["$ref"] == "#/$defs/ModelInner"
+
+
+def test_root_model_union_tool_schema_keeps_anyof() -> None:
+    class Approve(BaseModel):
+        action: Literal["approve"]
+        note: str
+
+    class Reject(BaseModel):
+        action: Literal["reject"]
+        reason: str
+
+    class Decision(RootModel[Union[Approve, Reject]]):
+        pass
+
+    schema = ToolMetadata(
+        description="d", name="t", fn_schema=Decision
+    ).get_parameters_dict()
+    assert "$defs" in schema
+    assert "anyOf" in schema
+    assert len(schema["anyOf"]) == 2
+
+
+def test_root_model_list_tool_schema_keeps_items() -> None:
+    class ItemList(RootModel[List[int]]):
+        pass
+
+    schema = ToolMetadata(
+        description="d", name="t", fn_schema=ItemList
+    ).get_parameters_dict()
+    assert schema == {"type": "array", "items": {"type": "integer"}}


### PR DESCRIPTION
# Description

In `llama-index-core/llama_index/core/tools/types.py`, `ToolMetadata.get_parameters_dict()` extracts schema metadata from `fn_schema.model_json_schema()`:

1. **Missing `required: []` on Parameterless / All-Optional Tools**: When a tool function takes zero arguments (`def ping() -> str:`) or only default arguments (`def greet(name: str = "world") -> str:`), `model_json_schema()` omits the `"required"` key. Strict JSON-schema validators (such as vLLM and OpenAI-compatible endpoints) require `"required"` and `"properties"` on object schemas, leading to `400 Validation Error: 0.function.arguments Field required` or schema rejection.
2. **Stripping Composition and Pointer Keywords (`$ref`, `anyOf`, `items`, etc.)**: The previous keyword whitelist (`["type", "properties", "required", "definitions", "$defs"]`) stripped out essential JSON-schema keywords such as `$ref`, `anyOf`, `oneOf`, `allOf`, `items`, `prefixItems`, `additionalProperties`, `enum`, and `default`. Consequently:
   - `RootModel[Inner]` retained `$defs` but dropped the root `$ref` pointer into `$defs`.
   - `RootModel[Union[A, B]]` retained `$defs` but dropped `anyOf`, sending an empty shell to the LLM.
   - `RootModel[List[T]]` kept `"type": "array"` but stripped `"items"`, hiding the element type from the model.
   - Strict schemas with `additionalProperties: False` had their constraint dropped.

### Solution

- Expand keyword preservation in `ToolMetadata.get_parameters_dict()` to retain `$ref`, `anyOf`, `oneOf`, `allOf`, `items`, `prefixItems`, `additionalProperties`, `enum`, and `default`.
- For object schemas (or schemas defining `properties`), default `"type"` to `"object"`, `"properties"` to `{}`, and `"required"` to `[]` when absent.
- Export `RootModel` in `llama_index.core.bridge.pydantic` for structured output usage.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core` is exempt)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added unit tests in `llama-index-core/tests/tools/test_types.py`:
  - `test_parameterless_tool_schema` (asserts valid empty properties and required array)
  - `test_all_default_args_tool_schema` (asserts default arguments schema)
  - `test_root_model_tool_schema_keeps_defs_and_ref` (asserts `$ref` and `$defs` preservation)
  - `test_root_model_union_tool_schema_keeps_anyof` (asserts `anyOf` and `$defs` preservation)
  - `test_root_model_list_tool_schema_keeps_items` (asserts array `items` schema preservation)
- Ran `pytest tests/tools/` (72 passed, 4 skipped)
- Ran `ruff check` and `ruff format --check`

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
