### PR TITLE
fix(core): dedupe kg entities within a single insert batch

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/base.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/base.py
@@ -233,13 +233,23 @@ class PropertyGraphIndex(BaseIndex[IndexLPG]):
             kg_nodes_to_insert.extend(kg_nodes)
             kg_rels_to_insert.extend(kg_rels)
 
-        # filter out duplicate kg nodes
+        # filter out duplicate kg nodes: the ones already in the graph store, and
+        # repeats within this batch. The same entity is routinely extracted from
+        # several source nodes, and each copy would otherwise be embedded again
+        # and written to the vector store again. First occurrence wins, matching
+        # what already happens across calls -- an entity in the store is dropped,
+        # so the version written first is the one that stays.
         kg_node_ids = {node.id for node in kg_nodes_to_insert}
         existing_kg_nodes = self.property_graph_store.get(ids=list(kg_node_ids))
-        existing_kg_node_ids = {node.id for node in existing_kg_nodes}
-        kg_nodes_to_insert = [
-            node for node in kg_nodes_to_insert if node.id not in existing_kg_node_ids
-        ]
+        seen_kg_node_ids = {node.id for node in existing_kg_nodes}
+
+        deduped_kg_nodes_to_insert: List[LabelledNode] = []
+        for kg_node in kg_nodes_to_insert:
+            if kg_node.id in seen_kg_node_ids:
+                continue
+            seen_kg_node_ids.add(kg_node.id)
+            deduped_kg_nodes_to_insert.append(kg_node)
+        kg_nodes_to_insert = deduped_kg_nodes_to_insert
 
         # filter out duplicate llama nodes
         existing_nodes = self.property_graph_store.get_llama_nodes(

--- a/llama-index-core/tests/indices/property_graph/test_property_graph.py
+++ b/llama-index-core/tests/indices/property_graph/test_property_graph.py
@@ -34,6 +34,43 @@ class MockKGExtractor(TransformComponent):
         ]
 
 
+class MockSharedEntityKGExtractor(TransformComponent):
+    """
+    A mock extractor that pulls the same entity out of two source nodes.
+
+    This is the ordinary case for a corpus rather than an edge case: one entity
+    is mentioned in more than one document, so it appears once per document in
+    a single insert.
+    """
+
+    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        source_nodes = []
+        for i, (text, other_name, other_label, relation_label) in enumerate(
+            [
+                ("Logan was born in Canada", "Canada", "LOCATION", "BORN_IN"),
+                ("Logan works at LlamaIndex", "LlamaIndex", "ORG", "WORKS_AT"),
+            ]
+        ):
+            person = EntityNode(name="Logan", label="PERSON")
+            other = EntityNode(name=other_name, label=other_label)
+            relation = Relation(
+                label=relation_label, source_id=person.id, target_id=other.id
+            )
+
+            source_nodes.append(
+                TextNode(
+                    id_=f"test-{i}",
+                    text=text,
+                    metadata={
+                        KG_NODES_KEY: [person, other],
+                        KG_RELATIONS_KEY: [relation],
+                    },
+                )
+            )
+
+        return source_nodes
+
+
 def test_construction() -> None:
     graph_store = SimplePropertyGraphStore()
     vector_store = SimpleVectorStore()
@@ -66,3 +103,34 @@ def test_construction() -> None:
     index.insert_nodes(kg_extractor([]))
 
     assert index._insert_nodes_to_vector_index.call_count == 0
+
+
+def test_kg_nodes_are_deduped_within_a_single_insert() -> None:
+    graph_store = SimplePropertyGraphStore()
+    vector_store = SimpleVectorStore()
+    kg_extractor = MockSharedEntityKGExtractor()
+
+    index = PropertyGraphIndex.from_existing(
+        property_graph_store=graph_store,
+        vector_store=vector_store,
+        llm=MockLLM(),
+        embed_model=MockEmbedding(embed_dim=256),
+        kg_extractors=[kg_extractor],
+    )
+
+    index._insert_nodes_to_vector_index = MagicMock()
+    index.insert_nodes(kg_extractor([]))
+
+    # this list is both what gets embedded and what reaches the vector store,
+    # so one entry per distinct entity is the whole of the fix
+    index._insert_nodes_to_vector_index.assert_called_once()
+    inserted_ids = [
+        node.id for node in index._insert_nodes_to_vector_index.call_args[0][0]
+    ]
+    assert sorted(inserted_ids) == ["Canada", "LlamaIndex", "Logan"]
+
+    # nothing is lost by deduping: every distinct entity is in the graph, and
+    # both relations that mention "Logan" survive
+    kg_nodes = graph_store.get(ids=["Logan", "Canada", "LlamaIndex"])
+    assert len(kg_nodes) == 3
+    assert len(graph_store.get_triplets(entity_names=["Logan"])) == 2


### PR DESCRIPTION
# Description

`PropertyGraphIndex._insert_nodes` removes KG entities that are already in the
property graph store before inserting, but it never removes repeats **inside
the batch it is about to insert**. When the same entity is extracted from more
than one source document — the ordinary case for a corpus, and the point of
building a knowledge graph — every copy survives to the end of `_insert_nodes`.

The graph store absorbs this, because `upsert_nodes` is keyed by id. The vector
index does not:

- each copy is embedded separately, so N mentions of one entity cost N calls to
  the embedding model rather than one;
- `_insert_nodes_to_vector_index` builds a `TextNode` per copy, and in any store
  with `stores_text=True` that `TextNode` gets a **fresh random `id_`**. The
  store ends up holding N rows for one entity, each under a different id, which
  nothing downstream can collapse afterwards;
- retrieval then returns the same entity several times inside one top-k,
  crowding out the entities the query should have surfaced.

The cause is a two-line mismatch. The set comprehension that gathers ids for the
store query already collapses the duplicates, but it is only used to ask the
store a question — the list comprehension that does the filtering runs over the
uncollapsed list:

```python
kg_node_ids = {node.id for node in kg_nodes_to_insert}          # collapsed
existing_kg_nodes = self.property_graph_store.get(ids=list(kg_node_ids))
existing_kg_node_ids = {node.id for node in existing_kg_nodes}
kg_nodes_to_insert = [                                          # not collapsed
    node for node in kg_nodes_to_insert if node.id not in existing_kg_node_ids
]
```

For what it is worth, that block arrived in #13891 — *"avoid empty or duplicate
inserts in property graph index"* — and nothing has touched it since. So this is
not a new opinion about how the index should behave; it is the within-batch half
of what that pull request already set out to do.

This carries that set forward instead, adding each id as it is emitted, so the
first occurrence wins. Keep-first rather than keep-last is deliberate: it is
already what happens across calls, where an entity found in the store is dropped
and the version written first is the one that stays. Keep-last within a batch
would make the two directions disagree.

Relations are left alone. `kg_rels_to_insert` can carry duplicates by the same
route, but relations are neither embedded nor written to the vector store, so
neither cost above applies to them.

Fixes #22394

Written with AI assistance. The reproduction, the fix and the test are mine to
stand behind: I took the baseline before changing anything, confirmed the new
test fails with the fix reverted and passes with it, and ran the full
`llama-index-core` suite and the linters below.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No — this is `llama-index-core`, which the template excepts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_kg_nodes_are_deduped_within_a_single_insert` in
`llama-index-core/tests/indices/property_graph/test_property_graph.py`. A mock
extractor pulls `Logan` out of two source nodes, plus `Canada` from one and
`LlamaIndex` from the other. With this change reverted:

```
>   assert sorted(inserted_ids) == ["Canada", "LlamaIndex", "Logan"]
E   AssertionError: assert ['Canada', 'L...gan', 'Logan'] == ['Canada', 'L...dex', 'Logan']
E     Left contains one more item: 'Logan'
```

The list it asserts on is `kg_nodes_to_insert`, which is both what
`get_text_embedding_batch` is handed and what `_insert_nodes_to_vector_index`
writes — so the extra `Logan` is one extra embedding call and one extra vector
row. The test also checks that nothing is lost: all three distinct entities
reach the graph store, and both relations mentioning `Logan` survive.

One note on why the assertion is where it is rather than on the vector store
itself. `SimpleVectorStore.stores_text` is `False`, so
`_insert_nodes_to_vector_index` sets `llama_nodes[-1].id_ = node.id` and `add()`
writes into a dict keyed by that id — duplicates silently overwrite, and a test
that counted rows in `SimpleVectorStore` would pass on the unfixed code. The
in-memory store is the one place this bug is invisible. Inspecting the argument
to a mocked `_insert_nodes_to_vector_index` is also what the existing
`test_construction` already does for the store-level duplicate case.

Full `llama-index-core` suite, Python 3.12:

| | |
|---|---|
| before | 1494 passed, 22 skipped, 6 xfailed, 0 failed |
| after | 1495 passed, 22 skipped, 6 xfailed, 0 failed |

`ruff check` and `ruff format --check` are clean on both touched files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the linters (`ruff check`, `ruff format`) over the files I touched
