### PR TITLE
feat(core): add async paths to SentenceEmbeddingOptimizer and EmbeddingRecencyPostprocessor

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/node_recency.py
+++ b/llama-index-core/llama_index/core/postprocessor/node_recency.py
@@ -1,7 +1,7 @@
 """Node recency post-processor."""
 
 from datetime import datetime
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 import numpy as np
 
@@ -105,12 +105,12 @@ class EmbeddingRecencyPostprocessor(BaseNodePostprocessor):
     def class_name(cls) -> str:
         return "EmbeddingRecencyPostprocessor"
 
-    def _postprocess_nodes(
+    def _sort_nodes_by_date(
         self,
         nodes: List[NodeWithScore],
-        query_bundle: Optional[QueryBundle] = None,
-    ) -> List[NodeWithScore]:
-        """Postprocess nodes."""
+        query_bundle: Optional[QueryBundle],
+    ) -> Tuple[List[NodeWithScore], List[str]]:
+        """Validate the query bundle and order nodes newest-first."""
         try:
             import pandas as pd
         except ImportError:
@@ -128,32 +128,92 @@ class EmbeddingRecencyPostprocessor(BaseNodePostprocessor):
         sorted_node_idxs = np.flip(node_dates.argsort())
         sorted_nodes: List[NodeWithScore] = [nodes[idx] for idx in sorted_node_idxs]
 
-        # get embeddings for each node
         texts = [node.get_content(metadata_mode=MetadataMode.EMBED) for node in nodes]
+        return sorted_nodes, texts
+
+    def _get_query_text(self, node: NodeWithScore) -> str:
+        """
+        Build the "query" text for a node.
+
+        NOTE: not the same as the text embedding because
+        we want to optimize for retrieval results
+        """
+        return self.query_embedding_tmpl.format(
+            context_str=node.node.get_content(metadata_mode=MetadataMode.EMBED),
+        )
+
+    def _mark_duplicates(
+        self,
+        sorted_nodes: List[NodeWithScore],
+        text_embeddings: List[List[float]],
+        idx: int,
+        query_embedding: List[float],
+        node_ids_to_skip: Set[str],
+    ) -> None:
+        """Mark later nodes that are too similar to the node at ``idx``."""
+        for idx2 in range(idx + 1, len(sorted_nodes)):
+            if sorted_nodes[idx2].node.node_id in node_ids_to_skip:
+                continue
+            node2 = sorted_nodes[idx2]
+            if np.dot(query_embedding, text_embeddings[idx2]) > self.similarity_cutoff:
+                node_ids_to_skip.add(node2.node.node_id)
+
+    def _postprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """Postprocess nodes."""
+        sorted_nodes, texts = self._sort_nodes_by_date(nodes, query_bundle)
+
+        # get embeddings for each node
         text_embeddings = self.embed_model.get_text_embedding_batch(texts=texts)
 
         node_ids_to_skip: Set[str] = set()
         for idx, node in enumerate(sorted_nodes):
             if node.node.node_id in node_ids_to_skip:
                 continue
-            # get query embedding for the "query" node
-            # NOTE: not the same as the text embedding because
-            # we want to optimize for retrieval results
-
-            query_text = self.query_embedding_tmpl.format(
-                context_str=node.node.get_content(metadata_mode=MetadataMode.EMBED),
+            query_embedding = self.embed_model.get_query_embedding(
+                self._get_query_text(node)
             )
-            query_embedding = self.embed_model.get_query_embedding(query_text)
+            self._mark_duplicates(
+                sorted_nodes, text_embeddings, idx, query_embedding, node_ids_to_skip
+            )
 
-            for idx2 in range(idx + 1, len(sorted_nodes)):
-                if sorted_nodes[idx2].node.node_id in node_ids_to_skip:
-                    continue
-                node2 = sorted_nodes[idx2]
-                if (
-                    np.dot(query_embedding, text_embeddings[idx2])
-                    > self.similarity_cutoff
-                ):
-                    node_ids_to_skip.add(node2.node.node_id)
+        return [
+            node for node in sorted_nodes if node.node.node_id not in node_ids_to_skip
+        ]
+
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """
+        Postprocess nodes (async).
+
+        NOTE: the de-duplication loop is inherently sequential. ``node_ids_to_skip``
+        grows as it runs and decides whether the next node needs a query embedding
+        at all, so dispatching those embeddings concurrently would return the same
+        nodes while issuing embedding requests for nodes the sync path never embeds.
+        They are awaited in order instead: this frees the event loop and the default
+        thread pool without changing the number of requests made.
+        """
+        sorted_nodes, texts = self._sort_nodes_by_date(nodes, query_bundle)
+
+        # get embeddings for each node
+        text_embeddings = await self.embed_model.aget_text_embedding_batch(texts=texts)
+
+        node_ids_to_skip: Set[str] = set()
+        for idx, node in enumerate(sorted_nodes):
+            if node.node.node_id in node_ids_to_skip:
+                continue
+            query_embedding = await self.embed_model.aget_query_embedding(
+                self._get_query_text(node)
+            )
+            self._mark_duplicates(
+                sorted_nodes, text_embeddings, idx, query_embedding, node_ids_to_skip
+            )
 
         return [
             node for node in sorted_nodes if node.node.node_id not in node_ids_to_skip

--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -96,6 +96,26 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
     def class_name(cls) -> str:
         return "SentenceEmbeddingOptimizer"
 
+    def _resolve_query_embedding(self, query_bundle: QueryBundle) -> List[float]:
+        """Return the query embedding, computing and caching it on first use."""
+        query_embedding = query_bundle.embedding
+        if query_embedding is None:
+            query_embedding = self._embed_model.get_agg_embedding_from_queries(
+                query_bundle.embedding_strs
+            )
+            query_bundle.embedding = query_embedding
+        return query_embedding
+
+    async def _aresolve_query_embedding(self, query_bundle: QueryBundle) -> List[float]:
+        """Return the query embedding, computing and caching it on first use."""
+        query_embedding = query_bundle.embedding
+        if query_embedding is None:
+            query_embedding = await self._embed_model.aget_agg_embedding_from_queries(
+                query_bundle.embedding_strs
+            )
+            query_bundle.embedding = query_embedding
+        return query_embedding
+
     def _split_node_text(self, node_with_score: NodeWithScore) -> List[str]:
         """Tokenize a node's text into sentences."""
         text = node_with_score.node.get_content(metadata_mode=MetadataMode.LLM)
@@ -106,7 +126,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
         node_with_score: NodeWithScore,
         split_text: List[str],
         text_embeddings: List[List[float]],
-        query_bundle: QueryBundle,
+        query_embedding: List[float],
     ) -> None:
         """Shorten a single node in place, keeping only its top sentences."""
         num_top_k = None
@@ -117,7 +137,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             threshold = self.threshold_cutoff
 
         top_similarities, top_idxs = get_top_k_embeddings(
-            query_embedding=query_bundle.embedding,
+            query_embedding=query_embedding,
             embeddings=text_embeddings,
             similarity_fn=self._embed_model.similarity,
             similarity_top_k=num_top_k,
@@ -165,18 +185,13 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
         for node_idx in range(len(nodes)):
             split_text = self._split_node_text(nodes[node_idx])
 
-            if query_bundle.embedding is None:
-                query_bundle.embedding = (
-                    self._embed_model.get_agg_embedding_from_queries(
-                        query_bundle.embedding_strs
-                    )
-                )
+            query_embedding = self._resolve_query_embedding(query_bundle)
 
             # embed each node's sentences independently
             text_embeddings = self._embed_model._get_text_embeddings(split_text)
 
             self._apply_optimization(
-                nodes[node_idx], split_text, text_embeddings, query_bundle
+                nodes[node_idx], split_text, text_embeddings, query_embedding
             )
 
         return nodes
@@ -190,14 +205,12 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
         if query_bundle is None:
             return nodes
 
+        if not nodes:
+            return nodes
+
         split_texts = [self._split_node_text(node) for node in nodes]
 
-        if query_bundle.embedding is None:
-            query_bundle.embedding = (
-                await self._embed_model.aget_agg_embedding_from_queries(
-                    query_bundle.embedding_strs
-                )
-            )
+        query_embedding = await self._aresolve_query_embedding(query_bundle)
 
         # embed each node's sentences independently, in parallel
         embeddings_per_node = await run_jobs(
@@ -211,7 +224,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             nodes, split_texts, embeddings_per_node
         ):
             self._apply_optimization(
-                node_with_score, split_text, text_embeddings, query_bundle
+                node_with_score, split_text, text_embeddings, query_embedding
             )
 
         return nodes

--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Callable, List, Optional
 
+from llama_index.core.async_utils import run_jobs
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.indices.query.embedding_utils import get_top_k_embeddings
@@ -95,6 +96,63 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
     def class_name(cls) -> str:
         return "SentenceEmbeddingOptimizer"
 
+    def _split_node_text(self, node_with_score: NodeWithScore) -> List[str]:
+        """Tokenize a node's text into sentences."""
+        text = node_with_score.node.get_content(metadata_mode=MetadataMode.LLM)
+        return self._tokenizer_fn(text)
+
+    def _apply_optimization(
+        self,
+        node_with_score: NodeWithScore,
+        split_text: List[str],
+        text_embeddings: List[List[float]],
+        query_bundle: QueryBundle,
+    ) -> None:
+        """Shorten a single node in place, keeping only its top sentences."""
+        num_top_k = None
+        threshold = None
+        if self.percentile_cutoff is not None:
+            num_top_k = int(len(split_text) * self.percentile_cutoff)
+        if self.threshold_cutoff is not None:
+            threshold = self.threshold_cutoff
+
+        top_similarities, top_idxs = get_top_k_embeddings(
+            query_embedding=query_bundle.embedding,
+            embeddings=text_embeddings,
+            similarity_fn=self._embed_model.similarity,
+            similarity_top_k=num_top_k,
+            embedding_ids=list(range(len(text_embeddings))),
+            similarity_cutoff=threshold,
+        )
+
+        if len(top_idxs) == 0:
+            raise ValueError("Optimizer returned zero sentences.")
+
+        rangeMin, rangeMax = 0, len(split_text)
+
+        if self.context_before is None:
+            self.context_before = 1
+        if self.context_after is None:
+            self.context_after = 1
+
+        top_sentences = [
+            " ".join(
+                split_text[
+                    max(idx - self.context_before, rangeMin) : min(
+                        idx + self.context_after + 1, rangeMax
+                    )
+                ]
+            )
+            for idx in top_idxs
+        ]
+
+        logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
+        if logger.isEnabledFor(logging.DEBUG):
+            for idx in range(len(top_idxs)):
+                logger.debug(f"{idx}. {top_sentences[idx]} ({top_similarities[idx]})")
+
+        node_with_score.node.set_content(" ".join(top_sentences))
+
     def _postprocess_nodes(
         self,
         nodes: List[NodeWithScore],
@@ -105,9 +163,7 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             return nodes
 
         for node_idx in range(len(nodes)):
-            text = nodes[node_idx].node.get_content(metadata_mode=MetadataMode.LLM)
-
-            split_text = self._tokenizer_fn(text)
+            split_text = self._split_node_text(nodes[node_idx])
 
             if query_bundle.embedding is None:
                 query_bundle.embedding = (
@@ -116,52 +172,46 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
                     )
                 )
 
+            # embed each node's sentences independently
             text_embeddings = self._embed_model._get_text_embeddings(split_text)
 
-            num_top_k = None
-            threshold = None
-            if self.percentile_cutoff is not None:
-                num_top_k = int(len(split_text) * self.percentile_cutoff)
-            if self.threshold_cutoff is not None:
-                threshold = self.threshold_cutoff
-
-            top_similarities, top_idxs = get_top_k_embeddings(
-                query_embedding=query_bundle.embedding,
-                embeddings=text_embeddings,
-                similarity_fn=self._embed_model.similarity,
-                similarity_top_k=num_top_k,
-                embedding_ids=list(range(len(text_embeddings))),
-                similarity_cutoff=threshold,
+            self._apply_optimization(
+                nodes[node_idx], split_text, text_embeddings, query_bundle
             )
 
-            if len(top_idxs) == 0:
-                raise ValueError("Optimizer returned zero sentences.")
+        return nodes
 
-            rangeMin, rangeMax = 0, len(split_text)
+    async def _apostprocess_nodes(
+        self,
+        nodes: List[NodeWithScore],
+        query_bundle: Optional[QueryBundle] = None,
+    ) -> List[NodeWithScore]:
+        """Optimize a node text given the query by shortening the node text."""
+        if query_bundle is None:
+            return nodes
 
-            if self.context_before is None:
-                self.context_before = 1
-            if self.context_after is None:
-                self.context_after = 1
+        split_texts = [self._split_node_text(node) for node in nodes]
 
-            top_sentences = [
-                " ".join(
-                    split_text[
-                        max(idx - self.context_before, rangeMin) : min(
-                            idx + self.context_after + 1, rangeMax
-                        )
-                    ]
+        if query_bundle.embedding is None:
+            query_bundle.embedding = (
+                await self._embed_model.aget_agg_embedding_from_queries(
+                    query_bundle.embedding_strs
                 )
-                for idx in top_idxs
+            )
+
+        # embed each node's sentences independently, in parallel
+        embeddings_per_node = await run_jobs(
+            [
+                self._embed_model._aget_text_embeddings(split_text)
+                for split_text in split_texts
             ]
+        )
 
-            logger.debug(f"> Top {len(top_idxs)} sentences with scores:\n")
-            if logger.isEnabledFor(logging.DEBUG):
-                for idx in range(len(top_idxs)):
-                    logger.debug(
-                        f"{idx}. {top_sentences[idx]} ({top_similarities[idx]})"
-                    )
-
-            nodes[node_idx].node.set_content(" ".join(top_sentences))
+        for node_with_score, split_text, text_embeddings in zip(
+            nodes, split_texts, embeddings_per_node
+        ):
+            self._apply_optimization(
+                node_with_score, split_text, text_embeddings, query_bundle
+            )
 
         return nodes

--- a/llama-index-core/tests/postprocessor/test_base.py
+++ b/llama-index-core/tests/postprocessor/test_base.py
@@ -3,8 +3,10 @@
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Dict, cast
+from unittest.mock import patch
 
 import pytest
+
 from llama_index.core.postprocessor.node import (
     KeywordNodePostprocessor,
     PrevNextNodePostprocessor,
@@ -379,3 +381,139 @@ def test_keyword_postprocessor_for_non_english() -> None:
         assert len(new_nodes) == 2
     except ImportError:
         pass
+
+
+def _recency_nodes() -> list:
+    """Node set shared by the sync/async recency equivalence tests."""
+    return [
+        TextNode(
+            text="Hello world.",
+            id_="1",
+            metadata={"date": "2020-01-01"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="This is a test.",
+            id_="2",
+            metadata={"date": "2020-01-02"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="This is another test.",
+            id_="3",
+            metadata={"date": "2020-01-02"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="This is another test.",
+            id_="3v2",
+            metadata={"date": "2020-01-03"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+        TextNode(
+            text="This is a test v2.",
+            id_="4",
+            metadata={"date": "2020-01-04"},
+            excluded_embed_metadata_keys=["date"],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aembedding_recency_postprocessor() -> None:
+    """Async recency postprocessing must match the sync result."""
+    nodes_with_scores = [NodeWithScore(node=node) for node in _recency_nodes()]
+
+    postprocessor = EmbeddingRecencyPostprocessor(
+        top_k=1,
+        in_metadata=False,
+        query_embedding_tmpl="{context_str}",
+    )
+    query_bundle: QueryBundle = QueryBundle(query_str="What is?")
+    result_nodes = await postprocessor.apostprocess_nodes(
+        nodes_with_scores, query_bundle=query_bundle
+    )
+    assert result_nodes[0].node.get_content() == "This is a test v2."
+    assert cast(Dict, result_nodes[0].node.metadata)["date"] == "2020-01-04"
+
+
+@pytest.mark.asyncio
+async def test_aembedding_recency_postprocessor_matches_sync() -> None:
+    """Sync and async must return the same nodes in the same order."""
+    query_bundle: QueryBundle = QueryBundle(query_str="What is?")
+
+    def _make() -> EmbeddingRecencyPostprocessor:
+        return EmbeddingRecencyPostprocessor(
+            top_k=1,
+            in_metadata=False,
+            query_embedding_tmpl="{context_str}",
+        )
+
+    sync_result = _make().postprocess_nodes(
+        [NodeWithScore(node=n) for n in _recency_nodes()], query_bundle=query_bundle
+    )
+    async_result = await _make().apostprocess_nodes(
+        [NodeWithScore(node=n) for n in _recency_nodes()], query_bundle=query_bundle
+    )
+
+    assert [n.node.node_id for n in async_result] == [
+        n.node.node_id for n in sync_result
+    ]
+    assert [n.node.get_content() for n in async_result] == [
+        n.node.get_content() for n in sync_result
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aembedding_recency_makes_no_extra_requests() -> None:
+    """
+    The async path must not embed nodes the sync path skips.
+
+    The de-duplication loop is sequential by nature: `node_ids_to_skip` grows as
+    it runs and decides whether the next node needs a query embedding at all.
+    Dispatching those concurrently would return the same nodes while issuing
+    extra embedding requests, so the counts must match exactly.
+    """
+    query_bundle: QueryBundle = QueryBundle(query_str="What is?")
+
+    postprocessor = EmbeddingRecencyPostprocessor(
+        top_k=1,
+        in_metadata=False,
+        query_embedding_tmpl="{context_str}",
+    )
+    embed_model = postprocessor.embed_model
+    embed_cls = type(embed_model)
+
+    # bound to the instance before patching, so these keep the originals
+    orig_sync = embed_model.get_query_embedding
+    orig_async = embed_model.aget_query_embedding
+
+    sync_calls = 0
+    async_calls = 0
+
+    def counting_sync(query: str):
+        nonlocal sync_calls
+        sync_calls += 1
+        return orig_sync(query)
+
+    async def counting_async(query: str):
+        nonlocal async_calls
+        async_calls += 1
+        return await orig_async(query)
+
+    with patch.object(embed_cls, "get_query_embedding", side_effect=counting_sync):
+        postprocessor.postprocess_nodes(
+            [NodeWithScore(node=n) for n in _recency_nodes()],
+            query_bundle=query_bundle,
+        )
+
+    with patch.object(embed_cls, "aget_query_embedding", side_effect=counting_async):
+        await postprocessor.apostprocess_nodes(
+            [NodeWithScore(node=n) for n in _recency_nodes()],
+            query_bundle=query_bundle,
+        )
+
+    assert sync_calls > 0
+    assert async_calls == sync_calls, (
+        f"async issued {async_calls} query embeddings, sync issued {sync_calls}"
+    )

--- a/llama-index-core/tests/postprocessor/test_optimizer.py
+++ b/llama-index-core/tests/postprocessor/test_optimizer.py
@@ -1,7 +1,12 @@
 """Test optimization."""
 
+import asyncio
 from typing import Any, List
 from unittest.mock import patch
+
+import pytest
+
+from llama_index.core.async_utils import DEFAULT_NUM_WORKERS
 
 from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.postprocessor.optimizer import SentenceEmbeddingOptimizer
@@ -143,3 +148,127 @@ def test_optimizer(_mock_embeds: Any, _mock_embed: Any) -> None:
         [NodeWithScore(node=orig_node)], query
     )[0]
     assert optimized_node.node.get_content() == "world foo bar"
+
+
+async def amock_get_text_embeddings(texts: List[str]) -> List[List[float]]:
+    """Mock async get text embeddings."""
+    return mock_get_text_embeddings(texts)
+
+
+@patch.object(
+    MockEmbedding, "_aget_text_embeddings", side_effect=amock_get_text_embeddings
+)
+@pytest.mark.asyncio
+async def test_aoptimizer(_mock_aembeds: Any) -> None:
+    """Async optimization must match the sync result."""
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn,
+        percentile_cutoff=0.5,
+        context_before=0,
+        context_after=0,
+    )
+    query = QueryBundle(query_str="hello", embedding=[1, 0, 0, 0, 0])
+    optimized = await optimizer.apostprocess_nodes(
+        [NodeWithScore(node=TextNode(text="hello world"))], query
+    )
+    assert optimized[0].node.get_content() == "hello"
+
+    # test with threshold cutoff
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn,
+        threshold_cutoff=0.3,
+        context_after=0,
+        context_before=0,
+    )
+    query = QueryBundle(query_str="world", embedding=[0, 1, 0, 0, 0])
+    optimized = await optimizer.apostprocess_nodes(
+        [NodeWithScore(node=TextNode(text="hello world"))], query
+    )
+    assert optimized[0].node.get_content() == "world"
+
+    # test with context before and after the top sentence
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn2,
+        threshold_cutoff=0.3,
+        context_after=1,
+        context_before=1,
+    )
+    query = QueryBundle(query_str="foo", embedding=[0, 0, 1, 0, 0])
+    optimized = await optimizer.apostprocess_nodes(
+        [NodeWithScore(node=TextNode(text="hello,world,foo,bar"))], query
+    )
+    assert optimized[0].node.get_content() == "world foo bar"
+
+
+@patch.object(
+    MockEmbedding, "_aget_text_embeddings", side_effect=amock_get_text_embeddings
+)
+@pytest.mark.asyncio
+async def test_aoptimizer_multiple_nodes(_mock_aembeds: Any) -> None:
+    """Every node is optimized, and the input list is returned in order."""
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn2,
+        threshold_cutoff=0.3,
+        context_after=0,
+        context_before=0,
+    )
+    query = QueryBundle(query_str="foo", embedding=[0, 0, 1, 0, 0])
+    nodes = [
+        NodeWithScore(node=TextNode(text="hello,world,foo"), score=0.9),
+        NodeWithScore(node=TextNode(text="bar,foo"), score=0.5),
+        NodeWithScore(node=TextNode(text="foo,abc"), score=0.1),
+    ]
+    optimized = await optimizer.apostprocess_nodes(nodes, query)
+
+    assert [n.node.get_content() for n in optimized] == ["foo", "foo", "foo"]
+    assert [n.score for n in optimized] == [0.9, 0.5, 0.1]
+
+
+@pytest.mark.asyncio
+async def test_aoptimizer_runs_nodes_concurrently() -> None:
+    """Every node should be embedded in parallel, not one at a time."""
+    # 3 nodes, deliberately BELOW async_utils.DEFAULT_NUM_WORKERS (4) so the
+    # assertion measures this method's dispatch, not run_jobs' semaphore ceiling.
+    nodes = [
+        NodeWithScore(node=TextNode(text="hello,world,foo")),
+        NodeWithScore(node=TextNode(text="bar,foo")),
+        NodeWithScore(node=TextNode(text="foo,abc")),
+    ]
+    assert len(nodes) < DEFAULT_NUM_WORKERS
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def tracking_embeds(texts: List[str]) -> List[List[float]]:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            # yield control so a sequential implementation cannot overlap
+            await asyncio.sleep(0)
+            return mock_get_text_embeddings(texts)
+        finally:
+            in_flight -= 1
+
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn2,
+        threshold_cutoff=0.3,
+        context_after=0,
+        context_before=0,
+    )
+    query = QueryBundle(query_str="foo", embedding=[0, 0, 1, 0, 0])
+
+    with patch.object(
+        MockEmbedding, "_aget_text_embeddings", side_effect=tracking_embeds
+    ):
+        await optimizer.apostprocess_nodes(nodes, query)
+
+    assert max_in_flight == len(nodes), (
+        f"expected all {len(nodes)} nodes in flight concurrently, "
+        f"saw at most {max_in_flight}"
+    )


### PR DESCRIPTION
# Description

Neither `SentenceEmbeddingOptimizer` nor `EmbeddingRecencyPostprocessor` overrides `_apostprocess_nodes`, so `await postprocessor.apostprocess_nodes(...)` falls through to the default in `BaseNodePostprocessor`:

```python
async def _apostprocess_nodes(self, nodes, query_bundle=None):
    return await asyncio.to_thread(self._postprocess_nodes, nodes, query_bundle)
```

That moves the synchronous method onto a worker thread but does not make it concurrent: the blocking loop runs unchanged, while a thread from the default executor is held for the full chain of embedding calls.

These are the last two postprocessors in `llama-index-core` with this shape, following `LLMRerank` (#22597), `StructuredLLMRerank` (#22842), and `PIINodePostprocessor` (#22849, open).

The two classes are handled differently, and that difference is the main thing worth reviewing.

## 1. `SentenceEmbeddingOptimizer` — real concurrency

It made one embedding call per node, sequentially:

```python
for node_idx in range(len(nodes)):
    ...
    text_embeddings = self._embed_model._get_text_embeddings(split_text)   # per node
```

The async path resolves the query embedding once up front (the sync path computes it lazily on the first iteration and caches it on `query_bundle`), then dispatches every node's sentence embeddings together via `run_jobs` over `_aget_text_embeddings`.

Shared logic is extracted into `_split_node_text` and `_apply_optimization` so the sync and async paths call the same code. Existing behaviour is preserved exactly, including the class's in-place mutation of the input nodes and of `query_bundle`.

## 2. `EmbeddingRecencyPostprocessor` — deliberately NOT parallel

This one looks identical from outside but cannot be fanned out safely. Its de-duplication loop has a genuine sequential dependency:

```python
node_ids_to_skip: Set[str] = set()
for idx, node in enumerate(sorted_nodes):
    if node.node.node_id in node_ids_to_skip:
        continue                                       # skips the embedding call
    query_embedding = self.embed_model.get_query_embedding(query_text)
    for idx2 in range(idx + 1, len(sorted_nodes)):
        if np.dot(query_embedding, text_embeddings[idx2]) > self.similarity_cutoff:
            node_ids_to_skip.add(node2.node.node_id)   # grows during the loop
```

`node_ids_to_skip` grows as the loop runs, and the `continue` means a node already marked as a duplicate never gets a query embedding at all.

Dispatching those embeddings concurrently would return **identical results while issuing materially more embedding requests**. In the worst case — many similar documents, which is exactly what this class exists to handle — the sync path makes ~1 query embedding call where a naive async version makes N. That trades the user's embedding spend for latency, and no results-based test would catch it.

So the async path awaits `aget_text_embedding_batch` and `aget_query_embedding` **in the original order** instead. The gain is that the event loop and the default thread pool are no longer blocked; the number of requests and their order are unchanged. The reasoning is recorded in the method's docstring so it isn't "optimised" into a fan-out later.

If you would prefer this class left alone entirely, or would prefer the fan-out with the extra requests documented, I am happy to change it — this seemed like the honest middle.

## Scope

- `FixedRecencyPostprocessor` and `TimeWeightedPostprocessor` are untouched: pure sorting and arithmetic, no I/O.
- A pre-existing bug is deliberately **not** fixed here: in `EmbeddingRecencyPostprocessor`, `text_embeddings` is built from `nodes` in original order but indexed with `idx2`, which indexes `sorted_nodes`. That is what #22346 addresses, so this change stays off it.
- `run_jobs` caps concurrency at `DEFAULT_NUM_WORKERS` (4) via an internal semaphore, so the optimizer change is not an unbounded fan-out. This matches how the existing rerankers call it.

Sync behaviour is unchanged in both classes.

Related to #22596, which reports the same underlying problem for `LLMRerank`. That issue is worded specifically about `LLMRerank`, so this PR does not claim to close it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Six tests added — three in `tests/postprocessor/test_optimizer.py`, three in `tests/postprocessor/test_base.py`:

- `test_aoptimizer` — async matches the sync result across cutoff and context settings
- `test_aoptimizer_multiple_nodes` — every node optimized, order and scores preserved
- `test_aoptimizer_runs_nodes_concurrently` — counts in-flight calls and asserts all nodes overlap. Uses 3 nodes, deliberately below `DEFAULT_NUM_WORKERS` (4), so the assertion measures dispatch rather than `run_jobs`' semaphore ceiling.
- `test_aembedding_recency_postprocessor` — async recency matches the existing sync assertions
- `test_aembedding_recency_postprocessor_matches_sync` — same nodes, same order
- `test_aembedding_recency_makes_no_extra_requests` — asserts the async path issues exactly as many query embeddings as the sync path

That last test is worth calling out. Because the recency change is deliberately not concurrent, its results are byte-identical and **no results-based test can detect it** — with the override removed, the other two recency tests still pass. `test_aembedding_recency_makes_no_extra_requests` is the only thing that fails, and the only thing guarding against a later regression to fan-out.

Verification performed:

- Full `llama-index-core` suite: **1500 passed**, 22 skipped, 6 xfailed. Baseline on the same commit is 1494 — the 6 new tests are the difference, no regressions.
- Differential check, old vs new **sync** `SentenceEmbeddingOptimizer` across 972 configurations (node counts × percentile cutoffs × threshold cutoffs × context-before × context-after), comparing content and scores in order plus exception types and messages: **0 mismatches**.
- Differential check, old **sync** vs new **async** optimizer over the same 972 configurations: **0 mismatches**.
- Differential check for `EmbeddingRecencyPostprocessor` across 80 configurations (node counts × similarity cutoffs × distinct/identical dates), old sync vs new sync and old sync vs new async: **0 mismatches** each.
- Confirmed the optimizer's async tests all fail when its `_apostprocess_nodes` override is removed, so they measure the fix rather than passing incidentally.
- Rebased onto current `main` and re-verified after the recent dependency bumps (#22880, #22881).

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

## A note on CI

The `test (3.10/3.11/3.12)` jobs fail on most open PRs in this repo, including #22842 which was merged with them. `llama-dev test` runs `changed_packages | dependants`, so any change to `llama-index-core` pulls in hundreds of integrations; the failures there are `onnxruntime==1.24.3` having no cp310 wheel plus unrelated breakage in ai21 / azure-inference / vllm / slide / yugabytedb. `test-core-py314`, which runs only the changed package, passes.

## AI Assistance

Per the contributing guidelines: I used an AI assistant while writing this change. It was used for the mechanical helper extraction and to draft the tests. I reviewed every line, and validated the result with the differential runs described above. The decision not to parallelise `EmbeddingRecencyPostprocessor` was a deliberate one made after reading the de-duplication loop. I understand this code and am able to maintain it.
