### PR TITLE
Apply metadata filters to BM25Retriever results

### DIFF
--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/llama_index/retrievers/bm25/base.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Set, cast
 
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.callbacks.base import CallbackManager
@@ -146,6 +146,16 @@ class BM25Retriever(BaseRetriever):
                     "Please adjust your filters or add more data."
                 )
 
+        # bm25s only zeroes out the scores of masked documents, so they are still
+        # returned once similarity_top_k exceeds the number of unmasked ones.
+        self._excluded_node_ids: Set[str] = {
+            corpus_item["node_id"]
+            for corpus_item, weight in zip(
+                self.corpus or [], self.corpus_weight_mask or []
+            )
+            if not weight and isinstance(corpus_item, dict) and "node_id" in corpus_item
+        }
+
         super().__init__(
             callback_manager=callback_manager,
             object_map=object_map,
@@ -250,11 +260,13 @@ class BM25Retriever(BaseRetriever):
         nodes: List[NodeWithScore] = []
         for idx, score in zip(indexes, scores):
             # idx can be an int or a dict of the node
-            if isinstance(idx, dict):
-                node = metadata_dict_to_node(idx)
-            else:
-                node_dict = self.corpus[int(idx)]
-                node = metadata_dict_to_node(node_dict)
-            nodes.append(NodeWithScore(node=node, score=float(score)))
+            node_dict = idx if isinstance(idx, dict) else self.corpus[int(idx)]
+            if self._excluded_node_ids and (
+                node_dict.get("node_id") in self._excluded_node_ids
+            ):
+                continue
+            nodes.append(
+                NodeWithScore(node=metadata_dict_to_node(node_dict), score=float(score))
+            )
 
         return nodes

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-retrievers-bm25"
-version = "0.8.0"
+version = "0.8.1"
 description = "llama-index retrievers bm25 integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
+++ b/llama-index-integrations/retrievers/llama-index-retrievers-bm25/tests/test_retrievers_bm25_retriever.py
@@ -126,6 +126,33 @@ def _count_score_greater_than_zero(nodes):
     return count
 
 
+def test_metadata_filtering_excludes_non_matching_nodes():
+    documents = [
+        Document(text="apple pie recipe with cinnamon", metadata={"cat": "food"}),
+        Document(text="apple stock price analysis", metadata={"cat": "finance"}),
+        Document(text="banana bread baking guide", metadata={"cat": "food"}),
+        Document(text="banana republic clothing sale", metadata={"cat": "retail"}),
+    ]
+
+    splitter = SentenceSplitter(chunk_size=1024)
+    nodes = splitter.get_nodes_from_documents(documents)
+
+    # similarity_top_k is larger than the number of nodes the filter keeps
+    retriever = BM25Retriever.from_defaults(
+        nodes=nodes,
+        similarity_top_k=4,
+        filters=MetadataFilters(
+            filters=[
+                MetadataFilter(key="cat", operator=FilterOperator.EQ, value="food")
+            ]
+        ),
+    )
+    result_nodes = retriever.retrieve("apple")
+
+    assert len(result_nodes) == 2
+    assert all(node.node.metadata["cat"] == "food" for node in result_nodes)
+
+
 def test_persist_and_load():
     documents = [Document.example()]
 


### PR DESCRIPTION
# Description

`BM25Retriever` turns `filters` into a `corpus_weight_mask` and passes it to `bm25s.retrieve`. bm25s only sets the *scores* of masked documents to 0 — its docstring says the mask sets those scores to 0 "to avoid returning them in the results", which only holds while `k` is at most the number of unmasked documents. `_retrieve` appends every index bm25s hands back, so as soon as `similarity_top_k` is larger than the number of nodes the filter keeps, nodes that fail the filter come back with `score=0.0`.

```python
nodes = [
    TextNode(text="apple pie recipe with cinnamon", metadata={"cat": "food"}),
    TextNode(text="apple stock price analysis", metadata={"cat": "finance"}),
    TextNode(text="banana bread baking guide", metadata={"cat": "food"}),
    TextNode(text="banana republic clothing sale", metadata={"cat": "retail"}),
    TextNode(text="cherry orchard farming tips", metadata={"cat": "agri"}),
]
filters = MetadataFilters(filters=[MetadataFilter(key="cat", value="food", operator=FilterOperator.EQ)])
BM25Retriever.from_defaults(nodes=nodes, similarity_top_k=4, filters=filters).retrieve("apple")

# main:
#   0.3502  cat='food'    apple pie recipe with cinnamon
#   0.0000  cat='agri'    cherry orchard farming tips     <- fails the filter
#   0.0000  cat='retail'  banana republic clothing sale   <- fails the filter
#   0.0000  cat='food'    banana bread baking guide
# this PR:
#   0.3502  cat='food'    apple pie recipe with cinnamon
#   0.0000  cat='food'    banana bread baking guide
```

The example in `docs/examples/retrievers/bm25_retriever.ipynb` under "BM25 Retriever + MetadataFiltering" hits this: four documents, a filter matching two of them, `similarity_top_k=3`. Someone using filters to keep one tenant's or one user's documents apart gets another tenant's document in the result list.

The rest of the class already treats a masked node as excluded rather than down-weighted — the constructor raises `"All nodes were filtered out by the metadata filters"` when the mask is all zeros — and `SimpleVectorStore.query` builds its filter from the same `build_metadata_filter_fn` and prefilters, returning only matching nodes. This makes the BM25 retriever agree with both.

The change records which node ids the mask excludes and skips them when building the result. Filtering is by mask, not by score, so a matching node that legitimately scores 0.0 is still returned. A filtered retriever now returns fewer than `similarity_top_k` results when fewer nodes match, which is the same thing it already does when the corpus is smaller than `similarity_top_k`.

Fixes # (no issue; found while sweeping retrieval filters)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (`llama-index-retrievers-bm25` 0.8.0 -> 0.8.1)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`test_metadata_filtering_excludes_non_matching_nodes` uses the case above; it fails on `main` with `assert 4 == 2` and passes with this change. The existing `test_metadata_filtering` passes untouched — it counts nodes scoring above zero, and both matching nodes still score above zero. I also checked the neighbouring cases by hand: no filters at all, `top_k` smaller than the match count, an `OR` condition, a `corpus_weight_mask` passed directly to the constructor, a persist/load round trip (which is the path where bm25s returns corpus dicts rather than indices), an all-filtered corpus still raising, and a query that matches no filtered node — that last one confirms a zero-scoring node that does pass the filter is still returned.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the formatter and linter over the changed files

Disclosure: I used AI assistance while investigating and writing this change. I reproduced the behavior, reviewed the code, and take responsibility for it.