### PR TITLE
Add llama-index-tools-ictfax integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-ictfax/.gitignore
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+dist/
+build/
+*.egg-info/
+.pytest_cache/

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/CHANGELOG.md
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## [0.1.0]
+- Initial release: send and track faxes via the ICTFax / ICTCore REST API.
+- Tools: upload_fax_document, send_fax, get_fax_status, list_faxes.

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/LICENSE
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ICT Innovations
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/Makefile
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/Makefile
@@ -1,0 +1,13 @@
+help:	## Show all Makefile targets.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+format:	## Run code autoformatters (ruff).
+	ruff format .
+
+lint:	## Run linters: ruff.
+	ruff check .
+
+test:	## Run tests via pytest.
+	pytest tests
+
+.PHONY: help format lint test

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/README.md
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/README.md
@@ -1,0 +1,35 @@
+# LlamaIndex Tools Integration: ICTFax
+
+Send and track faxes from a LlamaIndex agent through an [ICTFax](https://ictfax.org)
+server. ICTFax is an open source fax server built on the ICTCore framework; the same
+REST API also backs ICTPBX and ICTDialer.
+
+## Tools
+
+- `upload_fax_document(file_path, name)` — upload a PDF/TIFF/image, returns a document id
+- `send_fax(to_number, document_id, title, recipient_name)` — send a fax and return its transmission id
+- `get_fax_status(transmission_id)` — poll delivery status
+- `list_faxes()` — list transmissions with their status
+
+## Usage
+
+```python
+from llama_index.tools.ictfax import ICTFaxToolSpec
+from llama_index.agent.openai import OpenAIAgent
+
+tool_spec = ICTFaxToolSpec(
+    base_url="https://fax.example.com/api",
+    username="admin",
+    password="mysecret",
+)
+
+agent = OpenAIAgent.from_tools(tool_spec.to_tool_list())
+agent.chat("Fax document 12 to +12025550123 and tell me when it goes through")
+```
+
+This tool is a client for an ICTFax server, so it needs a reachable ICTFax/ICTCore
+install and an API account. It does not deliver faxes on its own.
+
+---
+
+Built and maintained by [ICT Innovations](https://www.ictinnovations.com/) — the team behind [ICTFax](https://ictfax.org), ICTPBX, ICTDialer and ICTContact.

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/examples/example.py
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/examples/example.py
@@ -1,0 +1,10 @@
+"""Minimal ICTFax tool example."""
+from llama_index.tools.ictfax import ICTFaxToolSpec
+
+spec = ICTFaxToolSpec(
+    base_url="https://fax.example.com/api", username="admin", password="mysecret"
+)
+doc = spec.upload_fax_document("invoice.pdf", name="April invoice")
+print(doc)  # -> "Uploaded document id N"
+print(spec.send_fax(to_number="+12025550123", document_id=12, title="April invoice"))
+print(spec.get_fax_status(1))

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/llama_index/tools/ictfax/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/llama_index/tools/ictfax/__init__.py
@@ -1,0 +1,3 @@
+from llama_index.tools.ictfax.base import ICTFaxToolSpec
+
+__all__ = ["ICTFaxToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/llama_index/tools/ictfax/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/llama_index/tools/ictfax/base.py
@@ -1,0 +1,203 @@
+"""ICTFax tool spec.
+
+Tools for sending and tracking faxes through an ICTFax / ICTCore server over its
+REST API. ICTFax is an open source fax server (https://ictfax.org) built on the
+ICTCore framework; the same API also backs ICTPBX and ICTDialer.
+
+The ICTCore send flow is: authenticate for a JWT, create a document record and
+upload its file, register the document as a ``sendfax`` program, create a contact
+for the recipient number, then create a transmission and send it. These tools wrap
+that flow so an agent can send a fax in a couple of calls and poll its status.
+"""
+
+from typing import Any, List, Optional
+
+import requests
+
+from llama_index.core.schema import Document
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+
+class ICTFaxToolSpec(BaseToolSpec):
+    """ICTFax fax tool spec.
+
+    Args:
+        base_url: Base URL of the ICTCore REST API, e.g. ``https://fax.example.com/api``.
+        username: API username.
+        password: API password.
+        account_id: Account/route id used for outbound faxes. Defaults to 1.
+        verify_tls: Verify TLS certificates. Set False only for self-signed test boxes.
+        timeout: Per-request timeout in seconds.
+    """
+
+    spec_functions = [
+        "send_fax",
+        "get_fax_status",
+        "list_faxes",
+        "upload_fax_document",
+    ]
+
+    def __init__(
+        self,
+        base_url: str,
+        username: str,
+        password: str,
+        account_id: int = 1,
+        verify_tls: bool = True,
+        timeout: int = 30,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._username = username
+        self._password = password
+        self.account_id = account_id
+        self.verify_tls = verify_tls
+        self.timeout = timeout
+        self._token: Optional[str] = None
+
+    # ---- internal helpers -------------------------------------------------
+    def _authenticate(self) -> str:
+        resp = requests.post(
+            f"{self.base_url}/authenticate",
+            json={"username": self._username, "password": self._password},
+            verify=self.verify_tls,
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        token = resp.json().get("token")
+        if not token:
+            raise RuntimeError("ICTCore authenticate returned no token")
+        self._token = token
+        return token
+
+    @staticmethod
+    def _id(resp: Any) -> Optional[int]:
+        if isinstance(resp, bool):
+            return None
+        if isinstance(resp, (int, float)):
+            return int(resp)
+        if isinstance(resp, str) and resp.strip().lstrip("-").isdigit():
+            return int(resp.strip())
+        if isinstance(resp, dict):
+            for k in ("document_id", "contact_id", "program_id", "transmission_id", "id"):
+                if resp.get(k) is not None:
+                    return resp[k]
+        return None
+
+    def _request(self, method: str, path: str, content_type: Optional[str] = None, **kwargs: Any) -> Any:
+        if self._token is None:
+            self._authenticate()
+
+        def _do() -> requests.Response:
+            # ICTCore reads the JWT from the standard Authorization header.
+            headers = {"Authorization": f"Bearer {self._token}"}
+            if content_type:
+                headers["Content-Type"] = content_type
+            elif "files" not in kwargs and "data" not in kwargs:
+                headers["Content-Type"] = "application/json"
+            return requests.request(
+                method, f"{self.base_url}/{path.lstrip('/')}", headers=headers,
+                verify=self.verify_tls, timeout=self.timeout, **kwargs,
+            )
+
+        resp = _do()
+        if resp.status_code == 401:
+            self._authenticate()
+            resp = _do()
+        resp.raise_for_status()
+        if resp.content:
+            try:
+                return resp.json()
+            except ValueError:
+                return resp.text
+        return None
+
+    # ---- tools ------------------------------------------------------------
+    def upload_fax_document(self, file_path: str, name: Optional[str] = None,
+                            mime: str = "application/pdf") -> str:
+        """
+        Upload a document (PDF, TIFF or image) to fax and return its document id.
+
+        Call this first when you have a local file to fax; pass the returned id to
+        send_fax as document_id.
+
+        Args:
+            file_path (str): Path to the local file to upload.
+            name (str): Optional display name for the document.
+            mime (str): MIME type of the file. Defaults to application/pdf.
+
+        """
+        meta = self._request("POST", "/documents",
+                             json={"name": name or file_path.split("/")[-1]})
+        doc_id = self._id(meta)
+        with open(file_path, "rb") as fh:
+            body = fh.read()
+        self._request("POST", f"/documents/{doc_id}/media", data=body, content_type=mime)
+        return f"Uploaded document id {doc_id}"
+
+    def send_fax(
+        self,
+        to_number: str,
+        document_id: int,
+        title: str = "Fax",
+        recipient_name: str = "Fax recipient",
+    ) -> str:
+        """
+        Send a fax of an already-uploaded document to a destination number.
+
+        Args:
+            to_number (str): Destination fax number in international format.
+            document_id (int): Id of a document already uploaded with upload_fax_document.
+            title (str): Short label for this fax, shown in the transmission list.
+            recipient_name (str): Name to store on the recipient contact.
+
+        """
+        contact_id = self._id(self._request(
+            "POST", "/contacts", json={"first_name": recipient_name, "phone": to_number}))
+        program_id = self._id(self._request(
+            "POST", "/programs/sendfax", json={"name": title, "document_id": document_id}))
+        transmission_id = self._id(self._request("POST", "/transmissions", json={
+            "title": title, "contact_id": contact_id, "program_id": program_id,
+            "account_id": self.account_id, "direction": "outbound"}))
+        self._request("POST", f"/transmissions/{transmission_id}/send")
+        return (
+            f"Fax queued to {to_number}. transmission_id={transmission_id}. "
+            f"Use get_fax_status({transmission_id}) to track it."
+        )
+
+    def get_fax_status(self, transmission_id: int) -> str:
+        """
+        Get the delivery status of a fax transmission.
+
+        Args:
+            transmission_id (int): Id returned by send_fax.
+
+        """
+        t = self._request("GET", f"/transmissions/{transmission_id}")
+        status = t.get("status", "unknown") if isinstance(t, dict) else "unknown"
+        response = t.get("response", "") if isinstance(t, dict) else ""
+        line = f"transmission {transmission_id}: status={status}"
+        if response:
+            line += f" ({response})"
+        return line
+
+    def list_faxes(self) -> List[Document]:
+        """
+        List fax transmissions on the server with their status.
+
+        Returns one Document per transmission so results can be read or indexed.
+        """
+        items = self._request("GET", "/transmissions")
+        if isinstance(items, dict):
+            items = items.get("data", items.get("transmissions", [items]))
+        docs: List[Document] = []
+        for t in items or []:
+            docs.append(
+                Document(
+                    text=(
+                        f"transmission {t.get('transmission_id', t.get('id'))}: "
+                        f"title={t.get('title')} direction={t.get('direction')} "
+                        f"status={t.get('status')} {t.get('response', '')}"
+                    )
+                )
+            )
+        return docs

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/pyproject.toml
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "llama-index-tools-ictfax"
+version = "0.1.0"
+description = "llama-index tools ICTFax integration — send and track faxes over the ICTCore REST API"
+authors = [{name = "ICT Innovations", email = "tahir@ictinnovations.com"}]
+requires-python = ">=3.9,<4.0"
+readme = "README.md"
+license = "MIT"
+keywords = ["fax", "ictfax", "ictcore", "telephony", "t38"]
+dependencies = [
+    "llama-index-core>=0.11.0",
+    "requests>=2.31.0",
+]
+
+[project.urls]
+Homepage = "https://ictfax.org"
+Repository = "https://github.com/ictinnovations/ictfax"
+"ICT Innovations" = "https://www.ictinnovations.com/"
+
+[tool.hatch.build.targets.wheel]
+packages = ["llama_index"]

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/requirements.txt
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/requirements.txt
@@ -1,0 +1,2 @@
+llama-index-core>=0.11.0
+requests>=2.31.0

--- a/llama-index-integrations/tools/llama-index-tools-ictfax/tests/test_ictfax.py
+++ b/llama-index-integrations/tools/llama-index-tools-ictfax/tests/test_ictfax.py
@@ -1,0 +1,16 @@
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+from llama_index.tools.ictfax import ICTFaxToolSpec
+
+
+def test_class():
+    names = {b.__name__ for b in ICTFaxToolSpec.__mro__}
+    assert BaseToolSpec.__name__ in names
+
+
+def test_spec_functions():
+    spec = ICTFaxToolSpec(base_url="http://x/api", username="u", password="p")
+    assert set(spec.spec_functions) == {
+        "send_fax", "get_fax_status", "list_faxes", "upload_fax_document",
+    }
+    # tool list builds without contacting the server
+    assert len(spec.to_tool_list()) == 4


### PR DESCRIPTION
### Description

Adds `llama-index-tools-ictfax`, a tool integration for sending and tracking faxes through an [ICTFax](https://ictfax.org) / ICTCore server over its REST API. ICTFax is an open source fax server; the same API also backs ICTPBX and ICTDialer.

Tools: `upload_fax_document`, `send_fax`, `get_fax_status`, `list_faxes` (an `ICTFaxToolSpec`). It's a client for an ICTFax server, so it needs a reachable install and an API account.

I followed the `llama-index-tools-arxiv` package as the template. The tools were verified end to end against a running ICTFax container (auth, document upload with PDF→TIFF conversion, sendfax program, contact, transmission and status all work). Happy to add a `uv.lock` or adjust anything to match current contribution requirements — pointers welcome.

### New Package?

- [x] Yes
- [ ] No

Maintained by [ICT Innovations](https://www.ictinnovations.com/).
