### PR TITLE
fix: keep SentenceEmbeddingOptimizer output in document order

### DIFF
--- a/llama-index-core/llama_index/core/postprocessor/optimizer.py
+++ b/llama-index-core/llama_index/core/postprocessor/optimizer.py
@@ -137,6 +137,13 @@ class SentenceEmbeddingOptimizer(BaseNodePostprocessor):
             if len(top_idxs) == 0:
                 raise ValueError("Optimizer returned zero sentences.")
 
+            # The retriever hands back indices ordered by similarity. Reading them
+            # back in that order rearranges the node text, so put the selection
+            # back into the order the sentences appear in the document.
+            top_idxs, top_similarities = (
+                list(t) for t in zip(*sorted(zip(top_idxs, top_similarities)))
+            )
+
             rangeMin, rangeMax = 0, len(split_text)
 
             if self.context_before is None:

--- a/llama-index-core/tests/postprocessor/test_optimizer.py
+++ b/llama-index-core/tests/postprocessor/test_optimizer.py
@@ -143,3 +143,26 @@ def test_optimizer(_mock_embeds: Any, _mock_embed: Any) -> None:
         [NodeWithScore(node=orig_node)], query
     )[0]
     assert optimized_node.node.get_content() == "world foo bar"
+
+
+@patch.object(MockEmbedding, "_get_text_embedding", side_effect=mock_get_text_embedding)
+@patch.object(
+    MockEmbedding, "_get_text_embeddings", side_effect=mock_get_text_embeddings
+)
+def test_optimizer_keeps_document_order(_mock_embeds: Any, _mock_embed: Any) -> None:
+    """Sentences are kept in the order they appear, not in similarity order."""
+    optimizer = SentenceEmbeddingOptimizer(
+        embed_model=MockEmbedding(embed_dim=5),
+        tokenizer_fn=mock_tokenizer_fn2,
+        threshold_cutoff=0.3,
+        context_before=0,
+        context_after=0,
+    )
+    # Closest to "bar", second closest to "foo", so both clear the threshold
+    # and "bar" is the stronger match even though it comes second in the text.
+    query = QueryBundle(query_str="foo bar", embedding=[0, 0, 0.4, 0.9, 0])
+    orig_node = TextNode(text="hello,world,foo,bar")
+    optimized_node = optimizer.postprocess_nodes(
+        [NodeWithScore(node=orig_node)], query
+    )[0]
+    assert optimized_node.node.get_content() == "foo bar"


### PR DESCRIPTION
## Description

`SentenceEmbeddingOptimizer` shortens a node by keeping the sentences closest to the query. It gets those sentences from `get_top_k_embeddings`, which returns indices sorted by similarity with the best match first:

```python
result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
```

The optimizer then iterated that list as-is:

```python
top_sentences = [
    " ".join(split_text[max(idx - self.context_before, rangeMin) : ...])
    for idx in top_idxs
]
```

So the sentences it kept were joined in relevance order, not in the order they appear in the document. The node text handed to the LLM comes back rearranged, and nothing about the result signals that it happened.

Here is the behavior on `main`, using the mock embeddings from the existing test file. The query matches `bar` most strongly and `foo` second, and both clear the threshold:

| | |
|---|---|
| node text | `hello,world,foo,bar` |
| expected | `foo bar` |
| actual on `main` | `bar foo` |

With longer nodes and a lower cutoff the reordering gets more thorough, and it lands on exactly the text a RAG pipeline is about to reason over.

## Fix

Sort the selection back into document order before the context windows are sliced. `top_similarities` is sorted alongside `top_idxs` so the debug logging below it still pairs each sentence with its own score.

```python
top_idxs, top_similarities = (
    list(t) for t in zip(*sorted(zip(top_idxs, top_similarities)))
)
```

That is the whole change. Which sentences get selected, the cutoffs, and the context window sizes all behave exactly as before.

## How I tested it

Added `test_optimizer_keeps_document_order`, which selects two sentences and asserts the original order survives. The four existing cases in that file each select exactly one sentence, which is why this went unnoticed.

I checked the test actually guards the regression by reverting only the `optimizer.py` change and re-running it, which then fails with `+ bar foo`, and passes with the fix applied.

- `pytest tests/postprocessor/`: 22 passed, 2 skipped
- `ruff check` and `ruff format` on both files: clean

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Suggested Checklist

- [x] I have added new unit tests to cover this change
- [x] I ran `ruff format` and `ruff check` locally
- [x] I have performed a self-review of my own code
