### PR TITLE
fix(embeddings-bedrock): forward additional_kwargs to Cohere request body (#22648)

### DIFF
--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/llama_index/embeddings/bedrock/base.py
@@ -531,6 +531,7 @@ class BedrockEmbedding(BaseEmbedding):
                 {
                     "texts": payload,
                     "input_type": input_types[input_type],
+                    **self.additional_kwargs,
                 }
             )
         else:

--- a/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
+++ b/llama-index-integrations/embeddings/llama-index-embeddings-bedrock/tests/test_bedrock_embedding.py
@@ -88,6 +88,29 @@ def test_non_empty_payload_still_builds_request_body():
     body = embedding._get_request_body("cohere", ["hello", "world"], "text")
     assert '"hello"' in body and '"world"' in body
 
+
+def test_cohere_additional_kwargs_forwarded_to_request_body():
+    """
+    additional_kwargs (e.g. output_dimension) must reach the Cohere request body.
+
+    Regression for #22648: the Cohere branch in _get_request_body ignored
+    self.additional_kwargs, so output_dimension was silently dropped and Cohere
+    Embed v4 always returned its default dimension.
+    """
+    import json
+
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    embedding = BedrockEmbedding(
+        model_name="cohere.embed-v4:0",
+        additional_kwargs={"output_dimension": 256},
+        client=bedrock_client,
+    )
+
+    body = json.loads(embedding._get_request_body("cohere", ["hello"], "text"))
+    assert body.get("output_dimension") == 256, (
+        "additional_kwargs must be forwarded into the Cohere request body"
+    )
+
     embedding = BedrockEmbedding(
         model_name="too.many.parts.in.name", client=bedrock_client
     )


### PR DESCRIPTION
## Summary

Fixes #22648.

`BedrockEmbedding._get_request_body()` accepted `additional_kwargs` but only forwarded them to the **Amazon/Titan** request body. The **Cohere** branch built `{"texts": ..., "input_type": ...}` and silently discarded `self.additional_kwargs`, so callers passing `additional_kwargs={"output_dimension": 256}` for Cohere Embed v4 always received the model's default dimension.

**Root cause**: the Cohere branch simply never spread `self.additional_kwargs` into the JSON body, unlike the Titan branch which already reads `dimensions` and `normalize` from it.

**Change** (one-liner):
```python
# before
request_body = json.dumps({"texts": payload, "input_type": input_types[input_type]})

# after
request_body = json.dumps({"texts": payload, "input_type": input_types[input_type], **self.additional_kwargs})
```

## Test plan

- [x] Added `test_cohere_additional_kwargs_forwarded_to_request_body` — asserts `output_dimension` appears in the Cohere request body (fails before this fix, passes after).
- [x] All 27 existing unit tests still pass (`pytest llama-index-embeddings-bedrock/tests/ -q`).
- [x] Pre-commit hooks (ruff, black, mypy, codespell) all pass.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.