### PR TITLE
fix(core): preserve zero similarity scores in recursive retrieval

### DIFF
--- a/llama-index-core/llama_index/core/base/base_retriever.py
+++ b/llama-index-core/llama_index/core/base/base_retriever.py
@@ -124,7 +124,7 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
         retrieved_nodes: List[NodeWithScore] = []
         for n in nodes:
             node = n.node
-            score = n.score or 1.0
+            score = 1.0 if n.score is None else n.score
             if isinstance(node, IndexNode):
                 obj = node.obj or self.object_map.get(node.index_id, None)
                 if obj is not None:
@@ -158,7 +158,7 @@ class BaseRetriever(PromptMixin, DispatcherSpanMixin):
         retrieved_nodes: List[NodeWithScore] = []
         for n in nodes:
             node = n.node
-            score = n.score or 1.0
+            score = 1.0 if n.score is None else n.score
             if isinstance(node, IndexNode):
                 obj = node.obj or self.object_map.get(node.index_id, None)
                 if obj is not None:

--- a/llama-index-core/llama_index/core/retrievers/recursive_retriever.py
+++ b/llama-index-core/llama_index/core/retrievers/recursive_retriever.py
@@ -168,7 +168,7 @@ class RecursiveRetriever(BaseRetriever):
                 color="blue",
             )
         query_id = query_id or self._root_id
-        cur_similarity = cur_similarity or 1.0
+        cur_similarity = 1.0 if cur_similarity is None else cur_similarity
 
         obj = self._get_object(query_id)
         if isinstance(obj, BaseNode):

--- a/llama-index-core/tests/retrievers/test_composable_retriever.py
+++ b/llama-index-core/tests/retrievers/test_composable_retriever.py
@@ -1,13 +1,54 @@
+from typing import List
+
 import pytest
 
 from llama_index.core import MockEmbedding, VectorStoreIndex
+from llama_index.core.base.base_retriever import BaseRetriever
+from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.indices import SummaryIndex
 from llama_index.core.llms.mock import MockLLM
+from llama_index.core.retrievers import RecursiveRetriever
 from llama_index.core.schema import (
     Document,
     IndexNode,
+    NodeWithScore,
+    QueryBundle,
     TextNode,
 )
+
+
+class OrthogonalEmbedding(BaseEmbedding):
+    """Return orthogonal document and query vectors for deterministic zero scores."""
+
+    def __init__(self) -> None:
+        super().__init__(embed_dim=2)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "OrthogonalEmbedding"
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return [1.0, 0.0]
+
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return [0.0, 1.0]
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return self._get_text_embedding(text)
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return self._get_query_embedding(query)
+
+
+class ZeroScoreIndexNodeRetriever(BaseRetriever):
+    """Return an index node whose score is exactly zero."""
+
+    def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
+        return [
+            NodeWithScore(
+                node=IndexNode(text="child link", index_id="child"), score=0.0
+            )
+        ]
 
 
 def test_composable_retrieval() -> None:
@@ -29,6 +70,45 @@ def test_composable_retrieval() -> None:
     assert len(nodes) == 2
     assert nodes[0].node.id_ == "test_text_node"
     assert nodes[1].node.id_ == "hidden_node"
+
+
+def _build_zero_score_composable_retriever():
+    target = TextNode(text="reachable child", id_="child")
+    index = VectorStoreIndex(
+        nodes=[],
+        objects=[IndexNode(text="sub-index", index_id="sub", obj=target)],
+        embed_model=OrthogonalEmbedding(),
+    )
+    return index.as_retriever(similarity_top_k=1)
+
+
+def test_composable_retrieval_preserves_zero_score() -> None:
+    retriever = _build_zero_score_composable_retriever()
+
+    nodes = retriever.retrieve("orthogonal query")
+
+    assert [(node.node.node_id, node.score) for node in nodes] == [("child", 0.0)]
+
+
+@pytest.mark.asyncio
+async def test_async_composable_retrieval_preserves_zero_score() -> None:
+    retriever = _build_zero_score_composable_retriever()
+
+    nodes = await retriever.aretrieve("orthogonal query")
+
+    assert [(node.node.node_id, node.score) for node in nodes] == [("child", 0.0)]
+
+
+def test_recursive_retriever_preserves_zero_score() -> None:
+    retriever = RecursiveRetriever(
+        root_id="root",
+        retriever_dict={"root": ZeroScoreIndexNodeRetriever()},
+        node_dict={"child": TextNode(text="reachable child", id_="child-node")},
+    )
+
+    nodes = retriever.retrieve("query")
+
+    assert [(node.node.node_id, node.score) for node in nodes] == [("child-node", 0.0)]
 
 
 def _build_retriever_with_query_engine_object():


### PR DESCRIPTION
## Description

Recursive retrieval currently treats a legitimate `0.0` similarity score as absent because it defaults scores with `score or 1.0`. This silently promotes zero-score `IndexNode` results to `1.0` when resolving objects or traversing `RecursiveRetriever` links.

This change defaults to `1.0` only when the score is `None`, preserving valid zero scores in the synchronous and asynchronous `BaseRetriever` paths and in `RecursiveRetriever`.

No linked issue. This bug was discovered through a code audit and reproduced with the public `VectorStoreIndex` plus `IndexNode` composition flow.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

No version bump is required for `llama-index-core`.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added deterministic regressions for:

- sync and async `VectorStoreIndex` composition with orthogonal embeddings, verifying that the returned child keeps score `0.0`;
- `RecursiveRetriever`, verifying that a zero-score `IndexNode` link keeps score `0.0`.

Validated locally:

- `uv run pytest llama-index-core/tests/retrievers/test_composable_retriever.py -q` -> `7 passed`;
- `uv run pytest llama-index-core/tests/retrievers llama-index-core/tests/indices/vector_store -q` -> `33 passed`;
- `uv run pre-commit run --files ...` -> all configured hooks passed, including mypy, Ruff, formatting, and codespell;
- full core suite: `1480 passed, 39 skipped, 6 xfailed`; one external image URL check failed once while the remote image was unavailable, then passed on rerun after connectivity recovered.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] Targeted and relevant existing tests pass locally
- [x] I ran the repository pre-commit hooks for all changed files

## AI Assistance

AI assistance was used for code exploration and drafting. The final change, regression tests, diff, and verification results were reviewed before submission.