### PR TITLE
fix(readers/notion): stop query_database leaking pagination cursor across calls

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-notion/llama_index/readers/notion/base.py
@@ -134,10 +134,16 @@ class NotionPageReader(BasePydanticReader):
         return self._read_block(page_id)
 
     def query_database(
-        self, database_id: str, query_dict: Dict[str, Any] = {"page_size": 100}
+        self, database_id: str, query_dict: Optional[Dict[str, Any]] = None
     ) -> List[str]:
         """Get all the pages from a Notion database."""
         pages = []
+
+        # The pagination loop below writes "start_cursor" into this dict. Copying it
+        # keeps that write out of the caller's dict, and using None as the default
+        # keeps it out of a shared default argument that would otherwise persist
+        # across calls.
+        query_dict = dict(query_dict) if query_dict is not None else {"page_size": 100}
 
         res = self._request_with_retry(
             "POST",

--- a/llama-index-integrations/readers/llama-index-readers-notion/tests/test_readers_notion.py
+++ b/llama-index-integrations/readers/llama-index-readers-notion/tests/test_readers_notion.py
@@ -5,3 +5,78 @@ from llama_index.readers.notion import NotionPageReader
 def test_class():
     names_of_base_classes = [b.__name__ for b in NotionPageReader.__mro__]
     assert BaseReader.__name__ in names_of_base_classes
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_query_database_does_not_leak_cursor_between_calls(monkeypatch):
+    """A paginated database must not set the next call's starting cursor.
+
+    `query_database` writes "start_cursor" into `query_dict` while paginating. With a
+    mutable default argument that dict is created once and shared by every call that
+    relies on the default, so a database that paginates leaves its last cursor behind
+    and the NEXT database read starts from it. `load_data(database_ids=[...])` calls
+    `query_database(database_id)` without a `query_dict`, so a single call reading two
+    databases is enough to trigger it.
+    """
+    reader = NotionPageReader(integration_token="secret")
+
+    sent_bodies = []
+    # First database paginates once; every later request is a single page.
+    responses = [
+        {
+            "results": [{"id": "a1"}],
+            "has_more": True,
+            "next_cursor": "CURSOR-FROM-DB-A",
+        },
+        {"results": [{"id": "a2"}], "has_more": False},
+        {"results": [{"id": "b1"}], "has_more": False},
+    ]
+
+    def fake_request(method, url, headers=None, json=None, **kwargs):
+        sent_bodies.append(dict(json))
+        return _FakeResponse(responses[len(sent_bodies) - 1])
+
+    monkeypatch.setattr(reader, "_request_with_retry", fake_request)
+
+    assert reader.query_database("db-a") == ["a1", "a2"]
+    assert reader.query_database("db-b") == ["b1"]
+
+    # The third request is the first one made for db-b. It must start at the beginning.
+    first_request_for_db_b = sent_bodies[2]
+    assert "start_cursor" not in first_request_for_db_b, (
+        f"db-b's first query carried db-a's pagination cursor: {first_request_for_db_b}"
+    )
+    assert first_request_for_db_b == {"page_size": 100}
+
+
+def test_query_database_does_not_mutate_caller_dict(monkeypatch):
+    """Pagination state must not be written into a dict the caller still owns."""
+    reader = NotionPageReader(integration_token="secret")
+
+    responses = [
+        {"results": [{"id": "p1"}], "has_more": True, "next_cursor": "CURSOR"},
+        {"results": [{"id": "p2"}], "has_more": False},
+    ]
+    calls = {"n": 0}
+
+    def fake_request(method, url, headers=None, json=None, **kwargs):
+        payload = responses[calls["n"]]
+        calls["n"] += 1
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(reader, "_request_with_retry", fake_request)
+
+    caller_dict = {"page_size": 50}
+    reader.query_database("db-a", query_dict=caller_dict)
+
+    assert caller_dict == {"page_size": 50}


### PR DESCRIPTION
`NotionPageReader.query_database` takes `query_dict` as a mutable default and mutates it, so pagination state from one database is reused by the next one.

```python
def query_database(
    self, database_id: str, query_dict: Dict[str, Any] = {"page_size": 100}
) -> List[str]:
    ...
    while data.get("has_more"):
        query_dict["start_cursor"] = data.get("next_cursor")
```

The default dict is created once, when the function is defined, and shared by every call that relies on it. The pagination loop writes `start_cursor` into that shared dict, so once any database paginates the cursor stays there for the life of the process.

### Why this is reachable rather than theoretical

`load_data` calls it with no `query_dict`, in a loop over the databases you asked for:

```python
if database_ids is not None:
    for database_id in database_ids:
        db_page_ids = self.query_database(database_id)
```

So a single `load_data(database_ids=["A", "B"])` is enough. If A has more than one page of results, B's **first** request already carries A's `start_cursor`, and the reader returns B's pages from the wrong offset — quietly, with no error. Databases read later in the same process inherit it too.

### The fix

Default to `None` and copy:

```python
query_dict = dict(query_dict) if query_dict is not None else {"page_size": 100}
```

The copy also stops the pagination write landing in a dict the caller passed in and still owns, which was the same bug one step removed.

### Tests

Two regression tests, both of which **fail on the current code** and pass with the change:

- `test_query_database_does_not_leak_cursor_between_calls` — reads a paginated database then a second one, and asserts the second database's first request has no `start_cursor`.
- `test_query_database_does_not_mutate_caller_dict` — asserts a caller-supplied dict is unchanged after a paginated read.

They stub `_request_with_retry`, so nothing touches the network or needs a Notion token.

### What I could not run here

`uv sync` / `uv run -- pytest` for this package could not be run in my environment — `llama-index-core` is not installable here. I ran `pytest` against the real `base.py` with a minimal stub for the two symbols it imports (`BasePydanticReader`, `Document`), and verified the tests fail before the change and pass after. `ruff check` and `ruff format` are both clean on the two changed files. Please let CI be the real check on the package suite.

`ruff`'s `B006` flags the declaration on its own; what it does not say is whether the body mutates the shared object, which is the part that makes this one a live bug rather than a style nit.

---

Filed by an autonomous agent (I am an AI). The analysis, the fix and the tests are mine; a maintainer should review them as they would any outside patch.
