### PR TITLE
fix(core): honor explicit empty chat history in CondenseQuestionChatEngine

### DIFF
--- a/llama-index-core/llama_index/core/chat_engine/condense_question.py
+++ b/llama-index-core/llama_index/core/chat_engine/condense_question.py
@@ -174,7 +174,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     def chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
-        chat_history = chat_history or self._memory.get(input=message)
+        if chat_history is None:
+            chat_history = self._memory.get(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
@@ -219,7 +220,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     def stream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
-        chat_history = chat_history or self._memory.get(input=message)
+        if chat_history is None:
+            chat_history = self._memory.get(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = self._condense_question(chat_history, message)
@@ -277,7 +279,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     async def achat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> AgentChatResponse:
-        chat_history = chat_history or await self._memory.aget(input=message)
+        if chat_history is None:
+            chat_history = await self._memory.aget(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)
@@ -322,7 +325,8 @@ class CondenseQuestionChatEngine(BaseChatEngine):
     async def astream_chat(
         self, message: str, chat_history: Optional[List[ChatMessage]] = None
     ) -> StreamingAgentChatResponse:
-        chat_history = chat_history or await self._memory.aget(input=message)
+        if chat_history is None:
+            chat_history = await self._memory.aget(input=message)
 
         # Generate standalone question from conversation context and last message
         condensed_question = await self._acondense_question(chat_history, message)

--- a/llama-index-core/tests/chat_engine/test_condense_question.py
+++ b/llama-index-core/tests/chat_engine/test_condense_question.py
@@ -1,13 +1,32 @@
 from unittest.mock import Mock
 
+import pytest
+
 from llama_index.core.base.base_query_engine import BaseQueryEngine
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
-from llama_index.core.base.response.schema import Response, StreamingResponse
+from llama_index.core.base.response.schema import (
+    AsyncStreamingResponse,
+    Response,
+    StreamingResponse,
+)
 from llama_index.core.chat_engine.condense_question import (
     CondenseQuestionChatEngine,
 )
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.memory import ChatMemoryBuffer
+
+
+def _make_engine_with_history():
+    query_engine = Mock(spec=BaseQueryEngine)
+    engine = CondenseQuestionChatEngine.from_defaults(
+        query_engine=query_engine,
+        chat_history=[
+            ChatMessage(role=MessageRole.USER, content="old question"),
+            ChatMessage(role=MessageRole.ASSISTANT, content="old answer"),
+        ],
+        llm=MockLLM(),
+    )
+    return engine, query_engine
 
 
 def test_condense_question_chat_engine(patch_llm_predictor) -> None:
@@ -48,6 +67,66 @@ def test_condense_question_chat_engine_with_init_history(patch_llm_predictor) ->
         "{'question': 'new human message', 'chat_history': 'user: test human "
         "message\\nassistant: test ai message'}"
     )
+
+
+def test_chat_honors_explicit_empty_history() -> None:
+    engine, query_engine = _make_engine_with_history()
+    query_engine.query.side_effect = lambda query: Response(response=query)
+
+    engine.chat("fresh question", chat_history=[])
+
+    assert query_engine.query.call_args.args == ("fresh question",)
+
+
+def test_stream_chat_honors_explicit_empty_history() -> None:
+    def response_gen():
+        yield "response"
+
+    engine, query_engine = _make_engine_with_history()
+    query_engine.query.return_value = StreamingResponse(response_gen=response_gen())
+
+    response = engine.stream_chat("fresh question", chat_history=[])
+    list(response.response_gen)
+
+    assert query_engine.query.call_args.args == ("fresh question",)
+
+
+@pytest.mark.asyncio
+async def test_achat_honors_explicit_empty_history() -> None:
+    async def aquery(query):
+        return Response(response=query)
+
+    engine, query_engine = _make_engine_with_history()
+    query_engine.aquery.side_effect = aquery
+
+    await engine.achat("fresh question", chat_history=[])
+
+    assert query_engine.aquery.call_args.args == ("fresh question",)
+
+    engine, query_engine = _make_engine_with_history()
+    query_engine.aquery.side_effect = aquery
+
+    await engine.achat("fresh question")
+
+    assert "old question" in query_engine.aquery.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_honors_explicit_empty_history() -> None:
+    async def response_gen():
+        yield "response"
+
+    async def aquery(query):
+        return AsyncStreamingResponse(response_gen=response_gen())
+
+    engine, query_engine = _make_engine_with_history()
+    query_engine.aquery.side_effect = aquery
+
+    response = await engine.astream_chat("fresh question", chat_history=[])
+    async for _ in response.async_response_gen():
+        pass
+
+    assert query_engine.aquery.call_args.args == ("fresh question",)
 
 
 def test_stream_chat_history_write_completes_on_early_exit() -> None:


### PR DESCRIPTION
## Description

`CondenseQuestionChatEngine` currently resolves `chat_history` with `chat_history or memory.get(...)`. An explicit empty list therefore behaves the same as an omitted argument and unexpectedly reuses the engine memory.

This is especially problematic when an engine is shared across independent requests: `chat_history=[]` is meant to suppress prior context, but an earlier conversation can instead rewrite the new question before it reaches the query engine.

This change only reads from memory when `chat_history is None`. Empty histories continue through the existing no-history path, which keeps the user message unchanged. The behavior is aligned across `chat`, `stream_chat`, `achat`, and `astream_chat`.

No linked issue. This bug was discovered through a code audit and reproduced with a pre-populated engine memory.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

No version bump is required for `llama-index-core`.

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added deterministic regressions covering:

- `chat`, `stream_chat`, `achat`, and `astream_chat` with a pre-populated memory and explicit `chat_history=[]`, asserting that the query engine receives the new question unchanged;
- the async omitted-history path, asserting that `None` still reads the existing memory. The existing synchronous initial-history regression continues to cover the corresponding sync behavior.

Validated locally:

- `uv run pytest llama-index-core/tests/chat_engine/test_condense_question.py -q` -> `7 passed`;
- `uv run pytest llama-index-core/tests/chat_engine -q` -> `41 passed`;
- `uv run pytest llama-index-core/tests -q` -> `1482 passed, 39 skipped, 6 xfailed`;
- `uv run pre-commit run --files ...` -> all configured hooks passed, including mypy, Ruff, formatting, and codespell.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] Targeted and existing tests pass locally
- [x] I ran the repository pre-commit hooks for all changed files

## AI Assistance

AI assistance was used for code exploration and drafting. The final change, regression tests, diff, and verification results were reviewed before submission.