### PR TITLE
fix(core): raise on truncated JSON instead of returning None

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -33,6 +33,14 @@ def _marshal_llm_to_json(output: str) -> str:
         left = left_brace
         right = output.rfind("}")
 
+    if left == -1:
+        return ""
+
+    # rfind returns -1 when the payload was truncated before its closer, and
+    # output[left:0] would then collapse to "" and hide the partial JSON.
+    if right == -1:
+        return output[left:]
+
     return output[left : right + 1]
 
 
@@ -58,6 +66,13 @@ def parse_json_markdown(text: str) -> Any:
             )
         except NameError as exc:
             raise ImportError("Please pip install PyYAML.") from exc
+
+        # yaml.safe_load returns None for a document it cannot read, it does not raise.
+        if json_obj is None:
+            raise OutputParserException(
+                f"Got invalid JSON object. Error: {e_json}. "
+                f"Got JSON string: {json_string}"
+            )
 
     return json_obj
 

--- a/llama-index-core/tests/output_parsers/test_selection.py
+++ b/llama-index-core/tests/output_parsers/test_selection.py
@@ -1,5 +1,8 @@
 import pytest
-from llama_index.core.output_parsers.base import StructuredOutput
+from llama_index.core.output_parsers.base import (
+    OutputParserException,
+    StructuredOutput,
+)
 from llama_index.core.output_parsers.selection import SelectionOutputParser
 
 
@@ -80,3 +83,10 @@ def test_failed_parse(output_parser: SelectionOutputParser) -> None:
     )
     with pytest.raises(ValueError, match="Failed to convert*") as exc_info:
         output_parser.parse(output=no_json_in_response)
+
+
+def test_truncated_parse(output_parser: SelectionOutputParser) -> None:
+    truncated_response = 'Here is the result: [{"choice": 1, "reason": "because'
+    with pytest.raises(OutputParserException) as exc_info:
+        output_parser.parse(output=truncated_response)
+    assert '[{"choice": 1, "reason": "because' in str(exc_info.value)

--- a/llama-index-core/tests/output_parsers/test_utils.py
+++ b/llama-index-core/tests/output_parsers/test_utils.py
@@ -1,4 +1,10 @@
-from llama_index.core.output_parsers.utils import extract_json_str
+import pytest
+from llama_index.core.output_parsers.base import OutputParserException
+from llama_index.core.output_parsers.utils import (
+    _marshal_llm_to_json,
+    extract_json_str,
+    parse_json_markdown,
+)
 
 
 def test_extract_json_str() -> None:
@@ -22,3 +28,35 @@ Here is the valid JSON:
 }\
 """
     assert extract_json_str(input) == expected
+
+
+def test_marshal_unclosed_array_keeps_truncated_payload() -> None:
+    output = 'Here is the result: [{"choice": 1, "reason": "because'
+    assert _marshal_llm_to_json(output) == '[{"choice": 1, "reason": "because'
+
+
+def test_marshal_unclosed_object_keeps_truncated_payload() -> None:
+    output = 'Here is the result: {"a": 1, "b":'
+    assert _marshal_llm_to_json(output) == '{"a": 1, "b":'
+
+
+def test_parse_json_markdown_truncated_array_raises() -> None:
+    truncated = 'Here is the result: [{"choice": 1, "reason": "because'
+    with pytest.raises(OutputParserException) as exc_info:
+        parse_json_markdown(truncated)
+    assert '[{"choice": 1, "reason": "because' in str(exc_info.value)
+
+
+def test_parse_json_markdown_truncated_object_raises() -> None:
+    with pytest.raises(OutputParserException):
+        parse_json_markdown('Here is the result: {"a": 1, "b":')
+
+
+def test_parse_json_markdown_without_json_raises() -> None:
+    with pytest.raises(OutputParserException):
+        parse_json_markdown("there is no json in this answer")
+
+
+def test_parse_json_markdown_closed_array() -> None:
+    output = 'Here is the result: [{"choice": 1, "reason": "because"}]'
+    assert parse_json_markdown(output) == [{"choice": 1, "reason": "because"}]


### PR DESCRIPTION
# Description

`_marshal_llm_to_json` sliced `output[left : right + 1]` even when `rfind` found no closing bracket and returned `-1`. With `right + 1 == 0` that slice collapses to `""` for any truncated payload, so `parse_json_markdown` handed `""` to `yaml.safe_load`, which reads an empty document as `None` without raising. Model output cut short by a token limit therefore parsed as a valid empty answer instead of surfacing an error.

This returns the slice from the opening bracket to the end of the string when the closer is missing, and raises `OutputParserException` naming the offending string when the YAML fallback yields `None`. Balanced, closed payloads take the same path as before; truncated JSON is reported, not repaired.

`SelectionOutputParser.parse` needed no change of its own: with the slice fixed, the truncated text reaches YAML, YAML raises, and the existing handler already turns that into an `OutputParserException` carrying the payload. Covered by a new test.

Fixes #22909

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

`uv run -- pytest tests/output_parsers/` in `llama-index-core`: the six new tests fail on `main` and pass with this change. The full `llama-index-core` suite is green.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
