### PR TITLE
fix: raise OutputParserException on truncated/unclosed JSON

### DIFF
--- a/llama-index-core/llama_index/core/output_parsers/utils.py
+++ b/llama-index-core/llama_index/core/output_parsers/utils.py
@@ -33,6 +33,12 @@ def _marshal_llm_to_json(output: str) -> str:
         left = left_brace
         right = output.rfind("}")
 
+    if left == -1:
+        return ""
+
+    if right == -1 or right < left:
+        return output[left:]
+
     return output[left : right + 1]
 
 
@@ -41,6 +47,11 @@ def parse_json_markdown(text: str) -> Any:
         text = text.split("```json")[1].strip().strip("```").strip()
 
     json_string = _marshal_llm_to_json(text)
+
+    if not json_string:
+        raise OutputParserException(
+            f"No JSON object or array found in output: {text}"
+        )
 
     try:
         json_obj = json.loads(json_string)
@@ -58,6 +69,12 @@ def parse_json_markdown(text: str) -> Any:
             )
         except NameError as exc:
             raise ImportError("Please pip install PyYAML.") from exc
+
+    if json_obj is None:
+        raise OutputParserException(
+            f"Got invalid JSON object (parsed as None). "
+            f"Got JSON string: {json_string}"
+        )
 
     return json_obj
 

--- a/llama-index-core/tests/output_parsers/test_utils.py
+++ b/llama-index-core/tests/output_parsers/test_utils.py
@@ -1,4 +1,11 @@
-from llama_index.core.output_parsers.utils import extract_json_str
+import pytest
+
+from llama_index.core.output_parsers.base import OutputParserException
+from llama_index.core.output_parsers.utils import (
+    _marshal_llm_to_json,
+    extract_json_str,
+    parse_json_markdown,
+)
 
 
 def test_extract_json_str() -> None:
@@ -22,3 +29,59 @@ Here is the valid JSON:
 }\
 """
     assert extract_json_str(input) == expected
+
+
+class TestMarshalLlmToJson:
+    def test_valid_object(self) -> None:
+        assert _marshal_llm_to_json('result: {"a": 1}') == '{"a": 1}'
+
+    def test_valid_array(self) -> None:
+        assert _marshal_llm_to_json("here: [1, 2, 3]") == "[1, 2, 3]"
+
+    def test_no_brackets(self) -> None:
+        assert _marshal_llm_to_json("just plain text") == ""
+
+    def test_unclosed_object(self) -> None:
+        text = 'Here is the result: {"choice": 1, "reason": "because'
+        result = _marshal_llm_to_json(text)
+        assert result.startswith("{")
+        assert "choice" in result
+
+    def test_unclosed_array(self) -> None:
+        text = 'Here is the result: [{"choice": 1, "reason": "because'
+        result = _marshal_llm_to_json(text)
+        assert result.startswith("[")
+        assert "choice" in result
+
+    def test_closing_before_opening(self) -> None:
+        text = "} some text { valid"
+        result = _marshal_llm_to_json(text)
+        assert result.startswith("{")
+
+
+class TestParseJsonMarkdown:
+    def test_valid_json(self) -> None:
+        assert parse_json_markdown('{"a": 1}') == {"a": 1}
+
+    def test_valid_json_with_markdown(self) -> None:
+        assert parse_json_markdown('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_valid_array(self) -> None:
+        assert parse_json_markdown("[1, 2]") == [1, 2]
+
+    def test_trailing_comma_via_yaml(self) -> None:
+        result = parse_json_markdown('{"a": 1,}')
+        assert result == {"a": 1}
+
+    def test_truncated_json_raises(self) -> None:
+        text = 'Here is the result: [{"choice": 1, "reason": "because'
+        with pytest.raises(OutputParserException):
+            parse_json_markdown(text)
+
+    def test_no_json_raises(self) -> None:
+        with pytest.raises(OutputParserException, match="No JSON object"):
+            parse_json_markdown("just plain text with no brackets")
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(OutputParserException, match="No JSON object"):
+            parse_json_markdown("")


### PR DESCRIPTION
## Summary
- `_marshal_llm_to_json()` returned an empty string when LLM output contained an opening bracket (`{`/`[`) but no matching closer (common when `max_tokens` truncates mid-object). The slice `output[left:0]` silently produced `""`.
- That empty string passed through `yaml.safe_load("")` → `None` with no error, so `parse_json_markdown` returned `None` instead of raising `OutputParserException`.
- Now `_marshal_llm_to_json` returns from the opening bracket to end-of-string when no closer is found, giving downstream parsers the actual truncated content.
- `parse_json_markdown` raises `OutputParserException` for empty extraction results and for `None` parse results.

Closes #22909

## Test plan
- [x] Added `TestMarshalLlmToJson` covering: valid object, valid array, no brackets, unclosed object, unclosed array, closing-before-opening
- [x] Added `TestParseJsonMarkdown` covering: valid JSON, markdown-fenced JSON, valid array, trailing comma (yaml fallback), truncated JSON raises, no-JSON raises, empty string raises
- [x] All 24 tests in `tests/output_parsers/` pass (including existing selection and pydantic parser tests — no regressions)