### PR TITLE
fix(google-genai): keep images on Gemini function responses

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -443,9 +443,21 @@ async def chat_message_to_gemini(
     # the tool call response is the content of the message, overriding the existing content
     # (the only content before this should be the tool call)
     if message.additional_kwargs.get("tool_call_id"):
+        # A tool may return an image, and FunctionResponse.parts takes
+        # FunctionResponsePart inline media. The loop above already built those
+        # images as ordinary Parts, which this branch then threw away.
+        image_parts = [
+            types.FunctionResponsePart.from_bytes(
+                data=block.resolve_image(as_base64=False).read(),
+                mime_type=block.image_mimetype or "image/jpeg",
+            )
+            for block in message.blocks
+            if isinstance(block, ImageBlock)
+        ]
         function_response_part = types.Part.from_function_response(
             name=message.additional_kwargs.get("tool_call_id"),
             response={"result": message.content},
+            parts=image_parts or None,
         )
         return (
             types.Content(

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-google-genai"
-version = "0.11.0"
+version = "0.11.1"
 description = "llama-index llms google genai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -2077,6 +2077,88 @@ async def test_chat_message_to_gemini_thought_signatures() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_message_to_gemini_tool_result_image_becomes_function_response_parts() -> (
+    None
+):
+    """Test that an image returned by a tool reaches Gemini as functionResponse.parts."""
+    from llama_index.llms.google_genai.utils import chat_message_to_gemini
+
+    msg = ChatMessage(
+        role=MessageRole.TOOL,
+        blocks=[
+            TextBlock(text="Retrieved embedded image."),
+            ImageBlock(image=b"png bytes", image_mimetype="image/png"),
+        ],
+        additional_kwargs={"tool_call_id": "read_image"},
+    )
+
+    content, _ = await chat_message_to_gemini(msg, client=None, file_mode="inline")
+
+    response = content.parts[0].function_response
+    assert response.name == "read_image"
+    assert response.response == {"result": "Retrieved embedded image."}
+    assert [
+        (part.inline_data.mime_type, part.inline_data.data) for part in response.parts
+    ] == [("image/png", b"png bytes")]
+
+
+@pytest.mark.asyncio
+async def test_chat_message_to_gemini_text_only_tool_result_has_no_parts() -> None:
+    """Test that a tool result with no image is still sent as text-only."""
+    from llama_index.llms.google_genai.utils import chat_message_to_gemini
+
+    msg = ChatMessage(
+        role=MessageRole.TOOL,
+        blocks=[TextBlock(text="xml result")],
+        additional_kwargs={"tool_call_id": "read_xml"},
+    )
+
+    content, _ = await chat_message_to_gemini(msg, client=None, file_mode="inline")
+
+    response = content.parts[0].function_response
+    assert response.response == {"result": "xml result"}
+    assert not response.parts
+
+
+@pytest.mark.asyncio
+async def test_prepare_chat_params_keeps_each_tool_image_on_its_own_response() -> None:
+    """Test that merged parallel tool results each keep the image they returned."""
+    next_msg, _, _ = await prepare_chat_params(
+        "models/gemini-3-flash-preview",
+        [
+            ChatMessage(content="look at these", role=MessageRole.USER),
+            ChatMessage(
+                role=MessageRole.ASSISTANT,
+                additional_kwargs={
+                    "tool_calls": [
+                        {"name": "tool_a", "args": {}},
+                        {"name": "tool_b", "args": {}},
+                    ]
+                },
+            ),
+            ChatMessage(
+                role=MessageRole.TOOL,
+                blocks=[
+                    TextBlock(text="first"),
+                    ImageBlock(image=b"first", image_mimetype="image/png"),
+                ],
+                additional_kwargs={"tool_call_id": "tool_a"},
+            ),
+            ChatMessage(
+                role=MessageRole.TOOL,
+                content="xml result",
+                additional_kwargs={"tool_call_id": "tool_b"},
+            ),
+        ],
+    )
+
+    responses = [part.function_response for part in next_msg.parts]
+    assert [response.name for response in responses] == ["tool_a", "tool_b"]
+    assert [part.inline_data.data for part in (responses[0].parts or [])] == [b"first"]
+    assert not responses[1].parts
+
+
+@pytest.mark.asyncio
 async def test_create_file_part_passes_display_name_to_file_api():
     mock_file = MagicMock()
     mock_file.state.name = "ACTIVE"


### PR DESCRIPTION
# Description

A tool that returns an `ImageBlock` silently loses it on Gemini. The block never makes it into the request, so the model answers as though the tool had returned only its text, and there is no error anywhere to point at.

The API does accept these. `FunctionResponse.parts` is a list of `FunctionResponsePart` with `inline_data` / `file_data`. `Part.from_function_response` already takes `parts`. But `chat_message_to_gemini` only ever passes `response={"result": message.content}`, so the image is thrown away.

This builds those parts when the tool result carries an image, and leaves them off otherwise. The text still lives in `response["result"]`, which is what Gemini already uses for the textual result.

Before:

```python
types.Part.from_function_response(
    name="read_image",
    response={"result": "Retrieved embedded image."},
)
```

After:

```python
types.Part.from_function_response(
    name="read_image",
    response={"result": "Retrieved embedded image."},
    parts=[
        types.FunctionResponsePart.from_bytes(
            data=b"png bytes",
            mime_type="image/png",
        )
    ],
)
```

Gemini 2.5 rejects `functionResponse.parts`, so an image-bearing tool result will error there instead of silently dropping the image. Text-only results are unchanged. This field exists for Gemini 3.x.

Sibling of #22906, which does the same for the OpenAI Responses API.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes
- [ ] No

`llama-index-llms-google-genai` 0.11.0 to 0.11.1.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Three tests in `tests/test_llms_google_genai.py`: an image-bearing tool result serializing onto `functionResponse.parts`, a text-only tool result still serializing with no parts, and merged parallel tool results each keeping the image they returned.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run ruff check` / `uv run ruff format` to appease the lint gods

Made with [Cursor](https://cursor.com)