### PR TITLE
fix(google-genai): surface Gemini 2.5 token counts in streamed responses (#19293)

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/base.py
@@ -54,6 +54,7 @@ from llama_index.core.types import PydanticProgramMode
 from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
     chat_message_to_gemini,
+    chat_response_from_usage_metadata,
     convert_schema_to_function_declaration,
     prepare_chat_params,
     handle_streaming_flexible_model,
@@ -421,30 +422,38 @@ class GoogleGenAI(FunctionCallingLLM):
                 content = []
                 thought_signatures = []
                 for r in response:
-                    if candidates := r.candidates:
-                        if not candidates:
-                            continue
+                    top_candidate = r.candidates[0] if r.candidates else None
+                    if (
+                        top_candidate is not None
+                        and top_candidate.content
+                        and top_candidate.content.parts
+                    ):
+                        parts = top_candidate.content.parts
+                        # Only use non-thought text parts for the delta
+                        content_delta = "".join(
+                            part.text
+                            for part in parts
+                            if part.text and not part.thought
+                        )
 
-                        top_candidate = candidates[0]
-                        if response_content := top_candidate.content:
-                            if parts := response_content.parts:
-                                # Only use non-thought text parts for the delta
-                                content_delta = "".join(
-                                    part.text
-                                    for part in parts
-                                    if part.text and not part.thought
-                                )
+                        llama_resp = chat_from_gemini_response(
+                            r,
+                            existing_content=content,
+                            thought_signatures=thought_signatures,
+                        )
+                        llama_resp.delta = llama_resp.delta or content_delta or ""
 
-                                llama_resp = chat_from_gemini_response(
-                                    r,
-                                    existing_content=content,
-                                    thought_signatures=thought_signatures,
-                                )
-                                llama_resp.delta = (
-                                    llama_resp.delta or content_delta or ""
-                                )
-
-                                yield llama_resp
+                        yield llama_resp
+                    elif r.usage_metadata:
+                        # Gemini streams report token usage on a trailing chunk
+                        # that carries no candidate content; surface it as the
+                        # final response so callbacks/instrumentation see it
+                        # (issue #19293).
+                        usage_resp = chat_response_from_usage_metadata(
+                            r, content, thought_signatures
+                        )
+                        usage_resp.delta = ""
+                        yield usage_resp
             finally:
                 if self.file_mode in ("fileapi", "hybrid"):
                     delete_uploaded_files(file_api_names, self._client)
@@ -477,30 +486,38 @@ class GoogleGenAI(FunctionCallingLLM):
                 async for r in await chat.send_message_stream(
                     next_msg.parts if isinstance(next_msg, types.Content) else next_msg
                 ):
-                    if candidates := r.candidates:
-                        if not candidates:
-                            continue
+                    top_candidate = r.candidates[0] if r.candidates else None
+                    if (
+                        top_candidate is not None
+                        and top_candidate.content
+                        and top_candidate.content.parts
+                    ):
+                        parts = top_candidate.content.parts
+                        # Only use non-thought text parts for the delta
+                        content_delta = "".join(
+                            part.text
+                            for part in parts
+                            if part.text and not part.thought
+                        )
 
-                        top_candidate = candidates[0]
-                        if response_content := top_candidate.content:
-                            if parts := response_content.parts:
-                                # Only use non-thought text parts for the delta
-                                content_delta = "".join(
-                                    part.text
-                                    for part in parts
-                                    if part.text and not part.thought
-                                )
+                        llama_resp = chat_from_gemini_response(
+                            r,
+                            existing_content=content,
+                            thought_signatures=thought_signatures,
+                        )
+                        llama_resp.delta = llama_resp.delta or content_delta or ""
 
-                                llama_resp = chat_from_gemini_response(
-                                    r,
-                                    existing_content=content,
-                                    thought_signatures=thought_signatures,
-                                )
-                                llama_resp.delta = (
-                                    llama_resp.delta or content_delta or ""
-                                )
-
-                                yield llama_resp
+                        yield llama_resp
+                    elif r.usage_metadata:
+                        # Gemini streams report token usage on a trailing chunk
+                        # that carries no candidate content; surface it as the
+                        # final response so callbacks/instrumentation see it
+                        # (issue #19293).
+                        usage_resp = chat_response_from_usage_metadata(
+                            r, content, thought_signatures
+                        )
+                        usage_resp.delta = ""
+                        yield usage_resp
             finally:
                 if self.file_mode in ("fileapi", "hybrid"):
                     await adelete_uploaded_files(file_api_names, self._client)

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/llama_index/llms/google_genai/utils.py
@@ -140,6 +140,57 @@ def _error_if_finished_early(candidate: types.Candidate) -> None:
             raise RuntimeError(f"Response was terminated early: {reason}")
 
 
+def _apply_usage_metadata(
+    response: types.GenerateContentResponse,
+    raw: Dict[str, Any],
+    additional_kwargs: Dict[str, Any],
+) -> Optional[int]:
+    """
+    Copy Gemini usage metadata onto the response surfaces used by tracing.
+
+    Sets ``raw["usage_metadata"]`` and the token-count keys on
+    ``additional_kwargs`` that MLFlow tracing, TokenCountingHandler and
+    OpenInference-style instrumentation consume. Gemini 2.5 thinking models
+    also report ``thoughts_token_count``; it is returned so callers can
+    annotate thinking blocks.
+    """
+    if not response.usage_metadata:
+        return None
+
+    raw["usage_metadata"] = response.usage_metadata.model_dump()
+
+    # Set token usage information as required by MLFlow Tracing
+    additional_kwargs["prompt_tokens"] = response.usage_metadata.prompt_token_count
+    additional_kwargs["completion_tokens"] = (
+        response.usage_metadata.candidates_token_count
+    )
+    additional_kwargs["total_tokens"] = response.usage_metadata.total_token_count
+
+    thought_tokens: Optional[int] = None
+    if response.usage_metadata.thoughts_token_count:
+        thought_tokens = response.usage_metadata.thoughts_token_count
+        # Gemini 2.5 thinking models: expose reasoning tokens so observability
+        # tools can break them out from completion tokens (issue #19293).
+        additional_kwargs["thoughts_token_count"] = thought_tokens
+
+    return thought_tokens
+
+
+def _annotate_thought_tokens(
+    content_blocks: List[ContentBlock], thought_tokens: int
+) -> None:
+    """Attach a thinking-token count to the ThinkingBlock(s) in content_blocks."""
+    thinking_blocks = [
+        i for i, block in enumerate(content_blocks) if isinstance(block, ThinkingBlock)
+    ]
+    if len(thinking_blocks) == 1:
+        content_blocks[thinking_blocks[0]].num_tokens = thought_tokens
+    elif len(thinking_blocks) > 1:
+        content_blocks[thinking_blocks[-1]].additional_information.update(
+            {"total_thinking_tokens": thought_tokens}
+        )
+
+
 def chat_from_gemini_response(
     response: types.GenerateContentResponse,
     existing_content: List[ContentBlock],
@@ -158,24 +209,12 @@ def chat_from_gemini_response(
         **(top_candidate.model_dump()),
         **response_feedback,
     }
-    thought_tokens: Optional[int] = None
 
     if thought_signatures is None:
         thought_signatures = []
 
     additional_kwargs: Dict[str, Any] = {"thought_signatures": thought_signatures}
-    if response.usage_metadata:
-        raw["usage_metadata"] = response.usage_metadata.model_dump()
-
-        # Set token usage information as required by MLFlow Tracing
-        additional_kwargs["prompt_tokens"] = response.usage_metadata.prompt_token_count
-        additional_kwargs["completion_tokens"] = (
-            response.usage_metadata.candidates_token_count
-        )
-        additional_kwargs["total_tokens"] = response.usage_metadata.total_token_count
-
-        if response.usage_metadata.thoughts_token_count:
-            thought_tokens = response.usage_metadata.thoughts_token_count
+    thought_tokens = _apply_usage_metadata(response, raw, additional_kwargs)
 
     if hasattr(response, "cached_content") and response.cached_content:
         raw["cached_content"] = response.cached_content
@@ -251,22 +290,46 @@ def chat_from_gemini_response(
                 )
 
     if thought_tokens:
-        thinking_blocks = [
-            i
-            for i, block in enumerate(content_blocks)
-            if isinstance(block, ThinkingBlock)
-        ]
-        if len(thinking_blocks) == 1:
-            content_blocks[thinking_blocks[0]].num_tokens = thought_tokens
-        elif len(thinking_blocks) > 1:
-            content_blocks[thinking_blocks[-1]].additional_information.update(
-                {"total_thinking_tokens": thought_tokens}
-            )
+        _annotate_thought_tokens(content_blocks, thought_tokens)
 
     role = ROLES_FROM_GEMINI[top_candidate.content.role or "model"]
     return ChatResponse(
         message=ChatMessage(
             role=role, blocks=content_blocks, additional_kwargs=additional_kwargs
+        ),
+        raw=raw,
+        additional_kwargs=additional_kwargs,
+    )
+
+
+def chat_response_from_usage_metadata(
+    response: types.GenerateContentResponse,
+    existing_content: List[ContentBlock],
+    thought_signatures: Optional[List[Optional[str]]] = None,
+) -> ChatResponse:
+    """
+    Build a ChatResponse carrying token counts from a trailing stream chunk.
+
+    Gemini streams report ``usage_metadata`` on a trailing chunk that usually
+    carries no candidate content (only token usage). Streaming generators used
+    to drop that chunk, so streamed responses never exposed token counts to
+    callbacks and instrumentation (issue #19293). This rebuilds the final
+    response from the blocks accumulated so far plus the chunk's usage.
+    """
+    if thought_signatures is None:
+        thought_signatures = []
+
+    additional_kwargs: Dict[str, Any] = {"thought_signatures": thought_signatures}
+    raw: Dict[str, Any] = {}
+    thought_tokens = _apply_usage_metadata(response, raw, additional_kwargs)
+    if thought_tokens:
+        _annotate_thought_tokens(existing_content, thought_tokens)
+
+    return ChatResponse(
+        message=ChatMessage(
+            role=MessageRole.ASSISTANT,
+            blocks=existing_content,
+            additional_kwargs=additional_kwargs,
         ),
         raw=raw,
         additional_kwargs=additional_kwargs,

--- a/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
+++ b/llama-index-integrations/llms/llama-index-llms-google-genai/tests/test_llms_google_genai.py
@@ -30,7 +30,6 @@ from llama_index.llms.google_genai.utils import (
     chat_from_gemini_response,
 )
 
-
 SKIP_GEMINI = (
     os.environ.get("GOOGLE_API_KEY") is None
     or os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "false") == "true"
@@ -2124,3 +2123,191 @@ async def test_create_file_part_no_display_name_by_default():
     call_kwargs = mock_client.aio.files.upload.call_args
     upload_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
     assert upload_config.display_name is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/run-llama/llama_index/issues/19293
+# Token counts for Gemini 2.5 models must reach instrumentation surfaces
+# (ChatResponse.additional_kwargs / raw) in both chat and streaming paths.
+# ---------------------------------------------------------------------------
+
+
+def _mock_usage_metadata(
+    prompt: int = 11,
+    candidates: int = 22,
+    total: int = 40,
+    thoughts: int = 7,
+    cached: int = 3,
+) -> MagicMock:
+    """Build a Gemini 2.5-style usage metadata mock (incl. thinking tokens)."""
+    usage_metadata = MagicMock()
+    usage_metadata.prompt_token_count = prompt
+    usage_metadata.candidates_token_count = candidates
+    usage_metadata.total_token_count = total
+    usage_metadata.thoughts_token_count = thoughts
+    usage_metadata.cached_content_token_count = cached
+    usage_metadata.model_dump.return_value = {
+        "prompt_token_count": prompt,
+        "candidates_token_count": candidates,
+        "total_token_count": total,
+        "thoughts_token_count": thoughts,
+        "cached_content_token_count": cached,
+    }
+    return usage_metadata
+
+
+def _mock_text_chunk(text: str, usage_metadata: Any = None) -> MagicMock:
+    """Build a GenerateContentResponse-shaped stream chunk with one text part."""
+    part = MagicMock()
+    part.text = text
+    part.thought = None
+    part.thought_signature = None
+    part.inline_data = None
+    part.function_call = None
+    part.function_response = None
+
+    candidate = MagicMock()
+    candidate.finish_reason = types.FinishReason.STOP
+    candidate.content.role = "model"
+    candidate.content.parts = [part]
+    candidate.model_dump.return_value = {
+        "finish_reason": types.FinishReason.STOP,
+        "content": {"role": "model", "parts": [{"text": text}]},
+    }
+
+    chunk = MagicMock()
+    chunk.candidates = [candidate]
+    chunk.usage_metadata = usage_metadata
+    chunk.prompt_feedback = None
+    chunk.function_calls = None
+    del chunk.cached_content
+    return chunk
+
+
+def _mock_usage_only_chunk(usage_metadata: MagicMock) -> MagicMock:
+    """Build the trailing Gemini stream chunk that carries usage only."""
+    chunk = MagicMock()
+    chunk.candidates = []
+    chunk.usage_metadata = usage_metadata
+    return chunk
+
+
+def _mock_google_genai_llm() -> GoogleGenAI:
+    """Build a GoogleGenAI instance against a fully mocked client."""
+    with patch("google.genai.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+
+        mock_model = MagicMock()
+        mock_model.supported_generation_methods = ["generateContent"]
+        mock_model.input_token_limit = 1000000
+        mock_model.output_token_limit = 8192
+        mock_client.models.get.return_value = mock_model
+
+        llm = GoogleGenAI(
+            model="gemini-2.5-flash",
+            max_tokens=8192,
+            context_window=1000000,
+        )
+        llm._client = mock_client  # keep the mocked client for the caller
+        return llm
+
+
+def test_usage_metadata_exposes_gemini_2_5_token_counts() -> None:
+    """Token counts, incl. Gemini 2.5 thinking tokens, surface on the response."""
+    mock_response = MagicMock()
+    mock_response.candidates = [MagicMock()]
+    mock_response.candidates[0].finish_reason = types.FinishReason.STOP
+    mock_response.candidates[0].content.role = "model"
+    part = MagicMock()
+    part.text = "Hello."
+    part.thought = None
+    part.thought_signature = None
+    part.inline_data = None
+    part.function_call = None
+    part.function_response = None
+    mock_response.candidates[0].content.parts = [part]
+    mock_response.candidates[0].model_dump = MagicMock(return_value={})
+    mock_response.prompt_feedback = None
+    mock_response.function_calls = None
+    del mock_response.cached_content
+    mock_response.usage_metadata = _mock_usage_metadata()
+
+    chat_response = chat_from_gemini_response(mock_response, [])
+
+    assert chat_response.additional_kwargs["prompt_tokens"] == 11
+    assert chat_response.additional_kwargs["completion_tokens"] == 22
+    assert chat_response.additional_kwargs["total_tokens"] == 40
+    # Gemini 2.5 thinking models: reasoning tokens must be visible to
+    # instrumentation that reads additional_kwargs.
+    assert chat_response.additional_kwargs["thoughts_token_count"] == 7
+    assert chat_response.raw["usage_metadata"] == {
+        "prompt_token_count": 11,
+        "candidates_token_count": 22,
+        "total_token_count": 40,
+        "thoughts_token_count": 7,
+        "cached_content_token_count": 3,
+    }
+
+
+def test_stream_chat_surfaces_usage_metadata_from_trailing_chunk() -> None:
+    """Gemini streams usage on a trailing chunk w/o content; last response must carry it."""
+    mock_client = MagicMock()
+    usage_metadata = _mock_usage_metadata()
+    mock_client.chats.create.return_value.send_message_stream.return_value = [
+        _mock_text_chunk("Hello from Gemini"),
+        _mock_usage_only_chunk(usage_metadata),
+    ]
+
+    llm = _mock_google_genai_llm()
+    llm._client = mock_client
+
+    responses = list(llm.stream_chat(messages=[ChatMessage(role="user", content="Hi")]))
+
+    assert len(responses) == 2
+    last = responses[-1]
+    assert last.delta == ""
+    assert last.additional_kwargs["prompt_tokens"] == 11
+    assert last.additional_kwargs["completion_tokens"] == 22
+    assert last.additional_kwargs["total_tokens"] == 40
+    assert last.additional_kwargs["thoughts_token_count"] == 7
+    assert last.raw["usage_metadata"]["prompt_token_count"] == 11
+    # accumulated content is preserved on the final response
+    assert "Hello from Gemini" in last.message.content
+    # earlier chunk keeps streaming deltas as before
+    assert responses[0].delta == "Hello from Gemini"
+
+
+@pytest.mark.asyncio
+async def test_astream_chat_surfaces_usage_metadata_from_trailing_chunk() -> None:
+    """Async streaming must also surface usage from the trailing usage-only chunk."""
+
+    async def async_chunks():
+        for chunk in [
+            _mock_text_chunk("Hello from Gemini"),
+            _mock_usage_only_chunk(_mock_usage_metadata()),
+        ]:
+            yield chunk
+
+    mock_client = MagicMock()
+    mock_chat = MagicMock()
+    mock_chat.send_message_stream = AsyncMock(return_value=async_chunks())
+    mock_client.aio.chats.create.return_value = mock_chat
+
+    llm = _mock_google_genai_llm()
+    llm._client = mock_client
+
+    responses = [
+        resp
+        async for resp in await llm.astream_chat(
+            messages=[ChatMessage(role="user", content="Hi")]
+        )
+    ]
+
+    assert len(responses) == 2
+    last = responses[-1]
+    assert last.delta == ""
+    assert last.additional_kwargs["prompt_tokens"] == 11
+    assert last.additional_kwargs["completion_tokens"] == 22
+    assert last.additional_kwargs["total_tokens"] == 40
+    assert last.raw["usage_metadata"]["prompt_token_count"] == 11


### PR DESCRIPTION
# Description

Fixes #19293 — no Input/Output token count for Gemini 2.5 models in LlamaIndex instrumentation.

## Root cause

Non-streaming `chat()` responses already expose `prompt_tokens` / `completion_tokens` / `total_tokens` in `ChatResponse.additional_kwargs` (same contract OpenAI uses). Two gaps remained for Gemini 2.5:

1. **Streaming drops usage entirely.** The Gemini API reports `usage_metadata` on a *trailing* stream chunk that usually carries no candidate content (just token usage). The `stream_chat` / `astream_chat` generators skipped every chunk without content parts, so the last yielded response — the one `TokenCountingHandler` and OpenInference-style instrumentation read from the LLM end event — never carried token counts. This is the path most Gemini 2.5 agents actually run on.
2. **Thinking tokens were not exposed.** Gemini 2.5 thinking models report `thoughts_token_count` (reasoning tokens billed as output). It was read to annotate `ThinkingBlock`s but never placed in `additional_kwargs`, so tracing/cost tooling could not see it.

## Changes

| File | What changed |
|------|--------------|
| `llama_index/llms/google_genai/base.py` | `_stream_chat` / `_astream_chat` now surface a trailing usage-only chunk as the final `ChatResponse` (empty delta) carrying the token counts, mirroring how the OpenAI integration yields its final usage chunk. |
| `llama_index/llms/google_genai/utils.py` | New `chat_response_from_usage_metadata()` builds that final response from the accumulated content blocks + usage; usage→`additional_kwargs` mapping extracted into `_apply_usage_metadata()` (shared by chat and stream paths), which now also sets `thoughts_token_count`. |
| `tests/test_llms_google_genai.py` | Regression tests for `chat`, `stream_chat` and `astream_chat` with mocked Gemini 2.5-style usage metadata (no API key required). |

Example of what stream consumers now see on the final chunk:

```python
additional_kwargs = {
    "prompt_tokens": 11,
    "completion_tokens": 22,
    "total_tokens": 40,
    "thoughts_token_count": 7,   # Gemini 2.5 reasoning tokens
    ...
}
```

## Relation to other open PRs

- #22516 (open) adds `cached_content_tokens` to the non-streaming chat response — intentionally not duplicated here; the two PRs are complementary.
- #21748 / #21897 (both closed unmerged, #21897 stale-closed) attempted related token-count surface changes; this PR supersedes their intent with a narrower, test-covered diff that also fixes the streaming path neither touched.

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Test evidence (local, mocked — no API key required):

```
$ uv run pytest tests/test_llms_google_genai.py -q
31 passed, 42 skipped          # 42 skipped = live GOOGLE_API_KEY tests

$ uv run ruff check <changed files>
All checks passed!

$ pre-commit (trailing-whitespace, ruff, ruff-format, mypy, prettier, codespell)
... Passed
```

End-to-end instrumentation check (mocked `gemini-2.5-flash` stream ending in a usage-only chunk, `TokenCountingHandler` attached):

```
chunks yielded: 2
last chunk additional_kwargs: {'thought_signatures': [None], 'prompt_tokens': 11,
                               'completion_tokens': 22, 'total_tokens': 40,
                               'thoughts_token_count': 7}
llm events: 1
  prompt=11 completion=22 total=33
E2E_OK: TokenCountingHandler sees Gemini 2.5 stream usage (33 tokens)
```

Second-agent review (fresh-context `hermes chat -Q` fallback — `claude -p` unavailable due to revoked OAuth token — on the exact diff): **CLEAN** — no blocking findings. Non-blocking notes: (1) tests could additionally assert the TokenCountingHandler contract directly — covered by the local e2e smoke check above; (2) `TokenCountingHandler.total_llm_token_count` sums prompt+completion, so Gemini thinking tokens report 33 for prompt=11/completion=22/total_tokens=40 — pre-existing core behavior, not changed here.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the repo pre-commit hooks (ruff, ruff-format, mypy, codespell) — all passed
