### PR TITLE
fix(wikipedia): handle DisambiguationError exception

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-wikipedia/llama_index/tools/wikipedia/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-wikipedia/llama_index/tools/wikipedia/base.py
@@ -26,6 +26,8 @@ class WikipediaToolSpec(BaseToolSpec):
             wikipedia_page = wikipedia.page(page, auto_suggest=False)
         except wikipedia.PageError:
             return "Unable to load page. Try searching instead."
+        except wikipedia.DisambiguationError as e:
+            return f"Disambiguation error: {e}. Try being more specific."
         return wikipedia_page.content
 
     def search_data(self, query: str, lang: str = "en") -> str:


### PR DESCRIPTION
Handle DisambiguationError in wikipedia tool load_data method. The original code only caught PageError, but disambiguation pages raise DisambiguationError which was unhandled.