### PR TITLE
fix: UPSERTS_AND_DELETE not deleting documents with shared hash

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -494,8 +494,9 @@ class IngestionPipeline(BaseModel):
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                self.docstore.get_all_document_hashes().values()
+            existing_ref_doc_info = self.docstore.get_all_ref_doc_info()
+            existing_doc_ids_before = (
+                set(existing_ref_doc_info.keys()) if existing_ref_doc_info else set()
             )
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:
@@ -730,8 +731,9 @@ class IngestionPipeline(BaseModel):
 
         if self.docstore_strategy == DocstoreStrategy.UPSERTS_AND_DELETE:
             # Identify missing docs and delete them from docstore and vector store
-            existing_doc_ids_before = set(
-                (await self.docstore.aget_all_document_hashes()).values()
+            existing_ref_doc_info = await self.docstore.aget_all_ref_doc_info()
+            existing_doc_ids_before = (
+                set(existing_ref_doc_info.keys()) if existing_ref_doc_info else set()
             )
             doc_ids_to_delete = existing_doc_ids_before - doc_ids_from_nodes
             for ref_doc_id in doc_ids_to_delete:


### PR DESCRIPTION
## Bug Description

When multiple documents share the same content hash, `get_all_document_hashes()` returns a dict keyed by hash, causing hash collisions and lost doc_ids.

The `_handle_upserts()` and `_ahandle_upserts()` methods were incorrectly using `get_all_document_hashes().values()` to get existing doc_ids, which loses doc_ids when two documents share the same hash.

## Fix

Use `get_all_ref_doc_info().keys()` instead, which correctly returns all ref_doc_ids regardless of hash collisions.

## Issue

Fixes #22706

## Reproduction

```python
from llama_index.core.ingestion import IngestionPipeline, DocstoreStrategy
from llama_index.core.storage.docstore import SimpleDocumentStore
from llama_index.core.vector_stores import SimpleVectorStore
from llama_index.core.node_parser import SentenceSplitter
from llama_index.core.embeddings import MockEmbedding
from llama_index.core.schema import Document

pipeline = IngestionPipeline(
    transformations=[SentenceSplitter(chunk_size=512), MockEmbedding(embed_dim=8)],
    docstore=SimpleDocumentStore(),
    vector_store=SimpleVectorStore(),
    docstore_strategy=DocstoreStrategy.UPSERTS_AND_DELETE,
)

# two distinct documents that happen to share identical content
pipeline.run(documents=[
    Document(id_="doc-a", text="shared boilerplate text"),
    Document(id_="doc-b", text="shared boilerplate text"),
])
print("after run 1:", sorted(pipeline.docstore.docs.keys()))

# neither doc-a nor doc-b is supplied any more, so both should be deleted
pipeline.run(documents=[Document(id_="doc-c", text="totally new content")])
print("after run 2:", sorted(pipeline.docstore.docs.keys()))
# Expected: after run 2: ['doc-c']
# Before fix: after run 2: ['doc-a', 'doc-c']  <-- doc-a should have been deleted
```