### PR TITLE
fix: CohereRerank raises KeyError instead of IndexError when COHERE_API_KEY missing

### DIFF
--- a/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
+++ b/llama-index-integrations/postprocessor/llama-index-postprocessor-cohere-rerank/llama_index/postprocessor/cohere_rerank/base.py
@@ -72,7 +72,7 @@ class CohereRerank(BaseNodePostprocessor):
         super().__init__(top_n=top_n, model=model, max_retries=max_retries)
         try:
             api_key = api_key or os.environ["COHERE_API_KEY"]
-        except IndexError:
+        except KeyError:
             raise ValueError(
                 "Must pass in cohere api key or "
                 "specify via COHERE_API_KEY environment variable "


### PR DESCRIPTION
## Description

The exception handler was catching `IndexError` but `os.environ["key"]` raises `KeyError` when the key is not found. This bug caused the actual `KeyError` to leak instead of raising a user-friendly `ValueError`.

## Fix

Changed `except IndexError:` to `except KeyError:` in the CohereRerank `__init__` method.

## Related Issue

Fixes #22774