### PR TITLE
Add transport, retry and stream-event coverage to llama-index-llms-openai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.8.1"
+version = "0.8.2"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_http_client.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_http_client.py
@@ -1,0 +1,148 @@
+"""Custom ``http_client`` pass-through, across both openai major versions.
+
+openai 3 migrated to HTTPX2 and stopped installing ``httpx`` itself, so the
+``http_client``/``async_http_client`` arguments may now be handed either an
+``httpx`` or an ``httpx2`` client. Both must reach the wire. These tests run
+against a local stdlib HTTP server so they need no API key and no network.
+"""
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Iterator, List, Tuple
+
+import httpx
+import pytest
+
+from llama_index.core.llms import ChatMessage
+from llama_index.llms.openai import OpenAI
+
+try:
+    import httpx2
+except ImportError:  # openai<3 does not install httpx2
+    httpx2 = None
+
+_COMPLETION = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion",
+    "created": 1,
+    "model": "gpt-4o-mini",
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": "pong"},
+        }
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+
+_CHUNK = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion.chunk",
+    "created": 1,
+    "model": "gpt-4o-mini",
+    "choices": [{"index": 0, "delta": {"role": "assistant", "content": "pong"}}],
+}
+
+
+SEEN_HEADERS: List[Any] = []
+MARKER = "x-llamaindex-custom-client"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        SEEN_HEADERS.append(dict(self.headers))
+        raw = self.rfile.read(int(self.headers.get("content-length", 0)) or 0)
+        streaming = json.loads(raw or b"{}").get("stream", False)
+        if streaming:
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(f"data: {json.dumps(_CHUNK)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            return
+        body = json.dumps(_COMPLETION).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: Any) -> None:
+        """Silence the default stderr request logging."""
+
+
+@pytest.fixture(scope="module")
+def api_base() -> Iterator[str]:
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.server_port}/v1"
+    server.shutdown()
+
+
+def _sync_clients() -> List[Tuple[str, Any]]:
+    clients = [("httpx", httpx.Client)]
+    if httpx2 is not None:
+        clients.append(("httpx2", httpx2.Client))
+    return clients
+
+
+def _async_clients() -> List[Tuple[str, Any]]:
+    clients = [("httpx", httpx.AsyncClient)]
+    if httpx2 is not None:
+        clients.append(("httpx2", httpx2.AsyncClient))
+    return clients
+
+
+def _llm(api_base: str, **kwargs: Any) -> OpenAI:
+    return OpenAI(model="gpt-4o-mini", api_key="sk-test", api_base=api_base, **kwargs)
+
+
+@pytest.mark.parametrize(("name", "client_cls"), _sync_clients())
+def test_custom_http_client_chat(api_base: str, name: str, client_cls: Any) -> None:
+    SEEN_HEADERS.clear()
+    with client_cls(headers={MARKER: name}) as client:
+        response = _llm(api_base, http_client=client).chat(
+            [ChatMessage(role="user", content="ping")]
+        )
+    assert response.message.content == "pong"
+    # proves the supplied client carried the request, not the SDK default
+    assert SEEN_HEADERS and SEEN_HEADERS[-1].get(MARKER) == name
+
+
+@pytest.mark.parametrize(("name", "client_cls"), _sync_clients())
+def test_custom_http_client_stream(api_base: str, name: str, client_cls: Any) -> None:
+    SEEN_HEADERS.clear()
+    with client_cls(headers={MARKER: name}) as client:
+        chunks = list(
+            _llm(api_base, http_client=client).stream_chat(
+                [ChatMessage(role="user", content="ping")]
+            )
+        )
+    assert chunks
+    assert chunks[-1].message.content == "pong"
+    assert SEEN_HEADERS and SEEN_HEADERS[-1].get(MARKER) == name
+
+
+@pytest.mark.parametrize(("name", "client_cls"), _async_clients())
+def test_custom_async_http_client_chat(
+    api_base: str, name: str, client_cls: Any
+) -> None:
+    SEEN_HEADERS.clear()
+
+    async def go() -> Any:
+        async with client_cls(headers={MARKER: name}) as client:
+            return await _llm(api_base, async_http_client=client).achat(
+                [ChatMessage(role="user", content="ping")]
+            )
+
+    assert asyncio.run(go()).message.content == "pong"
+    assert SEEN_HEADERS and SEEN_HEADERS[-1].get(MARKER) == name
+
+
+def test_default_client_needs_no_explicit_http_client(api_base: str) -> None:
+    """The SDK's own default transport still works when nothing is passed."""
+    response = _llm(api_base).chat([ChatMessage(role="user", content="ping")])
+    assert response.message.content == "pong"

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -1009,3 +1009,43 @@ def test__parse_response_output(response_output: List[ResponseOutputItem]):
     assert [
         block for block in result.message.blocks if isinstance(block, ThinkingBlock)
     ][3].content == "hello\nworld"
+
+
+def test_process_response_event_ignores_unhandled_event_type():
+    """An event the isinstance chain does not recognise must pass through cleanly.
+
+    ``ResponseStreamEvent`` is an open union that openai keeps extending, with
+    3.x adding five shell-call events alone. process_response_event dispatches on
+    isinstance with no else branch, so unrecognised members are dropped; this
+    pins that they are dropped *silently* rather than raising or corrupting the
+    accumulated state.
+    """
+    from openai.types.responses import ResponseRefusalDeltaEvent
+
+    built_in_tool_calls: List = []
+    additional_kwargs = {"existing": "value"}
+
+    event = ResponseRefusalDeltaEvent(
+        content_index=0,
+        delta="refused",
+        item_id="123",
+        output_index=0,
+        sequence_number=1,
+        type="response.refusal.delta",
+    )
+
+    blocks, tool_calls, updated_kwargs, current_call, prev_id, delta = (
+        OpenAIResponses.process_response_event(
+            event=event,
+            built_in_tool_calls=built_in_tool_calls,
+            additional_kwargs=additional_kwargs,
+            current_tool_call=None,
+            track_previous_responses=False,
+        )
+    )
+
+    assert blocks == []
+    assert tool_calls == []
+    assert updated_kwargs == {"existing": "value"}
+    assert current_call is None
+    assert delta == ""

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_retry_after.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_retry_after.py
@@ -216,3 +216,56 @@ def test_create_retry_decorator_non_rate_limit_still_retries():
 
     assert result == "ok"
     assert call_count == 2
+
+
+# -- transport-independence of the Retry-After lookup --
+#
+# openai>=3 retyped ``APIStatusError.response`` from ``httpx.Response`` to
+# ``httpx2.Response``, so in production _parse_retry_after receives whichever
+# response class the installed openai major uses. It reads the header via
+# ``headers.get("retry-after")`` and relies on that lookup being
+# case-insensitive; these pin that assumption for both transports.
+
+try:
+    import httpx2
+except ImportError:  # openai<3 does not install httpx2
+    httpx2 = None
+
+
+def _response_classes():
+    classes = [pytest.param(httpx, id="httpx")]
+    if httpx2 is not None:
+        classes.append(pytest.param(httpx2, id="httpx2"))
+    return classes
+
+
+def _rate_limit_error_via(module, headers):
+    """Build a RateLimitError whose response comes from ``module`` (httpx/httpx2)."""
+    response = module.Response(
+        status_code=429,
+        headers=headers,
+        request=module.Request("POST", "https://api.openai.com/v1/chat/completions"),
+    )
+    return openai.RateLimitError(
+        message="Rate limit exceeded", response=response, body=None
+    )
+
+
+@pytest.mark.parametrize("module", _response_classes())
+@pytest.mark.parametrize("header_name", ["Retry-After", "retry-after", "RETRY-AFTER"])
+def test_parse_retry_after_is_transport_and_case_independent(module, header_name):
+    exc = _rate_limit_error_via(module, {header_name: "30"})
+    assert _parse_retry_after(exc) == 30.0
+
+
+@pytest.mark.parametrize("module", _response_classes())
+def test_parse_retry_after_missing_header_across_transports(module):
+    exc = _rate_limit_error_via(module, {})
+    assert _parse_retry_after(exc) is None
+
+
+@pytest.mark.parametrize("module", _response_classes())
+def test_wait_retry_after_honours_header_across_transports(module):
+    exc = _rate_limit_error_via(module, {"Retry-After": "12"})
+    wait = _WaitRetryAfter(fallback=wait_exponential(multiplier=1, min=4, max=10))
+    assert wait(_make_retry_state(exc)) == 12.0


### PR DESCRIPTION
# Description

Adds test coverage for three areas of `llama-index-llms-openai` that currently have none. This is a tests-only change: no library code is modified, and the `openai` dependency range is untouched.

**1. `http_client` / `async_http_client` have no tests at all.**

Both arguments are documented and threaded through to the SDK client, but nothing exercises them. `tests/test_http_client.py` covers them across sync, async and streaming against a local `http.server` stub, following the CONTRIBUTING guidance to mock remote systems rather than depend on a live API. Each custom client is given a marker header that the stub asserts it received, so the test proves the *supplied* client carried the request rather than the SDK's default. An earlier draft asserted only on the response body, which passed even with the pass-through removed; the marker is what makes it meaningful.

**2. `_parse_retry_after` relies on case-insensitive header lookup, which was only covered for one transport and one spelling.**

It reads `headers.get("retry-after")`, and the inline comment notes it depends on the header mapping being case-insensitive. The existing tests build the response one way and use one spelling. This parametrises over the available response transports and over `Retry-After`, `retry-after` and `RETRY-AFTER`, so the assumption is pinned rather than incidental.

**3. Unrecognised `ResponseStreamEvent` members are silently dropped, with nothing asserting it.**

`process_response_event` dispatches on `isinstance` with no `else` branch. Given that `ResponseStreamEvent` is an open union the SDK keeps extending, dropping unknown members is reasonable behaviour, but it was unpinned. The new test asserts an unhandled event passes through without raising and leaves the accumulated state intact.

Fixes # (no issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.8.0 to 0.8.1)
- [ ] No

## Type of Change

- [x] This change adds test coverage only (no behaviour change)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Full suite run locally for the package. The new tests need no API key and no network, so they run in CI alongside the existing unit tests.

The new tests guard their `httpx2` imports, so they degrade to the available transport rather than failing where `httpx2` is not installed. That keeps them valid across the whole `openai` range the package currently allows.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the linters (`ruff check` and `ruff format --check` both clean for the touched files)

## AI assistance disclosure

Per the "How to Use AI when Contributing" section of CONTRIBUTING.md: these tests were written with AI assistance. Validation was done by me and did not rely on the model's say-so. Specifically, each new test was mutation-tested: replacing the `http_client` pass-through in `base.py` with `None` makes 6 of the 7 new client tests fail, and the 7th is the default-client case which correctly still passes. The three gaps were identified by diffing the `openai` SDK surface across versions and cross-referencing it against what the suite actually exercises.
