### PR TITLE
Allow openai 3.x in llama-index-llms-openai

### DIFF
--- a/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
+++ b/llama-index-integrations/llms/llama-index-llms-openai/pyproject.toml
@@ -27,13 +27,13 @@ dev = [
 
 [project]
 name = "llama-index-llms-openai"
-version = "0.8.1"
+version = "0.9.0"
 description = "llama-index llms openai integration"
 authors = [{name = "llama-index"}]
 requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = "MIT"
-dependencies = ["openai>=1.108.1,<3", "llama-index-core>=0.14.5,<0.15"]
+dependencies = ["openai>=1.108.1", "llama-index-core>=0.14.5,<0.15"]
 
 [tool.codespell]
 check-filenames = true

--- a/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
+++ b/llama-index-integrations/llms/llama-index-llms-openai/tests/test_openai_responses.py
@@ -292,7 +292,13 @@ def test_process_response_event_with_text_annotation():
         content_index=0,
         annotation_index=0,
         type="response.output_text.annotation.added",
-        annotation={"type": "test_annotation", "value": 42},
+        annotation={
+            "type": "url_citation",
+            "start_index": 0,
+            "end_index": 5,
+            "title": "Example",
+            "url": "https://example.com",
+        },
         sequence_number=1,
     )
 
@@ -307,9 +313,13 @@ def test_process_response_event_with_text_annotation():
     # The annotation should be added to additional_kwargs["annotations"]
     _, _, updated_additional_kwargs, _, _, _ = result
     assert "annotations" in updated_additional_kwargs
-    assert updated_additional_kwargs["annotations"] == [
-        {"type": "test_annotation", "value": 42}
-    ]
+    assert len(updated_additional_kwargs["annotations"]) == 1
+    stored = updated_additional_kwargs["annotations"][0]
+    # openai<3 types this field as bare ``object`` and leaves the dict alone;
+    # openai>=3 parses it into a discriminated annotation model.
+    stored = stored if isinstance(stored, dict) else stored.model_dump()
+    assert stored["type"] == "url_citation"
+    assert stored["url"] == "https://example.com"
 
 
 def test_get_tool_calls_from_response():


### PR DESCRIPTION
# Description

Removes the `openai<3` upper bound from `llama-index-llms-openai`, allowing `openai>=1.108.1`.

**Why I am raising this.** I want to use a 3.x release of the `openai` SDK in one of my projects, and I currently cannot: this package pins `openai<3`, and because it is pulled in transitively (in my case via `OpenAILike`), the resolver refuses the newer SDK for the whole environment. Rather than just ask for the bump, I did the testing to check the package actually handles it, and this PR is the result.

**The cap looks precautionary rather than reactive.** It was introduced in 0.7.0 on 2026-03-12, and openai 3.0.0 shipped on 2026-08-12, five months later. So it was a routine next-major bound in the same style as the `llama-index-core<0.15` pin, not a response to a known incompatibility. I could not find an existing issue or PR proposing 3.x support.

## What I checked

Against `openai==3.7.0`, with `openai==2.54.0` as the baseline for comparison:

* **The full package suite passes on both majors**, including the API-backed tests that are normally skipped when `OPENAI_API_KEY` is unset. Those cover chat, completion, sync and async streaming, structured prediction, built-in tools and document upload, so the real serialisation path is exercised, not only mocks.
* **Every `openai` import path the package uses still resolves**, including all of the `openai.types.responses` and `openai.types.chat` symbols in `base.py` and `responses.py`, and the four exception types `utils.py` retries on. Nothing the package references was removed or moved.
* **No parameter was removed** from any client method the package calls (`chat.completions.create`, `completions.create`, `responses.create`, `responses.parse`) or from the client constructors.
* **HTTPX2**, the one documented breaking change in 3.0.0, is not a problem here. The package never constructs a transport itself, it only forwards an optional `http_client` / `async_http_client`. openai 3 accepts both an `httpx` and an `httpx2` client, and requests succeed through either, including streaming.

## The one test change

`ResponseOutputTextAnnotationAddedEvent.annotation` was typed as a bare `object` in openai 2 and is a discriminated union of annotation models in openai 3. `test_process_response_event_with_text_annotation` built a placeholder `{"type": "test_annotation", "value": 42}` payload, which only validated because the field previously accepted anything.

The test now uses a real `url_citation` annotation and normalises the stored value, since openai 2 leaves it as a dict while openai 3 parses it into a model. It passes on both majors. The library code needed no change: `process_response_event` appends the annotation without inspecting it.

## One thing worth flagging separately

`base.py` and `responses.py` both `import httpx` at module scope, but the package does not declare `httpx` as a dependency. Under openai 2 this was masked because openai installed `httpx` itself. openai 3 depends on `httpx2` instead, so after this change the import survives only because `llama-index-core` happens to declare `httpx`.

I have deliberately not bundled a fix here, because the right answer may be to accept both client families rather than to adopt a dependency the SDK is moving away from, and that is a maintainer call. Happy to open a separate issue or PR for it, whichever you prefer.

Fixes # (no issue)

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes (0.8.0 to 0.9.0, minor since the dependency range widens)
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue): removes an upper bound that blocks downstream resolution

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

The existing suite was run in full against both `openai==2.54.0` and `openai==3.7.0`.

Note that CI does not set `OPENAI_API_KEY`, so the API-backed tests are skipped there. I ran them locally with my own key, on both majors, which is what gives me confidence the change is safe beyond the mocked paths. I have opened #22938 separately to add coverage for some untested areas, including `http_client`, which is the surface this change touches most directly. That PR is independent of this one and passes on the current pinned range, but it would make this change better covered if merged first.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I ran the linters (`ruff check` and `ruff format --check` both clean for the touched files)

## AI assistance disclosure

Per the "How to Use AI when Contributing" section of CONTRIBUTING.md: this change was investigated with AI assistance. The conclusions are backed by actual test runs against both openai majors rather than by model inspection alone, including the live API-backed tests, and the SDK comparison was done by diffing the installed packages and reading the upstream diff between the two versions.
