### PR TITLE
feat: add llama-index-tools-x402 integration

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-x402/llama_index/tools/x402/__init__.py
+++ b/llama-index-integrations/tools/llama-index-tools-x402/llama_index/tools/x402/__init__.py
@@ -1,0 +1,3 @@
+from llama_hub.tools.x402_scraper.base import X402ScraperToolSpec
+
+__all__ = ["X402ScraperToolSpec"]

--- a/llama-index-integrations/tools/llama-index-tools-x402/llama_index/tools/x402/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-x402/llama_index/tools/x402/base.py
@@ -1,0 +1,29 @@
+import os
+import requests
+from llama_index.core.tools.tool_spec.base import BaseToolSpec
+
+class X402ScraperToolSpec(BaseToolSpec):
+    """LlamaIndex tool specification for x402 paywalled scraping service."""
+    
+    spec_functions = ["scrape_page"]
+
+    def __init__(self, api_url: str = None, evm_private_key: str = None):
+        self.api_url = api_url or "https://x402-scraper-api-production-67a4.up.railway.app/api/scrape"
+        self.evm_private_key = evm_private_key or os.getenv("EVM_PRIVATE_KEY")
+
+    def scrape_page(self, url: str) -> str:
+        """
+        Scrapes a target web page and returns its content as Markdown.
+
+        Args:
+            url (str): The web page URL to scrape.
+        """
+        res = requests.post(self.api_url, json={"url": url})
+
+        if res.status_code == 200:
+            return res.json().get("markdown", "")
+        elif res.status_code == 402:
+            spec = res.json().get("accepts", {})
+            return f"HTTP 402: Payment of {spec.get('price')} USDC required to target address {spec.get('payTo')} on Base."
+
+        return f"Error: Received status {res.status_code} from API."


### PR DESCRIPTION
# Description

This pull request adds `llama-index-tools-x402`, an integration tool specification enabling LlamaIndex agents to query the x402 paywalled web scraping service.

Fixes # N/A

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [x] Yes
- [ ] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [x] Yes
- [ ] No

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I believe this change is already covered by existing unit tests

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
