### PR TITLE
fix: Preserve ToolOutput in FunctionTool

### DIFF
--- a/llama-index-core/llama_index/core/tools/function_tool.py
+++ b/llama-index-core/llama_index/core/tools/function_tool.py
@@ -341,6 +341,10 @@ class FunctionTool(AsyncBaseTool):
 
         raw_output = self._fn(*args, **all_kwargs)
 
+        # A check if function already returns ToolOutput
+        if isinstance(raw_output, ToolOutput):
+            return raw_output
+
         # Exclude the Context param from the tool output so that the Context can be serialized
         tool_output_kwargs = {
             k: v for k, v in all_kwargs.items() if k != self.ctx_param_name
@@ -379,6 +383,9 @@ class FunctionTool(AsyncBaseTool):
                 raise ValueError("Context is required for this tool")
 
         raw_output = await self._async_fn(*args, **all_kwargs)
+
+        if isinstance(raw_output, ToolOutput):
+            return raw_output
 
         # Exclude the Context param from the tool output so that the Context can be serialized
         tool_output_kwargs = {

--- a/llama-index-core/tests/tools/test_base.py
+++ b/llama-index-core/tests/tools/test_base.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pytest
 from llama_index.core.bridge.pydantic import BaseModel, Field
 from llama_index.core.llms import TextBlock, ImageBlock, DocumentBlock, VideoBlock
-from llama_index.core.tools.function_tool import FunctionTool
+from llama_index.core.tools.function_tool import FunctionTool, ToolOutput
 from llama_index.core.schema import Document, TextNode
 from llama_index.core.workflow.context import Context
 from llama_index.core.workflow import Context
@@ -326,6 +326,45 @@ async def test_function_tool_output_single_block() -> None:
 
     assert len(tool_output.blocks) == 1
     assert tool_output.content == "Hello"
+
+
+def test_function_tool_preserves_tool_output() -> None:
+    def failing_tool() -> ToolOutput:
+        return ToolOutput(
+            content="The lookup failed: index down",
+            tool_name="failing_tool",
+            raw_input={},
+            raw_output=None,
+            is_error=True,
+        )
+
+    tool = FunctionTool.from_defaults(failing_tool)
+
+    result = tool.call()
+
+    assert result.is_error is True
+    assert result.content == "The lookup failed: index down"
+    assert result.tool_name == "failing_tool"
+
+
+@pytest.mark.asyncio
+async def test_function_tool_preserves_tool_output_async() -> None:
+    async def failing_tool() -> ToolOutput:
+        return ToolOutput(
+            content="The lookup failed: index down",
+            tool_name="failing_tool",
+            raw_input={},
+            raw_output=None,
+            is_error=True,
+        )
+
+    tool = FunctionTool.from_defaults(async_fn=failing_tool)
+
+    result = await tool.acall()
+
+    assert result.is_error is True
+    assert result.content == "The lookup failed: index down"
+    assert result.tool_name == "failing_tool"
 
 
 def test_fn_schema_docstring_descriptions():


### PR DESCRIPTION
Fix FunctionTool dropping is_error when function returns a ToolOutput directly

## Problem

`FunctionTool.call()` and `.acall()` always build a new `ToolOutput` around whatever the wrapped function returns. If a function returns a `ToolOutput` itself (e.g. to explicitly set `is_error=True`), that gets thrown away the outer wrapper builds its own `ToolOutput` with `is_error` defaulting to `False`, silently overwriting it. An agent calling that tool sees a "successful" result even though the function reported a failure.

## Fix

Added a check right after the function call in both `call()` and `acall()`: if the return value is already a `ToolOutput`, return it as-is instead of re-wrapping it. This mirrors the existing pattern already used a few lines below for callback overrides (`isinstance(callback_result, ToolOutput)`), so it's consistent with how the rest of the file handles this case.

Non - `ToolOutput` return values are unaffected the existing wrapping behavior stays exactly the same.

One tradeoff worth flagging: since this returns early, it skips the callback-override step (`_run_sync_callback` /`_run_async_callback`) for this path. The original issue doesn't touch on callbacks, so I kept the fix scoped to what was reported happy to adjust if you'd rather the callback still run on top of a returned `ToolOutput`.

## Testing

Added tests covering both the sync and async paths: a function returning a `ToolOutput` with `is_error=True` confirms that the error state is preserved, while existing non-`ToolOutput` behavior remains covered by the existing tests.

Tests run locally:

- `uv run pytest tests/tools/test_base.py`
- `uv run pytest tests/tools`
- `uv run pre-commit run --all-files`

Fixes #22929