### PR TITLE
fix(tools/mcp): carry MCP tool failures into ToolOutput.is_error

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -8,12 +8,28 @@ from pydantic import BaseModel, create_model
 
 from llama_index.core.tools.function_tool import FunctionTool
 from llama_index.core.tools.tool_spec.base import BaseToolSpec
-from llama_index.core.tools.types import ToolMetadata
+from llama_index.core.tools.types import ToolMetadata, ToolOutput
 from llama_index.tools.mcp.tool_spec_mixins import (
     TypeResolutionMixin,
     TypeCreationMixin,
     FieldExtractionMixin,
 )
+
+
+def _result_text(result: Any) -> str:
+    """
+    The text a server sent with a failed call.
+
+    The blocks carry the reason the call failed, so they are what the agent
+    needs to read. Falls back to the result itself when a server sends
+    something other than text.
+    """
+    texts = [
+        block.text
+        for block in getattr(result, "content", None) or []
+        if getattr(block, "text", None)
+    ]
+    return "\n".join(texts) if texts else str(result)
 
 
 class McpToolSpec(
@@ -113,6 +129,34 @@ class McpToolSpec(
 
         return async_tool_fn
 
+    def _create_tool_callback(self, tool_name: str) -> Callable:
+        """
+        Create the async callback that carries an MCP failure into ToolOutput.
+
+        A server reports a failed call with ``isError`` on the result rather than
+        by raising, so without this the failure reaches the agent as a success:
+        ``ToolOutput.is_error`` defaults to False, and both agent workflows gate
+        ``return_direct`` on it.
+        """
+
+        async def async_tool_callback(raw_output: Any) -> Optional[ToolOutput]:
+            # The field is `is_error` on the Python model and `isError` on the
+            # wire; read both so this holds whichever the client hands back.
+            failed = getattr(raw_output, "is_error", None)
+            if failed is None:
+                failed = getattr(raw_output, "isError", False)
+            if not failed:
+                return None
+            return ToolOutput(
+                content=_result_text(raw_output),
+                tool_name=tool_name,
+                raw_input={},
+                raw_output=raw_output,
+                is_error=True,
+            )
+
+        return async_tool_callback
+
     def _create_resource_fn(self, resource_uri: str) -> Callable:
         """
         Create a resource call function for a specified MCP resource name. The function internally wraps the read_resource call to the MCP Client.
@@ -166,7 +210,10 @@ class McpToolSpec(
                 fn_schema=model_schema,
             )
             function_tool = FunctionTool.from_defaults(
-                async_fn=fn, tool_metadata=metadata, partial_params=tool_partial_params
+                async_fn=fn,
+                async_callback=self._create_tool_callback(tool.name),
+                tool_metadata=metadata,
+                partial_params=tool_partial_params,
             )
             function_tool_list.append(function_tool)
 

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/server.py
@@ -72,6 +72,11 @@ def add(a: float, b: float) -> float:
     return a + b
 
 
+@mcp.tool(description="Always fails, for exercising the error path")
+def always_fails() -> str:
+    raise ValueError("this tool always fails")
+
+
 @mcp.tool(description="Get current server time")
 def get_time() -> str:
     """Get the current server time to test tools without arguments."""

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -47,6 +47,27 @@ async def test_get_tools_async(client: BasicMCPClient):
     assert len(tools_plus_resources) > len(tools)
 
 
+@pytest.mark.asyncio
+async def test_failed_tool_call_sets_is_error(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=["always_fails"])
+    tools = await tool_spec.to_tool_list_async()
+
+    output = await tools[0].acall()
+
+    assert output.is_error is True
+    assert "Error executing tool always_fails" in str(output)
+
+
+@pytest.mark.asyncio
+async def test_successful_tool_call_is_not_an_error(client: BasicMCPClient):
+    tool_spec = McpToolSpec(client, allowed_tools=["echo"])
+    tools = await tool_spec.to_tool_list_async()
+
+    output = await tools[0].acall(message="hello")
+
+    assert output.is_error is False
+
+
 def test_get_single_tool(client: BasicMCPClient):
     tool_spec = McpToolSpec(client, allowed_tools=["echo"])
 


### PR DESCRIPTION
Closes #22943

## Description

An MCP server reports a failed call with `is_error` on the result rather than by raising. `McpToolSpec` passed that result through untouched, and `ToolOutput.is_error` defaults to `False`, so a failed tool call reached the agent as a success.

`grep -rn "isError\|is_error"` over `llama-index-tools-mcp` returned nothing before this change, in the package or its tests.

The consequence worth fixing: `base_agent.py:688,696` and `multi_agent_workflow.py:717,725` both gate `return_direct` on `not tool_call_result.tool_output.is_error`. A `return_direct` MCP tool whose server failed therefore ended the run, and its error text was emitted as the agent's final answer instead of the agent getting a chance to recover.

## Changes

- `llama_index/tools/mcp/base.py`: `_create_tool_callback` returns an `async_callback` that sets `is_error=True` when the result reports a failure, and fills the output with the server's own text via `_result_text` rather than `str(CallToolResult)`.
- `to_tool_list_async` passes that callback to `FunctionTool.from_defaults`.
- `tests/server.py`: an `always_fails` tool so the error path has a fixture.
- `tests/test_tools_mcp.py`: one test for the failure path and one asserting a successful call is still not an error.

This uses `FunctionTool`'s existing `async_callback` hook, which `acall` already honours by returning the callback's `ToolOutput` directly. No public API changes, no new package.

Successful calls take exactly the path they did before: the callback returns `None` and `FunctionTool` builds its default output.

## Note on the field name

The Python model exposes this as `is_error` with `isError` as the serialization alias, so the guard reads `is_error` first and falls back to `isError`. I checked `CallToolResult.model_fields` to confirm which is which.

## Validation

```bash
uv run --with pytest-asyncio -- pytest tests/
uv run pre-commit run --files <the three changed files>
```

54 passed. All hooks pass, including ruff, ruff-format and mypy.

Confirmed the tests are load-bearing: with `base.py` reverted, `test_failed_tool_call_sets_is_error` fails.

## Left out

`_parse_tool_output` has no branch for `CallToolResult`, so on the success path the LLM still receives the pydantic repr rather than the result's text blocks. That is a wider change to what every MCP tool returns, so it is not in this PR. Happy to open it separately if you want it.
