### PR TITLE
docs: document two omitted llama-index-core parameters

### DIFF
--- a/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
+++ b/llama-index-core/llama_index/core/indices/property_graph/transformations/dynamic_llm.py
@@ -233,7 +233,13 @@ class DynamicLLMPathExtractor(TransformComponent):
             max_triplets_per_chunk (int): Maximum number of triplets to extract per chunk.
             num_workers (int): Number of workers for parallel processing.
             allowed_entity_types (Optional[List[str]]): List of initial entity types for the ontology.
+            allowed_entity_props (Optional[Union[List[str], List[Tuple[str, str]]]]): List of initial
+                entity properties for the ontology. Can be either property names or tuples of
+                (name, description).
             allowed_relation_types (Optional[List[str]]): List of initial relation types for the ontology.
+            allowed_relation_props (Optional[Union[List[str], List[Tuple[str, str]]]]): List of initial
+                relation properties for the ontology. Can be either property names or tuples of
+                (name, description).
             raise_on_error (bool): Whether to raise exceptions if extraction fails. Defaults to False.
 
         """

--- a/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
+++ b/llama-index-core/llama_index/core/node_parser/relational/llama_parse_json_element.py
@@ -75,6 +75,8 @@ class LlamaParseJsonNodeParser(BaseElementNodeParser):
             mode: different modes for returning different types of elements based on the selected mode
             node_id: unique id for the node
             node_metadata: metadata for the node. the json output for the nodes contains a lot of fields for elements
+            table_filters: optional list of predicates applied to each candidate table element; a
+                table is kept only when every filter returns True
 
         """
         elements: List[Element] = []


### PR DESCRIPTION
# Description

Fixes #22945

Two `llama-index-core` docstrings omit a parameter that the rest of their `Args:` block documents, so
the gap reads as an oversight rather than a deliberate style choice. Documentation only — no behavior
change.

**`DynamicLLMPathExtractor.__init__`** (`dynamic_llm.py:219`) documented 8 of 10 parameters, skipping
`allowed_entity_props` and `allowed_relation_props`. The evidence that this is accidental is in the
same file: the **class-level** docstring at `:190`/`:194` already describes both, including the
`(name, description)` tuple form that `:258` specifically handles. Both are load-bearing (`:246`,
`:252`, `:258`), and they sit directly beside `allowed_entity_types` / `allowed_relation_types`, which
*are* documented in `__init__`. I reused the class docstring's own wording rather than paraphrasing
from the parameter names.

**`LlamaParseJsonNodeParser.extract_elements`** (`llama_parse_json_element.py:60`) documented four of
five, skipping `table_filters`. Description taken from the code that consumes it (`:227-228`): a
candidate table is kept only when every filter returns `True`.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — **N/A**: the template exempts `llama-index-core`, which is the only package touched.
- [ ] No

## Type of Change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] I added new unit tests to cover this change
- [x] I believe this change is already covered by existing unit tests

No new tests: the diff adds only docstring text, so there is no behavior to assert. If you would
rather have a mechanical guard against this class of gap, I have an AST check that compares each
function's documented parameter names against its real signature — it reports **0** for
`llama-index-core` after this change, and it is what surfaced these two. Happy to propose it as a
lint/CI check separately if that is useful.

## Suggested Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks — N/A, no notebooks
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — see above
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods

On that last item, being precise about what I actually ran: `make lint` runs pre-commit over
`git ls-files`, and my checkout is sparse, so I ran the same hook set scoped to the two changed files
instead:

```
$ pre-commit run --files <the two changed files>
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
codespell................................................................Passed
prettier.................................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
check BOM................................................................Passed
detect private key.......................................................Passed
```

`git diff --stat`: 2 files, +8/-0.

## Deliberately not included

The same AST pass reports nothing else in `llama-index-core`. I also checked `docs/` for the
duplicated-word class fixed in #22800-era cleanups and found only one remaining instance
(`terms_definitions_tutorial.md:48`, `"Write each line as as follows"`) — I left it out because it
lives inside a `DEFAULT_TERM_STR` prompt string that is fed to an LLM, and editing prompt text is a
behavior question rather than a typo fix. Flagging it here so it is a recorded decision rather than an
oversight; happy to send it separately if you consider it safe.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). Both sites were read in context and
each description was checked against the code that consumes the value.
