### PR TITLE
fix(core): include model and temperature in LLM.to_payload()

### DIFF
--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -231,6 +231,16 @@ class LLM(BaseLLM):
 
     # -- Utils --
 
+    def to_payload(self) -> Dict[str, Any]:
+        payload = super().to_payload()
+        model = getattr(self, "model", None)
+        if model is not None:
+            payload["model"] = model
+        temperature = getattr(self, "temperature", None)
+        if temperature is not None:
+            payload["temperature"] = temperature
+        return payload
+
     def _log_template_data(
         self, prompt: BasePromptTemplate, **prompt_args: Any
     ) -> None:

--- a/llama-index-core/tests/llms/test_callbacks.py
+++ b/llama-index-core/tests/llms/test_callbacks.py
@@ -130,6 +130,20 @@ def test_to_payload_excludes_secrets() -> None:
     assert payload["class_name"] == llm.class_name()
 
 
+class _ModelMockLLM(MockLLM):
+    """MockLLM with model/temperature fields, like concrete LLM integrations."""
+
+    model: str = "test-model"
+    temperature: float = 0.5
+
+
+def test_to_payload_includes_model_and_temperature() -> None:
+    llm = _ModelMockLLM()
+    payload = llm.to_payload()
+    assert payload["model"] == "test-model"
+    assert payload["temperature"] == 0.5
+
+
 def test_callback_serialized_excludes_secrets(prompt: str) -> None:
     handler = _CapturingHandler()
     llm = _SecretMockLLM(callback_manager=CallbackManager([handler]))


### PR DESCRIPTION
# Description

`BaseLLM.to_payload()` only returns `{"class_name": ..., **self.metadata.model_dump()}`. The metadata exposes `model_name` (not `model`) and never includes `temperature`, even though concrete LLM integrations (OpenAI, OpenAILike, Anthropic, ...) define both as first-class pydantic fields. Downstream OpenTelemetry instrumentors (e.g. `opentelemetry-instrumentation-llamaindex`) read `model_dict["model"]` and `model_dict["temperature"]` from the `LLMChatStartEvent` payload to set the `gen_ai.request.model` / `gen_ai.request.temperature` span attributes; both resolve to `None`, and OTel logs `Invalid type NoneType for attribute ...` warnings on every LLM call while the spans lose their model/temperature metadata.

This PR overrides `to_payload()` on `LLM` (`llama_index/core/llms/llm.py`) to add `model` and `temperature` on top of the base payload, using `getattr` so LLM subclasses that don't define those fields are unaffected, and skipping `None` values so spans never receive invalid attribute types. No new dependencies.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Added `test_to_payload_includes_model_and_temperature` in `llama-index-core/tests/llms/test_callbacks.py`, asserting that an LLM subclass with `model`/`temperature` fields exposes them in `to_payload()`. All 13 tests in that file pass.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran `uv run make format; uv run make lint` to appease the lint gods