### PR TITLE
fix(models): include model and temperature in model.to_payload() for instrumentation

### DIFF
--- a/llama-index-core/llama_index/core/llms/llm.py
+++ b/llama-index-core/llama_index/core/llms/llm.py
@@ -231,6 +231,26 @@ class LLM(BaseLLM):
 
     # -- Utils --
 
+    def to_payload(self) -> Dict[str, Any]:
+        """
+        Non-sensitive representation of this LLM for observability.
+
+        Extends the base payload with model and temperature fields if available,
+        ensuring compatibility with OpenTelemetry instrumentors that expect
+        these fields for gen_ai.request.model and gen_ai.request.temperature
+        span attributes.
+        """
+        payload = super().to_payload()
+        # Add model field if present (concrete implementations like OpenAI define it)
+        model = getattr(self, "model", None)
+        if model is not None:
+            payload["model"] = model
+        # Add temperature field if present
+        temperature = getattr(self, "temperature", None)
+        if temperature is not None:
+            payload["temperature"] = temperature
+        return payload
+
     def _log_template_data(
         self, prompt: BasePromptTemplate, **prompt_args: Any
     ) -> None:

--- a/llama-index-core/tests/llms/test_callbacks.py
+++ b/llama-index-core/tests/llms/test_callbacks.py
@@ -140,3 +140,26 @@ def test_callback_serialized_excludes_secrets(prompt: str) -> None:
     for serialized in handler.serialized_payloads:
         assert "api_key" not in serialized
         assert "sk-super-secret" not in str(serialized)
+
+
+class _LLMWithModelAndTemperature(MockLLM):
+    """MockLLM with model and temperature fields like concrete LLM implementations."""
+
+    model: str = "test-model"
+    temperature: float = 0.7
+
+
+def test_to_payload_includes_model_and_temperature() -> None:
+    llm = _LLMWithModelAndTemperature()
+    payload = llm.to_payload()
+    assert payload["model"] == "test-model"
+    assert payload["temperature"] == 0.7
+    assert payload["class_name"] == llm.class_name()
+
+
+def test_to_payload_omits_none_fields() -> None:
+    llm = MockLLM()
+    payload = llm.to_payload()
+    # MockLLM doesn't define model or temperature, so they shouldn't be in payload
+    assert "model" not in payload or payload.get("model") is None
+    assert "temperature" not in payload or payload.get("temperature") is None


### PR DESCRIPTION
## Description

`BaseLLM.to_payload()` only serializes `self.metadata` via `model_dump()`, which exposes `model_name` (not `model`) and excludes `temperature` entirely. Concrete implementations define both `model` and `temperature` as first-class pydantic fields, but these fields are missing from the payload emitted in `LLMChatStartEvent`.

Telemetry instrumentors (e.g. `opentelemetry-instrumentation-llamaindex`) read `model_dict.get("model")` and `model_dict.get("temperature")` from the event payload to populate `gen_ai.request.model` and `gen_ai.request.temperature` span attributes per OTel GenAI semantic conventions. When these keys resolve to `None`, OTel logs validation warnings and the exported spans lose critical metadata.

This PR overrides `to_payload()` in the `LLM` class to augment the base payload with `model` and `temperature` fields extracted via `getattr()`, filtering out `None` values to avoid breaking subclasses that lack these fields. Includes unit tests to verify the payload includes these keys when present and omits them when absent.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added two unit tests in `tests/llms/test_callbacks.py`:
- `test_to_payload_includes_model_and_temperature()` verifies that a subclass with `model` and `temperature` fields includes them in the payload
- `test_to_payload_omits_none_fields()` verifies that implementations without these fields do not break (payload either omits the keys or contains `None`)

Fixes #22949