### PR TITLE
fix(core): honor markdown_response in NLSQLTableQueryEngine.aquery

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -465,7 +465,10 @@ class BaseSQLTableQueryEngine(BaseQueryEngine):
                 return cast(AsyncStreamingResponse, response)
             return cast(Response, response)
         else:
-            response_str = "\n".join([node.text for node in retrieved_nodes])
+            if self._markdown_response:
+                response_str = self._format_result_markdown(retrieved_nodes)
+            else:
+                response_str = "\n".join([node.text for node in retrieved_nodes])
             return Response(response=response_str, metadata=metadata)
 
 

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -172,6 +172,20 @@ def test_sql_index_async_query(
     response = asyncio_run(task)
     assert str(response) == sql_to_test
 
+    # query with markdown return (#16720: aquery ignored markdown_response)
+    nl_table_engine = NLSQLTableQueryEngine(
+        index.sql_database, synthesize_response=False, markdown_response=True
+    )
+    task = nl_table_engine.aquery("test_table:user_id,foo")
+    response = asyncio_run(task)
+    assert (
+        str(response)
+        == """| user_id | foo |
+|---|---|
+| 2 | bar |
+| 8 | hello |"""
+    )
+
 
 def test_default_output_parser() -> None:
     """Test default output parser."""


### PR DESCRIPTION
# Description

`BaseSQLTableQueryEngine._query` formats results as a markdown table when `synthesize_response=False` and `markdown_response=True`, but `_aquery` skipped that branch and always joined the raw node text. The same engine returned a markdown table from `query()` and `[(2, 'bar'), (8, 'hello')]` from `aquery()`.

This was reported in #16720 (Oct 2024) and closed by the stale bot without a fix. It still reproduces on `main` (d2ac544a2).

The change applies the same `markdown_response` check in `_aquery`. Nothing changes for `synthesize_response=True` or `markdown_response=False`.

Fixes #16720

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added the async counterpart of the existing sync markdown test in `tests/indices/struct_store/test_sql_query.py`. It fails on `main` (`aquery` returns the tuple string) and passes with this change.

- `uv run -- pytest tests/` in `llama-index-core`: 1494 passed, 22 skipped, 6 xfailed
- `uv run pre-commit run --files <changed files>`: ruff, ruff-format, mypy, codespell all pass

AI assistance: I used an AI coding assistant to help scan for sync/async divergences, draft the fix and the test. I verified it myself by reproducing the `query()` / `aquery()` mismatch, confirming the new test fails without the change, and running the suite and linters above.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods