### PR TITLE
fix(core): return sql_only result metadata from NLSQLRetriever.aretrieve_with_metadata

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_retriever.py
@@ -373,7 +373,7 @@ class NLSQLRetriever(BaseRetriever, PromptMixin):
         if self._sql_only:
             sql_only_node = TextNode(text=f"{sql_query_str}")
             retrieved_nodes = [NodeWithScore(node=sql_only_node)]
-            metadata: Dict[str, Any] = {}
+            metadata: Dict[str, Any] = {"result": sql_query_str}
         else:
             try:
                 (

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -92,6 +92,8 @@ def test_sql_index_query(
     nl_table_engine = NLSQLTableQueryEngine(index.sql_database, sql_only=True)
     response = nl_table_engine.query("test_table:user_id,foo")
     assert str(response) == sql_to_test
+    assert response.metadata["sql_query"] == sql_to_test
+    assert response.metadata["result"] == sql_to_test
 
     # query with markdown return
     nl_table_engine = NLSQLTableQueryEngine(
@@ -171,6 +173,8 @@ def test_sql_index_async_query(
     task = nl_table_engine.aquery("test_table:user_id,foo")
     response = asyncio_run(task)
     assert str(response) == sql_to_test
+    assert response.metadata["sql_query"] == sql_to_test
+    assert response.metadata["result"] == sql_to_test
 
 
 def test_default_output_parser() -> None:


### PR DESCRIPTION
# Description

With `sql_only=True`, `NLSQLRetriever.retrieve_with_metadata` returns `{"sql_query": <sql>, "result": <sql>}`, but `aretrieve_with_metadata` returned `{"sql_query": <sql>}` only. For the same `NLSQLTableQueryEngine(sql_only=True)`, `response.metadata["result"]` works after `query()` and raises `KeyError` after `aquery()`.

The change populates the same `"result"` entry in the async `sql_only` branch. The non-`sql_only` path already gets `result` from `SQLRetriever` on both sides and is untouched.

Same family as #22952 (async SQL path diverging from sync), kept as a separate PR so each is a one-line review.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `metadata["sql_query"]` and `metadata["result"]` assertions to the existing `sql_only` sections of both `test_sql_index_query` and `test_sql_index_async_query`. The sync assertions pass on `main`; the async one fails on `main` with `KeyError: 'result'` and passes with this change.

- `uv run -- pytest tests/` in `llama-index-core`: 1494 passed, 22 skipped, 6 xfailed
- `uv run pre-commit run --files <changed files>`: ruff, ruff-format, mypy, codespell all pass

AI assistance: I used an AI coding assistant to scan for sync/async divergences and draft the change and assertions. I verified it myself by reproducing the `query()` / `aquery()` metadata mismatch, confirming the async assertion fails without the change, and running the suite and linters above.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods