### PR TITLE
fix(core): forward insert_kwargs from BaseIndex.ainsert_nodes to _insert

### DIFF
--- a/llama-index-core/llama_index/core/indices/base.py
+++ b/llama-index-core/llama_index/core/indices/base.py
@@ -221,7 +221,7 @@ class BaseIndex(Generic[IS], ABC):
 
         with self._callback_manager.as_trace("ainsert_nodes"):
             await self.docstore.async_add_documents(nodes, allow_update=True)
-            self._insert(nodes=nodes)
+            self._insert(nodes, **insert_kwargs)
             await self._storage_context.index_store.async_add_index_struct(
                 self._index_struct
             )

--- a/llama-index-core/tests/indices/list/test_index.py
+++ b/llama-index-core/tests/indices/list/test_index.py
@@ -1,11 +1,11 @@
 """Test summary index."""
 
-from typing import Any, List
+from typing import Any, List, Sequence
 
 import pytest
 from llama_index.core.base.base_retriever import BaseRetriever
 from llama_index.core.indices.list.base import ListRetrieverMode, SummaryIndex
-from llama_index.core.schema import Document
+from llama_index.core.schema import BaseNode, Document, TextNode
 
 
 def test_build_list(documents: List[Document], patch_token_text_splitter) -> None:
@@ -118,6 +118,26 @@ async def test_arefresh_ref_docs_applies_insert_kwargs_to_every_document(
 
     assert refreshed_docs == [True, True]
     assert captured_kwargs == [insert_kwargs, insert_kwargs]
+
+
+@pytest.mark.asyncio
+async def test_ainsert_nodes_forwards_insert_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ainsert_nodes should pass insert kwargs to _insert like insert_nodes does."""
+    summary_index = SummaryIndex([])
+    nodes = [TextNode(id_="1", text="One")]
+    captured_kwargs: List[dict[str, Any]] = []
+
+    def mock_insert(nodes: Sequence[BaseNode], **kwargs: Any) -> None:
+        captured_kwargs.append(kwargs)
+
+    monkeypatch.setattr(summary_index, "_insert", mock_insert)
+
+    summary_index.insert_nodes(nodes, foo="bar")
+    await summary_index.ainsert_nodes(nodes, foo="bar")
+
+    assert captured_kwargs == [{"foo": "bar"}, {"foo": "bar"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

`BaseIndex.insert_nodes` calls `self._insert(nodes, **insert_kwargs)`, but `ainsert_nodes` called `self._insert(nodes=nodes)` and dropped the kwargs. So `await index.ainsert_nodes(nodes, ...)` and `await index.ainsert(document, ...)` silently ignored insert kwargs on any index that relies on the base implementation. `VectorStoreIndex` is unaffected because it overrides `ainsert_nodes`; the managed Google index (`_insert` forwards `**insert_kwargs` and does not override `ainsert_nodes`) and any custom `BaseIndex` subclass are affected.

The change passes `insert_kwargs` through, matching the sync path. Introduced when the async methods were added in #18711.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added `test_ainsert_nodes_forwards_insert_kwargs` in `tests/indices/list/test_index.py`, next to the existing async kwargs tests. It captures what `_insert` receives from `insert_nodes` and `ainsert_nodes`; on `main` the async call receives `{}` (`assert [{'foo': 'bar'}, {}] == [{'foo': 'bar'}, {'foo': 'bar'}]`), with this change both receive the kwargs.

- `uv run -- pytest tests/` in `llama-index-core`: 1495 passed, 22 skipped, 6 xfailed
- `uv run make lint`: all hooks pass

AI assistance: I used an AI coding assistant to scan for sync/async divergences and draft the change and test. I verified it myself by confirming the test fails without the change and running the suite and linters above.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods