### PR TITLE
fix(core): synthesize responses in NLStructStoreQueryEngine._aquery

### DIFF
--- a/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
+++ b/llama-index-core/llama_index/core/indices/struct_store/sql_query.py
@@ -302,8 +302,20 @@ class NLStructStoreQueryEngine(BaseQueryEngine):
         # assume that it's a valid SQL query
         logger.debug(f"> Predicted SQL query: {sql_query_str}")
 
-        response_str, metadata = self._run_with_sql_only_check(sql_query_str)
+        raw_response_str, metadata = self._run_with_sql_only_check(sql_query_str)
+
         metadata["sql_query"] = sql_query_str
+
+        if self._synthesize_response:
+            response_str = await self._llm.apredict(
+                self._response_synthesis_prompt,
+                query_str=query_bundle.query_str,
+                sql_query=sql_query_str,
+                sql_response_str=raw_response_str,
+            )
+        else:
+            response_str = raw_response_str
+
         return Response(response=response_str, metadata=metadata)
 
 

--- a/llama-index-core/tests/indices/struct_store/test_sql_query.py
+++ b/llama-index-core/tests/indices/struct_store/test_sql_query.py
@@ -11,6 +11,8 @@ from llama_index.core.indices.struct_store.sql_query import (
     SQLStructStoreQueryEngine,
     SQLTableRetrieverQueryEngine,
 )
+from llama_index.core.prompts import PromptTemplate
+from llama_index.core.prompts.prompt_type import PromptType
 from llama_index.core.objects import (
     SQLTableNodeMapping,
     ObjectIndex,
@@ -148,6 +150,19 @@ def test_sql_index_async_query(
     task = nl_query_engine.aquery("test_table:user_id,foo")
     response = asyncio_run(task)
     assert str(response) == "[(2, 'bar'), (8, 'hello')]"
+
+    # response synthesis must run on the async path like the sync path
+    synthesis_prompt = PromptTemplate(
+        "{query_str}", prompt_type=PromptType.SIMPLE_INPUT
+    )
+    nl_query_engine = NLStructStoreQueryEngine(
+        index, response_synthesis_prompt=synthesis_prompt, **query_kwargs
+    )
+    response = nl_query_engine.query("test_table:user_id,foo")
+    assert str(response) == "test_table:user_id,foo"
+    task = nl_query_engine.aquery("test_table:user_id,foo")
+    response = asyncio_run(task)
+    assert str(response) == "test_table:user_id,foo"
 
     nl_table_engine = NLSQLTableQueryEngine(index.sql_database)
     task = nl_table_engine.aquery("test_table:user_id,foo")


### PR DESCRIPTION
# Description

`NLStructStoreQueryEngine._query` runs the response synthesis prompt when `synthesize_response=True` (the default), but `_aquery` returned the raw SQL result string without synthesizing. The same engine returned a synthesized answer from `query()` and the raw tuple string from `aquery()`.

The change mirrors the sync branch in `_aquery`: run `apredict` with the response synthesis prompt when `synthesize_response` is set, otherwise return the raw result. `sql_only` and `synthesize_response=False` behave as before.

I know this class is marked deprecated in favor of `NLSQLTableQueryEngine`; it is still exported and tested, and the async path silently doing less than the sync path seemed worth a one-branch fix. Happy to close if you'd rather leave it alone.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [ ] Yes
- [x] No (`llama-index-core`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change

Added a section to `test_sql_index_async_query` that builds the engine with a synthesis prompt whose mock output differs from the raw result (`PromptType.SIMPLE_INPUT` echoes `query_str`), then asserts `query()` and `aquery()` both return the synthesized string. On `main` the async assertion fails with `"[(2, 'bar'), (8, 'hello')]" == "test_table:user_id,foo"`; with this change both pass.

- `uv run -- pytest tests/` in `llama-index-core`: 1494 passed, 22 skipped, 6 xfailed
- `uv run make lint`: all hooks pass

AI assistance: I used an AI coding assistant to scan for sync/async divergences and draft the change and test. I verified it myself by confirming the async assertion fails without the change and running the suite and linters above.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods