### PR TITLE
fix(redis-chat-store): import redis.exceptions to fix NameError on connection failure

### DIFF
--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/llama_index/storage/chat_store/redis/base.py
@@ -8,6 +8,7 @@ from llama_index.core.bridge.pydantic import Field, PrivateAttr
 from llama_index.core.llms import ChatMessage
 from llama_index.core.storage.chat_store.base import BaseChatStore
 
+import redis.exceptions
 from redis.asyncio.client import Redis as AsyncRedis
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
 from redis.asyncio.sentinel import Sentinel as AsyncSentinel

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [project]
 name = "llama-index-storage-chat-store-redis"
-version = "0.8.0"
+version = "0.8.1"
 description = "llama-index storage-chat-store redis integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/test_chat_store_redis_chat_store.py
+++ b/llama-index-integrations/storage/chat_store/llama-index-storage-chat-store-redis/tests/test_chat_store_redis_chat_store.py
@@ -1,6 +1,7 @@
 from typing import Generator
 
 import pytest
+import redis.exceptions
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from llama_index.core.storage.chat_store.base import BaseChatStore
 from llama_index.storage.chat_store.redis import RedisChatStore
@@ -32,6 +33,19 @@ test is skipped.
 def test_class():
     names_of_base_classes = [b.__name__ for b in RedisChatStore.__mro__]
     assert BaseChatStore.__name__ in names_of_base_classes
+
+
+def test_unreachable_redis_does_not_raise_name_error():
+    # A privileged, closed port that refuses connections. `_check_for_cluster`
+    # should catch the resulting redis.exceptions.RedisError and treat the
+    # server as a non-cluster instance, rather than crashing with a NameError
+    # because `redis.exceptions` was never imported.
+    try:
+        RedisChatStore(redis_url="redis://localhost:1")
+    except NameError:
+        pytest.fail("RedisChatStore raised NameError instead of a redis error")
+    except redis.exceptions.RedisError:
+        pass
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fixes #22956

## Problem

`RedisChatStore._check_for_cluster` catches `redis.exceptions.RedisError`,
but the file never imports the top-level `redis` package — only specific
submodules/classes (`redis.client.Redis`, `redis.cluster.RedisCluster`,
etc.). When Redis is unreachable, `redis_client.info("cluster")` raises a
`redis.exceptions.ConnectionError`, and evaluating the `except
redis.exceptions.RedisError` clause itself raises `NameError: name 'redis'
is not defined` because `redis` was never bound as a name in this module.
So instead of surfacing (or here, being caught and swallowed as
non-cluster) the real Redis error, users get an opaque `NameError`, as
reported in the issue:

```
except redis.exceptions.RedisError:
       ^^^^^
NameError: name 'redis' is not defined. Did you mean: 'Redis'?
```

The same missing-name problem also affects the two `except
redis.exceptions.AuthenticationError` clauses used for Sentinel
authentication fallback.

## Fix

Add `import redis.exceptions` alongside the existing submodule imports.

## Test plan

Added a regression test that constructs a `RedisChatStore` pointed at an
unreachable Redis URL (a closed, privileged port that refuses
connections) and asserts no `NameError` is raised.

Verified the test fails without the fix and passes with it:

```
$ uv run --frozen -- pytest tests -v
...
tests/test_chat_store_redis_chat_store.py::test_class PASSED
tests/test_chat_store_redis_chat_store.py::test_unreachable_redis_does_not_raise_name_error PASSED
...
======================== 2 passed, 12 skipped in 1.32s =========================
```

Without the fix (`git stash` of `base.py` only):

```
NameError: name 'redis' is not defined

...
FAILED tests/test_chat_store_redis_chat_store.py::test_unreachable_redis_does_not_raise_name_error - Failed: RedisChatStore raised NameError instead of a redis error
=================== 1 failed, 1 passed, 12 skipped in 1.77s ====================
```

Also ran:
```
$ uv run -- ruff check llama_index tests   # All checks passed!
$ uv run -- ruff format --check llama_index tests   # 5 files already formatted
```

Bumped the package's patch version (0.8.0 → 0.8.1) for this bugfix,
consistent with prior changes in this integration.

## AI assistance disclosure

This change was written with the assistance of an AI coding agent
(Claude), including the code change, regression test, and this PR
description. All commands and test output shown above were run and
verified by the agent against this repository.
