### PR TITLE
async docstore deletes leave zombie node ids in ref-doc bookkeeping

### DIFF
--- a/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
+++ b/llama-index-core/llama_index/core/storage/docstore/keyval_docstore.py
@@ -511,11 +511,11 @@ class KVDocumentStore(BaseDocumentStore):
         Helper function to remove node doc_id from ref_doc_collection.
         If ref_doc has no more doc_ids, delete it from the collection.
         """
-        ref_doc_id, ref_doc_info = await asyncio.gather(
-            self._aget_ref_doc_id(doc_id),
-            self.aget_ref_doc_info(doc_id),
-        )
-        if ref_doc_id is None or ref_doc_info is None:
+        ref_doc_id = await self._aget_ref_doc_id(doc_id)
+        if ref_doc_id is None:
+            return
+        ref_doc_info = await self.aget_ref_doc_info(ref_doc_id)
+        if ref_doc_info is None:
             return
 
         if doc_id in ref_doc_info.node_ids:  # sanity check
@@ -545,8 +545,13 @@ class KVDocumentStore(BaseDocumentStore):
 
     async def adelete_document(self, doc_id: str, raise_error: bool = True) -> None:
         """Delete a document from the store."""
-        _, delete_success, _ = await asyncio.gather(
-            self._aremove_from_ref_doc_node(doc_id),
+        # Resolve the ref doc and update its bookkeeping BEFORE deleting the
+        # node/metadata entries: the lookup reads the metadata entry that the
+        # deletes below remove, so it has to run first. This mirrors the sync
+        # delete_document() ordering.
+        await self._aremove_from_ref_doc_node(doc_id)
+
+        delete_success, _ = await asyncio.gather(
             self._kvstore.adelete(doc_id, collection=self._node_collection),
             self._kvstore.adelete(doc_id, collection=self._metadata_collection),
         )

--- a/llama-index-core/tests/indices/vector_store/test_simple_async.py
+++ b/llama-index-core/tests/indices/vector_store/test_simple_async.py
@@ -229,3 +229,47 @@ async def test_adelete_ref_doc_calls_vector_store_with_ref_doc_id_only(
     assert delete_log == ["my-doc-id"], (
         f"Expected delete() called once with ref_doc_id only, got: {delete_log}"
     )
+
+
+@pytest.mark.asyncio
+async def test_adelete_nodes_removed_from_docstore_updates_ref_doc_info(
+    patch_llm_predictor, patch_token_text_splitter, mock_embed_model
+) -> None:
+    """
+    Test adelete_nodes with delete_from_docstore=True updates ref-doc bookkeeping.
+
+    Deleting an individual node through the async path should remove it from the
+    ref doc's node_ids list in the docstore, matching the sync delete_nodes()
+    behavior.
+    """
+    new_documents = [
+        Document(text="This is a test.", id_="test_id_1"),
+        Document(text="This is another test.", id_="test_id_2"),
+    ]
+    index = SimpleKeywordTableIndex.from_documents(
+        documents=new_documents, embed_model=mock_embed_model
+    )
+
+    # Get node IDs for test_id_1 before deletion
+    ref_doc_info = index.docstore.get_ref_doc_info("test_id_1")
+    assert ref_doc_info is not None
+    # snapshot: the store may hand out the live list
+    node_ids = list(ref_doc_info.node_ids)
+    assert len(node_ids) > 0
+
+    # Delete one node through the async path
+    await index.adelete_nodes([node_ids[0]], delete_from_docstore=True)
+
+    # The deleted node is gone from the docstore ...
+    assert index.docstore.get_node(node_ids[0], raise_error=False) is None
+
+    # ... and from the ref doc's node_ids bookkeeping
+    remaining_info = index.docstore.get_ref_doc_info("test_id_1")
+    if len(node_ids) > 1:
+        assert remaining_info is not None
+        assert node_ids[0] not in remaining_info.node_ids
+        for node_id in node_ids[1:]:
+            assert node_id in remaining_info.node_ids
+    else:
+        # last node deleted, ref doc entry should be gone entirely
+        assert remaining_info is None

--- a/llama-index-core/tests/storage/docstore/test_simple_docstore.py
+++ b/llama-index-core/tests/storage/docstore/test_simple_docstore.py
@@ -152,3 +152,49 @@ def test_docstore_delete_all_ref_doc_nodes() -> None:
     assert docstore._kvstore.get("d1", docstore._node_collection) is None
     assert docstore._kvstore.get("d1", docstore._metadata_collection) is None
     assert docstore._kvstore.get("d1", docstore._ref_doc_collection) is None
+
+
+def _ref_doc_nodes() -> tuple[Document, TextNode, TextNode]:
+    ref_doc = Document(text="hello world", id_="d1", metadata={"foo": "bar"})
+    doc = TextNode(text="first chunk", id_="d2", metadata={"node": "info"})
+    doc.relationships[NodeRelationship.SOURCE] = ref_doc.as_related_node_info()
+    node = TextNode(text="second chunk", id_="d3", metadata={"node": "info"})
+    node.relationships[NodeRelationship.SOURCE] = ref_doc.as_related_node_info()
+    return ref_doc, doc, node
+
+
+@pytest.mark.asyncio
+async def test_adocstore_delete_document_updates_ref_doc_info() -> None:
+    """Deleting a node via the async API keeps ref-doc bookkeeping in sync with the sync API."""
+    ref_doc, doc, node = _ref_doc_nodes()
+
+    docstore = SimpleDocumentStore()
+    docstore.add_documents([ref_doc, doc, node])
+
+    await docstore.adelete_document("d2")
+
+    assert docstore._kvstore.get("d1", docstore._ref_doc_collection)["node_ids"] == [
+        "d3"
+    ]
+    assert docstore._kvstore.get("d2", docstore._node_collection) is None
+    assert docstore._kvstore.get("d2", docstore._metadata_collection) is None
+
+
+@pytest.mark.asyncio
+async def test_adocstore_delete_all_ref_doc_nodes() -> None:
+    """Deleting the last node of a ref doc removes the ref-doc entry (sync parity)."""
+    ref_doc, doc, node = _ref_doc_nodes()
+
+    docstore = SimpleDocumentStore()
+    docstore.add_documents([ref_doc, doc, node])
+
+    await docstore.adelete_document("d2")
+    assert docstore._kvstore.get("d1", docstore._ref_doc_collection)["node_ids"] == [
+        "d3"
+    ]
+
+    await docstore.adelete_document("d3")
+    assert docstore._kvstore.get("d1", docstore._node_collection) is None
+    assert docstore._kvstore.get("d1", docstore._metadata_collection) is None
+    assert docstore._kvstore.get("d1", docstore._ref_doc_collection) is None
+    assert not await docstore.aref_doc_exists("d1")


### PR DESCRIPTION
# Description

Ran into this while reading the docstore code after the ingestion pipeline stuff: `adelete_document` ends up with different state than `delete_document`.

The async helper that removes a node from its ref doc's bookkeeping (`_aremove_from_ref_doc_node`) looked the ref doc up by the node id instead of the resolved ref_doc_id, so the lookup missed every time and the bookkeeping update was silently skipped. On top of that, the bookkeeping ran inside the same `asyncio.gather` as the metadata delete, so the lookup was racing the deletion of the very entry it reads.

Net effect: deleting nodes through the async API (`adelete_document`, `index.adelete_nodes(..., delete_from_docstore=True)`) left the deleted node ids in `ref_doc_info.node_ids`, and deleting the last node of a document never removed the ref-doc entry. The sync path handled both. Anything that trusts `ref_doc_info` after an async delete (later `delete_ref_doc` calls, re-ingests) saw stale nodes.

The fix mirrors the sync ordering: resolve the ref_doc_id first, update the ref-doc entry, then delete the node and metadata entries. Two docstore-level parity tests plus one through `adelete_nodes` on an index; all three fail on the old code and pass with the change.

No tracking issue, found this reading the code.

## New Package?

Did I fill in the `tool.llamahub` section in the `pyproject.toml` and provide a detailed README.md for my new integration or package?

- [ ] Yes
- [x] No

## Version Bump?

Did I bump the version in the `pyproject.toml` file of the package I am updating? (Except for the `llama-index-core` package)

- [ ] Yes
- [x] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Three new tests:

- `test_adocstore_delete_document_updates_ref_doc_info` — async delete of one node removes it from the ref doc's `node_ids` (parity with the sync test right above it).
- `test_adocstore_delete_all_ref_doc_nodes` — deleting the last node async removes the ref-doc entry entirely (parity with `test_docstore_delete_all_ref_doc_nodes`).
- `test_adelete_nodes_removed_from_docstore_updates_ref_doc_info` — `adelete_nodes(..., delete_from_docstore=True)` on an index, then checks the docstore bookkeeping.

All three fail on the old ordering and pass with the change. The `tests/storage/`, `tests/indices/vector_store/`, and `tests/ingestion/` suites pass locally (120 passed, 3 skipped). ruff check, ruff format, codespell, and `git diff --check` are all clean on the changed files.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
