### PR TITLE
feat(core): allow bounded concurrent memory block reads

### DIFF
--- a/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
+++ b/docs/src/content/docs/framework/module_guides/deploying/agents/memory.mdx
@@ -170,6 +170,25 @@ As the memory is used, the short-term memory will fill up. Once the short-term m
 
 When memory is retrieved, the short-term and long-term memories are merged together. The `Memory` object will ensure that the short-term memory + long-term memory content is less than or equal to the `token_limit`. If it is longer, the `.truncate()` method will be called on the memory blocks, using the `priority` to determine the truncation order.
 
+Memory blocks are read sequentially by default. If your blocks perform independent
+I/O, such as querying separate vector stores, set `memory_blocks_concurrency` to a
+positive integer to overlap their reads:
+
+```python
+memory = Memory.from_defaults(
+    session_id="my_session",
+    token_limit=40000,
+    memory_blocks=blocks,
+    memory_blocks_concurrency=3,
+)
+```
+
+The limit applies to each retrieval, not across all sessions. Results keep their
+priority order, and token budgeting and truncation are unchanged. If a read fails
+or the retrieval is cancelled, remaining reads are cancelled and awaited before
+the error is propagated. Keep the default of `1` for blocks that depend on another
+block's reads or mutate shared input. This option does not change memory writes.
+
 <Aside type="tip">
   By default, tokens are counted using tiktoken. To customize this, you can set
   the `tokenizer_fn` argument to a custom callable that given a string, returns

--- a/llama-index-core/llama_index/core/memory/memory.py
+++ b/llama-index-core/llama_index/core/memory/memory.py
@@ -197,7 +197,9 @@ class Memory(BaseMemory):
     When the FIFO queue reaches the token limit, the oldest messages within the pressure size are ejected from the FIFO queue.
     The messages are then processed by each memory block.
 
-    When pulling messages from this memory, the memory blocks are processed in order, and the messages are injected into the system message or the latest user message.
+    When pulling messages from this memory, the memory blocks are read sequentially by default.
+    Independent blocks can be read concurrently with `memory_blocks_concurrency`.
+    Results retain their priority order when injected into the system message or the latest user message.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -217,6 +219,11 @@ class Memory(BaseMemory):
     memory_blocks: List[BaseMemoryBlock] = Field(
         default_factory=list,
         description="The list of memory blocks to use.",
+    )
+    memory_blocks_concurrency: int = Field(
+        default=1,
+        ge=1,
+        description="Maximum simultaneous memory block reads per retrieval. Defaults to sequential reads.",
     )
     memory_blocks_template: RichPromptTemplate = Field(
         default=DEFAULT_MEMORY_BLOCKS_TEMPLATE,
@@ -308,6 +315,7 @@ class Memory(BaseMemory):
         async_database_uri: Optional[str] = None,
         async_engine: Optional[AsyncEngine] = None,
         db_schema: Optional[str] = None,
+        memory_blocks_concurrency: int = 1,
     ) -> "Memory":
         """Initialize Memory."""
         session_id = session_id or generate_chat_store_key()
@@ -331,6 +339,7 @@ class Memory(BaseMemory):
             sql_store=sql_store,
             session_id=session_id,
             memory_blocks=memory_blocks or [],
+            memory_blocks_concurrency=memory_blocks_concurrency,
             chat_history_token_ratio=chat_history_token_ratio,
             token_flush_size=token_flush_size,
             memory_blocks_template=memory_blocks_template,
@@ -456,25 +465,48 @@ class Memory(BaseMemory):
         if isinstance(input, str):
             block_input = [*chat_history, ChatMessage(role="user", content=input)]
 
-        # Process memory blocks in priority order
-        for memory_block in sorted(self.memory_blocks, key=lambda x: -x.priority):
+        async def read_block(memory_block: BaseMemoryBlock) -> Tuple[str, Any]:
             content = await memory_block.aget(
                 block_input, session_id=self.session_id, **block_kwargs
             )
-
-            # Handle different return types from memory blocks
-            if content and isinstance(content, list):
-                # Memory block returned content blocks
-                content_per_memory_block[memory_block.name] = content
-            elif content and isinstance(content, str):
-                # Memory block returned a string
-                content_per_memory_block[memory_block.name] = content
-            elif not content:
-                continue
-            else:
+            if content and not isinstance(content, (list, str)):
                 raise ValueError(
                     f"Invalid content type received from memory block {memory_block.name}: {type(content)}"
                 )
+            return memory_block.name, content
+
+        memory_blocks = sorted(self.memory_blocks, key=lambda x: -x.priority)
+        if self.memory_blocks_concurrency == 1:
+            for memory_block in memory_blocks:
+                name, content = await read_block(memory_block)
+                if content:
+                    content_per_memory_block[name] = content
+        else:
+            semaphore = asyncio.Semaphore(self.memory_blocks_concurrency)
+
+            async def read_with_limit(memory_block: BaseMemoryBlock) -> Tuple[str, Any]:
+                async with semaphore:
+                    return await read_block(memory_block)
+
+            tasks = [
+                asyncio.create_task(read_with_limit(memory_block))
+                for memory_block in memory_blocks
+            ]
+            reads = asyncio.gather(*tasks)
+            try:
+                # Cancel reads explicitly below, so parent cancellation cannot
+                # cancel a block again while it is awaiting resource cleanup.
+                results = await asyncio.shield(reads)
+            finally:
+                # Finish cleanup before propagating a failed or cancelled retrieval.
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(reads, *tasks, return_exceptions=True)
+
+            for name, content in results:
+                if content:
+                    content_per_memory_block[name] = content
 
         return content_per_memory_block
 

--- a/llama-index-core/tests/memory/test_memory_blocks_base.py
+++ b/llama-index-core/tests/memory/test_memory_blocks_base.py
@@ -116,14 +116,15 @@ class ParameterizedMemoryBlock(BaseMemoryBlock[str]):
         pass
 
 
-@pytest.fixture()
-def memory_with_blocks():
+@pytest.fixture(params=[1, 3])
+def memory_with_blocks(request):
     """Set up memory with different types of memory blocks."""
     return Memory(
         token_limit=1000,
         token_flush_size=700,
         chat_history_token_ratio=0.9,
         session_id="test_blocks",
+        memory_blocks_concurrency=request.param,
         memory_blocks=[
             TextMemoryBlock(name="text_block", priority=1),
             ContentBlocksMemoryBlock(name="content_blocks", priority=2),

--- a/llama-index-core/tests/memory/test_memory_read_concurrency.py
+++ b/llama-index-core/tests/memory/test_memory_read_concurrency.py
@@ -1,0 +1,208 @@
+import asyncio
+from typing import Any, Awaitable, Callable, List, Optional
+
+import pytest
+from pydantic import ValidationError
+
+from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.memory.memory import BaseMemoryBlock, Memory
+
+
+class CallbackMemoryBlock(BaseMemoryBlock[str]):
+    reader: Callable[..., Awaitable[str]]
+
+    async def _aget(
+        self, messages: Optional[List[ChatMessage]] = None, **kwargs: Any
+    ) -> str:
+        return await self.reader(messages, **kwargs)
+
+    async def _aput(self, messages: List[ChatMessage]) -> None:
+        pass
+
+
+@pytest.mark.parametrize("concurrency", [0, -1])
+def test_read_concurrency_must_be_positive(concurrency: int) -> None:
+    with pytest.raises(ValidationError, match="memory_blocks_concurrency"):
+        Memory.from_defaults(memory_blocks_concurrency=concurrency)
+
+
+def test_from_defaults_preserves_read_concurrency() -> None:
+    assert Memory.from_defaults().memory_blocks_concurrency == 1
+    assert (
+        Memory.from_defaults(memory_blocks_concurrency=3).memory_blocks_concurrency == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_reads_stop_before_next_block_on_failure() -> None:
+    calls = []
+
+    async def failing_reader(*args: Any, **kwargs: Any) -> str:
+        calls.append("first")
+        raise RuntimeError("read failed")
+
+    async def later_reader(*args: Any, **kwargs: Any) -> str:
+        calls.append("second")
+        return "later content"
+
+    memory = Memory.from_defaults(
+        memory_blocks=[
+            CallbackMemoryBlock(name="second", priority=1, reader=later_reader),
+            CallbackMemoryBlock(name="first", priority=2, reader=failing_reader),
+        ]
+    )
+    with pytest.raises(RuntimeError, match="read failed"):
+        await memory._get_memory_blocks_content([])
+    assert calls == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_reads_overlap_with_limit_and_preserve_priority_order() -> None:
+    names = ["fourth", "first", "third", "second"]
+    priorities = {"first": 4, "second": 3, "third": 2, "fourth": 1}
+    started = {name: asyncio.Event() for name in names}
+    release = {name: asyncio.Event() for name in names}
+    received = {}
+    active = 0
+    peak = 0
+
+    def reader_for(name: str) -> Callable[..., Awaitable[str]]:
+        async def reader(messages: List[ChatMessage], **kwargs: Any) -> str:
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            received[name] = (messages, kwargs)
+            started[name].set()
+            try:
+                await release[name].wait()
+                return name
+            finally:
+                active -= 1
+
+        return reader
+
+    memory = Memory.from_defaults(
+        session_id="concurrent-session",
+        memory_blocks_concurrency=2,
+        memory_blocks=[
+            CallbackMemoryBlock(
+                name=name, priority=priorities[name], reader=reader_for(name)
+            )
+            for name in names
+        ],
+    )
+    history = [ChatMessage(role="user", content="Previous message")]
+    task = asyncio.create_task(
+        memory._get_memory_blocks_content(history, input="New message", context="value")
+    )
+    try:
+        await asyncio.wait_for(started["first"].wait(), timeout=5)
+        await asyncio.wait_for(started["second"].wait(), timeout=5)
+        assert not started["third"].is_set()
+        assert not started["fourth"].is_set()
+
+        release["second"].set()
+        await asyncio.wait_for(started["third"].wait(), timeout=5)
+        assert not started["fourth"].is_set()
+        release["third"].set()
+        await asyncio.wait_for(started["fourth"].wait(), timeout=5)
+        release["fourth"].set()
+        release["first"].set()
+        result = await asyncio.wait_for(task, timeout=5)
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert peak == 2
+    assert active == 0
+    assert list(result.items()) == [(name, name) for name in priorities]
+    assert len(history) == 1
+    for messages, kwargs in received.values():
+        assert [message.content for message in messages] == [
+            "Previous message",
+            "New message",
+        ]
+        assert kwargs == {"session_id": "concurrent-session", "context": "value"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_content", [False, True])
+async def test_failed_read_cancels_and_awaits_other_reads(
+    invalid_content: bool,
+) -> None:
+    started = asyncio.Event()
+    cleaned_up = asyncio.Event()
+
+    async def waiting_reader(*args: Any, **kwargs: Any) -> str:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return "unreachable"
+        finally:
+            await asyncio.sleep(0)
+            cleaned_up.set()
+
+    async def failing_reader(*args: Any, **kwargs: Any) -> Any:
+        await started.wait()
+        if invalid_content:
+            return {"unsupported": "content"}
+        raise RuntimeError("read failed")
+
+    memory = Memory.from_defaults(
+        memory_blocks_concurrency=2,
+        memory_blocks=[
+            CallbackMemoryBlock(name="waiting", reader=waiting_reader),
+            CallbackMemoryBlock(name="failing", reader=failing_reader),
+        ],
+    )
+    expected_error = ValueError if invalid_content else RuntimeError
+    with pytest.raises(expected_error):
+        await asyncio.wait_for(memory._get_memory_blocks_content([]), timeout=5)
+    assert cleaned_up.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_child", [False, True])
+async def test_cancelled_retrieval_awaits_active_reads(cancel_child: bool) -> None:
+    started = [asyncio.Event(), asyncio.Event()]
+    cleaned_up = [asyncio.Event(), asyncio.Event()]
+    cancel = asyncio.Event()
+
+    def reader_for(index: int) -> Callable[..., Awaitable[str]]:
+        async def reader(*args: Any, **kwargs: Any) -> str:
+            started[index].set()
+            try:
+                if cancel_child and index == 0:
+                    await cancel.wait()
+                    raise asyncio.CancelledError
+                await asyncio.Event().wait()
+                return "unreachable"
+            finally:
+                if index == 1:
+                    await asyncio.sleep(0)
+                cleaned_up[index].set()
+
+        return reader
+
+    memory = Memory.from_defaults(
+        memory_blocks_concurrency=2,
+        memory_blocks=[
+            CallbackMemoryBlock(name=str(index), reader=reader_for(index))
+            for index in range(2)
+        ],
+    )
+    task = asyncio.create_task(memory._get_memory_blocks_content([]))
+    try:
+        for event in started:
+            await asyncio.wait_for(event.wait(), timeout=5)
+        if cancel_child:
+            cancel.set()
+        else:
+            task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=5)
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+    assert all(event.is_set() for event in cleaned_up)


### PR DESCRIPTION
# Description

Reading several independent long-term memory blocks currently adds their I/O latency serially on every retrieval. Add an opt-in `Memory.memory_blocks_concurrency` setting, also available through `Memory.from_defaults`, to bound simultaneous reads while retaining priority order and the existing token-budgeting behavior.

The default remains `1`, preserving sequential execution and fail-before-next-read behavior. Concurrent reads use a per-retrieval semaphore. A failed or cancelled retrieval cancels and awaits its remaining reads, including asynchronous cleanup, before propagating the error. Writes are unchanged. The memory guide documents when this option is appropriate and its per-retrieval scope.

No new dependencies or integration package are added. A version bump is not required for this core-package change.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- The memory suite passes: **102 tests**. Coverage includes the concurrency bound, out-of-order completion with stable priority order, argument forwarding, default sequential behavior, invalid results, read failures, and parent/child cancellation with asynchronous resource cleanup. Existing formatting and truncation tests run in both sequential and concurrent modes.
- The core suite passes with one network-dependent test excluded: **1,510 passed, 22 skipped, 6 xfailed, 1 deselected**. The excluded `test_document_block_amerge` fetches a W3C PDF; an earlier complete run failed at that download with a TLS `UNEXPECTED_EOF_WHILE_READING`. No product or fixture code was changed to bypass it. The suite emits dependency/deprecation and aiosqlite teardown warnings; I am not claiming a warning-free run.
- Repository-wide `pre-commit run --all-files` passes. Direct mypy checking of the changed memory module also passes.
- A local synthetic I/O experiment with three independent 50 ms reads (10 repetitions) measured median retrieval times of 153 ms at concurrency 1, 102 ms at 2, and 51 ms at 3. This demonstrates overlap only; it is not a production vector-store benchmark.

## Suggested Checklist

- [ ] I have performed a human self-review of the code
- [x] I have commented the cancellation handling
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that verify the feature

## AI assistance

Codex assisted with implementation, documentation, tests, and automated review, including an independent review of cancellation cleanup. The validation above was run against this branch. No human code review is claimed here.
