### PR TITLE
fix(core): rate limit cached embedding provider requests

### DIFF
--- a/llama-index-core/llama_index/core/base/embeddings/base.py
+++ b/llama-index-core/llama_index/core/base/embeddings/base.py
@@ -333,6 +333,8 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
             else:
                 non_cached_texts.append((i, txt))
         if len(non_cached_texts) > 0:
+            if self.rate_limiter is not None:
+                self.rate_limiter.acquire()
             text_embeddings = self._get_text_embeddings(
                 [x[1] for x in non_cached_texts]
             )
@@ -368,7 +370,7 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                 non_cached_texts.append((i, txt))
 
         if len(non_cached_texts) > 0:
-            text_embeddings = await self._aget_text_embeddings(
+            text_embeddings = await self._aget_text_embeddings_rate_limited(
                 [x[1] for x in non_cached_texts]
             )
             for j, text_embedding in enumerate(text_embeddings):
@@ -511,9 +513,9 @@ class BaseEmbedding(TransformComponent, DispatcherSpanMixin):
                     CBEventType.EMBEDDING,
                     payload={EventPayload.SERIALIZED: model_dict},
                 ) as event:
-                    if self.rate_limiter is not None:
-                        self.rate_limiter.acquire()
                     if not self.embeddings_cache:
+                        if self.rate_limiter is not None:
+                            self.rate_limiter.acquire()
                         embeddings = self._get_text_embeddings(cur_batch)
                     elif self.embeddings_cache is not None:
                         embeddings = self._get_text_embeddings_cached(cur_batch)

--- a/llama-index-core/tests/test_rate_limiter.py
+++ b/llama-index-core/tests/test_rate_limiter.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import time
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from llama_index.core.base.llms.types import ChatMessage
+from llama_index.core.embeddings.mock_embed_model import MockEmbedding
 from llama_index.core.llms.mock import MockLLM
 from llama_index.core.rate_limiter import (
     BaseRateLimiter,
@@ -14,6 +16,7 @@ from llama_index.core.rate_limiter import (
     SlidingWindowRateLimiter,
     TokenBucketRateLimiter,
 )
+from llama_index.core.storage.kvstore import SimpleKVStore
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +255,55 @@ def test_embedding_batch_calls_acquire_per_batch() -> None:
     texts = ["text"] * 12  # 3 batches: 5, 5, 2
     embed.get_text_embedding_batch(texts)
     assert mock_limiter.acquire.call_count == 3
+
+
+@pytest.mark.parametrize(("cached_count", "requests"), [(0, 3), (1, 3), (2, 2), (5, 0)])
+def test_cached_batches_only_rate_limit_provider_requests(
+    cached_count: int, requests: int
+) -> None:
+    cache = SimpleKVStore()
+    texts = [f"text-{i}" for i in range(5)]
+    expected_embedding = [0.5] * 4
+    for text in texts[:cached_count]:
+        cache.put(text, {"cached": expected_embedding}, collection="embeddings")
+    limiter = MagicMock()
+    model = MockEmbedding(
+        embed_dim=4, embed_batch_size=2, embeddings_cache=cache, rate_limiter=limiter
+    )
+
+    assert model.get_text_embedding_batch(texts) == [expected_embedding] * 5
+    assert limiter.acquire.call_count == requests
+    limiter.reset_mock()
+    assert model.get_text_embedding_batch(texts) == [expected_embedding] * 5
+    limiter.acquire.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("cached_count", "requests"), [(0, 3), (1, 3), (2, 2), (5, 0)])
+@pytest.mark.parametrize("num_workers", [None, 2])
+async def test_async_cached_batches_rate_limit_provider_requests(
+    cached_count: int, requests: int, num_workers: Optional[int]
+) -> None:
+    cache = SimpleKVStore()
+    texts = [f"text-{i}" for i in range(5)]
+    expected_embedding = [0.5] * 4
+    for text in texts[:cached_count]:
+        cache.put(text, {"cached": expected_embedding}, collection="embeddings")
+    limiter = MagicMock()
+    limiter.async_acquire = AsyncMock()
+    model = MockEmbedding(
+        embed_dim=4,
+        embed_batch_size=2,
+        embeddings_cache=cache,
+        rate_limiter=limiter,
+        num_workers=num_workers,
+    )
+
+    assert await model.aget_text_embedding_batch(texts) == [expected_embedding] * 5
+    assert limiter.async_acquire.await_count == requests
+    limiter.reset_mock()
+    assert await model.aget_text_embedding_batch(texts) == [expected_embedding] * 5
+    limiter.async_acquire.assert_not_awaited()
 
 
 def test_embedding_without_rate_limiter_works() -> None:


### PR DESCRIPTION
# Description

With an embeddings cache configured, `aget_text_embedding_batch` sends cache misses directly to the provider without awaiting the rate limiter. Conversely, the synchronous batch path acquires a permit before reading the cache, including batches that need no provider request.

Route asynchronous misses through the existing rate-limited helper, and acquire synchronous permits only when a batch actually needs embedding generation. This makes cached batching consistent with the single-text cache path. Public signatures and cache contents are unchanged.

This was found during source inspection, with no corresponding issue or overlapping open PR found. Related #20712 introduced rate limiting; #22402 addresses limiter locking rather than cached batch integration.

## New Package / Version

No new package. No version bump, as this changes `llama-index-core`.

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Regression coverage exercises empty, mixed and fully populated caches; batches containing both hits and misses; repeated all-hit calls; and async execution with and without multiple workers. The initial nine-case matrix failed in seven cases on the unmodified source, with the two all-hit async controls passing.

`uv run --no-sync pytest tests/embeddings tests/test_rate_limiter.py -q` passes (68 tests). Focused Ruff, source mypy and the scoped pre-commit hooks also pass. Tests use the project's MockEmbedding and SimpleKVStore without contacting an embedding provider.

- [x] Added regression tests
- [x] New and existing related tests pass locally

Implementation and regression tests were completed with AI assistance; validation is described above.