### PR TITLE
fix(core): avoid duplicate first-hop triplets in property graph retrieval

### DIFF
--- a/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
+++ b/llama-index-core/llama_index/core/graph_stores/simple_labelled.py
@@ -112,7 +112,7 @@ class SimplePropertyGraphStore(PropertyGraphStore):
 
         cur_depth = 0
         graph_triplets = self.get_triplets(ids=[gn.id for gn in graph_nodes])
-        seen_triplets = set()
+        seen_triplets = {str(t) for t in graph_triplets}
 
         while len(graph_triplets) > 0 and cur_depth < depth:
             triplets.extend(graph_triplets)

--- a/llama-index-core/tests/graph_stores/test_simple_labelled_rel_map.py
+++ b/llama-index-core/tests/graph_stores/test_simple_labelled_rel_map.py
@@ -1,0 +1,123 @@
+import pytest
+
+from llama_index.core.graph_stores.simple_labelled import SimplePropertyGraphStore
+from llama_index.core.graph_stores.types import EntityNode, Relation
+
+
+def _make_store(edges):
+    store = SimplePropertyGraphStore()
+    store.upsert_relations(
+        [
+            Relation(source_id=source, label=label, target_id=target)
+            for source, label, target in edges
+        ]
+    )
+    return store
+
+
+def _triplet_ids(triplets):
+    return [
+        (source.id, relation.id, target.id) for source, relation, target in triplets
+    ]
+
+
+@pytest.mark.parametrize("depth", [2, 3, 8])
+def test_rel_map_does_not_repeat_first_hop(depth):
+    store = _make_store([("A", "R", "B")])
+    result = store.get_rel_map([EntityNode(name="A")], depth=depth)
+    assert _triplet_ids(result) == [("A", "R", "B")]
+
+
+def test_rel_map_limit_counts_distinct_relationships():
+    edges = [("A", "R", "B"), ("B", "R", "C"), ("C", "R", "D")]
+    store = _make_store(edges)
+    result = store.get_rel_map([EntityNode(name="A")], depth=3, limit=3)
+    # A repeated first-hop edge must not displace the evidence at depth three.
+    assert _triplet_ids(result) == edges
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2, 3])
+def test_rel_map_preserves_depth_bound(depth):
+    edges = [("A", "R", "B"), ("B", "R", "C"), ("C", "R", "D")]
+    store = _make_store(edges)
+    result = store.get_rel_map([EntityNode(name="A")], depth=depth)
+    assert _triplet_ids(result) == edges[:depth]
+
+
+@pytest.mark.parametrize("limit", [0, 1, 2, 3])
+def test_rel_map_preserves_limit(limit):
+    edges = [("A", "R", "B"), ("B", "R", "C"), ("C", "R", "D")]
+    store = _make_store(edges)
+    result = store.get_rel_map([EntityNode(name="A")], depth=3, limit=limit)
+    assert _triplet_ids(result) == edges[:limit]
+
+
+def test_rel_map_cycle_and_self_loop_are_unique():
+    edges = [("A", "SELF", "A"), ("A", "R", "B"), ("B", "R", "A")]
+    store = _make_store(edges)
+    result = _triplet_ids(store.get_rel_map([EntityNode(name="A")], depth=10))
+    assert len(result) == len(edges)
+    assert set(result) == set(edges)
+
+
+def test_rel_map_does_not_merge_distinct_relation_labels():
+    edges = [("A", "SUPPORTS", "B"), ("A", "CONTRADICTS", "B")]
+    store = _make_store(edges)
+    result = _triplet_ids(store.get_rel_map([EntityNode(name="A")], depth=3))
+    assert len(result) == 2
+    assert set(result) == set(edges)
+
+
+def test_rel_map_overlapping_seeds_do_not_duplicate_evidence():
+    edges = [("A", "R", "B"), ("B", "R", "C"), ("C", "R", "D")]
+    store = _make_store(edges)
+    result = _triplet_ids(
+        store.get_rel_map([EntityNode(name="A"), EntityNode(name="B")], depth=3)
+    )
+    assert len(result) == len(edges)
+    assert set(result) == set(edges)
+
+
+def test_rel_map_ignored_relations_do_not_consume_result_limit():
+    store = _make_store([("A", "IGNORE", "B"), ("B", "KEEP", "C")])
+    result = store.get_rel_map(
+        [EntityNode(name="A")], depth=3, limit=1, ignore_rels=["IGNORE"]
+    )
+    assert _triplet_ids(result) == [("B", "KEEP", "C")]
+
+
+def test_rel_map_empty_seed_and_missing_seed():
+    store = _make_store([("A", "R", "B")])
+    assert store.get_rel_map([]) == []
+    assert store.get_rel_map([EntityNode(name="missing")]) == []
+
+
+def test_rel_map_preserves_properties_without_mutating_graph():
+    store = SimplePropertyGraphStore()
+    store.upsert_nodes([EntityNode(name="A", properties={"source_id": "doc-1"})])
+    store.upsert_relations(
+        [
+            Relation(
+                source_id="A",
+                label="R",
+                target_id="B",
+                properties={"source_id": "doc-2"},
+            )
+        ]
+    )
+    before = store.to_dict()
+    result = store.get_rel_map([EntityNode(name="A")], depth=3)
+    assert len(result) == 1
+    assert result[0][0].properties == {"source_id": "doc-1"}
+    assert result[0][1].properties == {"source_id": "doc-2"}
+    assert store.to_dict() == before
+
+
+def test_rel_map_after_persist_reload(tmp_path):
+    edges = [("A", "R", "B"), ("B", "R", "C"), ("C", "R", "D")]
+    store = _make_store(edges)
+    path = str(tmp_path / "graph.json")
+    store.persist(path)
+    restored = SimplePropertyGraphStore.from_persist_path(path)
+    result = restored.get_rel_map([EntityNode(name="A")], depth=3, limit=3)
+    assert _triplet_ids(result) == edges


### PR DESCRIPTION
## Description

Initialize `SimplePropertyGraphStore.get_rel_map()`'s visited set from its first-hop triplets. Previously those triplets could be appended again during the next traversal step, consuming the result limit and displacing deeper evidence.

For a chain `A -> B -> C -> D`, `depth=3, limit=3` now returns the three distinct relationships instead of repeating `A -> B` and omitting `C -> D`. Existing traversal direction, depth handling, ignored-relation filtering, and triplet identity rules are unchanged. No new package, dependency, or public API is added.

## Tests

Native editable core installation on Ubuntu / Python 3.12.14:

```bash
cd llama-index-core
python -m pytest tests/graph_stores/test_simple_labelled_rel_map.py -q
# unchanged source: 13 failed, 6 passed
python -m pytest tests/graph_stores -q
# fixed source: 27 passed (19 new cases and 8 existing tests)
```

Coverage includes cycles, self-loops, distinct relation labels, overlapping starting nodes, depth/limit boundaries, metadata preservation, and persistence/reloading. The new tests pass Ruff 0.11.11 and formatting checks; `git diff --check` passes. The full core suite and external graph-store integrations were not run.

[Executed native validation](https://github.com/Anormalm/llama_index/actions/runs/34042506847). Its fork-only workflow is not part of this PR.

## Contributor review

Draft pending contributor review. AI assistance was used to prepare the implementation, regression tests, and this description; the tests above were executed in a native project installation. No completed human self-review is being attested by this draft.