### PR TITLE
fix(lancedb): pass the node by keyword when building multimodal results

### DIFF
--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/llama_index/indices/managed/lancedb/utils.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/llama_index/indices/managed/lancedb/utils.py
@@ -255,7 +255,7 @@ def query_text(table: Table, query: str, **kwargs: Any) -> List[NodeWithScore]:
         else:
             documents.append(
                 NodeWithScore(
-                    ImageDocument(
+                    node=ImageDocument(
                         image_url=d["image_uri"],
                         image=d["image_bytes"],
                         id_=d["id"],
@@ -294,7 +294,7 @@ def query_multimodal(
     for d in data:
         documents.append(
             NodeWithScore(
-                ImageDocument(
+                node=ImageDocument(
                     image_url=d["image_uri"],
                     image=d["image_bytes"],
                     id_=d["id"],
@@ -329,7 +329,7 @@ async def aquery_text(
         else:
             documents.append(
                 NodeWithScore(
-                    ImageDocument(
+                    node=ImageDocument(
                         image_url=d["image_uri"],
                         image=d["image_bytes"],
                         id_=d["id"],
@@ -369,7 +369,7 @@ async def aquery_multimodal(
     for d in data:
         documents.append(
             NodeWithScore(
-                ImageDocument(
+                node=ImageDocument(
                     image_url=d["image_uri"],
                     image=d["image_bytes"],
                     id_=d["id"],

--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/pyproject.toml
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 
 [project]
 name = "llama-index-indices-managed-lancedb"
-version = "0.4.0"
+version = "0.4.1"
 description = "LlamaIndex x LanceDB MultiModal AI Lakehouse"
 authors = [{name = "Clelia Astra Bertelli", email = "clelia@runllama.ai"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/indices/llama-index-indices-managed-lancedb/tests/test_index.py
+++ b/llama-index-integrations/indices/llama-index-indices-managed-lancedb/tests/test_index.py
@@ -12,6 +12,10 @@ from llama_index.indices.managed.lancedb.retriever import LanceDBRetriever
 from llama_index.indices.managed.lancedb.query_engine import LanceDBRetrieverQueryEngine
 from llama_index.indices.managed.lancedb import LanceDBMultiModalIndex
 from llama_index.indices.managed.lancedb.utils import (
+    aquery_multimodal,
+    aquery_text,
+    query_multimodal,
+    query_text,
     TableConfig,
     EmbeddingConfig,
     IndexingConfig,
@@ -22,6 +26,7 @@ from llama_index.core.schema import Document, NodeWithScore
 from llama_index.core import Settings
 from llama_index.core.llms import MockLLM
 from typing import List
+from PIL import Image
 
 
 @pytest.fixture()
@@ -150,3 +155,80 @@ async def test_retriever_qe(uri: str, document_data: List[Document]) -> None:
     assert isinstance(qe, LanceDBRetrieverQueryEngine)
     response = await qe.aquery(query_str="Hello")
     assert isinstance(response.response, str)
+
+
+IMAGE_ROW = {
+    "id": "img-1",
+    "image_uri": "https://example.com/cat.png",
+    "image_bytes": b"\x89PNG\r\n",
+    "label": "cat",
+    "metadata": "{}",
+    "_distance": 0.42,
+}
+
+
+class _FakeQuery:
+    """Stands in for a lancedb query builder; only `to_list` is used here."""
+
+    def __init__(self, rows: List[dict]) -> None:
+        self._rows = rows
+
+    def to_list(self) -> List[dict]:
+        return self._rows
+
+
+class _FakeTable:
+    def __init__(self, rows: List[dict]) -> None:
+        self._rows = rows
+
+    def search(self, *args: object, **kwargs: object) -> _FakeQuery:
+        return _FakeQuery(self._rows)
+
+
+class _FakeAsyncQuery:
+    def __init__(self, rows: List[dict]) -> None:
+        self._rows = rows
+
+    async def to_list(self) -> List[dict]:
+        return self._rows
+
+
+class _FakeAsyncTable:
+    def __init__(self, rows: List[dict]) -> None:
+        self._rows = rows
+
+    async def search(self, *args: object, **kwargs: object) -> _FakeAsyncQuery:
+        return _FakeAsyncQuery(self._rows)
+
+
+def _assert_image_result(retrieved: List[NodeWithScore]) -> None:
+    assert len(retrieved) == 1
+    assert isinstance(retrieved[0], NodeWithScore)
+    assert retrieved[0].node.id_ == "img-1"
+    assert retrieved[0].score == pytest.approx(0.42)
+
+
+def test_query_multimodal_builds_nodes_from_image_rows() -> None:
+    """`NodeWithScore` takes its node by keyword; a positional node is a TypeError."""
+    _assert_image_result(
+        query_multimodal(_FakeTable([IMAGE_ROW]), query=Image.new("RGB", (4, 4)))
+    )
+
+
+def test_query_text_builds_nodes_from_image_rows() -> None:
+    """A row without a `text` column falls through to the image branch."""
+    _assert_image_result(query_text(_FakeTable([IMAGE_ROW]), query="a cat"))
+
+
+@pytest.mark.asyncio
+async def test_aquery_multimodal_builds_nodes_from_image_rows() -> None:
+    _assert_image_result(
+        await aquery_multimodal(
+            _FakeAsyncTable([IMAGE_ROW]), query=Image.new("RGB", (4, 4))
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_aquery_text_builds_nodes_from_image_rows() -> None:
+    _assert_image_result(await aquery_text(_FakeAsyncTable([IMAGE_ROW]), query="a cat"))


### PR DESCRIPTION
# Description

Fixes #22975.

`NodeWithScore` is a `BaseComponent(BaseModel)` and defines no `__init__`, so it inherits pydantic v2's `def __init__(self, /, **data)` — `self` is positional-only, everything else keyword-only. The four **image** branches in `managed-lancedb`'s `utils.py` passed the document positionally:

```python
            NodeWithScore(
                ImageDocument(...),
                score=d["_distance"],
            )
```

so every multimodal retrieval raised `TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given` while building its results — after the search had already run. That is `retriever.retrieve(query_image=...)`, `retriever.aretrieve(query_image=...)` and `query_engine.query(query_image=...)`, i.e. the feature this package is named for.

The two **text** branches in the same file (lines 251-253, 325-327) already used `NodeWithScore(node=..., score=...)`, so this was an oversight in the image branches rather than an intended signature. The fix is `node=` at the four sites: `query_text`, `query_multimodal`, `aquery_text`, `aquery_multimodal`.

## New Package?

- [ ] Yes
- [x] No

## Version Bump?

- [x] Yes — `llama-index-indices-managed-lancedb` 0.4.0 → 0.4.1
- [ ] No

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] I added new unit tests to cover this change
- [ ] I believe this change is already covered by existing unit tests

Four tests, one per affected call site, driven through a stub table so they need no LanceDB instance, no embedding model and no network — the defect is in result construction, which is reachable with a single fabricated row:

```
$ pytest tests/test_index.py -k image_rows
4 passed, 2 deselected in 14.78s
```

Reverting only the `utils.py` change and keeping the tests turns all four red, each at the corresponding line:

```
FAILED tests/test_index.py::test_query_multimodal_builds_nodes_from_image_rows
FAILED tests/test_index.py::test_query_text_builds_nodes_from_image_rows
FAILED tests/test_index.py::test_aquery_multimodal_builds_nodes_from_image_rows
FAILED tests/test_index.py::test_aquery_text_builds_nodes_from_image_rows
4 failed, 2 deselected in 4.16s
```

`ruff check` and `ruff format --check` are clean on both files.

The existing suite never retrieves from a multimodal index — `test_retriever_qe` is text-only — which is why CI stayed green on this. The new tests close that gap specifically.

## Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `uv run make format; uv run make lint` to appease the lint gods
