### PR TITLE
docs(vertexaivectorsearch): align find_neighbors docstring with its signature

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vertexaivectorsearch/llama_index/vector_stores/vertexaivectorsearch/utils.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vertexaivectorsearch/llama_index/vector_stores/vertexaivectorsearch/utils.py
@@ -329,12 +329,12 @@ def find_neighbors(  # noqa: D417
     return_full_datapoint: bool = True,
 ) -> list[MatchNeighbor]:
     """
-    Finds the k closes neighbors of each instance of embeddings.
+    Finds the k closest neighbors of each instance of embeddings.
 
     Args:
-        embedding: List of embeddings vectors.
-        k: Number of neighbors to be retrieved.
-        filter_: List of filters to apply.
+        embeddings: List of embedding vectors.
+        top_k: Number of neighbors to be retrieved.
+        filter: List of filters to apply.
 
     Returns:
         List of lists of Tuples (id, distance) for each embedding vector.

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-vertexaivectorsearch/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-vertexaivectorsearch/pyproject.toml
@@ -37,7 +37,7 @@ ci = [
 
 [project]
 name = "llama-index-vector-stores-vertexaivectorsearch"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index vector_stores Vertex AI Vector Search integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
`find_neighbors`'s docstring documented `embedding`, `k`, and `filter_` — none of which exist. The signature takes `embeddings`, `top_k`, and `filter`. Also "the k closes neighbors" → "closest". Package version bumped per the contribution guidelines.