### PR TITLE
docs(wordlift): drop the notebook link to a nonexistent examples dir

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/README.md
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/README.md
@@ -15,7 +15,7 @@ This integration enables the use of WordLift as a vector store for LlamaIndex, a
 
 ## Usage
 
-Please refer to the [notebook](./examples/wordlift_vector_store_demo.ipynb) for usage of WordLift as vector store in LlamaIndex.
+WordLift can be used as a vector store in LlamaIndex.
 
 WordLift Knowledge Graphs are built on the principles of fully Linked Data, where each entity is assigned a permanent dereferentiable URI.\
 When adding nodes to an existing Knowledge Graph, it's essential to include an "entity_id" in the metadata of each loaded document.\

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-wordlift/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-wordlift"
-version = "0.7.0"
+version = "0.7.1"
 description = "llama-index vector_stores wordlift integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
`llama-index-vector-stores-wordlift`'s README links `./examples/wordlift_vector_store_demo.ipynb`, but the package contains no `examples/` directory (LICENSE, Makefile, README.md, llama_index/, pyproject.toml, tests/, uv.lock only) — the link 404s on GitHub. The sentence is reworded to keep the pointer's meaning without the dead link. Version bumped per the contribution guidelines.