### PR TITLE
fix(rocksetdb): honor the documented embedding_col kwarg in with_new_collection

### DIFF
--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-rocksetdb/llama_index/vector_stores/rocksetdb/base.py
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-rocksetdb/llama_index/vector_stores/rocksetdb/base.py
@@ -334,7 +334,7 @@ class RocksetVectorStore(BasePydanticVectorStore):
             "name": rockset_vector_store_args.get("collection"),
         }
         embeddings_col = rockset_vector_store_args.get(
-            "embeddings_col", DEFAULT_EMBEDDING_KEY
+            "embedding_col", DEFAULT_EMBEDDING_KEY
         )
         if dimensions:
             collection_args["field_mapping_query"] = (

--- a/llama-index-integrations/vector_stores/llama-index-vector-stores-rocksetdb/pyproject.toml
+++ b/llama-index-integrations/vector_stores/llama-index-vector-stores-rocksetdb/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-vector-stores-rocksetdb"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index vector_stores rocksetdb integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
`RocksetVectorStore.with_new_collection` reads the custom column name from `rockset_vector_store_args` under the key `"embeddings_col"` — but the field (`self.embedding_col`), the `__init__` parameter, and both docstrings (`embedding_col (str)`) all use the singular `embedding_col`. A caller following the docs and passing `embedding_col="my_vec"` was silently ignored: `VECTOR_ENFORCE` in the generated field-mapping SQL was applied to the default key instead of the caller's column.

The lookup key now matches the documented, used-everywhere-else name. Package version bumped per the contribution guidelines.