### PR TITLE
docs(uniprot): drop the LICENSE link to the nonexistent file

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-uniprot/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-uniprot/README.md
@@ -143,4 +143,4 @@ We welcome contributions! Please see our [contributing guidelines](https://githu
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License.


### PR DESCRIPTION
`llama-index-readers-uniprot`'s README links `[LICENSE](LICENSE)`, but the package directory contains no LICENSE file (README.md, llama_index/, pyproject.toml, tests/, uv.lock only) — the link 404s on GitHub. The sentence keeps the license statement without the dead link.