### PR TITLE
docs(openalex): point the demo notebook link at examples/demo.ipynb

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-openalex/README.md
+++ b/llama-index-integrations/readers/llama-index-readers-openalex/README.md
@@ -20,7 +20,7 @@ documents = openalex_reader.load_data(query, full_text=False)
 
 ## What can it do?
 
-As shown in [demo.ipynb](demo.ipynb) we can get answers with citations.
+As shown in [demo.ipynb](examples/demo.ipynb) we can get answers with citations.
 
 ```python
 query = "biases in large language models"


### PR DESCRIPTION
`llama-index-readers-openalex`'s README links `[demo.ipynb](demo.ipynb)` at the package root; the notebook lives at `examples/demo.ipynb`. The link now resolves.