### PR TITLE
docs(readers): fix 'index to to organize' docstrings in faiss/txtai readers

### DIFF
--- a/llama-index-integrations/readers/llama-index-readers-faiss/llama_index/readers/faiss/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-faiss/llama_index/readers/faiss/base.py
@@ -13,7 +13,7 @@ class FaissReader(BaseReader):
 
     Retrieves documents through an existing in-memory Faiss index.
     These documents can then be used in a downstream LlamaIndex data structure.
-    If you wish use Faiss itself as an index to to organize documents,
+    If you wish to use Faiss itself as an index to organize documents,
     insert documents, and perform queries on them, please use VectorStoreIndex
     with FaissVectorStore.
 

--- a/llama-index-integrations/readers/llama-index-readers-faiss/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-faiss/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-faiss"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers faiss integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"

--- a/llama-index-integrations/readers/llama-index-readers-txtai/llama_index/readers/txtai/base.py
+++ b/llama-index-integrations/readers/llama-index-readers-txtai/llama_index/readers/txtai/base.py
@@ -13,7 +13,7 @@ class TxtaiReader(BaseReader):
 
     Retrieves documents through an existing in-memory txtai index.
     These documents can then be used in a downstream LlamaIndex data structure.
-    If you wish use txtai itself as an index to to organize documents,
+    If you wish to use txtai itself as an index to organize documents,
     insert documents, and perform queries on them, please use VectorStoreIndex
     with TxtaiVectorStore.
 

--- a/llama-index-integrations/readers/llama-index-readers-txtai/pyproject.toml
+++ b/llama-index-integrations/readers/llama-index-readers-txtai/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [project]
 name = "llama-index-readers-txtai"
-version = "0.5.0"
+version = "0.5.1"
 description = "llama-index readers txtai integration"
 authors = [{name = "Your Name", email = "you@example.com"}]
 requires-python = ">=3.10,<4.0"


### PR DESCRIPTION
The `FaissReader` and `TxtaiReader` class docstrings carry the same copy-pasted sentence: "If you wish use Faiss/txtai itself as an index **to to** organize documents...". Fixed to "If you wish to use ... as an index to organize documents...". Package versions bumped per the contribution guidelines.