### PR TITLE
fix(tools-mcp): capture tool call logs without relying on basicConfig

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/client.py
@@ -274,27 +274,26 @@ class BasicMCPClient(ClientSession):
                     await session.initialize()
                     yield session
 
-    def _configure_tool_call_logs_callback(self) -> io.StringIO:
-        handler = io.StringIO()
-        stream_handler = logging.StreamHandler(handler)
-
-        # Configure logging to capture all events
-        logging.basicConfig(
-            level=logging.DEBUG,  # Capture all log levels
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s\n",
-            handlers=[
-                stream_handler,
-            ],
+    def _configure_tool_call_logs_callback(
+        self,
+    ) -> Tuple[io.StringIO, logging.Handler, List[Tuple[logging.Logger, int]]]:
+        stream = io.StringIO()
+        stream_handler = logging.StreamHandler(stream)
+        stream_handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s\n")
         )
-        # Also enable logging for specific MCP components
-        mcp_logger = logging.getLogger("mcp")
-        mcp_logger.setLevel(logging.DEBUG)
 
-        # Enable HTTP transport logging to see network details
-        http_logger = logging.getLogger("httpx")
-        http_logger.setLevel(logging.DEBUG)
+        # Attach the handler directly to the relevant loggers instead of using
+        # logging.basicConfig(), which is a no-op once the root logger already
+        # has handlers (e.g. in apps that configure logging themselves).
+        previous_levels = []
+        for logger_name in ("mcp", "httpx"):
+            logger = logging.getLogger(logger_name)
+            previous_levels.append((logger, logger.level))
+            logger.addHandler(stream_handler)
+            logger.setLevel(logging.DEBUG)
 
-        return handler
+        return stream, stream_handler, previous_levels
 
     # Tool methods
     async def call_tool(
@@ -306,20 +305,32 @@ class BasicMCPClient(ClientSession):
         """Call a tool on the MCP server."""
         if self.tool_call_logs_callback is not None:
             # we use a string stream so that we can recover all logs at the end of the session
-            handler = self._configure_tool_call_logs_callback()
+            (
+                handler,
+                stream_handler,
+                previous_levels,
+            ) = self._configure_tool_call_logs_callback()
+            try:
+                async with self._run_session() as session:
+                    result = await session.call_tool(
+                        tool_name,
+                        arguments=arguments,
+                        progress_callback=progress_callback,
+                    )
 
-            async with self._run_session() as session:
-                result = await session.call_tool(
-                    tool_name, arguments=arguments, progress_callback=progress_callback
-                )
+                    # get all logs by dividing the string with \n, since the format of the log has an \n at the end of the log message
+                    extra_values = handler.getvalue().split("\n")
 
-                # get all logs by dividing the string with \n, since the format of the log has an \n at the end of the log message
-                extra_values = handler.getvalue().split("\n")
+                    # pipe the logs list into tool_call_logs_callback
+                    await self.tool_call_logs_callback(extra_values)
 
-                # pipe the logs list into tool_call_logs_callback
-                await self.tool_call_logs_callback(extra_values)
-
-                return result
+                    return result
+            finally:
+                # detach the temporary handler and restore prior logger levels
+                # so this call doesn't permanently change global logging config
+                for logger, previous_level in previous_levels:
+                    logger.removeHandler(stream_handler)
+                    logger.setLevel(previous_level)
         else:
             async with self._run_session() as session:
                 return await session.call_tool(

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from httpx2 import AsyncClient
 import pytest
@@ -211,6 +212,56 @@ async def test_long_running_task(client: BasicMCPClient):
     assert current_progress == 3.0
     assert current_progress == expected_total
     assert current_message == "Processing step 3/3"
+
+
+def test_configure_tool_call_logs_callback_ignores_prior_basicConfig(
+    client: BasicMCPClient,
+):
+    """
+    The capture must not rely on logging.basicConfig(), which is a no-op
+    once the root logger already has handlers (e.g. an app that configured
+    logging before constructing the client).
+    """
+    logging.basicConfig(level=logging.INFO, force=True)
+
+    stream, stream_handler, previous_levels = (
+        client._configure_tool_call_logs_callback()
+    )
+    try:
+        logging.getLogger("mcp").debug("mcp-debug-message")
+        assert "mcp-debug-message" in stream.getvalue()
+    finally:
+        for logger, previous_level in previous_levels:
+            logger.removeHandler(stream_handler)
+            logger.setLevel(previous_level)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_restores_logging_state(client: BasicMCPClient):
+    """
+    Enabling tool_call_logs_callback must not leak handlers or leave the
+    mcp/httpx loggers permanently at DEBUG after the call completes.
+    """
+    mcp_logger = logging.getLogger("mcp")
+    httpx_logger = logging.getLogger("httpx")
+    original_mcp_level = mcp_logger.level
+    original_httpx_level = httpx_logger.level
+    original_mcp_handlers = list(mcp_logger.handlers)
+    original_httpx_handlers = list(httpx_logger.handlers)
+
+    async def logs_callback(logs):
+        pass
+
+    client.tool_call_logs_callback = logs_callback
+    try:
+        await client.call_tool("echo", {"message": "hi"})
+    finally:
+        client.tool_call_logs_callback = None
+
+    assert mcp_logger.level == original_mcp_level
+    assert httpx_logger.level == original_httpx_level
+    assert mcp_logger.handlers == original_mcp_handlers
+    assert httpx_logger.handlers == original_httpx_handlers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #22996

### Problem

`BasicMCPClient._configure_tool_call_logs_callback()` used
`logging.basicConfig(..., handlers=[stream_handler])` to attach a
temporary `StringIO` handler before an MCP tool call. `logging.basicConfig()`
is a no-op once the root logger already has handlers unless `force=True` is
passed, so in any application that had already configured logging (FastAPI,
Jupyter, a CLI, etc.), the new handler was never attached and
`tool_call_logs_callback` silently received empty/partial logs.

The helper also set the `mcp` and `httpx` logger levels to `DEBUG` and never
restored them, so a single call with `tool_call_logs_callback` set would
permanently raise logging verbosity for the whole host application.

### Fix

Attach the temporary `StreamHandler` directly to the `mcp` and `httpx`
loggers instead of going through `logging.basicConfig()`, and restore each
logger's previous level and remove the handler in a `finally` block after
the tool call completes (successful or not).

### Test plan

Added two tests to `llama-index-integrations/tools/llama-index-tools-mcp/tests/test_client.py`:

- `test_configure_tool_call_logs_callback_ignores_prior_basicConfig` — reproduces the issue's repro case: calls `logging.basicConfig(force=True)` first (simulating an app that already configured logging), then asserts a debug log emitted on the `mcp` logger is captured.
- `test_call_tool_restores_logging_state` — calls a real tool with `tool_call_logs_callback` set and asserts the `mcp`/`httpx` logger levels and handlers are unchanged after the call.

Verified both tests fail on the pre-fix code (checked out via `git checkout HEAD~1 -- llama_index/tools/mcp/client.py`) and pass after the fix:

```
tests/test_client.py::test_configure_tool_call_logs_callback_ignores_prior_basicConfig FAILED (pre-fix: ValueError: not enough values to unpack)
tests/test_client.py::test_call_tool_restores_logging_state FAILED (pre-fix, run in isolation: assert 10 == 0)
```

After the fix, the full package test suite passes:

```
$ uv run -- pytest tests/
======================= 54 passed, 2 warnings in 55.27s ========================
```

Lint:

```
$ uv run -- ruff check llama_index/tools/mcp/client.py tests/test_client.py
All checks passed!
$ uv run -- ruff format --check llama_index/tools/mcp/client.py tests/test_client.py
2 files already formatted
```

### AI-assistance disclosure

This change was written with AI assistance (Claude). The diff is a small,
targeted fix confined to `llama-index-tools-mcp`'s MCP client logging helper;
it was verified by running the package's real test suite and lint locally,
and by reverting the source change to confirm the new tests fail without it.
