### PR TITLE
fix(tools-mcp): stop allowed_tools from filtering fetch_resources

### DIFF
--- a/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/llama_index/tools/mcp/base.py
@@ -87,21 +87,7 @@ class McpToolSpec(
             if hasattr(dynamic_response, "resource_templates")
             else []
         )
-        resources = static_resources + dynamic_resources
-        if self.allowed_tools is None:
-            return resources
-
-        if any(self.allowed_tools):
-            return [
-                resource
-                for resource in resources
-                if resource.name in self.allowed_tools
-            ]
-
-        logging.warning(
-            "Returning an empty resource list due to the empty `allowed_tools` list. Please ensure `allowed_tools` is set appropriately."
-        )
-        return []
+        return static_resources + dynamic_resources
 
     def _create_tool_fn(self, tool_name: str) -> Callable:
         """

--- a/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
+++ b/llama-index-integrations/tools/llama-index-tools-mcp/tests/test_tools_mcp.py
@@ -239,14 +239,12 @@ async def test_resource_tool_uses_uri_not_name(client: BasicMCPClient):
     internal function is created with the resource's name ('get_app_config')
     instead of its URI ('config://app'), causing the client call to fail.
     """
-    tool_spec = McpToolSpec(
-        client, allowed_tools=["get_app_config"], include_resources=True
-    )
+    tool_spec = McpToolSpec(client, allowed_tools=[], include_resources=True)
     tools = await tool_spec.to_tool_list_async()
 
-    assert len(tools) == 1
-    tool = tools[0]
-    assert tool.metadata.name == "get_app_config"
+    matching = [t for t in tools if t.metadata.name == "get_app_config"]
+    assert len(matching) == 1
+    tool = matching[0]
 
     # This call will fail due to the bug.
     result = await tool.acall()
@@ -265,6 +263,28 @@ async def test_dynamic_resource_template_tool_is_created(client: BasicMCPClient)
     # This should now be found.
     tool_names = {t.metadata.name for t in tools}
     assert "get_user_profile" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_fetch_resources_ignores_allowed_tools(client: BasicMCPClient):
+    """
+    allowed_tools filters callable tools, not resources. A resource whose
+    name is not in allowed_tools must still be returned by fetch_resources.
+    """
+    tool_spec = McpToolSpec(client, allowed_tools=["echo"], include_resources=True)
+    resources = await tool_spec.fetch_resources()
+    resource_names = {r.name for r in resources}
+    assert "get_app_config" in resource_names
+
+
+@pytest.mark.asyncio
+async def test_fetch_resources_not_disabled_by_empty_allowed_tools(
+    client: BasicMCPClient,
+):
+    """An empty allowed_tools list should not disable resources entirely."""
+    tool_spec = McpToolSpec(client, allowed_tools=[], include_resources=True)
+    resources = await tool_spec.fetch_resources()
+    assert len(resources) > 0
 
 
 # --- Tests for global_partial_params ---


### PR DESCRIPTION
Closes #22995

## Description

`McpToolSpec.allowed_tools` is documented as a filter for callable **tools**,
but `fetch_resources()` reused the same list to filter MCP **resources** and
resource templates too. Tool and resource namespaces in MCP are independent,
so this silently drops resources whose name doesn't happen to collide with an
allowed tool name, and it makes `allowed_tools=[]` disable resources entirely
even though the option's name and docstring only talk about tools.

Repro from the issue:

```python
McpToolSpec(client=client, allowed_tools=["search"], include_resources=True)
```

drops every resource (`docs`, `schema`, `project_context`, ...) unless one of
them happens to be named `search`.

## Fix

`fetch_resources()` now always returns all static resources and resource
templates, unfiltered by `allowed_tools`. `fetch_tools()` (used for callable
tools) is unchanged and still respects `allowed_tools` as before.

## Testing

Added two regression tests in `tests/test_tools_mcp.py`:
- `test_fetch_resources_ignores_allowed_tools`: a resource whose name isn't in
  `allowed_tools` is still returned.
- `test_fetch_resources_not_disabled_by_empty_allowed_tools`: an empty
  `allowed_tools` list doesn't wipe out resources.

Also updated `test_resource_tool_uses_uri_not_name`, which previously relied
on `allowed_tools` filtering resources down to exactly one as a way to isolate
a single resource tool — that behavior was itself the bug, so the test now
locates the tool by name instead.

Verified the new/updated tests fail on the pre-fix code
(`git checkout HEAD~1 -- llama_index/tools/mcp/base.py`) and pass after
restoring the fix:

```
FAILED tests/test_tools_mcp.py::test_fetch_resources_ignores_allowed_tools - AssertionError: assert 'get_app_config' in set()
FAILED tests/test_tools_mcp.py::test_fetch_resources_not_disabled_by_empty_allowed_tools - assert 0 > 0
FAILED tests/test_tools_mcp.py::test_resource_tool_uses_uri_not_name - assert 0 == 1
3 failed in 9.64s
```

Full suite after the fix:

```
$ uv run --frozen -- pytest tests/
54 passed, 2 warnings in 74.77s
```

`ruff check` and `ruff format --check` both clean on the changed files.

<sub>AI-assistance disclosure: this fix and its tests were prepared with an AI coding assistant (Claude Code), based on the repro and control-flow analysis in issue #22995.</sub>
