### PR TITLE
fix(core): make get_transformation_hash injective

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -59,14 +59,21 @@ def get_transformation_hash(
     nodes: Sequence[BaseNode], transformation: TransformComponent
 ) -> str:
     """Get the hash of a transformation."""
-    # Hash each node individually (including its id) before concatenating, so the
-    # combined string can't be produced by two different node lists: fixed-length
-    # digests can't be split ambiguously the way raw, unseparated content can, and
-    # including the id ties the cached result's identity to the key that looks it up.
+    # Hash each node individually (including its identity) before concatenating,
+    # so the combined string can't be produced by two different node lists:
+    # fixed-length digests can't be split ambiguously the way raw, unseparated
+    # content can, and including identity ties the cached result to the key that
+    # looks it up. Use the source document's id (falling back to the node's own
+    # id for a node with no SOURCE relationship, i.e. a top-level document) rather
+    # than the node's own id_: intermediate nodes produced by a splitter get a
+    # fresh id_ from the default `id_func` on every run even when their content
+    # is unchanged, so keying on node.id_ would make a later stage's cache entry
+    # (e.g. an embedder's) miss whenever an earlier stage's cache entry expired
+    # and had to be recomputed, even though nothing about the content changed.
     nodes_str = "".join(
         [
             sha256(
-                f"{node.id_}-{node.get_content(metadata_mode=MetadataMode.ALL)}".encode(
+                f"{node.source_node.node_id if node.source_node else node.id_}-{node.get_content(metadata_mode=MetadataMode.ALL)}".encode(
                     "utf-8"
                 )
             ).hexdigest()

--- a/llama-index-core/llama_index/core/ingestion/pipeline.py
+++ b/llama-index-core/llama_index/core/ingestion/pipeline.py
@@ -59,8 +59,19 @@ def get_transformation_hash(
     nodes: Sequence[BaseNode], transformation: TransformComponent
 ) -> str:
     """Get the hash of a transformation."""
+    # Hash each node individually (including its id) before concatenating, so the
+    # combined string can't be produced by two different node lists: fixed-length
+    # digests can't be split ambiguously the way raw, unseparated content can, and
+    # including the id ties the cached result's identity to the key that looks it up.
     nodes_str = "".join(
-        [str(node.get_content(metadata_mode=MetadataMode.ALL)) for node in nodes]
+        [
+            sha256(
+                f"{node.id_}-{node.get_content(metadata_mode=MetadataMode.ALL)}".encode(
+                    "utf-8"
+                )
+            ).hexdigest()
+            for node in nodes
+        ]
     )
 
     transformation_dict = transformation.to_dict()

--- a/llama-index-core/tests/ingestion/test_cache.py
+++ b/llama-index-core/tests/ingestion/test_cache.py
@@ -30,6 +30,28 @@ def test_cache() -> None:
     assert cache.get(new_hash) is None
 
 
+def test_get_transformation_hash_is_injective() -> None:
+    transformation = DummyTransform()
+
+    # Splitting the same combined text at a different node boundary must not
+    # collide: ["ab", "c"] and ["a", "bc"] previously hashed identically because
+    # node contents were concatenated with no separator.
+    nodes_ab_c = [TextNode(id_="1", text="ab"), TextNode(id_="2", text="c")]
+    nodes_a_bc = [TextNode(id_="3", text="a"), TextNode(id_="4", text="bc")]
+    assert get_transformation_hash(
+        nodes_ab_c, transformation
+    ) != get_transformation_hash(nodes_a_bc, transformation)
+
+    # Two distinct documents with identical content must not hash the same,
+    # since the cached value carries node identity (id_, ref_doc_id) that the
+    # key must also depend on.
+    node_a = TextNode(id_="doc_a", text="same content")
+    node_b = TextNode(id_="doc_b", text="same content")
+    assert get_transformation_hash([node_a], transformation) != get_transformation_hash(
+        [node_b], transformation
+    )
+
+
 def test_cache_clear() -> None:
     cache = IngestionCache()
     transformation = DummyTransform()

--- a/llama-index-core/tests/ingestion/test_cache.py
+++ b/llama-index-core/tests/ingestion/test_cache.py
@@ -1,14 +1,62 @@
 from typing import Any, List
 
+from llama_index.core.bridge.pydantic import PrivateAttr
 from llama_index.core.ingestion import IngestionCache
-from llama_index.core.ingestion.pipeline import get_transformation_hash
-from llama_index.core.schema import BaseNode, TextNode, TransformComponent
+from llama_index.core.ingestion.pipeline import (
+    get_transformation_hash,
+    run_transformations,
+)
+from llama_index.core.schema import (
+    BaseNode,
+    NodeRelationship,
+    TextNode,
+    TransformComponent,
+)
 
 
 class DummyTransform(TransformComponent):
     def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
         for node in nodes:
             node.set_content(node.get_content() + "\nTESTTEST")
+        return nodes
+
+
+class RandomIdSplitTransform(TransformComponent):
+    """
+    Mimics a real splitter using the default `id_func`: every call produces
+    brand-new node ids for its output, even when the input is unchanged, but
+    the output nodes carry a SOURCE relationship back to the (stable) input
+    node, exactly like `build_nodes_from_splits` does.
+    """
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "random_id_split_transform"
+
+    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        chunks = []
+        for node in nodes:
+            chunk = TextNode(text=node.get_content())
+            chunk.relationships[NodeRelationship.SOURCE] = node.as_related_node_info()
+            chunks.append(chunk)
+        return chunks
+
+
+class CountingTransform(TransformComponent):
+    # A private attribute so the running count isn't part of `to_dict()` and
+    # doesn't itself perturb the transformation hash between calls.
+    _call_count: int = PrivateAttr(default=0)
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "counting_transform"
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    def __call__(self, nodes: List[BaseNode], **kwargs: Any) -> List[BaseNode]:
+        self._call_count += 1
         return nodes
 
 
@@ -50,6 +98,33 @@ def test_get_transformation_hash_is_injective() -> None:
     assert get_transformation_hash([node_a], transformation) != get_transformation_hash(
         [node_b], transformation
     )
+
+
+def test_downstream_cache_survives_upstream_id_regeneration() -> None:
+    """
+    A splitter's output nodes get fresh random ids on every run (the default
+    `id_func`), even when the input document is unchanged, so the hash used to
+    key a *later* stage's cache entry must not depend on those transient ids.
+    Otherwise, evicting only the upstream stage's cache entry would silently
+    cascade into a downstream cache miss too - forcing an expensive stage
+    (e.g. embedding) to redundantly re-run even though the document content
+    never changed.
+    """
+    cache = IngestionCache()
+    split = RandomIdSplitTransform()
+    embed = CountingTransform()
+    doc = TextNode(id_="stable-doc-id", text="unchanged content")
+
+    run_transformations([doc], [split, embed], cache=cache)
+    assert embed.call_count == 1
+
+    # Evict only the splitter's cache entry, forcing it to re-run and produce
+    # chunk nodes with brand-new random ids on the next call.
+    split_hash = get_transformation_hash([doc], split)
+    cache.cache.delete(split_hash, collection=cache.collection)
+
+    run_transformations([doc], [split, embed], cache=cache)
+    assert embed.call_count == 1  # still cached: content never changed
 
 
 def test_cache_clear() -> None:


### PR DESCRIPTION
## Summary

Fixes the second of the two defects reported in #23002: the `IngestionCache`
key computed by `get_transformation_hash` in
`llama-index-core/llama_index/core/ingestion/pipeline.py` is not injective.

`nodes_str` concatenated each node's content with no separator and never
included node identity:

```python
nodes_str = "".join(
    [str(node.get_content(metadata_mode=MetadataMode.ALL)) for node in nodes]
)
```

Two independent problems follow from this:

1. **Boundary ambiguity.** `["ab", "c"]` and `["a", "bc"]` concatenate to the
   same string, so they hash to the same cache key even though they are
   different node lists.
2. **Missing identity.** The key depends only on content, but the cached
   *value* is a list of nodes carrying `id_`/`ref_doc_id`. Two different
   documents with identical content (a common case — boilerplate pages,
   repeated licence text, empty placeholder pages) hash to the same key, so
   the second document's transformation is skipped and it silently gets the
   first document's cached nodes back, with the first document's `ref_doc_id`.
   Every downstream consumer of that identity (citations, `delete_ref_doc`,
   `get_ref_doc_info`) is then wrong.

This PR only addresses defect #2 from the issue (the cache-key injectivity
problem). Defect #1 (`UPSERTS_AND_DELETE` losing doc_ids when
`get_all_document_hashes().values()` collapses same-hash documents) is
already fixed by the open PR #22935, so it's out of scope here to avoid
duplicating that work.

## Fix

Hash each node's identity plus its content individually into a fixed-length
SHA-256 digest before concatenating:

```python
nodes_str = "".join(
    [
        sha256(
            f"{node.source_node.node_id if node.source_node else node.id_}-{node.get_content(metadata_mode=MetadataMode.ALL)}".encode(
                "utf-8"
            )
        ).hexdigest()
        for node in nodes
    ]
)
```

Fixed-length digests can't be split ambiguously the way raw, unseparated
content can, which fixes the boundary-ambiguity collision.

**Revision note:** the first version of this fix hashed `node.id_` directly.
An independent review caught that this regresses multi-stage pipelines:
nodes produced by a splitter get a *fresh, random* `id_` from the default
`id_func` on every run, even when their content is unchanged, so a
downstream stage's cache entry (e.g. an embedder's) would miss whenever an
upstream stage's own cache entry expired and had to be recomputed — even
though nothing about the content changed. The fix now uses the node's
*source-document* id (`node.source_node.node_id`) when the node has a SOURCE
relationship, falling back to the node's own `id_` only for a node with no
such relationship (i.e. a top-level document passed directly into the
pipeline). Source-document ids are assigned once and stay stable across
reruns, unlike a splitter's per-node ids, while still distinguishing distinct
documents with identical content — so the original injectivity fix and
multi-stage cache stability both hold.

## Test plan

Added two tests in `llama-index-core/tests/ingestion/test_cache.py`:

- `test_get_transformation_hash_is_injective` — covers both collision
  scenarios from the issue (boundary ambiguity and distinct documents with
  identical content).
- `test_downstream_cache_survives_upstream_id_regeneration` — runs a
  two-stage pipeline (`RandomIdSplitTransform` → `CountingTransform`) twice,
  evicting only the upstream stage's cache entry between runs, and asserts
  the downstream stage still hits cache for unchanged content. This is the
  regression the independent review found in the first revision.

Confirmed the new regression test fails against the first revision of this
fix (which keyed on `node.id_` directly):

```
$ git checkout HEAD~1 -- llama-index-core/llama_index/core/ingestion/pipeline.py
$ uv run -- pytest tests/ingestion/test_cache.py -q
..F.
AssertionError: assert 2 == 1
 +  where 2 = CountingTransform().call_count
1 failed, 3 passed in 0.18s
$ git checkout HEAD -- llama-index-core/llama_index/core/ingestion/pipeline.py
```

With the current fix applied:

```
$ uv run -- pytest tests/ingestion/test_cache.py -q
....                                                                     [100%]
4 passed in 0.03s

$ uv run -- pytest tests/ingestion/ -q
...sss.............................................                      [100%]
49 passed, 3 skipped, 17 warnings in 7.38s

$ uv run -- ruff check llama_index/core/ingestion/pipeline.py tests/ingestion/test_cache.py
All checks passed!

$ uv run -- ruff format --check llama_index/core/ingestion/pipeline.py tests/ingestion/test_cache.py
2 files already formatted
```

## AI assistance disclosure

This change was written with AI assistance (Claude). The root cause, fix
approach, and tests were reviewed line-by-line — including an independent
review that caught a real regression in the first revision (see "Revision
note" above) — before submitting; the diff is minimal (one function body
plus two tests) and I understand and can maintain it.
