### PR TITLE
fix(core): return empty results when similarity_top_k=0 in embedding …

### DIFF
--- a/llama-index-core/llama_index/core/indices/query/embedding_utils.py
+++ b/llama-index-core/llama_index/core/indices/query/embedding_utils.py
@@ -18,6 +18,9 @@ def get_top_k_embeddings(
     similarity_cutoff: Optional[float] = None,
 ) -> Tuple[List[float], List]:
     """Get top nodes by similarity to the query."""
+    if similarity_top_k == 0:
+        return [], []
+
     if embedding_ids is None:
         embedding_ids = list(range(len(embeddings)))
 
@@ -31,7 +34,7 @@ def get_top_k_embeddings(
         similarity = similarity_fn(query_embedding_np, emb)  # type: ignore[arg-type]
         if similarity_cutoff is None or similarity > similarity_cutoff:
             heapq.heappush(similarity_heap, (similarity, embedding_ids[i]))
-            if similarity_top_k and len(similarity_heap) > similarity_top_k:
+            if similarity_top_k is not None and len(similarity_heap) > similarity_top_k:
                 heapq.heappop(similarity_heap)
     result_tups = sorted(similarity_heap, key=lambda x: x[0], reverse=True)
 
@@ -57,6 +60,9 @@ def get_top_k_embeddings_learner(
     Can fit SVM, linear regression, and more.
 
     """
+    if similarity_top_k == 0:
+        return [], []
+
     try:
         from sklearn import linear_model, svm
     except ImportError:
@@ -115,6 +121,9 @@ def get_top_k_mmr_embeddings(
     A mmr_threshold of 1 will check similarity the query and ignore previous results.
 
     """
+    if similarity_top_k == 0:
+        return [], []
+
     threshold = mmr_threshold if mmr_threshold is not None else 0.5
     similarity_fn = similarity_fn or default_similarity_fn
 
@@ -136,7 +145,9 @@ def get_top_k_mmr_embeddings(
     results: List[Tuple[Any, Any]] = []
 
     embedding_length = len(embeddings or [])
-    similarity_top_k_count = similarity_top_k or embedding_length
+    similarity_top_k_count = (
+        similarity_top_k if similarity_top_k is not None else embedding_length
+    )
     while len(results) < min(similarity_top_k_count, embedding_length):
         # Calculate the similarity score the for the leading one.
         results.append((score, high_score_id))

--- a/llama-index-core/tests/indices/query/test_embedding_utils.py
+++ b/llama-index-core/tests/indices/query/test_embedding_utils.py
@@ -3,6 +3,7 @@
 import numpy as np
 from llama_index.core.indices.query.embedding_utils import (
     get_top_k_embeddings,
+    get_top_k_embeddings_learner,
     get_top_k_mmr_embeddings,
 )
 
@@ -108,3 +109,37 @@ def test_get_top_k_mmr_embeddings_threshold_zero() -> None:
         query_embedding, embeddings, similarity_top_k=2
     )
     assert unset_ids == [0, 1]
+
+
+def test_get_top_k_embeddings_top_k_zero() -> None:
+    """Test that similarity_top_k=0 returns empty results instead of all embeddings (#22508)."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0]]
+
+    sims, ids = get_top_k_embeddings(query_embedding, embeddings, similarity_top_k=0)
+    assert sims == []
+    assert ids == []
+
+
+def test_get_top_k_mmr_embeddings_top_k_zero() -> None:
+    """Test that similarity_top_k=0 in MMR returns empty results (#22508)."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0]]
+
+    sims, ids = get_top_k_mmr_embeddings(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert sims == []
+    assert ids == []
+
+
+def test_get_top_k_embeddings_learner_top_k_zero() -> None:
+    """Test that similarity_top_k=0 in learner returns empty results (#22508)."""
+    query_embedding = [1.0, 0.0]
+    embeddings = [[1.0, 0.0], [0.0, 1.0]]
+
+    sims, ids = get_top_k_embeddings_learner(
+        query_embedding, embeddings, similarity_top_k=0
+    )
+    assert len(sims) == 0
+    assert len(ids) == 0


### PR DESCRIPTION
Fixes #22508

### Summary
`get_top_k_embeddings` and `get_top_k_mmr_embeddings` previously treated `similarity_top_k` truthily (`if similarity_top_k and len(...) > similarity_top_k` and `similarity_top_k or embedding_length`), which caused an explicit `similarity_top_k=0` to be treated as `None` (unlimited) and return all embeddings rather than an empty list.

### Changes
1. Added early exit `if similarity_top_k == 0: return [], []` in `get_top_k_embeddings`, `get_top_k_mmr_embeddings`, and `get_top_k_embeddings_learner`.
2. Changed `if similarity_top_k and len(...)` to `if similarity_top_k is not None and len(...)` and `similarity_top_k if similarity_top_k is not None else embedding_length`.
3. Added unit tests in `test_embedding_utils.py` verifying that all three functions return empty lists when `similarity_top_k=0`.
